### PR TITLE
Remove new_nonce function in favour of random_nonce.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -57,7 +57,7 @@ START_TEST(test_basic)
     memcpy(handshake_plain + crypto_box_PUBLICKEYBYTES, f_nonce, crypto_box_NONCEBYTES);
     uint8_t handshake[TCP_CLIENT_HANDSHAKE_SIZE];
     memcpy(handshake, f_public_key, crypto_box_PUBLICKEYBYTES);
-    new_nonce(handshake + crypto_box_PUBLICKEYBYTES);
+    random_nonce(handshake + crypto_box_PUBLICKEYBYTES);
 
     ret = encrypt_data(self_public_key, f_secret_key, handshake + crypto_box_PUBLICKEYBYTES, handshake_plain,
                        TCP_HANDSHAKE_PLAIN_SIZE, handshake + crypto_box_PUBLICKEYBYTES + crypto_box_NONCEBYTES);
@@ -153,7 +153,7 @@ static struct sec_TCP_con *new_TCP_con(TCP_Server *tcp_s)
     memcpy(handshake_plain + crypto_box_PUBLICKEYBYTES, sec_c->sent_nonce, crypto_box_NONCEBYTES);
     uint8_t handshake[TCP_CLIENT_HANDSHAKE_SIZE];
     memcpy(handshake, sec_c->public_key, crypto_box_PUBLICKEYBYTES);
-    new_nonce(handshake + crypto_box_PUBLICKEYBYTES);
+    random_nonce(handshake + crypto_box_PUBLICKEYBYTES);
 
     ret = encrypt_data(tcp_server_public_key(tcp_s), f_secret_key, handshake + crypto_box_PUBLICKEYBYTES, handshake_plain,
                        TCP_HANDSHAKE_PLAIN_SIZE, handshake + crypto_box_PUBLICKEYBYTES + crypto_box_NONCEBYTES);

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -225,7 +225,7 @@ START_TEST(test_basic)
     Onion *onion3 = new_onion(new_DHT(NULL, new_networking(NULL, ip, 34569)));
     ck_assert_msg((onion3 != NULL), "Onion failed initializing.");
 
-    new_nonce(nonce);
+    random_nonce(nonce);
     ret = send_data_request(onion3->net, &path, nodes[3].ip_port, onion1->dht->self_public_key,
                             onion1->dht->self_public_key,
                             nonce, (const uint8_t *)"Install gentoo", sizeof("Install gentoo"));

