### PR TITLE
Add decode/encode PlainText test support.

### DIFF
--- a/testing/hstox/binary_encode.c
+++ b/testing/hstox/binary_encode.c
@@ -183,7 +183,7 @@ METHOD(u64, Binary_encode, PingPacket)
 
 METHOD(bin, Binary_encode, PlainText)
 {
-    return pending;
+    return Binary_encode_CipherText(args, res);
 }
 
 METHOD(u64, Binary_encode, PortNumber)


### PR DESCRIPTION
These are implemented in terms of decode/encode CipherText. They do the
exact same thing, since they are both simple length-prefixed byte arrays.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/257)
<!-- Reviewable:end -->
