### PR TITLE
Add option to build tox-bootstrapd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,20 +304,26 @@ add_c_executable(DHT_bootstrap
   other/bootstrap_node_packets.c)
 target_link_modules(DHT_bootstrap toxnetcrypto)
 
-if(LIBCONFIG_FOUND)
-  add_c_executable(tox-bootstrapd
-    other/bootstrap_daemon/src/command_line_arguments.c
-    other/bootstrap_daemon/src/command_line_arguments.h
-    other/bootstrap_daemon/src/config.c
-    other/bootstrap_daemon/src/config_defaults.h
-    other/bootstrap_daemon/src/config.h
-    other/bootstrap_daemon/src/log.c
-    other/bootstrap_daemon/src/log.h
-    other/bootstrap_daemon/src/tox-bootstrapd.c
-    other/bootstrap_daemon/src/global.h
-    other/bootstrap_node_packets.c
-    other/bootstrap_node_packets.h)
-  target_link_modules(tox-bootstrapd toxnetcrypto ${LIBCONFIG_LIBRARIES})
+option(BOOTSTRAP_DAEMON "Enable building of tox-bootstrapd" ON)
+if(BOOTSTRAP_DAEMON)
+  if(WIN32)
+    message(FATAL_ERROR "Building tox-bootstrapd for Windows is not supported")
+  endif()
+  if(LIBCONFIG_FOUND)
+    add_c_executable(tox-bootstrapd
+      other/bootstrap_daemon/src/command_line_arguments.c
+      other/bootstrap_daemon/src/command_line_arguments.h
+      other/bootstrap_daemon/src/config.c
+      other/bootstrap_daemon/src/config_defaults.h
+      other/bootstrap_daemon/src/config.h
+      other/bootstrap_daemon/src/log.c
+      other/bootstrap_daemon/src/log.h
+      other/bootstrap_daemon/src/tox-bootstrapd.c
+      other/bootstrap_daemon/src/global.h
+      other/bootstrap_node_packets.c
+      other/bootstrap_node_packets.h)
+    target_link_modules(tox-bootstrapd toxnetcrypto ${LIBCONFIG_LIBRARIES})
+  endif()
 endif()
 
 ################################################################################

--- a/other/travis/env-linux.sh
+++ b/other/travis/env-linux.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 CMAKE=cmake
+CMAKE_EXTRA_FLAGS=""
 NPROC=`nproc`
 CURDIR=$PWD
 

--- a/other/travis/env-osx.sh
+++ b/other/travis/env-osx.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 CMAKE=cmake
+CMAKE_EXTRA_FLAGS=""
 NPROC=`sysctl -n hw.ncpu`
 CURDIR=$PWD
 

--- a/other/travis/env-windows.sh
+++ b/other/travis/env-windows.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 CMAKE=$ARCH-w64-mingw32.shared-cmake
+CMAKE_EXTRA_FLAGS="-DBOOTSTRAP_DAEMON=OFF"
 NPROC=`nproc`
 CURDIR=/work
 

--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -13,7 +13,8 @@ RUN $CMAKE                                     \
   -DDEBUG=ON                                   \
   -DASSOC_DHT=ON                               \
   -DSTRICT_ABI=ON                              \
-  -DTEST_TIMEOUT_SECONDS=300 #-DASAN=ON
+  -DTEST_TIMEOUT_SECONDS=300                   \
+  $CMAKE_EXTRA_FLAGS #-DASAN=ON
 
 export CTEST_OUTPUT_ON_FAILURE=1
 


### PR DESCRIPTION
When cross-compiling to <target> from Linux, cmake might find native Linux
libconfig and decide to build tox-bootstrapd. If the target is Windows, this
will fail, as tox-bootstrapd can't be built for Windows in the first place. If
the target is Linux of some other architecture, then using host native
libconfig will fail too. Thus an option is needed to guard against this.