### PR TITLE
Enable address sanitizer on autotools build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       language: haskell
       ghc: 7.8
     - env: JOB=autotools ENV=linux
-      compiler: gcc
+      compiler: clang
     - env: JOB=toxcore ENV=linux
       compiler: clang
     - env: JOB=toxcore ENV=osx

--- a/other/travis/autotools-script
+++ b/other/travis/autotools-script
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Enable address sanitizer.
+export CFLAGS="$CFLAGS -fsanitize=address"
+
 # Build toxcore and run tests.
 ./autogen.sh
 ./configure \


### PR DESCRIPTION
Also, use clang on the autotools build. Previously, we used gcc on
autotools and clang on cmake, but now we have a gcc build for windows,
so we can use clang on all other builds. We'll be sure it builds on gcc
if the windows builds succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/244)
<!-- Reviewable:end -->
