### PR TITLE
Add option to set test timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,8 @@ target_link_modules(toxencryptsave toxcore)
 #
 ################################################################################
 
+set(TEST_TIMEOUT_SECONDS "" CACHE STRING "Limit runtime of each test to the number of seconds specified")
+
 if(APIDSL AND ASTYLE)
   add_test(
     NAME format_test
@@ -258,6 +260,7 @@ if(APIDSL AND ASTYLE)
       "${CMAKE_SOURCE_DIR}"
       "${APIDSL}"
       "${ASTYLE}")
+  set_tests_properties(format_test PROPERTIES TIMEOUT "${TEST_TIMEOUT_SECONDS}")
 endif()
 
 function(auto_test target)
@@ -271,6 +274,7 @@ function(auto_test target)
       target_link_modules(auto_${target}_test toxav)
     endif()
     add_test(NAME ${target} COMMAND auto_${target}_test)
+    set_tests_properties(${target} PROPERTIES TIMEOUT "${TEST_TIMEOUT_SECONDS}")
   endif()
 endfunction()
 

--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -6,13 +6,13 @@ export CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
 # Build toxcore and run tests.
 # TODO(iphydf): Enable ASAN. It currently has some bad interactions with gcov,
 # so it's disabled on Travis.
-RUN $CMAKE \
-  -B$BUILD_DIR \
-  -H. \
+RUN $CMAKE                                     \
+  -B$BUILD_DIR                                 \
+  -H.                                          \
   -DCMAKE_INSTALL_PREFIX:PATH=$CURDIR/_install \
-  -DDEBUG=ON \
-  -DASSOC_DHT=ON \
-  -DSTRICT_ABI=ON \
+  -DDEBUG=ON                                   \
+  -DASSOC_DHT=ON                               \
+  -DSTRICT_ABI=ON                              \
   -DTEST_TIMEOUT_SECONDS=300 #-DASAN=ON
 
 export CTEST_OUTPUT_ON_FAILURE=1

--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -6,7 +6,14 @@ export CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
 # Build toxcore and run tests.
 # TODO(iphydf): Enable ASAN. It currently has some bad interactions with gcov,
 # so it's disabled on Travis.
-RUN $CMAKE -B$BUILD_DIR -H. -DCMAKE_INSTALL_PREFIX:PATH=$CURDIR/_install -DDEBUG=ON -DASSOC_DHT=ON -DSTRICT_ABI=ON #-DASAN=ON
+RUN $CMAKE \
+  -B$BUILD_DIR \
+  -H. \
+  -DCMAKE_INSTALL_PREFIX:PATH=$CURDIR/_install \
+  -DDEBUG=ON \
+  -DASSOC_DHT=ON \
+  -DSTRICT_ABI=ON \
+  -DTEST_TIMEOUT_SECONDS=300 #-DASAN=ON
 
 export CTEST_OUTPUT_ON_FAILURE=1
 


### PR DESCRIPTION
Some tests take 20 or more minutes to run before they timeout, this allows
to limit their runtime if needed.