--- a/testing/hstox/methods.c
+++ b/testing/hstox/methods.c
@@ -67,7 +67,7 @@ METHOD(array, KeyPair, fromSecretKey)
 METHOD(array, Nonce, newNonce)
 {
     uint8_t nonce[24] = {0};
-    new_nonce(nonce);
+    random_nonce(nonce);
 
     SUCCESS {
         msgpack_pack_bin(res, sizeof nonce);

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -196,7 +196,7 @@ int create_request(const uint8_t *send_public_key, const uint8_t *send_secret_ke
     }
 
     uint8_t *nonce = packet + 1 + crypto_box_PUBLICKEYBYTES * 2;
-    new_nonce(nonce);
+    random_nonce(nonce);
     uint8_t temp[MAX_CRYPTO_REQUEST_SIZE]; // TODO(irungentoo): sodium_memzero before exit function
     memcpy(temp + 1, data, length);
     temp[0] = request_id;
@@ -1200,7 +1200,7 @@ static int getnodes(DHT *dht, IP_Port ip_port, const uint8_t *public_key, const 
     DHT_get_shared_key_sent(dht, shared_key, public_key);
 
     uint8_t nonce[crypto_box_NONCEBYTES];
-    new_nonce(nonce);
+    random_nonce(nonce);
 
     int len = encrypt_data_symmetric(shared_key,
                                      nonce,
@@ -1243,7 +1243,7 @@ static int sendnodes_ipv6(const DHT *dht, IP_Port ip_port, const uint8_t *public
     uint8_t plain[1 + Node_format_size * MAX_SENT_NODES + length];
     uint8_t encrypt[sizeof(plain) + crypto_box_MACBYTES];
     uint8_t nonce[crypto_box_NONCEBYTES];
-    new_nonce(nonce);
+    random_nonce(nonce);
 
     int nodes_length = 0;
 

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -228,7 +228,7 @@ static int generate_handshake(TCP_Client_Connection *TCP_conn)
     random_nonce(TCP_conn->sent_nonce);
     memcpy(plain + crypto_box_PUBLICKEYBYTES, TCP_conn->sent_nonce, crypto_box_NONCEBYTES);
     memcpy(TCP_conn->last_packet, TCP_conn->self_public_key, crypto_box_PUBLICKEYBYTES);
-    new_nonce(TCP_conn->last_packet + crypto_box_PUBLICKEYBYTES);
+    random_nonce(TCP_conn->last_packet + crypto_box_PUBLICKEYBYTES);
     int len = encrypt_data_symmetric(TCP_conn->shared_key, TCP_conn->last_packet + crypto_box_PUBLICKEYBYTES, plain,
                                      sizeof(plain), TCP_conn->last_packet + crypto_box_PUBLICKEYBYTES + crypto_box_NONCEBYTES);
 

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -565,7 +565,7 @@ static int handle_TCP_handshake(TCP_Secure_Connection *con, const uint8_t *data,
     memcpy(con->recv_nonce, plain + crypto_box_PUBLICKEYBYTES, crypto_box_NONCEBYTES);
 
     uint8_t response[TCP_SERVER_HANDSHAKE_SIZE];
-    new_nonce(response);
+    random_nonce(response);
 
     len = encrypt_data_symmetric(shared_key, response, resp_plain, TCP_HANDSHAKE_PLAIN_SIZE,
                                  response + crypto_box_NONCEBYTES);

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -209,9 +209,3 @@ void new_symmetric_key(uint8_t *key)
 {
     randombytes(key, crypto_box_KEYBYTES);
 }
-
-/* Gives a nonce guaranteed to be different from previous ones.*/
-void new_nonce(uint8_t *nonce)
-{
-    random_nonce(nonce);
-}

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -119,7 +119,4 @@ void random_nonce(uint8_t *nonce);
 /* Fill a key crypto_box_KEYBYTES big with random bytes */
 void new_symmetric_key(uint8_t *key);
 
-/*Gives a nonce guaranteed to be different from previous ones.*/
-void new_nonce(uint8_t *nonce);
-
 #endif

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -81,7 +81,7 @@ static int create_cookie_request(const Net_Crypto *c, uint8_t *packet, uint8_t *
 
     DHT_get_shared_key_sent(c->dht, shared_key, dht_public_key);
     uint8_t nonce[crypto_box_NONCEBYTES];
-    new_nonce(nonce);
+    random_nonce(nonce);
     packet[0] = NET_PACKET_COOKIE_REQUEST;
     memcpy(packet + 1, c->dht->self_public_key, crypto_box_PUBLICKEYBYTES);
     memcpy(packet + 1 + crypto_box_PUBLICKEYBYTES, nonce, crypto_box_NONCEBYTES);
@@ -106,7 +106,7 @@ static int create_cookie(uint8_t *cookie, const uint8_t *bytes, const uint8_t *e
     uint64_t temp_time = unix_time();
     memcpy(contents, &temp_time, sizeof(temp_time));
     memcpy(contents + sizeof(temp_time), bytes, COOKIE_DATA_LENGTH);
-    new_nonce(cookie);
+    random_nonce(cookie);
     int len = encrypt_data_symmetric(encryption_key, cookie, contents, sizeof(contents), cookie + crypto_box_NONCEBYTES);
 
     if (len != COOKIE_LENGTH - crypto_box_NONCEBYTES) {
@@ -165,7 +165,7 @@ static int create_cookie_response(const Net_Crypto *c, uint8_t *packet, const ui
 
     memcpy(plain + COOKIE_LENGTH, request_plain + COOKIE_DATA_LENGTH, sizeof(uint64_t));
     packet[0] = NET_PACKET_COOKIE_RESPONSE;
-    new_nonce(packet + 1);
+    random_nonce(packet + 1);
     int len = encrypt_data_symmetric(shared_key, packet + 1, plain, sizeof(plain), packet + 1 + crypto_box_NONCEBYTES);
 
     if (len != COOKIE_RESPONSE_LENGTH - (1 + crypto_box_NONCEBYTES)) {
@@ -331,7 +331,7 @@ static int create_crypto_handshake(const Net_Crypto *c, uint8_t *packet, const u
         return -1;
     }
 
-    new_nonce(packet + 1 + COOKIE_LENGTH);
+    random_nonce(packet + 1 + COOKIE_LENGTH);
     int len = encrypt_data(peer_real_pk, c->self_secret_key, packet + 1 + COOKIE_LENGTH, plain, sizeof(plain),
                            packet + 1 + COOKIE_LENGTH + crypto_box_NONCEBYTES);
 

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -375,7 +375,7 @@ int onion_send_1(const Onion *onion, const uint8_t *plain, uint16_t len, IP_Port
     memcpy(data + 1 + crypto_box_NONCEBYTES, plain + SIZE_IPPORT, len - SIZE_IPPORT);
     uint16_t data_len = 1 + crypto_box_NONCEBYTES + (len - SIZE_IPPORT);
     uint8_t *ret_part = data + data_len;
-    new_nonce(ret_part);
+    random_nonce(ret_part);
     len = encrypt_data_symmetric(onion->secret_symmetric_key, ret_part, ip_port, SIZE_IPPORT,
                                  ret_part + crypto_box_NONCEBYTES);
 
@@ -428,7 +428,7 @@ static int handle_send_1(void *object, IP_Port source, const uint8_t *packet, ui
     memcpy(data + 1 + crypto_box_NONCEBYTES, plain + SIZE_IPPORT, len - SIZE_IPPORT);
     uint16_t data_len = 1 + crypto_box_NONCEBYTES + (len - SIZE_IPPORT);
     uint8_t *ret_part = data + data_len;
-    new_nonce(ret_part);
+    random_nonce(ret_part);
     uint8_t ret_data[RETURN_1 + SIZE_IPPORT];
     ipport_pack(ret_data, &source);
     memcpy(ret_data + SIZE_IPPORT, packet + (length - RETURN_1), RETURN_1);
@@ -482,7 +482,7 @@ static int handle_send_2(void *object, IP_Port source, const uint8_t *packet, ui
     memcpy(data, plain + SIZE_IPPORT, len - SIZE_IPPORT);
     uint16_t data_len = (len - SIZE_IPPORT);
     uint8_t *ret_part = data + (len - SIZE_IPPORT);
-    new_nonce(ret_part);
+    random_nonce(ret_part);
     uint8_t ret_data[RETURN_2 + SIZE_IPPORT];
     ipport_pack(ret_data, &source);
     memcpy(ret_data + SIZE_IPPORT, packet + (length - RETURN_2), RETURN_2);

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -949,7 +949,7 @@ static int send_dht_dhtpk(const Onion_Client *onion_c, int friend_num, const uin
     }
 
     uint8_t nonce[crypto_box_NONCEBYTES];
-    new_nonce(nonce);
+    random_nonce(nonce);
 
     uint8_t temp[DATA_IN_RESPONSE_MIN_SIZE + crypto_box_NONCEBYTES + length];
     memcpy(temp, onion_c->c->self_public_key, crypto_box_PUBLICKEYBYTES);

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -88,7 +88,7 @@ int send_ping_request(PING *ping, IP_Port ipp, const uint8_t *public_key)
 
     pk[0] = NET_PACKET_PING_REQUEST;
     id_copy(pk + 1, ping->dht->self_public_key);     // Our pubkey
-    new_nonce(pk + 1 + crypto_box_PUBLICKEYBYTES); // Generate new nonce
+    random_nonce(pk + 1 + crypto_box_PUBLICKEYBYTES); // Generate new nonce
 
 
     rc = encrypt_data_symmetric(shared_key,
@@ -119,7 +119,7 @@ static int send_ping_response(PING *ping, IP_Port ipp, const uint8_t *public_key
 
     pk[0] = NET_PACKET_PING_RESPONSE;
     id_copy(pk + 1, ping->dht->self_public_key);     // Our pubkey
-    new_nonce(pk + 1 + crypto_box_PUBLICKEYBYTES); // Generate new nonce
+    random_nonce(pk + 1 + crypto_box_PUBLICKEYBYTES); // Generate new nonce
 
     // Encrypt ping_id using recipient privkey
     rc = encrypt_data_symmetric(shared_encryption_key,


### PR DESCRIPTION
`new_nonce` has been an alias for `random_nonce` for a while now. Having
two names for the same operation is confusing. `random_nonce` better
expresses the intent. The documentation for `new_nonce` talks about
guaranteeing that the nonce is different from previous ones, which is
incorrect, it's just quite likely to be different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/248)
<!-- Reviewable:end -->
