### PR TITLE
Set log level for DEBUG=ON to LOG_DEBUG.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,12 +26,21 @@ set(CMAKE_MACOSX_RPATH ON)
 
 option(DEBUG "Enable assertions and other debugging facilities" OFF)
 if(DEBUG)
+  set(MIN_LOGGER_LEVEL DEBUG)
   add_definitions(-DTOX_DEBUG=1)
-  add_definitions(-DMIN_LOGGER_LEVEL=LOG_TRACE)
   check_c_compiler_flag("-g3" HAVE_G3)
   if(HAVE_G3)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3")
   endif()
+endif()
+
+option(TRACE "Enable TRACE level logging (expensive, for network debugging)" OFF)
+if(TRACE)
+  set(MIN_LOGGER_LEVEL TRACE)
+endif()
+
+if(MIN_LOGGER_LEVEL)
+  add_definitions(-DMIN_LOGGER_LEVEL=LOG_${MIN_LOGGER_LEVEL})
 endif()
 
 option(ASSOC_DHT "Enable module to store currently unused ID <=> IP associations" OFF)

--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -6,15 +6,17 @@ export CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
 # Build toxcore and run tests.
 # TODO(iphydf): Enable ASAN. It currently has some bad interactions with gcov,
 # so it's disabled on Travis.
-RUN $CMAKE                                     \
-  -B$BUILD_DIR                                 \
-  -H.                                          \
-  -DCMAKE_INSTALL_PREFIX:PATH=$CURDIR/_install \
-  -DDEBUG=ON                                   \
-  -DASSOC_DHT=ON                               \
-  -DSTRICT_ABI=ON                              \
-  -DTEST_TIMEOUT_SECONDS=300                   \
-  $CMAKE_EXTRA_FLAGS #-DASAN=ON
+RUN $CMAKE                                      \
+  -B$BUILD_DIR                                  \
+  -H.                                           \
+  -DCMAKE_INSTALL_PREFIX:PATH=$CURDIR/_install  \
+  -DASSOC_DHT=ON                                \
+  -DDEBUG=ON                                    \
+  -DSTRICT_ABI=ON                               \
+  -DTEST_TIMEOUT_SECONDS=300                    \
+  -DTRACE=ON                                    \
+  $CMAKE_EXTRA_FLAGS                            \
+  #-DASAN=ON
 
 export CTEST_OUTPUT_ON_FAILURE=1
 


### PR DESCRIPTION
We use TRACE=ON (cmake flag) to enable LOG_TRACE. This way, a regular
build can enable DEBUG while not paying the price of TRACE. This is
particularly important for FFI bindings (especially Python), where
invoking callbacks can be an expensive operation.