### PR TITLE
Rename log levels to remove the extra "LOG" prefix.

### DIFF
--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -627,23 +627,23 @@ enum class LOG_LEVEL {
   /**
    * Very detailed traces including all network activity.
    */
-  LOG_TRACE,
+  TRACE,
   /**
    * Debug messages such as which port we bind to.
    */
-  LOG_DEBUG,
+  DEBUG,
   /**
    * Informational log messages such as video call status changes.
    */
-  LOG_INFO,
+  INFO,
   /**
    * Warnings about internal inconsistency or logic errors.
    */
-  LOG_WARNING,
+  WARNING,
   /**
    * Severe unexpected errors caused by external or internal inconsistency.
    */
-  LOG_ERROR,
+  ERROR,
 }
 
 /**

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -742,27 +742,27 @@ typedef enum TOX_LOG_LEVEL {
     /**
      * Very detailed traces including all network activity.
      */
-    TOX_LOG_LEVEL_LOG_TRACE,
+    TOX_LOG_LEVEL_TRACE,
 
     /**
      * Debug messages such as which port we bind to.
      */
-    TOX_LOG_LEVEL_LOG_DEBUG,
+    TOX_LOG_LEVEL_DEBUG,
 
     /**
      * Informational log messages such as video call status changes.
      */
-    TOX_LOG_LEVEL_LOG_INFO,
+    TOX_LOG_LEVEL_INFO,
 
     /**
      * Warnings about internal inconsistency or logic errors.
      */
-    TOX_LOG_LEVEL_LOG_WARNING,
+    TOX_LOG_LEVEL_WARNING,
 
     /**
      * Severe unexpected errors caused by external or internal inconsistency.
      */
-    TOX_LOG_LEVEL_LOG_ERROR,
+    TOX_LOG_LEVEL_ERROR,
 
 } TOX_LOG_LEVEL;
 


### PR DESCRIPTION
`TOX_LOG_LEVEL_LOG_TRACE` => `TOX_LOG_LEVEL_TRACE`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/251)
<!-- Reviewable:end -->
