### PR TITLE
Add the 'Tox' context object to the logger.

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -831,9 +831,9 @@ static void set_friend_typing(const Messenger *m, int32_t friendnumber, uint8_t 
     m->friendlist[friendnumber].is_typing = is_typing;
 }
 
-void m_callback_log(Messenger *m, logger_cb *function, void *userdata)
+void m_callback_log(Messenger *m, logger_cb *function, void *context, void *userdata)
 {
-    logger_callback_log(m->log, function, userdata);
+    logger_callback_log(m->log, function, context, userdata);
 }
 
 /* Set the function that will be executed when a friend request is received. */

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -460,7 +460,7 @@ int m_get_istyping(const Messenger *m, int32_t friendnumber);
 
 /* Set the logger callback.
  */
-void m_callback_log(Messenger *m, logger_cb *function, void *userdata);
+void m_callback_log(Messenger *m, logger_cb *function, void *context, void *userdata);
 
 /* Set the function that will be executed when a friend request is received.
  *  Function format is function(uint8_t * public_key, uint8_t * data, size_t length)

--- a/toxcore/logger.c
+++ b/toxcore/logger.c
@@ -28,6 +28,7 @@
 
 struct Logger {
     logger_cb *callback;
+    void *context;
     void *userdata;
 };
 
@@ -35,7 +36,7 @@ struct Logger {
 /**
  * Public Functions
  */
-Logger *logger_new(void)
+Logger *logger_new()
 {
     return (Logger *)calloc(1, sizeof(Logger));
 }
@@ -45,9 +46,10 @@ void logger_kill(Logger *log)
     free(log);
 }
 
-void logger_callback_log(Logger *log, logger_cb *function, void *userdata)
+void logger_callback_log(Logger *log, logger_cb *function, void *context, void *userdata)
 {
     log->callback = function;
+    log->context  = context;
     log->userdata = userdata;
 }
 
@@ -65,5 +67,5 @@ void logger_write(Logger *log, LOGGER_LEVEL level, const char *file, int line, c
     vsnprintf(msg, sizeof msg, format, args);
     va_end(args);
 
-    log->callback(level, file, line, func, msg, log->userdata);
+    log->callback(log->context, level, file, line, func, msg, log->userdata);
 }

--- a/toxcore/logger.h
+++ b/toxcore/logger.h
@@ -39,20 +39,21 @@ typedef enum {
 
 typedef struct Logger Logger;
 
-typedef void logger_cb(LOGGER_LEVEL level, const char *file, int line, const char *func,
-                       const char *message, void *userdata);
+typedef void logger_cb(void *context, LOGGER_LEVEL level, const char *file, int line,
+                       const char *func, const char *message, void *userdata);
 
 /**
  * Creates a new logger with logging disabled (callback is NULL) by default.
  */
-Logger *logger_new(void);
+Logger *logger_new();
 
 void logger_kill(Logger *log);
 
 /**
  * Sets the logger callback. Disables logging if set to NULL.
+ * The context parameter is passed to the callback as first argument.
  */
-void logger_callback_log(Logger *log, logger_cb *function, void *userdata);
+void logger_callback_log(Logger *log, logger_cb *function, void *context, void *userdata);
 
 /**
  * Main write function. If logging disabled does nothing.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -311,7 +311,7 @@ void tox_kill(Tox *tox)
 void tox_callback_log(Tox *tox, tox_log_cb *callback, void *user_data)
 {
     Messenger *m = tox;
-    m_callback_log(m, (logger_cb *)callback, user_data);
+    m_callback_log(m, (logger_cb *)callback, tox, user_data);
 }
 
 size_t tox_get_savedata_size(const Tox *tox)


### PR DESCRIPTION
We don't currently support callbacks without context object.