### PR TITLE
Move log callback to options.

### DIFF
--- a/auto_tests/conference_test.c
+++ b/auto_tests/conference_test.c
@@ -7,7 +7,6 @@
 
 #include <check.h>
 #include <inttypes.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 
@@ -91,13 +90,16 @@ group_test_restart:
     ;
 
     Tox *toxes[NUM_GROUP_TOX];
+    uint32_t tox_index[NUM_GROUP_TOX];
     unsigned int i, j, k;
     uint32_t to_comp = 234212;
     int test_run = 0;
     long long unsigned int cur_time = time(NULL);
 
     for (i = 0; i < NUM_GROUP_TOX; ++i) {
-        toxes[i] = tox_new(0, 0);
+        tox_index[i] = i + 1;
+        toxes[i] = tox_new_log(0, 0, &tox_index[i]);
+
         ck_assert_msg(toxes[i] != 0, "Failed to create tox instances %u", i);
         tox_callback_friend_request(toxes[i], &g_accept_friend_request);
         tox_callback_conference_invite(toxes[i], &print_group_invite_callback);

--- a/auto_tests/encryptsave_test.c
+++ b/auto_tests/encryptsave_test.c
@@ -56,8 +56,8 @@ END_TEST
 
 START_TEST(test_save_friend)
 {
-    Tox *tox1 = tox_new(0, 0);
-    Tox *tox2 = tox_new(0, 0);
+    Tox *tox1 = tox_new_log(0, 0, 0);
+    Tox *tox2 = tox_new_log(0, 0, 0);
     ck_assert_msg(tox1 || tox2, "Failed to create 2 tox instances");
     tox_callback_friend_request(tox2, accept_friend_request);
     uint8_t address[TOX_ADDRESS_SIZE];
@@ -82,7 +82,7 @@ START_TEST(test_save_friend)
     options.savedata_length = size2;
 
     TOX_ERR_NEW err2;
-    Tox *tox3 = tox_new(&options, &err2);
+    Tox *tox3 = tox_new_log(&options, &err2, 0);
     ck_assert_msg(err2 == TOX_ERR_NEW_LOAD_ENCRYPTED, "wrong error! %u. should fail with %u", err2,
                   TOX_ERR_NEW_LOAD_ENCRYPTED);
     ck_assert_msg(tox3 == NULL, "tox_new with error should return NULL");
@@ -92,7 +92,7 @@ START_TEST(test_save_friend)
     ck_assert_msg(ret, "failed to decrypt save: %u", err3);
     options.savedata_data = dec_data;
     options.savedata_length = size;
-    tox3 = tox_new(&options, &err2);
+    tox3 = tox_new_log(&options, &err2, 0);
     ck_assert_msg(err2 == TOX_ERR_NEW_OK, "failed to load from decrypted data: %u", err2);
     uint8_t address2[TOX_PUBLIC_KEY_SIZE];
     ret = tox_friend_get_public_key(tox3, 0, address2, 0);
@@ -122,7 +122,7 @@ START_TEST(test_save_friend)
     // to remove the manual check now that it's there)
     options.savedata_data = out1;
     options.savedata_length = size;
-    Tox *tox4 = tox_new(&options, &err2);
+    Tox *tox4 = tox_new_log(&options, &err2, 0);
     ck_assert_msg(err2 == TOX_ERR_NEW_OK, "failed to new the third");
     uint8_t address5[TOX_PUBLIC_KEY_SIZE];
     ret = tox_friend_get_public_key(tox4, 0, address5, 0);

--- a/auto_tests/helpers.h
+++ b/auto_tests/helpers.h
@@ -1,7 +1,10 @@
 #ifndef TOXCORE_TEST_HELPERS_H
 #define TOXCORE_TEST_HELPERS_H
 
+#include "../toxcore/tox.h"
+
 #include <check.h>
+#include <stdio.h>
 
 #define DEFTESTCASE(NAME)                   \
     TCase *tc_##NAME = tcase_create(#NAME); \
@@ -11,5 +14,53 @@
 #define DEFTESTCASE_SLOW(NAME, TIMEOUT) \
     DEFTESTCASE(NAME) \
     tcase_set_timeout(tc_##NAME, TIMEOUT);
+
+static const char *tox_log_level_name(TOX_LOG_LEVEL level)
+{
+    switch (level) {
+        case TOX_LOG_LEVEL_TRACE:
+            return "TRACE";
+
+        case TOX_LOG_LEVEL_DEBUG:
+            return "DEBUG";
+
+        case TOX_LOG_LEVEL_INFO:
+            return "INFO";
+
+        case TOX_LOG_LEVEL_WARNING:
+            return "WARNING";
+
+        case TOX_LOG_LEVEL_ERROR:
+            return "ERROR";
+    }
+}
+
+static void print_debug_log(Tox *m, TOX_LOG_LEVEL level, const char *path, uint32_t line, const char *func,
+                            const char *message, void *user_data)
+{
+    if (level == TOX_LOG_LEVEL_TRACE) {
+        return;
+    }
+
+    uint32_t index = user_data ? *(uint32_t *)user_data : 0;
+    const char *file = strrchr(path, '/');
+    file = file ? file + 1 : path;
+    printf("[#%d] %s %s:%d\t%s:\t%s\n", index, tox_log_level_name(level), file, line, func, message);
+}
+
+Tox *tox_new_log(struct Tox_Options *options, TOX_ERR_NEW *err, void *log_user_data)
+{
+    struct Tox_Options *my_options = tox_options_new(NULL);
+
+    if (options != NULL) {
+        *my_options = *options;
+    }
+
+    tox_options_set_log_callback(my_options, &print_debug_log);
+    tox_options_set_log_user_data(my_options, log_user_data);
+    Tox *tox = tox_new(my_options, err);
+    tox_options_free(my_options);
+    return tox;
+}
 
 #endif // TOXCORE_TEST_HELPERS_H

--- a/auto_tests/messenger_test.c
+++ b/auto_tests/messenger_test.c
@@ -342,7 +342,7 @@ int main(int argc, char *argv[])
     /* IPv6 status from global define */
     Messenger_Options options = {0};
     options.ipv6enabled = TOX_ENABLE_IPV6_DEFAULT;
-    m = new_messenger(NULL, &options, 0);
+    m = new_messenger(&options, 0);
 
     /* setup a default friend and friendnum */
     if (m_addfriend_norequest(m, (uint8_t *)friend_id) < 0) {

--- a/auto_tests/tox_many_tcp_test.c
+++ b/auto_tests/tox_many_tcp_test.c
@@ -50,6 +50,7 @@ START_TEST(test_many_clients_tcp)
 {
     long long unsigned int cur_time = time(NULL);
     Tox *toxes[NUM_TOXES_TCP];
+    uint32_t index[NUM_TOXES_TCP];
     uint32_t i, j;
     uint32_t to_comp = 974536;
 
@@ -63,7 +64,8 @@ START_TEST(test_many_clients_tcp)
             opts.udp_enabled = 0;
         }
 
-        toxes[i] = tox_new(&opts, 0);
+        index[i] = i + 1;
+        toxes[i] = tox_new_log(&opts, 0, &index[i]);
         ck_assert_msg(toxes[i] != 0, "Failed to create tox instances %u", i);
         tox_callback_friend_request(toxes[i], accept_friend_request);
         uint8_t dpk[TOX_PUBLIC_KEY_SIZE];
@@ -149,6 +151,7 @@ START_TEST(test_many_clients_tcp_b)
 {
     long long unsigned int cur_time = time(NULL);
     Tox *toxes[NUM_TOXES_TCP];
+    uint32_t index[NUM_TOXES_TCP];
     uint32_t i, j;
     uint32_t to_comp = 974536;
 
@@ -162,7 +165,8 @@ START_TEST(test_many_clients_tcp_b)
             opts.udp_enabled = 0;
         }
 
-        toxes[i] = tox_new(&opts, 0);
+        index[i] = i + 1;
+        toxes[i] = tox_new_log(&opts, 0, &index[i]);
         ck_assert_msg(toxes[i] != 0, "Failed to create tox instances %u", i);
         tox_callback_friend_request(toxes[i], accept_friend_request);
         uint8_t dpk[TOX_PUBLIC_KEY_SIZE];

--- a/auto_tests/tox_many_test.c
+++ b/auto_tests/tox_many_test.c
@@ -42,11 +42,13 @@ START_TEST(test_many_clients)
 {
     long long unsigned int cur_time = time(NULL);
     Tox *toxes[NUM_TOXES];
+    uint32_t index[NUM_TOXES];
     uint32_t i, j;
     uint32_t to_comp = 974536;
 
     for (i = 0; i < NUM_TOXES; ++i) {
-        toxes[i] = tox_new(0, 0);
+        index[i] = i + 1;
+        toxes[i] = tox_new_log(0, 0, &index[i]);
         ck_assert_msg(toxes[i] != 0, "Failed to create tox instances %u", i);
         tox_callback_friend_request(toxes[i], accept_friend_request);
     }

--- a/auto_tests/tox_one_test.c
+++ b/auto_tests/tox_one_test.c
@@ -26,8 +26,9 @@ START_TEST(test_one)
         tox_options_free(o1);
     }
 
-    Tox *tox1 = tox_new(0, 0);
-    Tox *tox2 = tox_new(0, 0);
+    uint32_t index[] = { 1, 2 };
+    Tox *tox1 = tox_new_log(0, 0, &index[0]);
+    Tox *tox2 = tox_new_log(0, 0, &index[1]);
 
     {
         TOX_ERR_GET_PORT error;
@@ -85,7 +86,7 @@ START_TEST(test_one)
     options.savedata_type = TOX_SAVEDATA_TYPE_TOX_SAVE;
     options.savedata_data = data;
     options.savedata_length = save_size;
-    tox2 = tox_new(&options, &err_n);
+    tox2 = tox_new_log(&options, &err_n, &index[1]);
     ck_assert_msg(err_n == TOX_ERR_NEW_OK, "Load failed");
 
     ck_assert_msg(tox_self_get_name_size(tox2) == sizeof name, "Wrong name size.");
@@ -105,7 +106,7 @@ START_TEST(test_one)
     options.savedata_type = TOX_SAVEDATA_TYPE_SECRET_KEY;
     options.savedata_data = sk;
     options.savedata_length = sizeof(sk);
-    tox2 = tox_new(&options, &err_n);
+    tox2 = tox_new_log(&options, &err_n, &index[1]);
     ck_assert_msg(err_n == TOX_ERR_NEW_OK, "Load failed");
     uint8_t address3[TOX_ADDRESS_SIZE];
     tox_self_get_address(tox2, address3);

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -321,13 +321,14 @@ static void tox_connection_status(Tox *tox, TOX_CONNECTION connection_status, vo
 
 START_TEST(test_few_clients)
 {
+    uint32_t index[] = { 1, 2, 3 };
     long long unsigned int con_time = 0, cur_time = time(NULL);
     TOX_ERR_NEW t_n_error;
-    Tox *tox1 = tox_new(0, &t_n_error);
+    Tox *tox1 = tox_new_log(0, &t_n_error, &index[0]);
     ck_assert_msg(t_n_error == TOX_ERR_NEW_OK, "wrong error");
-    Tox *tox2 = tox_new(0, &t_n_error);
+    Tox *tox2 = tox_new_log(0, &t_n_error, &index[1]);
     ck_assert_msg(t_n_error == TOX_ERR_NEW_OK, "wrong error");
-    Tox *tox3 = tox_new(0, &t_n_error);
+    Tox *tox3 = tox_new_log(0, &t_n_error, &index[2]);
     ck_assert_msg(t_n_error == TOX_ERR_NEW_OK, "wrong error");
 
     ck_assert_msg(tox1 && tox2 && tox3, "Failed to create 3 tox instances");
@@ -422,7 +423,7 @@ START_TEST(test_few_clients)
     options.savedata_type = TOX_SAVEDATA_TYPE_TOX_SAVE;
     options.savedata_data = save1;
     options.savedata_length = save_size1;
-    tox2 = tox_new(&options, NULL);
+    tox2 = tox_new_log(&options, NULL, &index[1]);
     cur_time = time(NULL);
     off = 1;
 

--- a/auto_tests/toxav_basic_test.c
+++ b/auto_tests/toxav_basic_test.c
@@ -2,15 +2,7 @@
 #include "config.h"
 #endif
 
-#ifndef HAVE_LIBCHECK
-#   include <assert.h>
-
-#   define ck_assert(X) assert(X);
-#   define START_TEST(NAME) static void NAME (void)
-#   define END_TEST
-#else
-#   include "helpers.h"
-#endif
+#include "helpers.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -149,19 +141,20 @@ START_TEST(test_AV_flows)
 {
     Tox *Alice, *Bob, *bootstrap;
     ToxAV *AliceAV, *BobAV;
+    uint32_t index[] = { 1, 2, 3 };
 
     CallControl AliceCC, BobCC;
 
     {
         TOX_ERR_NEW error;
 
-        bootstrap = tox_new(NULL, &error);
+        bootstrap = tox_new_log(NULL, &error, &index[0]);
         ck_assert(error == TOX_ERR_NEW_OK);
 
-        Alice = tox_new(NULL, &error);
+        Alice = tox_new_log(NULL, &error, &index[1]);
         ck_assert(error == TOX_ERR_NEW_OK);
 
-        Bob = tox_new(NULL, &error);
+        Bob = tox_new_log(NULL, &error, &index[2]);
         ck_assert(error == TOX_ERR_NEW_OK);
     }
 
@@ -591,16 +584,6 @@ START_TEST(test_AV_flows)
 }
 END_TEST
 
-#ifndef HAVE_LIBCHECK
-int main(int argc, char *argv[])
-{
-    (void) argc;
-    (void) argv;
-
-    test_AV_flows();
-    return 0;
-}
-#else
 static Suite *tox_suite(void)
 {
     Suite *s = suite_create("ToxAV");
@@ -625,4 +608,3 @@ int main(int argc, char *argv[])
 
     return number_failed;
 }
-#endif

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -2,15 +2,7 @@
 #include "config.h"
 #endif
 
-#ifndef HAVE_LIBCHECK
-#   include <assert.h>
-
-#   define ck_assert(X) assert(X);
-#   define START_TEST(NAME) static void NAME (void)
-#   define END_TEST
-#else
-#   include "helpers.h"
-#endif
+#include "helpers.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -207,6 +199,7 @@ static void *call_thread(void *pd)
 
 START_TEST(test_AV_three_calls)
 {
+    uint32_t index[] = { 1, 2, 3, 4, 5 };
     Tox *Alice, *bootstrap, *Bobs[3];
     ToxAV *AliceAV, *BobsAV[3];
 
@@ -215,19 +208,19 @@ START_TEST(test_AV_three_calls)
     {
         TOX_ERR_NEW error;
 
-        bootstrap = tox_new(NULL, &error);
+        bootstrap = tox_new_log(NULL, &error, &index[0]);
         ck_assert(error == TOX_ERR_NEW_OK);
 
-        Alice = tox_new(NULL, &error);
+        Alice = tox_new_log(NULL, &error, &index[1]);
         ck_assert(error == TOX_ERR_NEW_OK);
 
-        Bobs[0] = tox_new(NULL, &error);
+        Bobs[0] = tox_new_log(NULL, &error, &index[2]);
         ck_assert(error == TOX_ERR_NEW_OK);
 
-        Bobs[1] = tox_new(NULL, &error);
+        Bobs[1] = tox_new_log(NULL, &error, &index[3]);
         ck_assert(error == TOX_ERR_NEW_OK);
 
-        Bobs[2] = tox_new(NULL, &error);
+        Bobs[2] = tox_new_log(NULL, &error, &index[4]);
         ck_assert(error == TOX_ERR_NEW_OK);
     }
 
@@ -341,16 +334,6 @@ START_TEST(test_AV_three_calls)
 END_TEST
 
 
-#ifndef HAVE_LIBCHECK
-int main(int argc, char *argv[])
-{
-    (void) argc;
-    (void) argv;
-
-    test_AV_three_calls();
-    return 0;
-}
-#else
 static Suite *tox_suite(void)
 {
     Suite *s = suite_create("ToxAV");
@@ -380,4 +363,3 @@ int main(int argc, char *argv[])
 
     return number_failed;
 }
-#endif

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
 
     Messenger_Options options = {0};
     options.ipv6enabled = ipv6enabled;
-    m = new_messenger(NULL, &options, 0);
+    m = new_messenger(&options, 0);
 
     if (!m) {
         fputs("Failed to allocate messenger datastructure\n", stderr);

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1885,7 +1885,7 @@ static int friend_already_added(const uint8_t *real_pk, void *data)
 }
 
 /* Run this at startup. */
-Messenger *new_messenger(Logger *log, Messenger_Options *options, unsigned int *error)
+Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
 {
     Messenger *m = (Messenger *)calloc(1, sizeof(Messenger));
 
@@ -1893,8 +1893,18 @@ Messenger *new_messenger(Logger *log, Messenger_Options *options, unsigned int *
         *error = MESSENGER_ERROR_OTHER;
     }
 
-    if (! m) {
+    if (!m) {
         return NULL;
+    }
+
+    Logger *log = NULL;
+
+    if (options && options->log_callback) {
+        log = logger_new();
+
+        if (log != NULL) {
+            logger_callback_log(log, options->log_callback, m, options->log_user_data);
+        }
     }
 
     m->log = log;
@@ -2012,6 +2022,7 @@ void kill_messenger(Messenger *m)
         clear_receipts(m, i);
     }
 
+    logger_kill(m->log);
     free(m->friendlist);
     free(m);
 }

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -76,6 +76,9 @@ typedef struct {
     TCP_Proxy_Info proxy_info;
     uint16_t port_range[2];
     uint16_t tcp_server_port;
+
+    logger_cb *log_callback;
+    void *log_user_data;
 } Messenger_Options;
 
 
@@ -727,7 +730,7 @@ enum {
  *
  *  if error is not NULL it will be set to one of the values in the enum above.
  */
-Messenger *new_messenger(Logger *log, Messenger_Options *options, unsigned int *error);
+Messenger *new_messenger(Messenger_Options *options, unsigned int *error);
 
 /* Run this before closing shop
  * Free all datastructures.

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -376,6 +376,52 @@ enum class SAVEDATA_TYPE {
 }
 
 
+/**
+ * Severity level of log messages.
+ */
+enum class LOG_LEVEL {
+  /**
+   * Very detailed traces including all network activity.
+   */
+  TRACE,
+  /**
+   * Debug messages such as which port we bind to.
+   */
+  DEBUG,
+  /**
+   * Informational log messages such as video call status changes.
+   */
+  INFO,
+  /**
+   * Warnings about internal inconsistency or logic errors.
+   */
+  WARNING,
+  /**
+   * Severe unexpected errors caused by external or internal inconsistency.
+   */
+  ERROR,
+}
+
+/**
+ * This event is triggered when the toxcore library logs an internal message.
+ * This is mostly useful for debugging. This callback can be called from any
+ * function, not just $iterate. This means the user data lifetime must at
+ * least extend between registering and unregistering it or $kill.
+ *
+ * Other toxcore modules such as toxav may concurrently call this callback at
+ * any time. Thus, user code must make sure it is equipped to handle concurrent
+ * execution, e.g. by employing appropriate mutex locking.
+ *
+ * @param level The severity of the log message.
+ * @param file The source file from which the message originated.
+ * @param line The source line from which the message originated.
+ * @param func The function from which the message originated.
+ * @param message The log message.
+ * @param user_data The user data pointer passed to $new in options.
+ */
+typedef void log_cb(LOG_LEVEL level, string file, uint32_t line, string func, string message, any user_data);
+
+
 static class options {
   /**
    * This struct contains all the startup options for Tox. You can either
@@ -490,6 +536,18 @@ static class options {
        * The length of the savedata.
        */
       size_t length;
+    }
+
+    namespace log {
+      /**
+       * Logging callback for the new tox instance.
+       */
+      log_cb *callback;
+
+      /**
+       * User data pointer passed to the logging callback.
+       */
+      any user_data;
     }
   }
 
@@ -618,57 +676,6 @@ static this new(const options_t *options) {
  * functions can be called, and the pointer value can no longer be read.
  */
 void kill();
-
-
-/**
- * Severity level of log messages.
- */
-enum class LOG_LEVEL {
-  /**
-   * Very detailed traces including all network activity.
-   */
-  TRACE,
-  /**
-   * Debug messages such as which port we bind to.
-   */
-  DEBUG,
-  /**
-   * Informational log messages such as video call status changes.
-   */
-  INFO,
-  /**
-   * Warnings about internal inconsistency or logic errors.
-   */
-  WARNING,
-  /**
-   * Severe unexpected errors caused by external or internal inconsistency.
-   */
-  ERROR,
-}
-
-/**
- * This event is triggered when the toxcore library logs an internal message.
- * This is mostly useful for debugging. This callback can be called from any
- * function, not just $iterate. This means the user data lifetime must at
- * least extend between registering and unregistering it or $kill.
- *
- * Other toxcore modules such as toxav may concurrently call this callback at
- * any time. Thus, user code must make sure it is equipped to handle concurrent
- * execution, e.g. by employing appropriate mutex locking. The callback
- * registration function must not be called during execution of any other Tox
- * library function (toxcore or toxav).
- */
-event log {
-  /**
-   * @param level The severity of the log message.
-   * @param file The source file from which the message originated.
-   * @param line The source line from which the message originated.
-   * @param func The function from which the message originated.
-   * @param message The log message.
-   */
-  typedef void(LOG_LEVEL level, string file, uint32_t line, string func,
-               string message);
-}
 
 
 uint8_t[size] savedata {


### PR DESCRIPTION
Previously, all log messages generated by tox_new (which is quite a lot)
were dropped, because client code had no chance to register a logging
callback, yet. This change allows setting the log callback from the
beginning and removes the ability to unset it.

Since the log callback is forever special, since it can't be stateless,
we don't necessarily need to treat it uniformly (with `event`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/241)
<!-- Reviewable:end -->
