### PR TITLE
Support arbitrary video resolutions in av_test

### DIFF
--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -358,7 +358,7 @@ static void *iterate_toxav(void *data)
 
 static int send_opencv_img(ToxAV *av, uint32_t friend_number, const IplImage *img)
 {
-    int32_t strides[3] = { 1280, 640, 640 };
+    int32_t strides[3] = { img->width, img->width / 2, img->width / 2 };
     uint8_t *planes[3] = {
         (uint8_t *)malloc(img->height * img->width),
         (uint8_t *)malloc(img->height * img->width / 4),


### PR DESCRIPTION
Now it compiles and takes arbitrary resolutions video for input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/260)
<!-- Reviewable:end -->
