### PR TITLE
Work around Travis issue that causes build failures.

### DIFF
--- a/other/travis/env.sh
+++ b/other/travis/env.sh
@@ -9,3 +9,6 @@ export ASTYLE=$CACHE_DIR/astyle/build/gcc/bin/astyle
 export CFLAGS="-O3 -DTRAVIS_ENV=1"
 
 BUILD_DIR=_build
+
+# Workaround for broken Travis image.
+export TERM=xterm


### PR DESCRIPTION
Travis seems to no longer set $TERM, which breaks opam. We now manually
set it to some hopefully sane value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/261)
<!-- Reviewable:end -->
