### PR TITLE
Rename some internal "group chat" thing to "conference".

### DIFF
--- a/toxav/toxav_old.c
+++ b/toxav/toxav_old.c
@@ -40,7 +40,7 @@ int toxav_add_av_groupchat(struct Tox *tox, void (*audio_callback)(void *, int, 
                            uint8_t, unsigned int, void *), void *userdata)
 {
     Messenger *m = (Messenger *)tox;
-    return add_av_groupchat(m->log, (Group_Chats *)m->group_chat_object,
+    return add_av_groupchat(m->log, (Group_Chats *)m->conferences_object,
                             (void (*)(Messenger *, int, int, const int16_t *, unsigned int, uint8_t, unsigned int, void *))audio_callback,
                             userdata);
 }
@@ -60,9 +60,9 @@ int toxav_join_av_groupchat(struct Tox *tox, int32_t friendnumber, const uint8_t
                             void *userdata)
 {
     Messenger *m = (Messenger *)tox;
-    return join_av_groupchat(m->log, (Group_Chats *)m->group_chat_object, friendnumber, data, length, (void (*)(Messenger *,
-                             int, int,
-                             const int16_t *, unsigned int, uint8_t, unsigned int, void *))audio_callback, userdata);
+    return join_av_groupchat(m->log, (Group_Chats *)m->conferences_object, friendnumber, data, length,
+                             (void (*)(Messenger *, int, int, const int16_t *, unsigned int, uint8_t, unsigned int, void *))audio_callback,
+                             userdata);
 }
 
 /* Send audio to the group chat.
@@ -82,5 +82,5 @@ int toxav_group_send_audio(struct Tox *tox, int groupnumber, const int16_t *pcm,
                            unsigned int sample_rate)
 {
     Messenger *m = (Messenger *)tox;
-    return group_send_audio((Group_Chats *)m->group_chat_object, groupnumber, pcm, samples, channels, sample_rate);
+    return group_send_audio((Group_Chats *)m->conferences_object, groupnumber, pcm, samples, channels, sample_rate);
 }

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -979,27 +979,28 @@ static int write_cryptpacket_id(const Messenger *m, int32_t friendnumber, uint8_
                              m->friendlist[friendnumber].friendcon_id), packet, length + 1, congestion_control) != -1;
 }
 
-/**********GROUP CHATS************/
+/**********CONFERENCES************/
 
 
-/* Set the callback for group invites.
+/* Set the callback for conference invites.
  *
  *  Function(Messenger *m, uint32_t friendnumber, uint8_t *data, uint16_t length, void *userdata)
  */
-void m_callback_group_invite(Messenger *m, void (*function)(Messenger *m, uint32_t, const uint8_t *, uint16_t, void *))
+void m_callback_conference_invite(Messenger *m, void (*function)(Messenger *m, uint32_t, const uint8_t *, uint16_t,
+                                  void *))
 {
-    m->group_invite = function;
+    m->conference_invite = function;
 }
 
 
-/* Send a group invite packet.
+/* Send a conference invite packet.
  *
  *  return 1 on success
  *  return 0 on failure
  */
-int send_group_invite_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length)
+int send_conference_invite_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length)
 {
-    return write_cryptpacket_id(m, friendnumber, PACKET_ID_INVITE_GROUPCHAT, data, length, 0);
+    return write_cryptpacket_id(m, friendnumber, PACKET_ID_INVITE_CONFERENCE, data, length, 0);
 }
 
 /****************FILE SENDING*****************/
@@ -2175,13 +2176,13 @@ static int handle_packet(void *object, int i, const uint8_t *temp, uint16_t len,
             break;
         }
 
