### PR TITLE
Error if format_test can't be executed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,8 @@ target_link_modules(toxencryptsave toxcore)
 
 set(TEST_TIMEOUT_SECONDS "" CACHE STRING "Limit runtime of each test to the number of seconds specified")
 
+option(FORMAT_TEST "Require the format_test to be executed; fail cmake if it can't" OFF)
+
 if(APIDSL AND ASTYLE)
   add_test(
     NAME format_test
@@ -271,6 +273,8 @@ if(APIDSL AND ASTYLE)
       "${APIDSL}"
       "${ASTYLE}")
   set_tests_properties(format_test PROPERTIES TIMEOUT "${TEST_TIMEOUT_SECONDS}")
+elseif(FORMAT_TEST)
+  message(FATAL_ERROR "format_test can not be run, because either APIDSL (${APIDSL}) or ASTYLE (${ASTYLE}) could not be found")
 endif()
 
 function(auto_test target)

--- a/cmake/ApiDsl.cmake
+++ b/cmake/ApiDsl.cmake
@@ -10,14 +10,29 @@ find_program(APIDSL NAMES
   apidsl.byte
   ${CMAKE_SOURCE_DIR}/../apidsl/apigen.native)
 find_program(ASTYLE NAMES
-  astyle)
+  astyle
+  $ENV{ASTYLE})
 
 function(apidsl)
   if(APIDSL AND ASTYLE)
     foreach(in_file ${ARGN})
-      get_filename_component(dirname ${in_file} DIRECTORY)
+      # Get the directory component of the input file name.
+      if(CMAKE_VERSION VERSION_LESS 3.0)
+        execute_process(
+          COMMAND dirname ${in_file}
+          OUTPUT_VARIABLE dirname
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+      else()
+        get_filename_component(dirname ${in_file} DIRECTORY)
+      endif()
+
+      # Get the name without extension (i.e. without ".api.h").
       get_filename_component(filename ${in_file} NAME_WE)
+
+      # Put them together, with the new extension that is ".h".
       set(out_file ${CMAKE_SOURCE_DIR}/${dirname}/${filename}.h)
+
+      # Run apidsl.
       add_custom_command(
         OUTPUT ${out_file}
         COMMAND "${APIDSL}" "${CMAKE_SOURCE_DIR}/${in_file}"

--- a/other/astyle/format-source
+++ b/other/astyle/format-source
@@ -27,6 +27,7 @@ if ! which "$APIDSL"; then
     APIDSL=../apidsl/apigen.native
   else
     APIDSL=apidsl_curl
+  fi
 fi
 
 apidsl_curl() {

--- a/other/travis/env-linux.sh
+++ b/other/travis/env-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CMAKE=cmake
-CMAKE_EXTRA_FLAGS=""
+CMAKE_EXTRA_FLAGS="-DFORMAT_TEST=ON"
 NPROC=`nproc`
 CURDIR=$PWD
 


### PR DESCRIPTION
This ensures that on Travis, format_test will always be executed, or the
build fails.