-        case PACKET_ID_INVITE_GROUPCHAT: {
+        case PACKET_ID_INVITE_CONFERENCE: {
             if (data_length == 0) {
                 break;
             }
 
-            if (m->group_invite) {
-                (*m->group_invite)(m, i, data, data_length, userdata);
+            if (m->conference_invite) {
+                (*m->conference_invite)(m, i, data, data_length, userdata);
             }
 
             break;

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -59,11 +59,11 @@ enum {
 #define PACKET_ID_FILE_SENDREQUEST 80
 #define PACKET_ID_FILE_CONTROL 81
 #define PACKET_ID_FILE_DATA 82
-#define PACKET_ID_INVITE_GROUPCHAT 96
+#define PACKET_ID_INVITE_CONFERENCE 96
 #define PACKET_ID_ONLINE_PACKET 97
-#define PACKET_ID_DIRECT_GROUPCHAT 98
-#define PACKET_ID_MESSAGE_GROUPCHAT 99
-#define PACKET_ID_LOSSY_GROUPCHAT 199
+#define PACKET_ID_DIRECT_CONFERENCE 98
+#define PACKET_ID_MESSAGE_CONFERENCE 99
+#define PACKET_ID_LOSSY_CONFERENCE 199
 
 /* All packets starting with a byte in this range can be used for anything. */
 #define PACKET_ID_LOSSLESS_RANGE_START 160
@@ -248,8 +248,8 @@ struct Messenger {
     void (*friend_connectionstatuschange_internal)(struct Messenger *m, uint32_t, uint8_t, void *);
     void *friend_connectionstatuschange_internal_userdata;
 
-    void *group_chat_object; /* Set by new_groupchats()*/
-    void (*group_invite)(struct Messenger *m, uint32_t, const uint8_t *, uint16_t, void *);
+    void *conferences_object; /* Set by new_groupchats()*/
+    void (*conference_invite)(struct Messenger *m, uint32_t, const uint8_t *, uint16_t, void *);
 
     void (*file_sendrequest)(struct Messenger *m, uint32_t, uint32_t, uint32_t, uint64_t, const uint8_t *, size_t,
                              void *);
@@ -531,20 +531,21 @@ void m_callback_connectionstatus_internal_av(Messenger *m, void (*function)(Mess
  */
 void m_callback_core_connection(Messenger *m, void (*function)(Messenger *m, unsigned int, void *));
 
-/**********GROUP CHATS************/
+/**********CONFERENCES************/
 
-/* Set the callback for group invites.
+/* Set the callback for conference invites.
  *
  *  Function(Messenger *m, uint32_t friendnumber, uint8_t *data, uint16_t length, void *userdata)
  */
-void m_callback_group_invite(Messenger *m, void (*function)(Messenger *m, uint32_t, const uint8_t *, uint16_t, void *));
+void m_callback_conference_invite(Messenger *m, void (*function)(Messenger *m, uint32_t, const uint8_t *, uint16_t,
+                                  void *));
 
-/* Send a group invite packet.
+/* Send a conference invite packet.
  *
  *  return 1 on success
  *  return 0 on failure
  */
-int send_group_invite_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length);
+int send_conference_invite_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length);
 
 /****************FILE SENDING*****************/
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -303,7 +303,7 @@ void tox_kill(Tox *tox)
 
     Messenger *m = tox;
     Logger *log = m->log;
-    kill_groupchats((Group_Chats *)m->group_chat_object);
+    kill_groupchats((Group_Chats *)m->conferences_object);
     kill_messenger(m);
     logger_kill(log);
 }
@@ -476,7 +476,7 @@ void tox_iterate(Tox *tox, void *user_data)
 {
     Messenger *m = tox;
     do_messenger(m, user_data);
-    do_groupchats((Group_Chats *)m->group_chat_object, user_data);
+    do_groupchats((Group_Chats *)m->conferences_object, user_data);
 }
 
 void tox_self_get_address(const Tox *tox, uint8_t *address)
@@ -528,7 +528,7 @@ bool tox_self_set_name(Tox *tox, const uint8_t *name, size_t length, TOX_ERR_SET
 
     if (setname(m, name, length) == 0) {
         // TODO(irungentoo): function to set different per group names?
-        send_name_all_groups((Group_Chats *)m->group_chat_object);
+        send_name_all_groups((Group_Chats *)m->conferences_object);
         SET_ERROR_PARAMETER(error, TOX_ERR_SET_INFO_OK);
         return 1;
     }
@@ -1219,7 +1219,7 @@ void tox_callback_file_recv_chunk(Tox *tox, tox_file_recv_chunk_cb *callback)
 void tox_callback_conference_invite(Tox *tox, tox_conference_invite_cb *callback)
 {
     Messenger *m = tox;
-    g_callback_group_invite((Group_Chats *)m->group_chat_object, (void (*)(Messenger * m, uint32_t, int, const uint8_t *,
+    g_callback_group_invite((Group_Chats *)m->conferences_object, (void (*)(Messenger * m, uint32_t, int, const uint8_t *,
                             size_t,
                             void *))callback);
 }
@@ -1227,7 +1227,7 @@ void tox_callback_conference_invite(Tox *tox, tox_conference_invite_cb *callback
 void tox_callback_conference_message(Tox *tox, tox_conference_message_cb *callback)
 {
     Messenger *m = tox;
-    g_callback_group_message((Group_Chats *)m->group_chat_object, (void (*)(Messenger * m, uint32_t, uint32_t, int,
+    g_callback_group_message((Group_Chats *)m->conferences_object, (void (*)(Messenger * m, uint32_t, uint32_t, int,
                              const uint8_t *,
                              size_t, void *))callback);
 }
@@ -1235,20 +1235,20 @@ void tox_callback_conference_message(Tox *tox, tox_conference_message_cb *callba
 void tox_callback_conference_title(Tox *tox, tox_conference_title_cb *callback)
 {
     Messenger *m = tox;
-    g_callback_group_title((Group_Chats *)m->group_chat_object, callback);
+    g_callback_group_title((Group_Chats *)m->conferences_object, callback);
 }
 
 void tox_callback_conference_namelist_change(Tox *tox, tox_conference_namelist_change_cb *callback)
 {
     Messenger *m = tox;
-    g_callback_group_namelistchange((Group_Chats *)m->group_chat_object, (void (*)(struct Messenger *, int, int, uint8_t,
+    g_callback_group_namelistchange((Group_Chats *)m->conferences_object, (void (*)(struct Messenger *, int, int, uint8_t,
                                     void *))callback);
 }
 
 uint32_t tox_conference_new(Tox *tox, TOX_ERR_CONFERENCE_NEW *error)
 {
     Messenger *m = tox;
-    int ret = add_groupchat((Group_Chats *)m->group_chat_object, GROUPCHAT_TYPE_TEXT);
+    int ret = add_groupchat((Group_Chats *)m->conferences_object, GROUPCHAT_TYPE_TEXT);
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_NEW_INIT);
@@ -1262,7 +1262,7 @@ uint32_t tox_conference_new(Tox *tox, TOX_ERR_CONFERENCE_NEW *error)
 bool tox_conference_delete(Tox *tox, uint32_t conference_number, TOX_ERR_CONFERENCE_DELETE *error)
 {
     Messenger *m = tox;
-    int ret = del_groupchat((Group_Chats *)m->group_chat_object, conference_number);
+    int ret = del_groupchat((Group_Chats *)m->conferences_object, conference_number);
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_DELETE_CONFERENCE_NOT_FOUND);
@@ -1276,7 +1276,7 @@ bool tox_conference_delete(Tox *tox, uint32_t conference_number, TOX_ERR_CONFERE
 uint32_t tox_conference_peer_count(const Tox *tox, uint32_t conference_number, TOX_ERR_CONFERENCE_PEER_QUERY *error)
 {
     const Messenger *m = tox;
-    int ret = group_number_peers((Group_Chats *)m->group_chat_object, conference_number);
+    int ret = group_number_peers((Group_Chats *)m->conferences_object, conference_number);
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_CONFERENCE_NOT_FOUND);
@@ -1291,7 +1291,7 @@ size_t tox_conference_peer_get_name_size(const Tox *tox, uint32_t conference_num
         TOX_ERR_CONFERENCE_PEER_QUERY *error)
 {
     const Messenger *m = tox;
-    int ret = group_peername_size((Group_Chats *)m->group_chat_object, conference_number, peer_number);
+    int ret = group_peername_size((Group_Chats *)m->conferences_object, conference_number, peer_number);
 
     switch (ret) {
         case -1:
@@ -1311,7 +1311,7 @@ bool tox_conference_peer_get_name(const Tox *tox, uint32_t conference_number, ui
                                   TOX_ERR_CONFERENCE_PEER_QUERY *error)
 {
     const Messenger *m = tox;
-    int ret = group_peername((Group_Chats *)m->group_chat_object, conference_number, peer_number, name);
+    int ret = group_peername((Group_Chats *)m->conferences_object, conference_number, peer_number, name);
 
     switch (ret) {
         case -1:
@@ -1331,7 +1331,7 @@ bool tox_conference_peer_get_public_key(const Tox *tox, uint32_t conference_numb
                                         uint8_t *public_key, TOX_ERR_CONFERENCE_PEER_QUERY *error)
 {
     const Messenger *m = tox;
-    int ret = group_peer_pubkey((Group_Chats *)m->group_chat_object, conference_number, peer_number, public_key);
+    int ret = group_peer_pubkey((Group_Chats *)m->conferences_object, conference_number, peer_number, public_key);
 
     switch (ret) {
         case -1:
@@ -1351,7 +1351,7 @@ bool tox_conference_peer_number_is_ours(const Tox *tox, uint32_t conference_numb
                                         TOX_ERR_CONFERENCE_PEER_QUERY *error)
 {
     const Messenger *m = tox;
-    int ret = group_peernumber_is_ours((Group_Chats *)m->group_chat_object, conference_number, peer_number);
+    int ret = group_peernumber_is_ours((Group_Chats *)m->conferences_object, conference_number, peer_number);
 
     switch (ret) {
         case -1:
@@ -1375,7 +1375,7 @@ bool tox_conference_invite(Tox *tox, uint32_t friend_number, uint32_t conference
                            TOX_ERR_CONFERENCE_INVITE *error)
 {
     Messenger *m = tox;
-    int ret = invite_friend((Group_Chats *)m->group_chat_object, friend_number, conference_number);
+    int ret = invite_friend((Group_Chats *)m->conferences_object, friend_number, conference_number);
 
     switch (ret) {
         case -1:
@@ -1395,7 +1395,7 @@ uint32_t tox_conference_join(Tox *tox, uint32_t friend_number, const uint8_t *co
                              TOX_ERR_CONFERENCE_JOIN *error)
 {
     Messenger *m = tox;
-    int ret = join_groupchat((Group_Chats *)m->group_chat_object, friend_number, GROUPCHAT_TYPE_TEXT, cookie, length);
+    int ret = join_groupchat((Group_Chats *)m->conferences_object, friend_number, GROUPCHAT_TYPE_TEXT, cookie, length);
 
     switch (ret) {
         case -1:
@@ -1434,9 +1434,9 @@ bool tox_conference_send_message(Tox *tox, uint32_t conference_number, TOX_MESSA
     int ret = 0;
 
     if (type == TOX_MESSAGE_TYPE_NORMAL) {
-        ret = group_message_send((Group_Chats *)m->group_chat_object, conference_number, message, length);
+        ret = group_message_send((Group_Chats *)m->conferences_object, conference_number, message, length);
     } else {
-        ret = group_action_send((Group_Chats *)m->group_chat_object, conference_number, message, length);
+        ret = group_action_send((Group_Chats *)m->conferences_object, conference_number, message, length);
     }
 
     switch (ret) {
@@ -1464,7 +1464,7 @@ bool tox_conference_send_message(Tox *tox, uint32_t conference_number, TOX_MESSA
 size_t tox_conference_get_title_size(const Tox *tox, uint32_t conference_number, TOX_ERR_CONFERENCE_TITLE *error)
 {
     const Messenger *m = tox;
-    int ret = group_title_get_size((Group_Chats *)m->group_chat_object, conference_number);
+    int ret = group_title_get_size((Group_Chats *)m->conferences_object, conference_number);
 
     switch (ret) {
         case -1:
@@ -1484,7 +1484,7 @@ bool tox_conference_get_title(const Tox *tox, uint32_t conference_number, uint8_
                               TOX_ERR_CONFERENCE_TITLE *error)
 {
     const Messenger *m = tox;
-    int ret = group_title_get((Group_Chats *)m->group_chat_object, conference_number, title);
+    int ret = group_title_get((Group_Chats *)m->conferences_object, conference_number, title);
 
     switch (ret) {
         case -1:
@@ -1504,7 +1504,7 @@ bool tox_conference_set_title(Tox *tox, uint32_t conference_number, const uint8_
                               TOX_ERR_CONFERENCE_TITLE *error)
 {
     Messenger *m = tox;
-    int ret = group_title_send((Group_Chats *)m->group_chat_object, conference_number, title, length);
+    int ret = group_title_send((Group_Chats *)m->conferences_object, conference_number, title, length);
 
     switch (ret) {
         case -1:
@@ -1527,21 +1527,21 @@ bool tox_conference_set_title(Tox *tox, uint32_t conference_number, const uint8_
 size_t tox_conference_get_chatlist_size(const Tox *tox)
 {
     const Messenger *m = tox;
-    return count_chatlist((Group_Chats *)m->group_chat_object);
+    return count_chatlist((Group_Chats *)m->conferences_object);
 }
 
 void tox_conference_get_chatlist(const Tox *tox, uint32_t *chatlist)
 {
     const Messenger *m = tox;
     size_t list_size = tox_conference_get_chatlist_size(tox);
-    copy_chatlist((Group_Chats *)m->group_chat_object, chatlist, list_size);
+    copy_chatlist((Group_Chats *)m->conferences_object, chatlist, list_size);
 }
 
 TOX_CONFERENCE_TYPE tox_conference_get_type(const Tox *tox, uint32_t conference_number,
         TOX_ERR_CONFERENCE_GET_TYPE *error)
 {
     const Messenger *m = tox;
-    int ret = group_get_type((Group_Chats *)m->group_chat_object, conference_number);
+    int ret = group_get_type((Group_Chats *)m->conferences_object, conference_number);
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_GET_TYPE_CONFERENCE_NOT_FOUND);


### PR DESCRIPTION
This is to allow new group chats to coexist with old group chats. We do
not rename everything in group.[ch] to conference, yet, because it's not
currently necessary, and a general internal API overhaul is due at some
point anyway.