### PR TITLE
Make conferences persist across restarts

### DIFF
--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -261,7 +261,7 @@ static void group_av_peer_new(void *object, int groupnumber, int friendgroupnumb
     group_peer_set_object(group_av->g_c, groupnumber, friendgroupnumber, peer_av);
 }
 
-static void group_av_peer_delete(void *object, int groupnumber, int friendgroupnumber, void *peer_object)
+static void group_av_peer_delete(void *object, int groupnumber, void *peer_object)
 {
     Group_Peer_AV *peer_av = (Group_Peer_AV *)peer_object;
 
@@ -460,7 +460,7 @@ int add_av_groupchat(Logger *log, Group_Chats *g_c, void (*audio_callback)(Messe
                      unsigned int,
                      uint8_t, unsigned int, void *), void *userdata)
 {
-    int groupnumber = add_groupchat(g_c, GROUPCHAT_TYPE_AV);
+    int groupnumber = add_groupchat(g_c, GROUPCHAT_TYPE_AV, NULL);
 
     if (groupnumber == -1) {
         return -1;
@@ -477,7 +477,7 @@ int add_av_groupchat(Logger *log, Group_Chats *g_c, void (*audio_callback)(Messe
 /* Join a AV group (you need to have been invited first.)
  *
  * returns group number on success
- * returns -1 on failure.
+ * returns -1 .. -6 on failure (see join_groupchat)
  */
 int join_av_groupchat(Logger *log, Group_Chats *g_c, int32_t friendnumber, const uint8_t *data, uint16_t length,
                       void (*audio_callback)(Messenger *, int, int, const int16_t *, unsigned int, uint8_t, unsigned int, void *),
@@ -485,13 +485,13 @@ int join_av_groupchat(Logger *log, Group_Chats *g_c, int32_t friendnumber, const
 {
     int groupnumber = join_groupchat(g_c, friendnumber, GROUPCHAT_TYPE_AV, data, length);
 
-    if (groupnumber == -1) {
-        return -1;
+    if (groupnumber < 0) {
+        return groupnumber;
     }
 
     if (groupchat_enable_av(log, g_c, groupnumber, audio_callback, userdata) == -1) {
         del_groupchat(g_c, groupnumber);
-        return -1;
+        return -10;
     }
 
     return groupnumber;
@@ -509,14 +509,15 @@ static int send_audio_packet(Group_Chats *g_c, int groupnumber, uint8_t *packet,
     }
 
     Group_AV *group_av = (Group_AV *)group_get_object(g_c, groupnumber);
-    uint8_t data[1 + sizeof(uint16_t) + length];
+    uint8_t data[MAX_CRYPTO_DATA_SIZE]; // according to caller, length is maximum 1024 bytes (see group_send_audio)
     data[0] = GROUP_AUDIO_PACKET_ID;
+    size_t plen = 1 + sizeof(uint16_t) + length;
 
     uint16_t sequnum = htons(group_av->audio_sequnum);
     memcpy(data + 1, &sequnum, sizeof(sequnum));
     memcpy(data + 1 + sizeof(sequnum), packet, length);
 
-    if (send_group_lossy_packet(g_c, groupnumber, data, sizeof(data)) == -1) {
+    if (send_group_lossy_packet(g_c, groupnumber, data, (uint16_t)plen) == -1) {
         return -1;
     }
 

--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -491,7 +491,7 @@ int join_av_groupchat(Logger *log, Group_Chats *g_c, int32_t friendnumber, const
 
     if (groupchat_enable_av(log, g_c, groupnumber, audio_callback, userdata) == -1) {
         del_groupchat(g_c, groupnumber);
-        return -10;
+        return -5; /* initialization failed */
     }
 
     return groupnumber;
@@ -508,10 +508,20 @@ static int send_audio_packet(Group_Chats *g_c, int groupnumber, uint8_t *packet,
         return -1;
     }
 
-    Group_AV *group_av = (Group_AV *)group_get_object(g_c, groupnumber);
-    uint8_t data[MAX_CRYPTO_DATA_SIZE]; // according to caller, length is maximum 1024 bytes (see group_send_audio)
-    data[0] = GROUP_AUDIO_PACKET_ID;
     size_t plen = 1 + sizeof(uint16_t) + length;
+
+    if (plen > MAX_CRYPTO_DATA_SIZE) {
+        return -1;
+    }
+
+    Group_AV *group_av = (Group_AV *)group_get_object(g_c, groupnumber);
+
+    if (!group_av) {
+        return -1;
+    }
+
+    uint8_t data[MAX_CRYPTO_DATA_SIZE];
+    data[0] = GROUP_AUDIO_PACKET_ID;
 
     uint16_t sequnum = htons(group_av->audio_sequnum);
     memcpy(data + 1, &sequnum, sizeof(sequnum));

--- a/toxav/toxav.api.h
+++ b/toxav/toxav.api.h
@@ -604,7 +604,7 @@ int toxav_add_av_groupchat(Tox *tox, void (*audio_callback)(void *, int, int, co
 /* Join a AV group (you need to have been invited first.)
  *
  * returns group number on success
- * returns -1 on failure.
+ * returns < 0 on failure.
  *
  * Audio data callback format (same as the one for toxav_add_av_groupchat()):
  *   audio_callback(Tox *tox, int groupnumber, int peernumber, const int16_t *pcm, unsigned int samples, uint8_t channels, unsigned int sample_rate, void *userdata)

--- a/toxav/toxav.h
+++ b/toxav/toxav.h
@@ -728,7 +728,7 @@ int toxav_add_av_groupchat(Tox *tox, void (*audio_callback)(void *, int, int, co
 /* Join a AV group (you need to have been invited first.)
  *
  * returns group number on success
- * returns -1 on failure.
+ * returns < 0 on failure.
  *
  * Audio data callback format (same as the one for toxav_add_av_groupchat()):
  *   audio_callback(Tox *tox, int groupnumber, int peernumber, const int16_t *pcm, unsigned int samples, uint8_t channels, unsigned int sample_rate, void *userdata)

--- a/toxav/toxav_old.c
+++ b/toxav/toxav_old.c
@@ -48,7 +48,7 @@ int toxav_add_av_groupchat(struct Tox *tox, void (*audio_callback)(void *, int, 
 /* Join a AV group (you need to have been invited first.)
  *
  * returns group number on success
- * returns -1 on failure.
+ * returns < 0 on failure.
  *
  * Audio data callback format (same as the one for toxav_add_av_groupchat()):
  *   audio_callback(Tox *tox, int groupnumber, int peernumber, const int16_t *pcm, unsigned int samples, uint8_t channels, unsigned int sample_rate, void *userdata)

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2625,7 +2625,7 @@ void do_messenger(Messenger *m, void *userdata)
 #define MESSENGER_STATE_TYPE_STATUS        6
 #define MESSENGER_STATE_TYPE_TCP_RELAY     10
 #define MESSENGER_STATE_TYPE_PATH_NODE     11
-#define MESSENGER_STATE_TYPE_OLDGROUPCHATS 100
+#define MESSENGER_STATE_TYPE_CONFERENCES   100
 #define MESSENGER_STATE_TYPE_END           255
 
 #define SAVED_FRIEND_REQUEST_SIZE 1024
@@ -2732,9 +2732,9 @@ static int friends_list_load(Messenger *m, const uint8_t *data, uint32_t length)
     return num;
 }
 
-uint32_t saved_oldgroups_size(const Messenger *m);
-void oldgroups_save(const Messenger *m, uint8_t *data);
-int oldgroups_load(Messenger *m, const uint8_t *data, uint32_t length);
+uint32_t saved_conferences_size(const Messenger *m);
+void conferences_save(const Messenger *m, uint8_t *data);
+int conferences_load(Messenger *m, const uint8_t *data, uint32_t length);
 
 
 /*  return size of the messenger data (for saving) */
@@ -2750,7 +2750,7 @@ uint32_t messenger_size(const Messenger *m)
              + sizesubhead + 1                                 // status
              + sizesubhead + NUM_SAVED_TCP_RELAYS * packed_node_size(TCP_INET6) //TCP relays
              + sizesubhead + NUM_SAVED_PATH_NODES * packed_node_size(TCP_INET6) //saved path nodes
-             + sizesubhead + saved_oldgroups_size(m)           // old group chats
+             + sizesubhead + saved_conferences_size(m)           // old group chats
              + sizesubhead;
 }
 
@@ -2844,10 +2844,10 @@ void messenger_save(const Messenger *m, uint8_t *data)
         data += len;
     }
 
-    len = saved_oldgroups_size(m);
-    type = MESSENGER_STATE_TYPE_OLDGROUPCHATS;
+    len = saved_conferences_size(m);
+    type = MESSENGER_STATE_TYPE_CONFERENCES;
     data = z_state_save_subheader(data, len, type);
-    oldgroups_save(m, data);
+    conferences_save(m, data);
     data += len;
 
     z_state_save_subheader(data, 0, MESSENGER_STATE_TYPE_END);
@@ -2928,8 +2928,12 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
             break;
         }
 
-        case MESSENGER_STATE_TYPE_OLDGROUPCHATS: {
-            oldgroups_load(m, data, length);
+        case MESSENGER_STATE_TYPE_CONFERENCES: {
+            /*int err =*/ conferences_load(m, data, length);
+            /* No need to do something special if err < 0
+             * err < 0 just means that conferences data was damaged
+             * and skipped
+             */
             break;
         }
 

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -45,13 +45,13 @@ typedef enum {
 #define GROUP_PING_INTERVAL 20
 
 enum {
-	GROUP_MESSAGE_PING_ID = 0,
-	GROUP_MESSAGE_UNSUBSCRIBE_ID = 1,
-	GROUP_MESSAGE_NICKNAME_ID = 2,
-	GROUP_MESSAGE_NEW_PEER_ID = 16,
-	GROUP_MESSAGE_KILL_PEER_ID = 17,
-	GROUP_MESSAGE_NAME_ID = 48,
-	GROUP_MESSAGE_TITLE_ID = 49
+    GROUP_MESSAGE_PING_ID = 0,
+    GROUP_MESSAGE_UNSUBSCRIBE_ID = 1,
+    GROUP_MESSAGE_NICKNAME_ID = 2,
+    GROUP_MESSAGE_NEW_PEER_ID = 16,
+    GROUP_MESSAGE_KILL_PEER_ID = 17,
+    GROUP_MESSAGE_NAME_ID = 48,
+    GROUP_MESSAGE_TITLE_ID = 49
 };
 
 #define GROUP_MESSAGE_NEW_PEER_LENGTH (sizeof(uint16_t) + crypto_box_PUBLICKEYBYTES * 2)
@@ -60,10 +60,10 @@ enum {
 #define MAX_GROUP_MESSAGE_DATA_LEN (MAX_CRYPTO_DATA_SIZE - (1 + MIN_MESSAGE_PACKET_LEN))
 
 enum {
-	INVITE_ID = 0,
-	INVITE_RESPONSE_ID = 1,
-	INVITE_UNSUBSCRIBE_ID = 2,
-	INVITE_MYGROUP_ID = 3,
+    INVITE_ID = 0,
+    INVITE_RESPONSE_ID = 1,
+    INVITE_UNSUBSCRIBE_ID = 2,
+    INVITE_MYGROUP_ID = 3,
 };
 
 #define INVITE_PACKET_SIZE (1 + sizeof(uint16_t) + GROUP_IDENTIFIER_LENGTH)
@@ -72,11 +72,11 @@ enum {
 #define ONLINE_PACKET_DATA_SIZE (sizeof(uint16_t) + GROUP_IDENTIFIER_LENGTH)
 
 enum {
-	PEER_KILL_ID = 1,
-	PEER_QUERY_ID = 8,
-	PEER_RESPONSE_ID = 9,
-	PEER_TITLE_ID = 10,
-	PEER_GROUP_NUM_ID = 11,
+    PEER_KILL_ID = 1,
+    PEER_QUERY_ID = 8,
+    PEER_RESPONSE_ID = 9,
+    PEER_TITLE_ID = 10,
+    PEER_GROUP_NUM_ID = 11,
 };
 
 #define MIN_MESSAGE_PACKET_LEN (sizeof(uint16_t) * 2 + sizeof(uint32_t) + 1)
@@ -408,7 +408,7 @@ static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *use
 
         aint new_size_of_list = 0;
 
-		/* Put new peers to just deleted slots */
+        /* Put new peers to just deleted slots */
         for (i = 0; i < g->numpeers; ++i) {
 
             const Group_Peer *peer = g->peers + i;
@@ -449,7 +449,7 @@ static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *use
             /* all new peers were put into empty slots, so there are no new peers */
             /* just remove empty slots both in peers_list and peers*/
 
-			/* remove empty slots in peers_list */
+            /* remove empty slots in peers_list */
             for (j = 0; j < g->numpeers_in_list;) {
 
                 if (g->peers_list[j] == 0xffff) {
@@ -464,7 +464,7 @@ static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *use
                 ++j;
             }
 
-			/* remove empty slots in peers */
+            /* remove empty slots in peers */
             for (i = 0; i < g->numpeers;) {
 
                 Group_Peer *peer = g->peers + i;
@@ -473,7 +473,7 @@ static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *use
                     --g->numpeers;
                     memcpy(peer, g->peers + g->numpeers, sizeof(Group_Peer));
 
-					/* fix index in peers_list */
+                    /* fix index in peers_list */
                     for (j = 0; j < g->numpeers_in_list; ++j) {
                         if (g->peers_list[j] == g->numpeers) {
                             g->peers_list[j] = (uint16_t)i;
@@ -489,7 +489,7 @@ static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *use
 
         } else if (new_size_of_list > g->numpeers_in_list) {
 
-			/* Expand peers_list and put indexes of new peers into it */
+            /* Expand peers_list and put indexes of new peers into it */
 
             uint16_t *temp = (uint16_t *)realloc(g->peers_list, sizeof(uint16_t) * new_size_of_list);
 
@@ -523,7 +523,7 @@ static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *use
             }
         }
 
-		/* Now notify client by calling callbacks */
+        /* Now notify client by calling callbacks */
         if (g_c->group_namelistchange) {
             if (some_changes) {
 
@@ -594,7 +594,7 @@ static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *use
         g->dirty_list = false;
     }
 
-	/* notify client about nick change */
+    /* notify client about nick change */
     if (g->nick_changed && g_c->group_namelistchange) {
 
         size_t i;
@@ -611,7 +611,7 @@ static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *use
         g->nick_changed = false;
     }
 
-	/* notify client about title change */
+    /* notify client about title change */
     if (g->title_changed && g_c->title_callback) {
         size_t i;
         bool cb = false;

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -29,24 +29,78 @@
 
 #include "util.h"
 
-/* return 1 if the groupnumber is not valid.
- * return 0 if the groupnumber is valid.
- */
-static uint8_t groupnumber_not_valid(const Group_Chats *g_c, int groupnumber)
+typedef ptrdiff_t aint;
+
+#define CLOSEST( i ) ((g->closest_peers_entry & (1ull << i)) != 0)
+#define CLOSESTSET( i ) { g->closest_peers_entry |= (1ull << i); }
+
+typedef enum {
+    UNS_NONE,
+    UNS_TEMP,
+    UNS_FOREVER,
+
+} Unsubscribe;
+
+/* Interval in seconds to send ping messages */
+#define GROUP_PING_INTERVAL 20
+
+#define GROUP_MESSAGE_PING_ID 0
+#define GROUP_MESSAGE_UNSUBSCRIBE 1
+#define GROUP_MESSAGE_NEW_PEER_ID 16
+#define GROUP_MESSAGE_KILL_PEER_ID 17
+#define GROUP_MESSAGE_NAME_ID 48
+#define GROUP_MESSAGE_TITLE_ID 49
+
+#define GROUP_MESSAGE_NEW_PEER_LENGTH (sizeof(uint16_t) + crypto_box_PUBLICKEYBYTES * 2)
+#define GROUP_MESSAGE_KILL_PEER_LENGTH (sizeof(uint16_t))
+
+#define MAX_GROUP_MESSAGE_DATA_LEN (MAX_CRYPTO_DATA_SIZE - (1 + MIN_MESSAGE_PACKET_LEN))
+
+#define INVITE_ID 0
+#define INVITE_RESPONSE_ID 1
+#define INVITE_UNSUBSCRIBE_ID 2
+
+#define INVITE_PACKET_SIZE (1 + sizeof(uint16_t) + GROUP_IDENTIFIER_LENGTH)
+#define INVITE_RESPONSE_PACKET_SIZE (1 + sizeof(uint16_t) * 2 + GROUP_IDENTIFIER_LENGTH)
+
+#define ONLINE_PACKET_DATA_SIZE (sizeof(uint16_t) + GROUP_IDENTIFIER_LENGTH)
+
+#define PEER_KILL_ID 1
+#define PEER_QUERY_ID 8
+#define PEER_RESPONSE_ID 9
+#define PEER_TITLE_ID 10
+#define PEER_GROUP_NUM_ID 11
+
+#define MIN_MESSAGE_PACKET_LEN (sizeof(uint16_t) * 2 + sizeof(uint32_t) + 1)
+
+#define MAX_FAILED_JOIN_ATTEMPTS 16
+
+
+
+static void group_name_send(const Group_Chats *g_c, aint groupnumber, const uint8_t *nick, aint nick_len);
+static aint send_packet_online(Friend_Connections *fr_c, aint friendcon_id, uint16_t group_num, uint8_t *identifier);
+static void send_peer_kill(Group_Chats *g_c, aint friendcon_id, uint16_t group_num);
+static int handle_packet(void *object, int friendcon_id, const uint8_t *data, uint16_t length, void *userdata);
+static int handle_lossy(void *object, int friendcon_id, const uint8_t *data, uint16_t length, void *userdata);
+static void send_peers(Group_Chats *g_c, aint groupnumber, int friendcon_id, uint16_t other_group_num);
+static int get_self_peer_gid(Group_c *g);
+
+static bool really_connected(Group_Peer *peer)
 {
-    if ((unsigned int)groupnumber >= g_c->num_chats) {
-        return 1;
+    return peer->connected && peer->friendcon_id >= 0 && peer->group_number != 0xffff;
+}
+
+static bool is_groupnumber_valid(const Group_Chats *g_c, aint groupnumber)
+{
+    if ((unsigned)groupnumber >= g_c->num_chats) {
+        return false;
     }
 
-    if (g_c->chats == NULL) {
-        return 1;
+    if (!g_c->chats) {
+        return false;
     }
 
-    if (g_c->chats[groupnumber].status == GROUPCHAT_STATUS_NONE) {
-        return 1;
-    }
-
-    return 0;
+    return g_c->chats[groupnumber].live;
 }
 
 
@@ -55,7 +109,7 @@ static uint8_t groupnumber_not_valid(const Group_Chats *g_c, int groupnumber)
  *  return -1 if realloc fails.
  *  return 0 if it succeeds.
  */
-static int realloc_groupchats(Group_Chats *g_c, uint32_t num)
+static aint realloc_groupchats(Group_Chats *g_c, aint num)
 {
     if (num == 0) {
         free(g_c->chats);
@@ -73,69 +127,47 @@ static int realloc_groupchats(Group_Chats *g_c, uint32_t num)
     return 0;
 }
 
+static void setup_conference(Group_c *g)
+{
+    memset(g, 0, sizeof(Group_c));
+    g->keep_join_index = -1;
+    g->live = true;
+}
 
 /* Create a new empty groupchat connection.
  *
  * return -1 on failure.
  * return groupnumber on success.
  */
-static int create_group_chat(Group_Chats *g_c)
+static aint create_group_chat(Group_Chats *g_c)
 {
-    uint32_t i;
+    aint i;
 
     for (i = 0; i < g_c->num_chats; ++i) {
-        if (g_c->chats[i].status == GROUPCHAT_STATUS_NONE) {
+        if (!g_c->chats[i].live) {
+            setup_conference(g_c->chats + i);
             return i;
         }
     }
 
-    int id = -1;
+    aint id = -1;
 
     if (realloc_groupchats(g_c, g_c->num_chats + 1) == 0) {
         id = g_c->num_chats;
         ++g_c->num_chats;
-        memset(&(g_c->chats[id]), 0, sizeof(Group_c));
+        setup_conference(g_c->chats + id);
     }
 
     return id;
 }
 
-
-/* Wipe a groupchat.
- *
- * return -1 on failure.
- * return 0 on success.
- */
-static int wipe_group_chat(Group_Chats *g_c, int groupnumber)
+static Group_c *get_group_c(const Group_Chats *g_c, aint groupnumber)
 {
-    if (groupnumber_not_valid(g_c, groupnumber)) {
-        return -1;
+    if (!is_groupnumber_valid(g_c, groupnumber)) {
+        return NULL;
     }
 
-    uint32_t i;
-    sodium_memzero(&(g_c->chats[groupnumber]), sizeof(Group_c));
-
-    for (i = g_c->num_chats; i != 0; --i) {
-        if (g_c->chats[i - 1].status != GROUPCHAT_STATUS_NONE) {
-            break;
-        }
-    }
-
-    if (g_c->num_chats != i) {
-        g_c->num_chats = i;
-        realloc_groupchats(g_c, g_c->num_chats);
-    }
-
-    return 0;
-}
-
-static Group_c *get_group_c(const Group_Chats *g_c, int groupnumber)
-{
-    if (groupnumber_not_valid(g_c, groupnumber)) {
-        return 0;
-    }
-
-    return &g_c->chats[groupnumber];
+    return g_c->chats + groupnumber;
 }
 
 /*
@@ -147,12 +179,12 @@ static Group_c *get_group_c(const Group_Chats *g_c, int groupnumber)
  * TODO(irungentoo): make this more efficient.
  */
 
-static int peer_in_chat(const Group_c *chat, const uint8_t *real_pk)
+static aint peer_in_chat(const Group_c *chat, const uint8_t *real_pk)
 {
-    uint32_t i;
+    size_t i;
 
     for (i = 0; i < chat->numpeers; ++i) {
-        if (id_equal(chat->group[i].real_pk, real_pk)) {
+        if (chat->peers[i].friendcon_id != -2 && id_equal(chat->peers[i].real_pk, real_pk)) {
             return i;
         }
     }
@@ -170,15 +202,34 @@ static int peer_in_chat(const Group_c *chat, const uint8_t *real_pk)
  */
 static int get_group_num(const Group_Chats *g_c, const uint8_t *identifier)
 {
-    uint32_t i;
+    aint i;
 
     for (i = 0; i < g_c->num_chats; ++i) {
-        if (sodium_memcmp(g_c->chats[i].identifier, identifier, GROUP_IDENTIFIER_LENGTH) == 0) {
-            return i;
+        if (g_c->chats[i].live && sodium_memcmp(g_c->chats[i].identifier, identifier, GROUP_IDENTIFIER_LENGTH) == 0) {
+            return (int)i;
         }
     }
 
     return -1;
+}
+
+int conference_by_uid(const Group_Chats *g_c, const uint8_t *uid)
+{
+    aint i;
+
+    for (i = 0; i < g_c->num_chats; ++i) {
+
+        if (!g_c->chats[i].live) {
+            continue;
+        }
+
+        if (sodium_memcmp(g_c->chats[i].identifier + 1, uid, GROUP_IDENTIFIER_LENGTH - 1) == 0) {
+            return (int)i;
+        }
+    }
+
+    return -1;
+
 }
 
 /*
@@ -187,14 +238,13 @@ static int get_group_num(const Group_Chats *g_c, const uint8_t *identifier)
  * return peer number if peer is in chat.
  * return -1 if peer is not in chat.
  *
- * TODO(irungentoo): make this more efficient.
  */
-static int get_peer_index(Group_c *g, uint16_t peer_number)
+static aint get_peer_index(const Group_c *g, uint16_t peer_gid)
 {
-    uint32_t i;
+    aint i;
 
     for (i = 0; i < g->numpeers; ++i) {
-        if (g->group[i].peer_number == peer_number) {
+        if (g->peers[i].gid == (int)peer_gid) {
             return i;
         }
     }
@@ -202,12 +252,37 @@ static int get_peer_index(Group_c *g, uint16_t peer_number)
     return -1;
 }
 
+static uint16_t find_new_peer_gid(const Group_c *g)
+{
+    uint16_t peer_number;
+    randombytes((uint8_t *)&peer_number, 2);
+
+    size_t tries = 0;
+
+    while (get_peer_index(g, peer_number) != -1) {
+        randombytes((uint8_t *)&peer_number, 2);
+        ++tries;
+
+        if (tries > 32) {
+            /* just find first unused peer number */
+            peer_number = 0;
+
+            while (get_peer_index(g, peer_number) != -1) {
+                ++peer_number;
+            }
+
+            break;
+        }
+    }
+
+    return peer_number;
+}
 
 static uint64_t calculate_comp_value(const uint8_t *pk1, const uint8_t *pk2)
 {
     uint64_t cmp1 = 0, cmp2 = 0;
 
-    unsigned int i;
+    size_t i;
 
     for (i = 0; i < sizeof(uint64_t); ++i) {
         cmp1 = (cmp1 << 8) + (uint64_t)pk1[i];
@@ -217,279 +292,580 @@ static uint64_t calculate_comp_value(const uint8_t *pk1, const uint8_t *pk2)
     return (cmp1 - cmp2);
 }
 
-enum {
-    GROUPCHAT_CLOSEST_NONE,
-    GROUPCHAT_CLOSEST_ADDED,
-    GROUPCHAT_CLOSEST_REMOVED
-};
-
-static int friend_in_close(Group_c *g, int friendcon_id);
-static int add_conn_to_groupchat(Group_Chats *g_c, int friendcon_id, int groupnumber, uint8_t closest, uint8_t lock);
-
-static int add_to_closest(Group_Chats *g_c, int groupnumber, const uint8_t *real_pk, const uint8_t *temp_pk)
+static void add_closest(Group_c *g, size_t peerindex)
 {
-    Group_c *g = get_group_c(g_c, groupnumber);
-
-    if (!g) {
-        return -1;
-    }
-
-    if (public_key_cmp(g->real_pk, real_pk) == 0) {
-        return -1;
-    }
-
-    unsigned int i;
-    unsigned int index = DESIRED_CLOSE_CONNECTIONS;
+    size_t i;
 
     for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
-        if (g->closest_peers[i].entry && public_key_cmp(real_pk, g->closest_peers[i].real_pk) == 0) {
-            return 0;
+
+        if (!CLOSEST(i)) {
+
+            g->closest_peers[i] = (uint16_t)peerindex;
+            CLOSESTSET(i);
+            return;
         }
     }
 
-    for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
-        if (g->closest_peers[i].entry == 0) {
+    size_t index = DESIRED_CLOSE_CONNECTIONS;
+
+    const uint8_t *real_pk = g->peers[peerindex].real_pk;
+    uint64_t comp_val = calculate_comp_value(g->real_pk, real_pk);
+    uint64_t comp_d = 0;
+
+    for (i = 0; i < (DESIRED_CLOSE_CONNECTIONS / 2); ++i) {
+
+        uint64_t comp;
+        comp = calculate_comp_value(g->real_pk, g->peers[g->closest_peers[i]].real_pk);
+
+        if (comp > comp_val && comp > comp_d) {
             index = i;
-            break;
+            comp_d = comp;
         }
     }
 
-    if (index == DESIRED_CLOSE_CONNECTIONS) {
-        uint64_t comp_val = calculate_comp_value(g->real_pk, real_pk);
-        uint64_t comp_d = 0;
+    comp_val = calculate_comp_value(real_pk, g->real_pk);
 
-        for (i = 0; i < (DESIRED_CLOSE_CONNECTIONS / 2); ++i) {
-            uint64_t comp;
-            comp = calculate_comp_value(g->real_pk, g->closest_peers[i].real_pk);
+    for (i = (DESIRED_CLOSE_CONNECTIONS / 2); i < DESIRED_CLOSE_CONNECTIONS; ++i) {
 
-            if (comp > comp_val && comp > comp_d) {
-                index = i;
-                comp_d = comp;
-            }
-        }
+        uint64_t comp = calculate_comp_value(g->peers[g->closest_peers[i]].real_pk, g->real_pk);
 
-        comp_val = calculate_comp_value(real_pk, g->real_pk);
-
-        for (i = (DESIRED_CLOSE_CONNECTIONS / 2); i < DESIRED_CLOSE_CONNECTIONS; ++i) {
-            uint64_t comp = calculate_comp_value(g->closest_peers[i].real_pk, g->real_pk);
-
-            if (comp > comp_val && comp > comp_d) {
-                index = i;
-                comp_d = comp;
-            }
+        if (comp > comp_val && comp > comp_d) {
+            index = i;
+            comp_d = comp;
         }
     }
 
-    if (index == DESIRED_CLOSE_CONNECTIONS) {
-        return -1;
+    if (index < DESIRED_CLOSE_CONNECTIONS) {
+        aint rmpeer = g->closest_peers[index];
+        g->closest_peers[index] = (uint16_t)peerindex;
+        g->closest_peers_entry |= 1 << index;
+
+        add_closest(g, rmpeer);
     }
-
-    uint8_t old_real_pk[crypto_box_PUBLICKEYBYTES];
-    uint8_t old_temp_pk[crypto_box_PUBLICKEYBYTES];
-    uint8_t old = 0;
-
-    if (g->closest_peers[index].entry) {
-        memcpy(old_real_pk, g->closest_peers[index].real_pk, crypto_box_PUBLICKEYBYTES);
-        memcpy(old_temp_pk, g->closest_peers[index].temp_pk, crypto_box_PUBLICKEYBYTES);
-        old = 1;
-    }
-
-    g->closest_peers[index].entry = 1;
-    memcpy(g->closest_peers[index].real_pk, real_pk, crypto_box_PUBLICKEYBYTES);
-    memcpy(g->closest_peers[index].temp_pk, temp_pk, crypto_box_PUBLICKEYBYTES);
-
-    if (old) {
-        add_to_closest(g_c, groupnumber, old_real_pk, old_temp_pk);
-    }
-
-    if (!g->changed) {
-        g->changed = GROUPCHAT_CLOSEST_ADDED;
-    }
-
-    return 0;
 }
 
-static unsigned int pk_in_closest_peers(Group_c *g, uint8_t *real_pk)
+static int handle_status(void *object, int friendcon_id, uint8_t status, void *userdata)
 {
-    unsigned int i;
-
-    for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
-        if (!g->closest_peers[i].entry) {
-            continue;
-        }
-
-        if (public_key_cmp(g->closest_peers[i].real_pk, real_pk) == 0) {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-static int send_packet_online(Friend_Connections *fr_c, int friendcon_id, uint16_t group_num, uint8_t *identifier);
-
-static int connect_to_closest(Group_Chats *g_c, int groupnumber, void *userdata)
-{
-    Group_c *g = get_group_c(g_c, groupnumber);
-
-    if (!g) {
-        return -1;
-    }
-
-    if (!g->changed) {
+    if (status) {
         return 0;
     }
 
-    unsigned int i;
+    size_t ig, i;
+    Group_Chats *g_c = (Group_Chats *)object;
 
-    if (g->changed == GROUPCHAT_CLOSEST_REMOVED) {
+    for (ig = 0; ig < g_c->num_chats; ++ig) {
+
+        Group_c *g = get_group_c(g_c, ig);
+
+        if (!g) {
+            continue;
+        }
+
         for (i = 0; i < g->numpeers; ++i) {
-            add_to_closest(g_c, groupnumber, g->group[i].real_pk, g->group[i].temp_pk);
-        }
-    }
 
-    for (i = 0; i < MAX_GROUP_CONNECTIONS; ++i) {
-        if (g->close[i].type == GROUPCHAT_CLOSE_NONE) {
-            continue;
-        }
-
-        if (!g->close[i].closest) {
-            continue;
-        }
-
-        uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
-        uint8_t dht_temp_pk[crypto_box_PUBLICKEYBYTES];
-        get_friendcon_public_keys(real_pk, dht_temp_pk, g_c->fr_c, g->close[i].number);
-
-        if (!pk_in_closest_peers(g, real_pk)) {
-            g->close[i].type = GROUPCHAT_CLOSE_NONE;
-            kill_friend_connection(g_c->fr_c, g->close[i].number);
-        }
-    }
-
-    for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
-        if (!g->closest_peers[i].entry) {
-            continue;
-        }
-
-        int friendcon_id = getfriend_conn_id_pk(g_c->fr_c, g->closest_peers[i].real_pk);
-
-        uint8_t lock = 1;
-
-        if (friendcon_id == -1) {
-            friendcon_id = new_friend_connection(g_c->fr_c, g->closest_peers[i].real_pk);
-            lock = 0;
-
-            if (friendcon_id == -1) {
-                continue;
+            if (g->peers[i].friendcon_id == friendcon_id) {
+                g->peers[i].friendcon_id = -1;
+                g->peers[i].group_number = 0xffff;
+                g->peers[i].connected = false;
             }
-
-            set_dht_temp_pk(g_c->fr_c, friendcon_id, g->closest_peers[i].temp_pk, userdata);
-        }
-
-        add_conn_to_groupchat(g_c, friendcon_id, groupnumber, 1, lock);
-
-        if (friend_con_connected(g_c->fr_c, friendcon_id) == FRIENDCONN_STATUS_CONNECTED) {
-            send_packet_online(g_c->fr_c, friendcon_id, groupnumber, g->identifier);
         }
     }
-
-    g->changed = GROUPCHAT_CLOSEST_NONE;
 
     return 0;
 }
 
-/* Add a peer to the group chat.
- *
- * do_gc_callback indicates whether we want to trigger callbacks set by the client
- * via the public API. This should be set to false if this function is called
- * from outside of the tox_iterate() loop.
- *
- * return peer_index if success or peer already in chat.
- * return -1 if error.
- */
-static int addpeer(Group_Chats *g_c, int groupnumber, const uint8_t *real_pk, const uint8_t *temp_pk,
-                   uint16_t peer_number, void *userdata, bool do_gc_callback)
+static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *userdata)
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
     if (!g) {
-        return -1;
+        return;
     }
 
-    // TODO(irungentoo):
-    int peer_index = peer_in_chat(g, real_pk);
+    bool some_changes = false;
+
+    if (g->dirty_list) {
+
+        size_t i, j, empty_slots_in_list = 0;
+
+        /* detect deleted peers and notify client */
+        for (i = 0; i < g->numpeers_in_list; ++i) {
+
+            aint peer_index = g->peers_list[i];
+
+            if (g->peers[peer_index].friendcon_id == -2 || g->peers[peer_index].gid < 0) {
+
+                some_changes = true;
+                g->peers_list[i] = 0xffff;
+                ++empty_slots_in_list;
+            }
+        }
+
+        aint new_size_of_list = 0;
+
+        for (i = 0; i < g->numpeers; ++i) {
+
+            const Group_Peer *peer = g->peers + i;
+
+            if (peer->friendcon_id != -2 && peer->gid >= 0) {
+                ++new_size_of_list;
+
+                if (empty_slots_in_list > 0) {
+
+                    aint empty_slot = -1;
+                    bool present = false;
+
+                    for (j = 0; j < g->numpeers_in_list; ++j) {
+                        if (empty_slot < 0 && g->peers_list[j] == 0xffff) {
+                            empty_slot = j;
+                        }
+
+                        if (g->peers_list[j] == i) {
+                            present = true;
+                        }
+
+                        if (empty_slot >= 0 && present) {
+                            break;
+                        }
+                    }
+
+                    if (!present) {
+                        g->peers_list[empty_slot] = (uint16_t)i;
+                        --empty_slots_in_list;
+                        some_changes = true;
+                    }
+                }
+            }
+        }
+
+        if (empty_slots_in_list > 0) {
+
+            /* all new peers were put into empty slots, so there are no new peers */
+            /* just remove empty slots both in peers_list and peers*/
+
+            for (j = 0; j < g->numpeers_in_list;) {
+
+                if (g->peers_list[j] == 0xffff) {
+                    --g->numpeers_in_list;
+                    /* g->peers_list[j] = g->peers_list[g->numpeers_in_list]; */ /* faster */
+                    memcpy(g->peers_list + j, g->peers_list + j + 1,
+                           sizeof(uint16_t) * (g->numpeers_in_list - j)); /* slower, but accurate */
+                    some_changes = true;
+                    continue;
+                }
+
+                ++j;
+            }
+
+            for (i = 0; i < g->numpeers;) {
+
+                Group_Peer *peer = g->peers + i;
+
+                if (peer->friendcon_id == -2) {
+                    --g->numpeers;
+                    memcpy(peer, g->peers + g->numpeers, sizeof(Group_Peer));
+
+                    for (j = 0; j < g->numpeers_in_list; ++j) {
+                        if (g->peers_list[j] == g->numpeers) {
+                            g->peers_list[j] = (uint16_t)i;
+                            break;
+                        }
+                    }
+
+                    continue;
+                }
+
+                ++i;
+            }
+
+        } else if (new_size_of_list > g->numpeers_in_list) {
+
+            uint16_t *temp = (uint16_t *)realloc(g->peers_list, sizeof(uint16_t) * new_size_of_list);
+
+            if (temp) {
+
+                g->peers_list = temp;
+
+                for (i = 0; i < g->numpeers; ++i) {
+
+                    const Group_Peer *peer = g->peers + i;
+
+                    if (peer->friendcon_id != -2 && peer->gid >= 0) {
+
+                        bool present = false;
+
+                        for (j = 0; j < g->numpeers_in_list; ++j) {
+                            if (g->peers_list[j] == i) {
+                                present = true;
+                                break;
+                            }
+                        }
+
+                        if (!present) {
+
+                            g->peers_list[g->numpeers_in_list] = (uint16_t)i;
+                            ++g->numpeers_in_list;
+                            some_changes = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (g_c->group_namelistchange) {
+            if (some_changes) {
+
+                if (!g->invite_called && !g->join_mode) {
+                    if (g_c->invite_callback) {
+
+                        g->fake_join = true;
+                        g_c->invite_callback(g_c->m, UINT32_MAX, g->identifier[0], g->identifier + 1, GROUP_IDENTIFIER_LENGTH - 1, userdata);
+                        g->fake_join = false;
+
+                        if (!g->invite_called) {
+                            del_groupchat(g_c, (int)groupnumber);
+                            return;
+                        }
+                    }
+                }
+
+                g_c->group_namelistchange(g_c->m, (int)groupnumber, 0, CHAT_CHANGE_OCCURRED, userdata);
+                g->nick_changed = false;
+            }
+        }
+
+        /* and now rebuild closest */
+
+        uint16_t old_closest_peers[DESIRED_CLOSE_CONNECTIONS];
+        size_t inclose = 0;
+
+        for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
+            if (CLOSEST(i)) {
+                old_closest_peers[inclose++] = g->closest_peers[i];
+            }
+        }
+
+        g->closest_peers_entry = 0;
+
+        size_t np = g->numpeers;
+        uint64_t comp_d = 0;
+
+        for (i = 0; i < np; ++i) {
+
+            Group_Peer *peer = g->peers + i;
+
+            if (peer->friendcon_id == -2 || peer->auto_join || id_equal(g->real_pk, peer->real_pk)) {
+                continue;
+            }
+
+            add_closest(g, i);
+        }
+
+        for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
+            if (CLOSEST(i)) {
+                bool just_added = true;
+
+                for (j = 0; j < inclose; ++j) {
+                    if (g->closest_peers[i] == old_closest_peers[j]) {
+                        just_added = false;
+                        break;
+                    }
+                }
+
+                Group_Peer *peer = g->peers + g->closest_peers[i];
+
+                if (just_added && peer->connected) {
+                    send_packet_online(g_c->fr_c, peer->friendcon_id, (uint16_t)groupnumber, g->identifier);
+                }
+            }
+        }
+
+        g->dirty_list = false;
+    }
+
+    if (g->nick_changed && g_c->group_namelistchange) {
+
+        size_t i;
+
+        for (i = 0; i < g->numpeers_in_list; ++i) {
+            Group_Peer *peer = g->peers + g->peers_list[i];
+
+            if (peer->nick_changed) {
+                g_c->group_namelistchange(g_c->m, (int)groupnumber, (int)i, CHAT_CHANGE_PEER_NAME, userdata);
+                peer->nick_changed = false;
+            }
+        }
+
+        g->nick_changed = false;
+    }
+
+    if (g->title_changed && g_c->title_callback) {
+        size_t i;
+        bool cb = false;
+
+        for (i = 0; i < g->numpeers_in_list; ++i) {
+            Group_Peer *peer = g->peers + g->peers_list[i];
+
+            if (peer->title_changed) {
+
+                if (!cb) {
+                    g_c->title_callback(g_c->m, (int)groupnumber, (int)i, g->title, g->title_len, userdata);
+                }
+
+                peer->title_changed = false;
+                cb = true;
+            }
+        }
+
+        if (!cb) {
+            g_c->title_callback(g_c->m, (int)groupnumber, -1, g->title, g->title_len, userdata);
+        }
+
+        g->title_changed = false;
+    }
+
+}
+
+static void send_peer_nums(const Group_Chats *g_c, aint groupnumber, aint friendcon_id, uint16_t other_group_num);
+
+static void connect_to_closest(Group_Chats *g_c, aint groupnumber, void *userdata)
+{
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (!g) {
+        return;
+    }
+
+    if (g->dirty_list) {
+        return;
+    }
+
+    size_t i;
+
+    /* kill connections to non closest */
+    for (i = 0; i < g->numpeers; ++i) {
+
+        Group_Peer *peer = g->peers + i;
+
+        if (peer->friendcon_id < 0 || peer->keep_connection) {
+            continue;
+        }
+
+        size_t k;
+
+        for (k = 0; k < DESIRED_CLOSE_CONNECTIONS; ++k) {
+
+            if (CLOSEST(k) && g->closest_peers[k] == i) {
+                k = DESIRED_CLOSE_CONNECTIONS + 100;
+                break;
+            }
+        }
+
+        if (k == DESIRED_CLOSE_CONNECTIONS + 100) {
+            continue;
+        }
+
+        if (really_connected(peer)) {
+            send_peer_kill(g_c, peer->friendcon_id, peer->group_number);
+        }
+
+        kill_friend_connection(g_c->fr_c, peer->friendcon_id);
+        peer->friendcon_id = -1;
+        peer->group_number = 0xffff;
+        peer->connected = false;
+    }
+
+    for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
+        if (!CLOSEST(i)) {
+            continue;
+        }
+
+        Group_Peer *peer = g->peers + g->closest_peers[i];
+
+        if (peer->friendcon_id < 0) {
+
+            int friendcon_id = getfriend_conn_id_pk(g_c->fr_c, peer->real_pk);
+
+            bool addref = true;
+
+            if (friendcon_id < 0) {
+
+                friendcon_id = new_friend_connection(g_c->fr_c, peer->real_pk);
+                addref = false;
+
+                if (friendcon_id == -1) {
+                    continue;
+                }
+
+                set_dht_temp_pk(g_c->fr_c, friendcon_id, peer->temp_pk, userdata);
+            }
+
+            if (addref) {
+                friend_connection_lock(g_c->fr_c, friendcon_id);
+            }
+
+            peer->friendcon_id = friendcon_id;
+
+            friend_connection_callbacks(g_c->m->fr_c, friendcon_id, GROUPCHAT_CALLBACK_INDEX, &handle_status, &handle_packet,
+                                        &handle_lossy, g_c, friendcon_id);
+
+        }
+
+        if (friend_con_connected(g_c->fr_c, peer->friendcon_id) == FRIENDCONN_STATUS_CONNECTED) {
+
+            if (!peer->connected) {
+                peer->connected = true;
+                peer->need_send_peers = true;
+                send_packet_online(g_c->fr_c, peer->friendcon_id, (uint16_t)groupnumber, g->identifier);
+            }
+        } else {
+            peer->connected = false;
+        }
+
+        if (peer->need_send_peers && really_connected(peer)) {
+            send_peers(g_c, groupnumber, peer->friendcon_id, peer->group_number);
+            send_peer_nums(g_c, groupnumber, peer->friendcon_id, peer->group_number);
+        }
+
+        peer->need_send_peers = false;
+
+    }
+
+
+    if (g->need_send_name) {
+        group_name_send(g_c, groupnumber, g_c->m->name, g_c->m->name_length);
+    }
+
+}
+
+static void addjoinpeer(Group_c *g, const uint8_t *real_pk)
+{
+    if (id_equal(g->real_pk, real_pk)) {
+        return;
+    }
+
+    size_t i;
+    bool already_here = false;
+
+    for (i = 0; i < g->numjoinpeers; ++i) {
+        if (!already_here && id_equal(g->joinpeers[i].real_pk, real_pk)) {
+            already_here = true;
+            g->joinpeers[i].unsubscribed = false;
+        }
+
+        g->joinpeers[i].fails = MAX_FAILED_JOIN_ATTEMPTS;
+    }
+
+    if (!already_here) {
+
+        Group_Join_Peer *temp = (Group_Join_Peer *)realloc(g->joinpeers, sizeof(Group_Join_Peer) * (g->numjoinpeers + 1));
+
+        if (temp == NULL) {
+            return;
+        }
+
+        g->joinpeers = temp;
+        temp = g->joinpeers + g->numjoinpeers;
+        ++g->numjoinpeers;
+
+        memset(temp, 0, sizeof(Group_Join_Peer));
+        id_copy(temp->real_pk, real_pk);
+        temp->fails = MAX_FAILED_JOIN_ATTEMPTS;
+    }
+
+}
+
+static void need_send_peers(Group_c *g)
+{
+    size_t i;
+
+    for (i = 0; i < g->numpeers; ++i) {
+        g->peers[i].need_send_peers = true;
+    }
+}
+
+static aint addpeer(Group_c *g, aint groupnumber, const uint8_t *real_pk, const uint8_t *temp_pk, int peer_gid)
+{
+    if (peer_gid >= 0) {
+        addjoinpeer(g, real_pk);
+    }
+
+    aint peer_index = peer_in_chat(g, real_pk);
 
     if (peer_index != -1) {
-        id_copy(g->group[peer_index].temp_pk, temp_pk);
 
-        if (g->group[peer_index].peer_number != peer_number) {
-            return -1;
+        id_copy(g->peers[peer_index].temp_pk, temp_pk);
+
+        if (peer_gid != g->peers[peer_index].gid) {
+
+            g->dirty_list = true;
+
+            if (peer_gid >= 0) {
+                need_send_peers(g);
+            }
+
+            g->peers[peer_index].gid = peer_gid;
+
+            if (peer_gid >= 0) {
+                g->peers[peer_index].auto_join = false;
+            }
         }
 
         return peer_index;
     }
 
-    peer_index = get_peer_index(g, peer_number);
+    peer_index = get_peer_index(g, peer_gid);
 
     if (peer_index != -1) {
         return -1;
     }
 
-    Group_Peer *temp = (Group_Peer *)realloc(g->group, sizeof(Group_Peer) * (g->numpeers + 1));
+    Group_Peer *newpeer = (Group_Peer *)realloc(g->peers, sizeof(Group_Peer) * (g->numpeers + 1));
 
-    if (temp == NULL) {
+    if (newpeer == NULL) {
         return -1;
     }
 
-    memset(&(temp[g->numpeers]), 0, sizeof(Group_Peer));
-    g->group = temp;
-
-    id_copy(g->group[g->numpeers].real_pk, real_pk);
-    id_copy(g->group[g->numpeers].temp_pk, temp_pk);
-    g->group[g->numpeers].peer_number = peer_number;
-
-    g->group[g->numpeers].last_recv = unix_time();
+    g->peers = newpeer;
+    newpeer = newpeer + g->numpeers;
     ++g->numpeers;
 
-    add_to_closest(g_c, groupnumber, real_pk, temp_pk);
+    /* Group_Peer constructor */
 
-    if (do_gc_callback && g_c->group_namelistchange) {
-        g_c->group_namelistchange(g_c->m, groupnumber, g->numpeers - 1, CHAT_CHANGE_PEER_ADD, userdata);
+    memset(newpeer, 0, sizeof(Group_Peer));
+    newpeer->friendcon_id = -1; /* set undefined */
+    newpeer->group_number = id_equal(g->real_pk, real_pk) ? (uint16_t)groupnumber : 0xffff;   /* set undefined for other */
+
+    id_copy(newpeer->real_pk, real_pk);
+    id_copy(newpeer->temp_pk, temp_pk);
+
+    if (peer_gid >= 0) {
+        need_send_peers(g);
+        newpeer->gid = peer_gid;
+    } else {
+        newpeer->gid = -1;
     }
 
+    newpeer->last_recv = unix_time();
+
+    g->dirty_list = true;
+
     if (g->peer_on_join) {
-        g->peer_on_join(g->object, groupnumber, g->numpeers - 1);
+        g->peer_on_join(g->object, (int)groupnumber, g->numpeers - 1);
     }
 
     return (g->numpeers - 1);
 }
 
-static int remove_close_conn(Group_Chats *g_c, int groupnumber, int friendcon_id)
+static void free_peer_stuff(Group_Peer *peer)
 {
-    Group_c *g = get_group_c(g_c, groupnumber);
+    free(peer->lossy);
+    peer->lossy = NULL;
 
-    if (!g) {
-        return -1;
-    }
+    free(peer->nick);
+    peer->nick = NULL;
 
-    uint32_t i;
-
-    for (i = 0; i < MAX_GROUP_CONNECTIONS; ++i) {
-        if (g->close[i].type == GROUPCHAT_CLOSE_NONE) {
-            continue;
-        }
-
-        if (g->close[i].number == (unsigned int)friendcon_id) {
-            g->close[i].type = GROUPCHAT_CLOSE_NONE;
-            kill_friend_connection(g_c->fr_c, friendcon_id);
-            return 0;
-        }
-    }
-
-    return -1;
 }
-
 
 /*
  * Delete a peer from the group chat.
@@ -497,7 +873,7 @@ static int remove_close_conn(Group_Chats *g_c, int groupnumber, int friendcon_id
  * return 0 if success
  * return -1 if error.
  */
-static int delpeer(Group_Chats *g_c, int groupnumber, int peer_index, void *userdata)
+static int delpeer(Group_Chats *g_c, aint groupnumber, aint peer_index)
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
@@ -505,106 +881,88 @@ static int delpeer(Group_Chats *g_c, int groupnumber, int peer_index, void *user
         return -1;
     }
 
-    uint32_t i;
+    Group_Peer *peer = g->peers + peer_index;
 
-    for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) { /* If peer is in closest_peers list, remove it. */
-        if (g->closest_peers[i].entry && id_equal(g->closest_peers[i].real_pk, g->group[peer_index].real_pk)) {
-            g->closest_peers[i].entry = 0;
-            g->changed = GROUPCHAT_CLOSEST_REMOVED;
-            break;
-        }
+    if (peer->friendcon_id >= 0) {
+        kill_friend_connection(g_c->fr_c, peer->friendcon_id);
     }
 
-    int friendcon_id = getfriend_conn_id_pk(g_c->fr_c, g->group[peer_index].real_pk);
+    peer->friendcon_id = -2; /* -2 means about to delete */
+    peer->connected = false;
+    peer->group_number = 0xffff;
+    peer->gid = -1;
+    free_peer_stuff(peer);
 
-    if (friendcon_id != -1) {
-        remove_close_conn(g_c, groupnumber, friendcon_id);
-    }
-
-    --g->numpeers;
-
-    void *peer_object = g->group[peer_index].object;
-
-    if (g->numpeers == 0) {
-        free(g->group);
-        g->group = NULL;
-    } else {
-        if (g->numpeers != (uint32_t)peer_index) {
-            memcpy(&g->group[peer_index], &g->group[g->numpeers], sizeof(Group_Peer));
-        }
-
-        Group_Peer *temp = (Group_Peer *)realloc(g->group, sizeof(Group_Peer) * (g->numpeers));
-
-        if (temp == NULL) {
-            return -1;
-        }
-
-        g->group = temp;
-    }
-
-    if (g_c->group_namelistchange) {
-        g_c->group_namelistchange(g_c->m, groupnumber, peer_index, CHAT_CHANGE_PEER_DEL, userdata);
-    }
+    g->dirty_list = true;
 
     if (g->peer_on_leave) {
-        g->peer_on_leave(g->object, groupnumber, peer_index, peer_object);
+        g->peer_on_leave(g->object, (int)groupnumber, peer->object);
     }
+
+    peer->object = NULL;
 
     return 0;
 }
 
+int find_peer_index_in_list(const Group_c *g, aint peer_index)
+{
+    aint index = -1;
+    size_t i;
+
+    for (i = 0; i < g->numpeers_in_list; ++i) {
+        if (g->peers_list[i] == peer_index) {
+            return (int)i;
+        }
+    }
+
+    return -1;
+}
+
 /* Set the nick for a peer.
- *
- * do_gc_callback indicates whether we want to trigger callbacks set by the client
- * via the public API. This should be set to false if this function is called
- * from outside of the tox_iterate() loop.
  *
  * return 0 on success.
  * return -1 if error.
  */
-static int setnick(Group_Chats *g_c, int groupnumber, int peer_index, const uint8_t *nick, uint16_t nick_len,
-                   void *userdata, bool do_gc_callback)
+static aint setnick(Group_c *g, aint peer_index, const uint8_t *nick, aint nick_len)
 {
-    if (nick_len > MAX_NAME_LENGTH) {
+    if (nick_len > MAX_NAME_LENGTH || nick_len == 0) {
         return -1;
     }
 
-    Group_c *g = get_group_c(g_c, groupnumber);
-
-    if (!g) {
-        return -1;
-    }
+    Group_Peer *peer = g->peers + peer_index;
 
     /* same name as already stored? */
-    if (g->group[peer_index].nick_len == nick_len) {
-        if (nick_len == 0 || !memcmp(g->group[peer_index].nick, nick, nick_len)) {
+    if (peer->nick_len == nick_len) {
+        if (nick_len == 0 || !memcmp(peer->nick, nick, nick_len)) {
             return 0;
         }
     }
 
     if (nick_len) {
-        memcpy(g->group[peer_index].nick, nick, nick_len);
+
+        if (nick_len > peer->nick_len) {
+            uint8_t *new_nick = realloc(peer->nick, nick_len + 1);
+
+            if (!new_nick) {
+                return 0;
+            }
+
+            peer->nick = new_nick;
+            peer->nick[nick_len] = 0;
+        }
+
+        memcpy(peer->nick, nick, nick_len);
     }
 
-    g->group[peer_index].nick_len = nick_len;
-
-    if (do_gc_callback && g_c->group_namelistchange) {
-        g_c->group_namelistchange(g_c->m, groupnumber, peer_index, CHAT_CHANGE_PEER_NAME, userdata);
-    }
-
+    peer->nick_len = (uint8_t)nick_len;
+    peer->nick_changed = true;
+    g->nick_changed = true;
     return 0;
 }
 
-static int settitle(Group_Chats *g_c, int groupnumber, int peer_index, const uint8_t *title, uint8_t title_len,
-                    void *userdata)
+static aint settitle(Group_c *g, aint peer_index, const uint8_t *title, aint title_len)
 {
     if (title_len > MAX_NAME_LENGTH || title_len == 0) {
-        return -1;
-    }
-
-    Group_c *g = get_group_c(g_c, groupnumber);
-
-    if (!g) {
         return -1;
     }
 
@@ -614,111 +972,14 @@ static int settitle(Group_Chats *g_c, int groupnumber, int peer_index, const uin
     }
 
     memcpy(g->title, title, title_len);
-    g->title_len = title_len;
+    g->title_len = (uint8_t)title_len;
+    g->title_changed = true;
 
-    if (g_c->title_callback) {
-        g_c->title_callback(g_c->m, groupnumber, peer_index, title, title_len, userdata);
+    if (peer_index >= 0) {
+        g->peers[peer_index].title_changed = true;
     }
 
     return 0;
-}
-
-static void set_conns_type_close(Group_Chats *g_c, int groupnumber, int friendcon_id, uint8_t type)
-{
-    Group_c *g = get_group_c(g_c, groupnumber);
-
-    if (!g) {
-        return;
-    }
-
-    uint32_t i;
-
-    for (i = 0; i < MAX_GROUP_CONNECTIONS; ++i) {
-        if (g->close[i].type == GROUPCHAT_CLOSE_NONE) {
-            continue;
-        }
-
-        if (g->close[i].number != (unsigned int)friendcon_id) {
-            continue;
-        }
-
-        if (type == GROUPCHAT_CLOSE_ONLINE) {
-            send_packet_online(g_c->fr_c, friendcon_id, groupnumber, g->identifier);
-        } else {
-            g->close[i].type = type;
-        }
-    }
-}
-/* Set the type for all close connections with friendcon_id */
-static void set_conns_status_groups(Group_Chats *g_c, int friendcon_id, uint8_t type)
-{
-    uint32_t i;
-
-    for (i = 0; i < g_c->num_chats; ++i) {
-        set_conns_type_close(g_c, i, friendcon_id, type);
-    }
-}
-
-static int handle_status(void *object, int friendcon_id, uint8_t status, void *userdata)
-{
-    Group_Chats *g_c = (Group_Chats *)object;
-
-    if (status) { /* Went online */
-        set_conns_status_groups(g_c, friendcon_id, GROUPCHAT_CLOSE_ONLINE);
-    } else { /* Went offline */
-        set_conns_status_groups(g_c, friendcon_id, GROUPCHAT_CLOSE_CONNECTION);
-        // TODO(irungentoo): remove timedout connections?
-    }
-
-    return 0;
-}
-
-static int handle_packet(void *object, int friendcon_id, const uint8_t *data, uint16_t length, void *userdata);
-static int handle_lossy(void *object, int friendcon_id, const uint8_t *data, uint16_t length, void *userdata);
-
-/* Add friend to group chat.
- *
- * return close index on success
- * return -1 on failure.
- */
-static int add_conn_to_groupchat(Group_Chats *g_c, int friendcon_id, int groupnumber, uint8_t closest, uint8_t lock)
-{
-    Group_c *g = get_group_c(g_c, groupnumber);
-
-    if (!g) {
-        return -1;
-    }
-
-    uint16_t i, ind = MAX_GROUP_CONNECTIONS;
-
-    for (i = 0; i < MAX_GROUP_CONNECTIONS; ++i) {
-        if (g->close[i].type == GROUPCHAT_CLOSE_NONE) {
-            ind = i;
-            continue;
-        }
-
-        if (g->close[i].number == (uint32_t)friendcon_id) {
-            g->close[i].closest = closest;
-            return i; /* Already in list. */
-        }
-    }
-
-    if (ind == MAX_GROUP_CONNECTIONS) {
-        return -1;
-    }
-
-    if (lock) {
-        friend_connection_lock(g_c->fr_c, friendcon_id);
-    }
-
-    g->close[ind].type = GROUPCHAT_CLOSE_CONNECTION;
-    g->close[ind].number = friendcon_id;
-    g->close[ind].closest = closest;
-    // TODO(irungentoo):
-    friend_connection_callbacks(g_c->m->fr_c, friendcon_id, GROUPCHAT_CALLBACK_INDEX, &handle_status, &handle_packet,
-                                &handle_lossy, g_c, friendcon_id);
-
-    return ind;
 }
 
 /* Creates a new groupchat and puts it in the chats array.
@@ -728,40 +989,66 @@ static int add_conn_to_groupchat(Group_Chats *g_c, int friendcon_id, int groupnu
  * return group number on success.
  * return -1 on failure.
  */
-int add_groupchat(Group_Chats *g_c, uint8_t type)
+int add_groupchat(Group_Chats *g_c, uint8_t type, const uint8_t *uid)
 {
-    int groupnumber = create_group_chat(g_c);
+    aint groupnumber = create_group_chat(g_c);
 
     if (groupnumber == -1) {
         return -1;
     }
 
-    Group_c *g = &g_c->chats[groupnumber];
+    Group_c *g = g_c->chats + groupnumber;
 
-    g->status = GROUPCHAT_STATUS_CONNECTED;
-    g->number_joined = -1;
-    new_symmetric_key(g->identifier + 1);
+    g->invite_called = true;
+
+    if (uid != NULL) {
+        memcpy(g->identifier + 1, uid, GROUP_IDENTIFIER_LENGTH - 1);
+    } else {
+        new_symmetric_key(g->identifier + 1);
+    }
+
     g->identifier[0] = type;
-    g->peer_number = 0; /* Founder is peer 0. */
     memcpy(g->real_pk, g_c->m->net_crypto->self_public_key, crypto_box_PUBLICKEYBYTES);
-    int peer_index = addpeer(g_c, groupnumber, g->real_pk, g_c->m->dht->self_public_key, 0, NULL, false);
+    aint peer_index = addpeer(g, groupnumber, g->real_pk, g_c->m->dht->self_public_key, -1);
 
     if (peer_index == -1) {
         return -1;
     }
 
-    setnick(g_c, groupnumber, peer_index, g_c->m->name, g_c->m->name_length, NULL, false);
+    g->peers[peer_index].group_number = (uint16_t)groupnumber;
 
-    return groupnumber;
+    setnick(g, peer_index, g_c->m->name, g_c->m->name_length);
+
+    return (int)groupnumber;
 }
 
-static int group_kill_peer_send(const Group_Chats *g_c, int groupnumber, uint16_t peer_num);
-/* Delete a groupchat from the chats array.
- *
- * return 0 on success.
- * return -1 if groupnumber is invalid.
- */
-int del_groupchat(Group_Chats *g_c, int groupnumber)
+static Group_c *group_kill_peer_send(const Group_Chats *g_c, aint groupnumber);
+
+static void on_offline(Group_c *g)
+{
+    g->join_mode = true;
+    g->fake_join = false;
+    g->auto_join = false;
+    g->need_send_name = false;
+    g->title_changed = false;
+    g->invite_called = false;
+    g->keep_leave = false;
+    g->disable_auto_join = false;
+
+    g->keep_join_index = -1;
+    size_t i;
+
+    for (i = 0; i < g->numjoinpeers; ++i) {
+
+        Group_Join_Peer *j = g->joinpeers + i;
+        j->unsubscribed = false;
+        j->online = false;
+        j->fails = 0;
+        j->joingn = -1;
+    }
+}
+
+int enter_conference(Group_Chats *g_c, int groupnumber)
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
@@ -769,32 +1056,140 @@ int del_groupchat(Group_Chats *g_c, int groupnumber)
         return -1;
     }
 
-    group_kill_peer_send(g_c, groupnumber, g->peer_number);
+    if (!g->disable_auto_join) {
+        return -2;
+    }
 
-    unsigned int i;
+    on_offline(g);
+    return 0;
+}
 
-    for (i = 0; i < MAX_GROUP_CONNECTIONS; ++i) {
-        if (g->close[i].type == GROUPCHAT_CLOSE_NONE) {
+static int conference_unsubscribe(const Group_Chats *g_c, aint groupnumber, Unsubscribe u);
+
+static Group_c *disconnect_conference(const Group_Chats *g_c, aint groupnumber, Unsubscribe u)
+{
+    if (u) {
+        conference_unsubscribe(g_c, groupnumber, u);
+    }
+
+    Group_c *g = group_kill_peer_send(g_c, groupnumber);
+
+    if (!g) {
+        return NULL;
+    }
+
+    size_t i;
+
+    memset(g->closest_peers, 0, sizeof(g->closest_peers));
+    g->closest_peers_entry = 0;
+
+    g->invite_called = false;
+
+    g->message_number = 0;
+    g->lossy_message_number = 0;
+    g->keep_join_index = -1;
+
+    for (i = 0; i < g->numpeers; ++i) {
+
+        Group_Peer *peer = g->peers + i;
+
+        if (peer->friendcon_id == -2) {
             continue;
         }
 
-        g->close[i].type = GROUPCHAT_CLOSE_NONE;
-        kill_friend_connection(g_c->fr_c, g->close[i].number);
+        if (peer->friendcon_id >= 0) {
+            kill_friend_connection(g_c->fr_c, peer->friendcon_id);
+        }
+
+        if (g->peer_on_leave) {
+            g->peer_on_leave(g->object, (int)groupnumber, peer->object);
+        }
+
+        free_peer_stuff(peer);
     }
 
-    for (i = 0; i < g->numpeers; ++i) {
-        if (g->peer_on_leave) {
-            g->peer_on_leave(g->object, groupnumber, i, g->group[i].object);
+    free(g->peers);
+    g->numpeers = 0;
+    g->peers = NULL;
+    free(g->peers_list);
+    g->numpeers_in_list = 0;
+    g->peers_list = NULL;
+
+    if (g->group_on_delete) {
+        g->group_on_delete(g->object, (int)groupnumber);
+    }
+
+    g->object = NULL;
+    g->peer_on_leave = NULL;
+    g->peer_on_join = NULL;
+    g->group_on_delete = NULL;
+
+    return g;
+}
+
+int leave_conference(Group_Chats *g_c, int groupnumber, bool keep_leave)
+{
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (!g) {
+        return -1;
+    }
+
+    g->keep_leave = keep_leave;
+
+    if (g->disable_auto_join) {
+        return -2;
+    }
+
+    disconnect_conference(g_c, groupnumber, UNS_TEMP);
+
+    g->dirty_list = true;
+    g->disable_auto_join = true;
+    g->keep_leave = keep_leave;
+    g->join_mode = false;
+    g->fake_join = false;
+    g->auto_join = false;
+    g->need_send_name = false;
+    g->title_changed = false;
+    g->invite_called = false;
+
+    return 0;
+}
+
+/* Delete a groupchat from the chats array.
+ *
+ * return 0 on success.
+ * return -1 if groupnumber is invalid.
+ */
+static int del_groupchat_internal(Group_Chats *g_c, aint groupnumber, Unsubscribe uns)
+{
+    Group_c *g = disconnect_conference(g_c, groupnumber, uns);
+
+    if (!g) {
+        return -1;
+    }
+
+    free(g->joinpeers);
+
+    sodium_memzero(g_c->chats + groupnumber, sizeof(Group_c));
+
+    size_t i;
+
+    for (i = groupnumber + 1; i < g_c->num_chats; ++i) {
+        if (g_c->chats[i].live) {
+            return 0;
         }
     }
 
-    free(g->group);
+    g_c->num_chats = (uint16_t)groupnumber;
+    realloc_groupchats(g_c, groupnumber);
 
-    if (g->group_on_delete) {
-        g->group_on_delete(g->object, groupnumber);
-    }
+    return 0;
+}
 
-    return wipe_group_chat(g_c, groupnumber);
+int del_groupchat(Group_Chats *g_c, int groupnumber)
+{
+    return del_groupchat_internal(g_c, groupnumber, UNS_FOREVER);
 }
 
 /* Copy the public key of peernumber who is in groupnumber to pk.
@@ -812,11 +1207,15 @@ int group_peer_pubkey(const Group_Chats *g_c, int groupnumber, int peernumber, u
         return -1;
     }
 
-    if ((uint32_t)peernumber >= g->numpeers) {
+    if (peernumber < 0 || (uint32_t)peernumber >= g->numpeers_in_list) {
         return -2;
     }
 
-    memcpy(pk, g->group[peernumber].real_pk, crypto_box_PUBLICKEYBYTES);
+    if (g->peers_list[peernumber] == 0xffff) {
+        return -2;
+    }
+
+    memcpy(pk, g->peers[g->peers_list[peernumber]].real_pk, crypto_box_PUBLICKEYBYTES);
     return 0;
 }
 
@@ -834,15 +1233,21 @@ int group_peername_size(const Group_Chats *g_c, int groupnumber, int peernumber)
         return -1;
     }
 
-    if ((uint32_t)peernumber >= g->numpeers) {
+    if (peernumber < 0 || (uint32_t)peernumber >= g->numpeers_in_list) {
         return -2;
     }
 
-    if (g->group[peernumber].nick_len == 0) {
+    if (g->peers_list[peernumber] == 0xffff) {
+        return -2;
+    }
+
+    const Group_Peer *peer = g->peers + g->peers_list[peernumber];
+
+    if (peer->nick_len == 0) {
         return 8;
     }
 
-    return g->group[peernumber].nick_len;
+    return peer->nick_len;
 }
 
 /* Copy the name of peernumber who is in groupnumber to name.
@@ -860,17 +1265,25 @@ int group_peername(const Group_Chats *g_c, int groupnumber, int peernumber, uint
         return -1;
     }
 
-    if ((uint32_t)peernumber >= g->numpeers) {
+    if (peernumber < 0 || (uint32_t)peernumber >= g->numpeers_in_list) {
         return -2;
     }
 
-    if (g->group[peernumber].nick_len == 0) {
+    if (g->peers_list[peernumber] == 0xffff) {
+        return -2;
+    }
+
+    Group_Peer *peer = g->peers + g->peers_list[peernumber];
+
+    peer->nick_changed = false;
+
+    if (peer->nick_len == 0) {
         memcpy(name, "Tox User", 8);
         return 8;
     }
 
-    memcpy(name, g->group[peernumber].nick, g->group[peernumber].nick_len);
-    return g->group[peernumber].nick_len;
+    memcpy(name, peer->nick, peer->nick_len);
+    return peer->nick_len;
 }
 
 /* List all the peers in the group chat.
@@ -892,10 +1305,17 @@ int group_names(const Group_Chats *g_c, int groupnumber, uint8_t names[][MAX_NAM
         return -1;
     }
 
-    unsigned int i;
+    unsigned i;
 
-    for (i = 0; i < g->numpeers && i < length; ++i) {
-        lengths[i] = group_peername(g_c, groupnumber, i, names[i]);
+    for (i = 0; i < g->numpeers_in_list && i < length; ++i) {
+        int l = group_peername(g_c, groupnumber, i, names[i]);
+
+        if (l >= 0) {
+            lengths[i] = l;
+        } else {
+            lengths[i] = 0;
+            names[i][0] = 0;
+        }
     }
 
     return i;
@@ -912,7 +1332,7 @@ int group_number_peers(const Group_Chats *g_c, int groupnumber)
         return -1;
     }
 
-    return g->numpeers;
+    return g->numpeers_in_list;
 }
 
 /* return 1 if the peernumber corresponds to ours.
@@ -921,7 +1341,7 @@ int group_number_peers(const Group_Chats *g_c, int groupnumber)
  * return -2 if peernumber is invalid.
  * return -3 if we are not connected to the group chat.
  */
-int group_peernumber_is_ours(const Group_Chats *g_c, int groupnumber, int peernumber)
+int group_peernumber_is_ours(const Group_Chats *g_c, int groupnumber, int peer_index)
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
@@ -929,15 +1349,16 @@ int group_peernumber_is_ours(const Group_Chats *g_c, int groupnumber, int peernu
         return -1;
     }
 
-    if ((uint32_t)peernumber >= g->numpeers) {
+    if ((unsigned)peer_index >= g->numpeers_in_list) {
         return -2;
     }
 
-    if (g->status != GROUPCHAT_STATUS_CONNECTED) {
+    if (!g->live) {
         return -3;
     }
 
-    return g->peer_number == g->group[peernumber].peer_number;
+    const Group_Peer *peer = g->peers + g->peers_list[peer_index];
+    return id_equal(g->real_pk, peer->real_pk);
 }
 
 /* return the type of groupchat (GROUPCHAT_TYPE_) that groupnumber is.
@@ -956,25 +1377,44 @@ int group_get_type(const Group_Chats *g_c, int groupnumber)
     return g->identifier[0];
 }
 
+/* return the unique id of group chat that groupnumber is.
+*
+* return -1 on failure.
+* return type on success.
+*/
+int conference_get_id(const Group_Chats *g_c, int groupnumber, uint8_t *uid)
+{
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (!g) {
+        return -1;
+    }
+
+    memcpy(uid, g->identifier + 1, sizeof(g->identifier) - 1);
+    return 0;
+}
+
 /* Send a group packet to friendcon_id.
  *
  *  return 1 on success
  *  return 0 on failure
  */
-static unsigned int send_packet_group_peer(Friend_Connections *fr_c, int friendcon_id, uint8_t packet_id,
-        uint16_t group_num, const uint8_t *data, uint16_t length)
+static bool send_packet_group_peer(Friend_Connections *fr_c, aint friendcon_id, uint8_t packet_id,
+                                   uint16_t other_group_num, const uint8_t *data, aint length)
 {
-    if (1 + sizeof(uint16_t) + length > MAX_CRYPTO_DATA_SIZE) {
-        return 0;
+    size_t plen = 1 + sizeof(uint16_t) + length;
+
+    if (plen > MAX_CRYPTO_DATA_SIZE) {
+        return false;
     }
 
-    group_num = htons(group_num);
-    uint8_t packet[1 + sizeof(uint16_t) + length];
+    other_group_num = htons(other_group_num);
+    uint8_t  packet[MAX_CRYPTO_DATA_SIZE];
     packet[0] = packet_id;
-    memcpy(packet + 1, &group_num, sizeof(uint16_t));
+    memcpy(packet + 1, &other_group_num, sizeof(uint16_t));
     memcpy(packet + 1 + sizeof(uint16_t), data, length);
-    return write_cryptpacket(fr_c->net_crypto, friend_connection_crypt_connection_id(fr_c, friendcon_id), packet,
-                             sizeof(packet), 0) != -1;
+    return write_cryptpacket(fr_c->net_crypto, friend_connection_crypt_connection_id(fr_c, (int)friendcon_id), packet,
+                             (uint16_t)plen, 0) != -1;
 }
 
 /* Send a group lossy packet to friendcon_id.
@@ -982,27 +1422,23 @@ static unsigned int send_packet_group_peer(Friend_Connections *fr_c, int friendc
  *  return 1 on success
  *  return 0 on failure
  */
-static unsigned int send_lossy_group_peer(Friend_Connections *fr_c, int friendcon_id, uint8_t packet_id,
-        uint16_t group_num, const uint8_t *data, uint16_t length)
+static bool send_lossy_group_peer(Friend_Connections *fr_c, aint friendcon_id, uint8_t packet_id,
+                                  uint16_t group_num, const uint8_t *data, aint length)
 {
-    if (1 + sizeof(uint16_t) + length > MAX_CRYPTO_DATA_SIZE) {
-        return 0;
+    size_t plen = 1 + sizeof(uint16_t) + length;
+
+    if (plen > MAX_CRYPTO_DATA_SIZE) {
+        return false;
     }
 
     group_num = htons(group_num);
-    uint8_t packet[1 + sizeof(uint16_t) + length];
+    uint8_t packet[MAX_CRYPTO_DATA_SIZE];
     packet[0] = packet_id;
     memcpy(packet + 1, &group_num, sizeof(uint16_t));
     memcpy(packet + 1 + sizeof(uint16_t), data, length);
-    return send_lossy_cryptpacket(fr_c->net_crypto, friend_connection_crypt_connection_id(fr_c, friendcon_id), packet,
-                                  sizeof(packet)) != -1;
+    return send_lossy_cryptpacket(fr_c->net_crypto, friend_connection_crypt_connection_id(fr_c, (int)friendcon_id), packet,
+                                  (uint16_t)plen) != -1;
 }
-
-#define INVITE_PACKET_SIZE (1 + sizeof(uint16_t) + GROUP_IDENTIFIER_LENGTH)
-#define INVITE_ID 0
-
-#define INVITE_RESPONSE_PACKET_SIZE (1 + sizeof(uint16_t) * 2 + GROUP_IDENTIFIER_LENGTH)
-#define INVITE_RESPONSE_ID 1
 
 /* invite friendnumber to groupnumber.
  *
@@ -1028,11 +1464,13 @@ int invite_friend(Group_Chats *g_c, int32_t friendnumber, int groupnumber)
         return 0;
     }
 
-    wipe_group_chat(g_c, groupnumber);
     return -2;
 }
 
-static unsigned int send_peer_query(Group_Chats *g_c, int friendcon_id, uint16_t group_num);
+static aint send_message_group(const Group_Chats *g_c, aint groupnumber, uint8_t message_id, const uint8_t *data,
+                               aint len);
+
+static void send_peer_query(const Group_Chats *g_c, aint friendcon_id, uint16_t other_group_num);
 
 /* Join a group (you need to have been invited first.)
  *
@@ -1048,6 +1486,20 @@ static unsigned int send_peer_query(Group_Chats *g_c, int friendcon_id, uint16_t
  */
 int join_groupchat(Group_Chats *g_c, int32_t friendnumber, uint8_t expected_type, const uint8_t *data, uint16_t length)
 {
+    if (length == GROUP_IDENTIFIER_LENGTH - 1) {
+
+        int groupnumber = conference_by_uid(g_c, data);
+
+        if (groupnumber != -1) {
+            Group_c *g = g_c->chats + groupnumber;
+            g->invite_called |= g->fake_join;
+            return groupnumber;
+        }
+
+        /* create groupchat with exist id */
+        return add_groupchat(g_c, expected_type, data);
+    }
+
     if (length != sizeof(uint16_t) + GROUP_IDENTIFIER_LENGTH) {
         return -1;
     }
@@ -1056,52 +1508,100 @@ int join_groupchat(Group_Chats *g_c, int32_t friendnumber, uint8_t expected_type
         return -2;
     }
 
+    bool just_created = false;
+    aint groupnumber = get_group_num(g_c, data + sizeof(uint16_t));
+
+    if (groupnumber == -1) {
+        groupnumber = create_group_chat(g_c);
+        just_created = true;
+    }
+
+    if (groupnumber == -1) {
+        return -5;
+    }
+
+    Group_c *g = g_c->chats + groupnumber;
+
+    if (g->fake_join) {
+        g->need_send_name = true;
+        g->invite_called = true;
+        return (int)groupnumber;
+    }
+
     int friendcon_id = getfriendcon_id(g_c->m, friendnumber);
 
     if (friendcon_id == -1) {
         return -3;
     }
 
-    if (get_group_num(g_c, data + sizeof(uint16_t)) != -1) {
-        return -4;
-    }
-
-    int groupnumber = create_group_chat(g_c);
-
-    if (groupnumber == -1) {
-        return -5;
-    }
-
-    Group_c *g = &g_c->chats[groupnumber];
-
-    uint16_t group_num = htons(groupnumber);
-    g->status = GROUPCHAT_STATUS_VALID;
-    g->number_joined = -1;
     memcpy(g->real_pk, g_c->m->net_crypto->self_public_key, crypto_box_PUBLICKEYBYTES);
+
+    g->dirty_list = true;
+    g->need_send_name = true;
+
+    aint peer_index = addpeer(g, groupnumber, g->real_pk, g_c->m->dht->self_public_key,
+                              g->auto_join ? get_self_peer_gid(g) : -1);
+
+    if (peer_index != -1) {
+        setnick(g, peer_index, g_c->m->name, g_c->m->name_length);
+        g->peers[peer_index].group_number = (uint16_t)groupnumber;
+    }
 
     uint8_t response[INVITE_RESPONSE_PACKET_SIZE];
     response[0] = INVITE_RESPONSE_ID;
+    uint16_t group_num = htons((uint16_t)groupnumber);
     memcpy(response + 1, &group_num, sizeof(uint16_t));
     memcpy(response + 1 + sizeof(uint16_t), data, sizeof(uint16_t) + GROUP_IDENTIFIER_LENGTH);
 
     if (send_conference_invite_packet(g_c->m, friendnumber, response, sizeof(response))) {
-        uint16_t other_groupnum;
+
+        if (just_created) {
+            memcpy(g->identifier, data + sizeof(uint16_t), GROUP_IDENTIFIER_LENGTH);
+            g->invite_called = true; /* just created means client called join_groupchat */
+        }
+
+        uint16_t other_groupnum = 0;
         memcpy(&other_groupnum, data, sizeof(other_groupnum));
         other_groupnum = ntohs(other_groupnum);
-        memcpy(g->identifier, data + sizeof(uint16_t), GROUP_IDENTIFIER_LENGTH);
-        int close_index = add_conn_to_groupchat(g_c, friendcon_id, groupnumber, 0, 1);
 
-        if (close_index != -1) {
-            g->close[close_index].group_number = other_groupnum;
-            g->close[close_index].type = GROUPCHAT_CLOSE_ONLINE;
-            g->number_joined = friendcon_id;
+        uint8_t real_pk[crypto_box_PUBLICKEYBYTES], temp_pk[crypto_box_PUBLICKEYBYTES];
+        get_friendcon_public_keys(real_pk, temp_pk, g_c->fr_c, friendcon_id);
+        peer_index = addpeer(g, groupnumber, real_pk, temp_pk, -1);
+
+        if (g->peers[peer_index].friendcon_id != friendcon_id) {
+            if (g->peers[peer_index].friendcon_id >= 0) {
+                kill_friend_connection(g_c->fr_c, g->peers[peer_index].friendcon_id);
+                g->peers[peer_index].friendcon_id = -1;
+                g->peers[peer_index].connected = false;
+            }
+        }
+
+        if (g->auto_join) {
+
+            g->peers[peer_index].auto_join = true;
+            friend_connection_callbacks(g_c->m->fr_c, friendcon_id, GROUPCHAT_CALLBACK_INDEX, &handle_status, &handle_packet,
+                                        &handle_lossy, g_c, friendcon_id);
+
+            if (g->peers[peer_index].friendcon_id < 0) {
+                g->peers[peer_index].friendcon_id = friendcon_id;
+                g->peers[peer_index].connected = true;
+                friend_connection_lock(g_c->fr_c, friendcon_id);
+            }
+
+            g->peers[peer_index].group_number = 0xffff;
+            g->peers[peer_index].keep_connection = 2;
+        } else {
+            g->peers[peer_index].group_number = other_groupnum;
         }
 
         send_peer_query(g_c, friendcon_id, other_groupnum);
-        return groupnumber;
+        return (int)groupnumber;
     }
 
-    g->status = GROUPCHAT_STATUS_NONE;
+    if (just_created) {
+        g->live = false;
+    }
+
     return -6;
 }
 
@@ -1114,7 +1614,13 @@ int join_groupchat(Group_Chats *g_c, int32_t friendnumber, uint8_t expected_type
 void group_lossy_packet_registerhandler(Group_Chats *g_c, uint8_t byte, int (*function)(void *, int, int, void *,
                                         const uint8_t *, uint16_t))
 {
-    g_c->lossy_packethandlers[byte].function = function;
+    /* g_c->lossy_packethandlers[byte].function = function; */
+
+    if (192 /* GROUP_AUDIO_PACKET_ID */ == byte) {
+        g_c->lossy_packethandler = function;
+    }
+
+
 }
 
 /* Set the callback for group invites.
@@ -1175,7 +1681,16 @@ int callback_groupchat_peer_new(const Group_Chats *g_c, int groupnumber, void (*
         return -1;
     }
 
-    g->peer_on_join = function;
+    if (g->peer_on_join != function) {
+        g->peer_on_join = function;
+
+        size_t i;
+
+        for (i = 0; i < g->numpeers; ++i) {
+            g->peer_on_join(g->object, groupnumber, (int)i);
+        }
+    }
+
     return 0;
 }
 
@@ -1186,7 +1701,7 @@ int callback_groupchat_peer_new(const Group_Chats *g_c, int groupnumber, void (*
  * return 0 on success.
  * return -1 on failure.
  */
-int callback_groupchat_peer_delete(Group_Chats *g_c, int groupnumber, void (*function)(void *, int, int, void *))
+int callback_groupchat_peer_delete(Group_Chats *g_c, int groupnumber, void (*function)(void *, int, void *))
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
@@ -1217,10 +1732,6 @@ int callback_groupchat_delete(Group_Chats *g_c, int groupnumber, void (*function
     return 0;
 }
 
-static int send_message_group(const Group_Chats *g_c, int groupnumber, uint8_t message_id, const uint8_t *data,
-                              uint16_t len);
-
-#define GROUP_MESSAGE_PING_ID 0
 static int group_ping_send(const Group_Chats *g_c, int groupnumber)
 {
     if (send_message_group(g_c, groupnumber, GROUP_MESSAGE_PING_ID, 0, 0) > 0) {
@@ -1230,70 +1741,174 @@ static int group_ping_send(const Group_Chats *g_c, int groupnumber)
     return -1;
 }
 
-#define GROUP_MESSAGE_NEW_PEER_ID 16
-#define GROUP_MESSAGE_NEW_PEER_LENGTH (sizeof(uint16_t) + crypto_box_PUBLICKEYBYTES * 2)
+static int get_self_peer_gid(Group_c *g)
+{
+    size_t i;
+
+    for (i = 0; i < g->numpeers; ++i) {
+        if (id_equal(g->real_pk, g->peers[i].real_pk)) {
+            return g->peers[i].gid;
+        }
+    }
+
+    return -1;
+}
+
+static void change_self_peer_gid(Group_Chats *g_c, aint groupnumber, int self_peer_gid)
+{
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (!g) {
+        return;
+    }
+
+    size_t i;
+
+    for (i = 0; i < g->numpeers; ++i) {
+        if (id_equal(g->peers[i].real_pk, g->real_pk)) {
+
+            if (g->peers[i].gid != self_peer_gid) {
+                g->dirty_list = true;
+                g->peers[i].gid = self_peer_gid;
+            }
+
+            return;
+        }
+    }
+
+    /* no self peer found! Add it */
+
+    aint peer_index = addpeer(g, groupnumber, g->real_pk, g_c->m->dht->self_public_key, self_peer_gid);
+
+    if (peer_index == -1) {
+        return;
+    }
+
+    setnick(g, peer_index, g_c->m->name, g_c->m->name_length);
+}
+
 /* send a new_peer message
  * return 0 on success
  * return -1 on failure
  */
-static int group_new_peer_send(const Group_Chats *g_c, int groupnumber, uint16_t peer_num, const uint8_t *real_pk,
+static int group_new_peer_send(Group_Chats *g_c, aint groupnumber, uint16_t peer_gid, const uint8_t *real_pk,
                                uint8_t *temp_pk)
 {
-    uint8_t packet[GROUP_MESSAGE_NEW_PEER_LENGTH];
 
-    peer_num = htons(peer_num);
-    memcpy(packet, &peer_num, sizeof(uint16_t));
+    uint8_t packet[GROUP_MESSAGE_NEW_PEER_LENGTH];
+    peer_gid = htons(peer_gid);
+    memcpy(packet, &peer_gid, sizeof(uint16_t));
     memcpy(packet + sizeof(uint16_t), real_pk, crypto_box_PUBLICKEYBYTES);
     memcpy(packet + sizeof(uint16_t) + crypto_box_PUBLICKEYBYTES, temp_pk, crypto_box_PUBLICKEYBYTES);
 
-    if (send_message_group(g_c, groupnumber, GROUP_MESSAGE_NEW_PEER_ID, packet, sizeof(packet)) > 0) {
+    /* make self gid valid due self is inviter */
+    Group_c *g = g_c->chats + groupnumber;
+
+    if (get_self_peer_gid(g) < 0) {
+        change_self_peer_gid(g_c, groupnumber, find_new_peer_gid(g));
+    }
+
+    if (send_message_group(g_c, groupnumber, GROUP_MESSAGE_NEW_PEER_ID, packet, GROUP_MESSAGE_NEW_PEER_LENGTH) > 0) {
         return 0;
     }
 
     return -1;
 }
 
-#define GROUP_MESSAGE_KILL_PEER_ID 17
-#define GROUP_MESSAGE_KILL_PEER_LENGTH (sizeof(uint16_t))
-
-/* send a kill_peer message
- * return 0 on success
- * return -1 on failure
- */
-static int group_kill_peer_send(const Group_Chats *g_c, int groupnumber, uint16_t peer_num)
+static int conference_unsubscribe(const Group_Chats *g_c, aint groupnumber, Unsubscribe u)
 {
-    uint8_t packet[GROUP_MESSAGE_KILL_PEER_LENGTH];
+    Group_c *g = get_group_c(g_c, groupnumber);
 
-    peer_num = htons(peer_num);
-    memcpy(packet, &peer_num, sizeof(uint16_t));
-
-    if (send_message_group(g_c, groupnumber, GROUP_MESSAGE_KILL_PEER_ID, packet, sizeof(packet)) > 0) {
-        return 0;
-    }
-
-    return -1;
-}
-
-#define GROUP_MESSAGE_NAME_ID 48
-
-/* send a name message
- * return 0 on success
- * return -1 on failure
- */
-static int group_name_send(const Group_Chats *g_c, int groupnumber, const uint8_t *nick, uint16_t nick_len)
-{
-    if (nick_len > MAX_NAME_LENGTH) {
+    if (!g) {
         return -1;
     }
 
-    if (send_message_group(g_c, groupnumber, GROUP_MESSAGE_NAME_ID, nick, nick_len) > 0) {
+    uint8_t packet[GROUP_IDENTIFIER_LENGTH + crypto_box_PUBLICKEYBYTES];
+    packet[0] = (uint8_t)u;
+    memcpy(packet + 1, g->identifier + 1, GROUP_IDENTIFIER_LENGTH - 1);
+    memcpy(packet + GROUP_IDENTIFIER_LENGTH, g->real_pk, crypto_box_PUBLICKEYBYTES);
+
+    if (send_message_group(g_c, groupnumber, GROUP_MESSAGE_UNSUBSCRIBE, packet, sizeof(packet)) > 0) {
         return 0;
     }
 
     return -1;
 }
 
-#define GROUP_MESSAGE_TITLE_ID 49
+
+static void send_peer_nums(const Group_Chats *g_c, aint groupnumber, aint friendcon_id, uint16_t other_group_num)
+{
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (!g) {
+        return;
+    }
+
+    uint8_t packet[MAX_CRYPTO_DATA_SIZE - (1 + sizeof(uint16_t))];
+    packet[0] = PEER_GROUP_NUM_ID;
+    size_t ptr = 1, i;
+
+    for (i = 0; i < g->numpeers; ++i) {
+
+        Group_Peer *peer = g->peers + i;
+
+        if (peer->group_number == 0xffff) {
+            continue;
+        }
+
+        if (ptr + crypto_box_PUBLICKEYBYTES + sizeof(uint16_t) > sizeof(packet)) {
+            send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, other_group_num, packet, ptr);
+            ptr = 1;
+        }
+
+        memcpy(packet + ptr, peer->real_pk, crypto_box_PUBLICKEYBYTES);
+        ptr += crypto_box_PUBLICKEYBYTES;
+        *(uint16_t *)(packet + ptr) = htons(peer->group_number);
+        ptr += sizeof(uint16_t);
+    }
+
+    if (ptr > 1) {
+        send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, other_group_num, packet, ptr);
+    }
+}
+
+static Group_c *group_kill_peer_send(const Group_Chats *g_c, aint groupnumber)
+{
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (g) {
+
+        uint8_t packet[GROUP_MESSAGE_KILL_PEER_LENGTH];
+
+        int self_gid = get_self_peer_gid(g);
+
+        if (self_gid < 0) {
+            return g;
+        }
+
+        uint16_t peer_gid = htons((uint16_t)self_gid);
+        memcpy(packet, &peer_gid, sizeof(uint16_t));
+        send_message_group(g_c, groupnumber, GROUP_MESSAGE_KILL_PEER_ID, packet, sizeof(packet));
+    }
+
+    return g;
+}
+
+static void group_name_send(const Group_Chats *g_c, aint groupnumber, const uint8_t *nick, aint nick_len)
+{
+    if (nick_len > MAX_NAME_LENGTH) {
+        return;
+    }
+
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (!g) {
+        return;
+    }
+
+    g->need_send_name = false;
+    send_message_group(g_c, groupnumber, GROUP_MESSAGE_NAME_ID, nick, nick_len);
+}
 
 /* set the group's title, limited to MAX_NAME_LENGTH
  * return 0 on success
@@ -1374,6 +1989,60 @@ int group_title_get(const Group_Chats *g_c, int groupnumber, uint8_t *title)
     return g->title_len;
 }
 
+static void unsubscribe_peer(Group_Chats *g_c, const uint8_t *conf_id, const uint8_t *peer_pk, Unsubscribe u)
+{
+    Group_c *g = get_group_c(g_c, conference_by_uid(g_c, conf_id));
+
+    if (g != NULL) {
+
+        size_t i;
+
+        for (i = 0; i < g->numjoinpeers; ++i) {
+            Group_Join_Peer *jp = g->joinpeers + i;
+
+            if (id_equal(jp->real_pk, peer_pk)) {
+
+                if (UNS_FOREVER == u) {
+                    --g->numjoinpeers;
+
+                    if (g->numjoinpeers > 0) {
+                        memcpy(jp, g->joinpeers + g->numjoinpeers, sizeof(Group_Join_Peer));
+
+                    } else {
+                        free(g->joinpeers);
+                        g->joinpeers = NULL;
+                    }
+                } else if (UNS_TEMP == u) {
+                    jp->unsubscribed = true;
+                }
+
+                break;
+            }
+        }
+    }
+}
+
+static void set_peer_groupnum(Group_c *g, const uint8_t *peer_pk, uint16_t gn)
+{
+    if (id_equal(g->real_pk, peer_pk)) {
+        /* ignore */
+        return;
+    }
+
+    aint i = peer_in_chat(g, peer_pk);
+
+    if (i >= 0) {
+
+        Group_Peer *peer = g->peers + i;
+
+        if (peer->group_number == 0xffff) {
+            peer->group_number = gn;
+        }
+
+    }
+}
+
+
 static void handle_friend_invite_packet(Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length,
                                         void *userdata)
 {
@@ -1388,73 +2057,129 @@ static void handle_friend_invite_packet(Messenger *m, uint32_t friendnumber, con
 
     switch (data[0]) {
         case INVITE_ID: {
-            if (length != INVITE_PACKET_SIZE) {
+
+            if (length < INVITE_PACKET_SIZE) {
                 return;
             }
 
-            int groupnumber = get_group_num(g_c, data + 1 + sizeof(uint16_t));
+            aint groupnumber = get_group_num(g_c, data + 1 + sizeof(uint16_t));
 
             if (groupnumber == -1) {
+
                 if (g_c->invite_callback) {
                     g_c->invite_callback(m, friendnumber, *(invite_data + sizeof(uint16_t)), invite_data, invite_length, userdata);
                 }
 
-                return;
+            } else {
+
+                Group_c *g = get_group_c(g_c, groupnumber);
+
+                if (g->keep_leave) {
+                    return;
+                }
+
+                g->join_mode = false;
+                g->disable_auto_join = false;
+                g->invite_called = false;
+                join_groupchat(g_c, friendnumber, *(invite_data + sizeof(uint16_t)), invite_data, invite_length);
             }
 
-            break;
+            return;
         }
 
         case INVITE_RESPONSE_ID: {
+
             if (length != INVITE_RESPONSE_PACKET_SIZE) {
                 return;
             }
 
-            uint16_t other_groupnum, groupnum;
-            memcpy(&groupnum, data + 1 + sizeof(uint16_t), sizeof(uint16_t));
-            groupnum = ntohs(groupnum);
+            uint16_t groupnum_in;
 
-            Group_c *g = get_group_c(g_c, groupnum);
+            memcpy(&groupnum_in, data + 1 + sizeof(uint16_t), sizeof(uint16_t));
+            groupnum_in = ntohs(groupnum_in);
+
+            const uint8_t *conference_id = data + 2 + sizeof(uint16_t) * 2;
+
+            /* we absolutely do not care about groupnumber in packet
+             * but, in case groupnum_in != groupnumber,
+             * we should send INVITE_ID packet back to peer with correct groupnumber */
+
+            int groupnumber = get_group_num(g_c, data + 1 + sizeof(uint16_t) * 2);
+            Group_c *g = get_group_c(g_c, groupnumber);
 
             if (!g) {
+
+                uint8_t nosuchgroup[GROUP_IDENTIFIER_LENGTH + crypto_box_PUBLICKEYBYTES];
+                nosuchgroup[0] = INVITE_UNSUBSCRIBE_ID;
+                memcpy(nosuchgroup + 1, conference_id, GROUP_IDENTIFIER_LENGTH - 1);
+                memcpy(nosuchgroup + GROUP_IDENTIFIER_LENGTH, g_c->m->net_crypto->self_public_key, crypto_box_PUBLICKEYBYTES);
+                send_conference_invite_packet(g_c->m, friendnumber, nosuchgroup, sizeof(nosuchgroup));
                 return;
             }
 
-            if (sodium_memcmp(data + 1 + sizeof(uint16_t) * 2, g->identifier, GROUP_IDENTIFIER_LENGTH) != 0) {
+            if (g->numpeers >= 65534 || g->keep_leave) {
                 return;
             }
 
-            /* TODO(irungentoo): what if two people enter the group at the same time and
-               are given the same peer_number by different nodes? */
-            uint16_t peer_number = rand();
+            if (groupnumber != groupnum_in) {
 
-            unsigned int tries = 0;
+                /* send INVITE_ID to restore valid groupnum
+                 * old toxcore will ignore this packet,
+                 */
 
-            while (get_peer_index(g, peer_number) != -1) {
-                peer_number = rand();
-                ++tries;
+                uint8_t invite[INVITE_PACKET_SIZE];
+                invite[0] = INVITE_ID;
+                uint16_t groupchat_num = htons((uint16_t)groupnumber);
+                memcpy(invite + 1, &groupchat_num, sizeof(groupchat_num));
+                memcpy(invite + 1 + sizeof(groupchat_num), g->identifier, GROUP_IDENTIFIER_LENGTH);
 
-                if (tries > 32) {
-                    return;
-                }
+                send_conference_invite_packet(g_c->m, friendnumber, invite, sizeof(invite));
+                return;
             }
 
-            memcpy(&other_groupnum, data + 1, sizeof(uint16_t));
-            other_groupnum = ntohs(other_groupnum);
 
             int friendcon_id = getfriendcon_id(m, friendnumber);
             uint8_t real_pk[crypto_box_PUBLICKEYBYTES], temp_pk[crypto_box_PUBLICKEYBYTES];
             get_friendcon_public_keys(real_pk, temp_pk, g_c->fr_c, friendcon_id);
 
-            addpeer(g_c, groupnum, real_pk, temp_pk, peer_number, userdata, true);
-            int close_index = add_conn_to_groupchat(g_c, friendcon_id, groupnum, 0, 1);
+            /* peer_gid collision will be resolved */
+            uint16_t peer_gid = find_new_peer_gid(g);
 
-            if (close_index != -1) {
-                g->close[close_index].group_number = other_groupnum;
-                g->close[close_index].type = GROUPCHAT_CLOSE_ONLINE;
+            aint peer_index = addpeer(g, groupnumber, real_pk, temp_pk, peer_gid);
+
+            if (g->peers[peer_index].friendcon_id != friendcon_id) {
+                if (g->peers[peer_index].friendcon_id >= 0) {
+                    kill_friend_connection(g_c->fr_c, g->peers[peer_index].friendcon_id);
+                    g->peers[peer_index].friendcon_id = -1;
+                }
+
+                g->peers[peer_index].friendcon_id = friendcon_id;
+                g->peers[peer_index].connected = true;
+                friend_connection_lock(g_c->fr_c, friendcon_id);
             }
 
-            group_new_peer_send(g_c, groupnum, peer_number, real_pk, temp_pk);
+            friend_connection_callbacks(g_c->m->fr_c, friendcon_id, GROUPCHAT_CALLBACK_INDEX, &handle_status, &handle_packet,
+                                        &handle_lossy, g_c, friendcon_id);
+
+
+            g->peers[peer_index].group_number = ntohs(*(uint16_t *)(data + 1));
+
+            g->need_send_name = true;
+            group_new_peer_send(g_c, groupnumber, peer_gid, real_pk, temp_pk);
+
+            g->join_mode = false;
+            g->keep_leave = false;
+            g->disable_auto_join = false;
+            break;
+        }
+
+        case INVITE_UNSUBSCRIBE_ID: {
+
+            if (length < GROUP_IDENTIFIER_LENGTH + crypto_box_PUBLICKEYBYTES) {
+                return;
+            }
+
+            unsubscribe_peer(g_c, data + 1, data + GROUP_IDENTIFIER_LENGTH, UNS_FOREVER);
             break;
         }
 
@@ -1463,63 +2188,20 @@ static void handle_friend_invite_packet(Messenger *m, uint32_t friendnumber, con
     }
 }
 
-/* Find index of friend in the close list;
- *
- * returns index on success
- * returns -1 on failure.
- */
-static int friend_in_close(Group_c *g, int friendcon_id)
-{
-    unsigned int i;
-
-    for (i = 0; i < MAX_GROUP_CONNECTIONS; ++i) {
-        if (g->close[i].type == GROUPCHAT_CLOSE_NONE) {
-            continue;
-        }
-
-        if (g->close[i].number != (uint32_t)friendcon_id) {
-            continue;
-        }
-
-        return i;
-    }
-
-    return -1;
-}
-
-/* return number of connected close connections.
- */
-static unsigned int count_close_connected(Group_c *g)
-{
-    unsigned int i, count = 0;
-
-    for (i = 0; i < MAX_GROUP_CONNECTIONS; ++i) {
-        if (g->close[i].type == GROUPCHAT_CLOSE_ONLINE) {
-            ++count;
-        }
-    }
-
-    return count;
-}
-
-#define ONLINE_PACKET_DATA_SIZE (sizeof(uint16_t) + GROUP_IDENTIFIER_LENGTH)
-
-static int send_packet_online(Friend_Connections *fr_c, int friendcon_id, uint16_t group_num, uint8_t *identifier)
+static aint send_packet_online(Friend_Connections *fr_c, aint friendcon_id, uint16_t my_group_num, uint8_t *identifier)
 {
     uint8_t packet[1 + ONLINE_PACKET_DATA_SIZE];
-    group_num = htons(group_num);
+    my_group_num = htons(my_group_num);
     packet[0] = PACKET_ID_ONLINE_PACKET;
-    memcpy(packet + 1, &group_num, sizeof(uint16_t));
+    memcpy(packet + 1, &my_group_num, sizeof(uint16_t));
     memcpy(packet + 1 + sizeof(uint16_t), identifier, GROUP_IDENTIFIER_LENGTH);
-    return write_cryptpacket(fr_c->net_crypto, friend_connection_crypt_connection_id(fr_c, friendcon_id), packet,
+    return write_cryptpacket(fr_c->net_crypto, friend_connection_crypt_connection_id(fr_c, (int)friendcon_id), packet,
                              sizeof(packet), 0) != -1;
 }
 
-static unsigned int send_peer_kill(Group_Chats *g_c, int friendcon_id, uint16_t group_num);
-
-static int handle_packet_online(Group_Chats *g_c, int friendcon_id, const uint8_t *data, uint16_t length)
+static int handle_packet_online(Group_Chats *g_c, aint friendcon_id, const uint8_t *data, uint16_t length)
 {
-    if (length != ONLINE_PACKET_DATA_SIZE) {
+    if (length < ONLINE_PACKET_DATA_SIZE) {
         return -1;
     }
 
@@ -1534,157 +2216,142 @@ static int handle_packet_online(Group_Chats *g_c, int friendcon_id, const uint8_
         return -1;
     }
 
-    int index = friend_in_close(g, friendcon_id);
+    aint peer_index = -1, i;
 
-    if (index == -1) {
+    for (i = 0; i < g->numpeers; ++i) {
+        if (g->peers[i].friendcon_id == friendcon_id) {
+            peer_index = i;
+            break;
+        }
+    }
+
+    if (peer_index == -1) {
         return -1;
     }
 
-    if (g->close[index].type == GROUPCHAT_CLOSE_ONLINE) {
-        return -1;
-    }
+    Group_Peer *peer = g->peers + peer_index;
 
-    if (count_close_connected(g) == 0) {
+    if (peer->group_number != other_groupnum) {
+        peer->group_number = other_groupnum;
         send_peer_query(g_c, friendcon_id, other_groupnum);
     }
 
-    g->close[index].group_number = other_groupnum;
-    g->close[index].type = GROUPCHAT_CLOSE_ONLINE;
-    send_packet_online(g_c->fr_c, friendcon_id, groupnumber, g->identifier);
+    bool in_close = false;
 
-    if (g->number_joined != -1 && count_close_connected(g) >= DESIRED_CLOSE_CONNECTIONS) {
-        int fr_close_index = friend_in_close(g, g->number_joined);
+    for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
+        if (CLOSEST(i)) {
+            Group_Peer *peer_from = g->peers + g->closest_peers[i];
 
-        if (fr_close_index == -1) {
-            return -1;
+            if (peer_from->friendcon_id == friendcon_id) {
+                peer_from->need_send_peers = true;
+            }
+
+            if (g->closest_peers[i] == peer_index) {
+                in_close = true;
+            }
         }
+    }
 
-        if (!g->close[fr_close_index].closest) {
-            g->close[fr_close_index].type = GROUPCHAT_CLOSE_NONE;
-            send_peer_kill(g_c, g->close[fr_close_index].number, g->close[fr_close_index].group_number);
-            kill_friend_connection(g_c->fr_c, g->close[fr_close_index].number);
-            g->number_joined = -1;
-        }
+    if (!in_close) {
+        send_packet_online(g_c->fr_c, friendcon_id, (uint16_t)groupnumber, g->identifier);
     }
 
     return 0;
 }
 
-#define PEER_KILL_ID 1
-#define PEER_QUERY_ID 8
-#define PEER_RESPONSE_ID 9
-#define PEER_TITLE_ID 10
-// we could send title with invite, but then if it changes between sending and accepting inv, joinee won't see it
-
-/* return 1 on success.
- * return 0 on failure
- */
-static unsigned int send_peer_kill(Group_Chats *g_c, int friendcon_id, uint16_t group_num)
+static void send_peer_kill(Group_Chats *g_c, aint friendcon_id, uint16_t other_group_num)
 {
     uint8_t packet[1];
     packet[0] = PEER_KILL_ID;
-    return send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, group_num, packet, sizeof(packet));
+    send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, other_group_num, packet, sizeof(packet));
 }
 
 
-/* return 1 on success.
- * return 0 on failure
- */
-static unsigned int send_peer_query(Group_Chats *g_c, int friendcon_id, uint16_t group_num)
+static void send_peer_query(const Group_Chats *g_c, aint friendcon_id, uint16_t other_group_num)
 {
     uint8_t packet[1];
     packet[0] = PEER_QUERY_ID;
-    return send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, group_num, packet, sizeof(packet));
+    send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, other_group_num, packet, sizeof(packet));
 }
 
-/* return number of peers sent on success.
- * return 0 on failure.
- */
-static unsigned int send_peers(Group_Chats *g_c, int groupnumber, int friendcon_id, uint16_t group_num)
+static void send_peers(Group_Chats *g_c, aint groupnumber, int friendcon_id, uint16_t other_group_num)
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
     if (!g) {
-        return -1;
+        return;
     }
 
     uint8_t packet[MAX_CRYPTO_DATA_SIZE - (1 + sizeof(uint16_t))];
     packet[0] = PEER_RESPONSE_ID;
     uint8_t *p = packet + 1;
 
-    uint16_t sent = 0;
-    unsigned int i;
+    size_t sent = 0;
+    size_t i;
 
     for (i = 0; i < g->numpeers; ++i) {
-        if ((p - packet) + sizeof(uint16_t) + crypto_box_PUBLICKEYBYTES * 2 + 1 + g->group[i].nick_len > sizeof(packet)) {
-            if (send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, group_num, packet, (p - packet))) {
+
+        if (g->peers[i].gid < 0) {
+            continue;
+        }
+
+        if ((p - packet) + sizeof(uint16_t) + crypto_box_PUBLICKEYBYTES * 2 + 1 + g->peers[i].nick_len > sizeof(packet)) {
+            if (send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, other_group_num, packet,
+                                       (p - packet))) {
                 sent = i;
             } else {
-                return sent;
+                return;
             }
 
             p = packet + 1;
         }
 
-        uint16_t peer_num = htons(g->group[i].peer_number);
-        memcpy(p, &peer_num, sizeof(peer_num));
-        p += sizeof(peer_num);
-        memcpy(p, g->group[i].real_pk, crypto_box_PUBLICKEYBYTES);
+        uint16_t peer_gid = htons(g->peers[i].gid);
+        memcpy(p, &peer_gid, sizeof(peer_gid));
+        p += sizeof(peer_gid);
+        memcpy(p, g->peers[i].real_pk, crypto_box_PUBLICKEYBYTES);
         p += crypto_box_PUBLICKEYBYTES;
-        memcpy(p, g->group[i].temp_pk, crypto_box_PUBLICKEYBYTES);
+        memcpy(p, g->peers[i].temp_pk, crypto_box_PUBLICKEYBYTES);
         p += crypto_box_PUBLICKEYBYTES;
-        *p = g->group[i].nick_len;
+        *p = g->peers[i].nick_len;
         p += 1;
-        memcpy(p, g->group[i].nick, g->group[i].nick_len);
-        p += g->group[i].nick_len;
+        memcpy(p, g->peers[i].nick, g->peers[i].nick_len);
+        p += g->peers[i].nick_len;
     }
 
     if (sent != i) {
-        if (send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, group_num, packet, (p - packet))) {
+        if (send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, other_group_num, packet,
+                                   (p - packet))) {
             sent = i;
         }
     }
 
     if (g->title_len) {
-        uint8_t Packet[1 + g->title_len];
+
+        uint8_t Packet[1 + sizeof(g->title)];
         Packet[0] = PEER_TITLE_ID;
         memcpy(Packet + 1, g->title, g->title_len);
-        send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, group_num, Packet, sizeof(Packet));
+        send_packet_group_peer(g_c->fr_c, friendcon_id, PACKET_ID_DIRECT_CONFERENCE, other_group_num, Packet, 1 + g->title_len);
     }
-
-    return sent;
 }
 
-static int handle_send_peers(Group_Chats *g_c, int groupnumber, const uint8_t *data, uint16_t length, void *userdata)
+static void accept_peers_list(Group_c *g, aint groupnumber, const uint8_t *data, aint length)
 {
     if (length == 0) {
-        return -1;
-    }
-
-    Group_c *g = get_group_c(g_c, groupnumber);
-
-    if (!g) {
-        return -1;
+        return;
     }
 
     const uint8_t *d = data;
 
-    while ((unsigned int)(length - (d - data)) >= sizeof(uint16_t) + crypto_box_PUBLICKEYBYTES * 2 + 1) {
-        uint16_t peer_num;
-        memcpy(&peer_num, d, sizeof(peer_num));
-        peer_num = ntohs(peer_num);
+    while ((unsigned)(length - (d - data)) >= sizeof(uint16_t) + crypto_box_PUBLICKEYBYTES * 2 + 1) {
+        uint16_t peer_gid;
+        memcpy(&peer_gid, d, sizeof(peer_gid));
+        peer_gid = ntohs(peer_gid);
         d += sizeof(uint16_t);
-        int peer_index = addpeer(g_c, groupnumber, d, d + crypto_box_PUBLICKEYBYTES, peer_num, userdata, true);
+        aint peer_index = addpeer(g, groupnumber, d, d + crypto_box_PUBLICKEYBYTES, peer_gid);
 
         if (peer_index == -1) {
-            return -1;
-        }
-
-        if (g->status == GROUPCHAT_STATUS_VALID
-                && public_key_cmp(d, g_c->m->net_crypto->self_public_key) == 0) {
-            g->peer_number = peer_num;
-            g->status = GROUPCHAT_STATUS_CONNECTED;
-            group_name_send(g_c, groupnumber, g_c->m->name, g_c->m->name_length);
+            return;
         }
 
         d += crypto_box_PUBLICKEYBYTES * 2;
@@ -1692,18 +2359,46 @@ static int handle_send_peers(Group_Chats *g_c, int groupnumber, const uint8_t *d
         d += 1;
 
         if (name_length > (length - (d - data)) || name_length > MAX_NAME_LENGTH) {
-            return -1;
+            return;
         }
 
-        setnick(g_c, groupnumber, peer_index, d, name_length, userdata, true);
+        setnick(g, peer_index, d, name_length);
         d += name_length;
     }
 
-    return 0;
+    return;
 }
 
-static void handle_direct_packet(Group_Chats *g_c, int groupnumber, const uint8_t *data, uint16_t length,
-                                 int close_index, void *userdata)
+static bool self_peer_gid_collision(Group_c *g)
+{
+    size_t i, me = ~0;
+    int my_gid = 0;
+
+    for (i = 0; i < g->numpeers; ++i) {
+
+        if (id_equal(g->real_pk, g->peers[i].real_pk)) {
+            if (g->peers[i].gid < 0) {
+                return false;
+            }
+
+            me = i;
+            my_gid = g->peers[i].gid;
+            break;
+        }
+    }
+
+    for (i = 0; i < g->numpeers; ++i) {
+
+        if (me != i && my_gid == g->peers[i].gid) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void handle_direct_packet(Group_Chats *g_c, aint groupnumber, const uint8_t *data, aint length,
+                                 aint peer_index)
 {
     if (length == 0) {
         return;
@@ -1717,10 +2412,10 @@ static void handle_direct_packet(Group_Chats *g_c, int groupnumber, const uint8_
                 return;
             }
 
-            if (!g->close[close_index].closest) {
-                g->close[close_index].type = GROUPCHAT_CLOSE_NONE;
-                kill_friend_connection(g_c->fr_c, g->close[close_index].number);
-            }
+            kill_friend_connection(g_c->fr_c, g->peers[peer_index].friendcon_id);
+            g->peers[peer_index].friendcon_id = -1;
+            g->peers[peer_index].connected = false;
+            g->peers[peer_index].group_number = 0xffff;
         }
 
         break;
@@ -1732,34 +2427,101 @@ static void handle_direct_packet(Group_Chats *g_c, int groupnumber, const uint8_
                 return;
             }
 
-            send_peers(g_c, groupnumber, g->close[close_index].number, g->close[close_index].group_number);
+            Group_Peer *peer = g->peers + peer_index;
+
+            if (really_connected(peer)) {
+                send_peers(g_c, groupnumber, peer->friendcon_id, peer->group_number);
+                send_peer_nums(g_c, groupnumber, peer->friendcon_id, peer->group_number);
+                peer->need_send_peers = false;
+            }
         }
 
         break;
 
         case PEER_RESPONSE_ID: {
-            handle_send_peers(g_c, groupnumber, data + 1, length - 1, userdata);
+
+            size_t old_peers_num = 0;
+            int self_peer_gid = 0;
+            Group_c *g = get_group_c(g_c, groupnumber);
+
+            if (g) {
+                self_peer_gid = get_self_peer_gid(g);
+                old_peers_num = g->numpeers;
+
+                g->keep_leave = false;
+                g->disable_auto_join = false;
+                g->join_mode = false;
+
+                accept_peers_list(g, groupnumber, data + 1, length - 1);
+
+                if (g->numpeers > old_peers_num) {
+                    g->need_send_name = true;
+                    need_send_peers(g);
+                }
+
+                if (self_peer_gid != get_self_peer_gid(g)) {
+                    /* disallow change self peer gid by remote */
+
+                    change_self_peer_gid(g_c, groupnumber, self_peer_gid);
+
+                    if (self_peer_gid_collision(g)) {
+                        change_self_peer_gid(g_c, groupnumber, find_new_peer_gid(g));
+                    }
+
+                    if (self_peer_gid >= 0) {
+                        group_new_peer_send(g_c, groupnumber, self_peer_gid, g->real_pk, g_c->m->dht->self_public_key);
+                    }
+                }
+            }
         }
 
         break;
 
         case PEER_TITLE_ID: {
-            settitle(g_c, groupnumber, -1, data + 1, length - 1, userdata);
+            Group_c *g = get_group_c(g_c, groupnumber);
+
+            if (g) {
+                settitle(g, peer_index, data + 1, length - 1);
+            }
         }
+
+        break;
+
+        case PEER_GROUP_NUM_ID: {
+            if (length < (crypto_box_PUBLICKEYBYTES + sizeof(uint16_t) + 1)) {
+                return;
+            }
+
+            Group_c *g = get_group_c(g_c, groupnumber);
+
+            if (g) {
+                --length;
+                ++data;
+
+                for (; length > (crypto_box_PUBLICKEYBYTES + sizeof(uint16_t));
+                        length -= (crypto_box_PUBLICKEYBYTES + sizeof(uint16_t)),
+                        data += (crypto_box_PUBLICKEYBYTES + sizeof(uint16_t))) {
+
+                    set_peer_groupnum(g, data, ntohs(*(uint16_t *)(data + crypto_box_PUBLICKEYBYTES)));
+                }
+
+
+            }
+
+        }
+
 
         break;
     }
 }
-
-#define MIN_MESSAGE_PACKET_LEN (sizeof(uint16_t) * 2 + sizeof(uint32_t) + 1)
 
 /* Send message to all close except receiver (if receiver isn't -1)
  * NOTE: this function appends the group chat number to the data passed to it.
  *
  * return number of messages sent.
  */
-static unsigned int send_message_all_close(const Group_Chats *g_c, int groupnumber, const uint8_t *data,
-        uint16_t length, int receiver)
+static aint send_message_all_close(const Group_Chats *g_c, aint groupnumber, const uint8_t *data,
+                                   uint16_t length, aint except_peer)
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
@@ -1767,18 +2529,21 @@ static unsigned int send_message_all_close(const Group_Chats *g_c, int groupnumb
         return 0;
     }
 
-    uint16_t i, sent = 0;
+    aint i, sent = 0;
 
-    for (i = 0; i < MAX_GROUP_CONNECTIONS; ++i) {
-        if (g->close[i].type != GROUPCHAT_CLOSE_ONLINE) {
+    for (i = 0; i < g->numpeers; ++i) {
+
+        if (i == except_peer) {
             continue;
         }
 
-        if ((int)i == receiver) {
+        Group_Peer *peer = g->peers + i;
+
+        if (!really_connected(peer)) {
             continue;
         }
 
-        if (send_packet_group_peer(g_c->fr_c, g->close[i].number, PACKET_ID_MESSAGE_CONFERENCE, g->close[i].group_number, data,
+        if (send_packet_group_peer(g_c->fr_c, peer->friendcon_id, PACKET_ID_MESSAGE_CONFERENCE, peer->group_number, data,
                                    length)) {
             ++sent;
         }
@@ -1792,8 +2557,8 @@ static unsigned int send_message_all_close(const Group_Chats *g_c, int groupnumb
  *
  * return number of messages sent.
  */
-static unsigned int send_lossy_all_close(const Group_Chats *g_c, int groupnumber, const uint8_t *data, uint16_t length,
-        int receiver)
+static size_t send_lossy_all_close(const Group_Chats *g_c, aint groupnumber, const uint8_t *data, aint length,
+                                   aint receiver)
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
@@ -1801,64 +2566,101 @@ static unsigned int send_lossy_all_close(const Group_Chats *g_c, int groupnumber
         return 0;
     }
 
-    unsigned int i, sent = 0, num_connected_closest = 0, connected_closest[DESIRED_CLOSE_CONNECTIONS];
+    size_t i, sent = 0, num_closest = 0;
 
-    for (i = 0; i < MAX_GROUP_CONNECTIONS; ++i) {
-        if (g->close[i].type != GROUPCHAT_CLOSE_ONLINE) {
+    for (i = 0; i < g->numpeers; ++i) {
+
+        if (!really_connected(g->peers + i) || (aint)i == receiver) {
             continue;
         }
 
-        if ((int)i == receiver) {
+        size_t k;
+
+        for (k = 0; k < DESIRED_CLOSE_CONNECTIONS; ++k) {
+
+            if (CLOSEST(k) && g->closest_peers[k] == i) {
+                k = DESIRED_CLOSE_CONNECTIONS + 100;
+                ++num_closest;
+                break;
+            }
+        }
+
+        if (k == DESIRED_CLOSE_CONNECTIONS + 100) {
             continue;
         }
 
-        if (g->close[i].closest) {
-            connected_closest[num_connected_closest] = i;
-            ++num_connected_closest;
-            continue;
-        }
 
-        if (send_lossy_group_peer(g_c->fr_c, g->close[i].number, PACKET_ID_LOSSY_CONFERENCE, g->close[i].group_number, data,
+        if (send_lossy_group_peer(g_c->fr_c, g->peers[i].friendcon_id, PACKET_ID_LOSSY_CONFERENCE, g->peers[i].group_number,
+                                  data,
                                   length)) {
             ++sent;
         }
     }
 
-    if (!num_connected_closest) {
+    if (!num_closest) {
         return sent;
     }
 
-    unsigned int to_send = 0;
+    aint to_send = -1;
     uint64_t comp_val_old = ~0;
 
-    for (i = 0; i < num_connected_closest; ++i) {
-        uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
-        uint8_t dht_temp_pk[crypto_box_PUBLICKEYBYTES];
-        get_friendcon_public_keys(real_pk, dht_temp_pk, g_c->fr_c, g->close[connected_closest[i]].number);
-        uint64_t comp_val = calculate_comp_value(g->real_pk, real_pk);
+    for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
+
+        if (!CLOSEST(i)) {
+            continue;
+        }
+
+        aint peer_index = g->closest_peers[i];
+
+        if (peer_index == receiver) {
+            continue;
+        }
+
+        Group_Peer *peer = g->peers + peer_index;
+
+
+        if (!really_connected(peer)) {
+            continue;
+        }
+
+        uint64_t comp_val = calculate_comp_value(g->real_pk, peer->real_pk);
 
         if (comp_val < comp_val_old) {
-            to_send = connected_closest[i];
+            to_send = peer_index;
             comp_val_old = comp_val;
         }
     }
 
-    if (send_lossy_group_peer(g_c->fr_c, g->close[to_send].number, PACKET_ID_LOSSY_CONFERENCE,
-                              g->close[to_send].group_number, data, length)) {
+    if (to_send >= 0 && send_lossy_group_peer(g_c->fr_c, g->peers[to_send].friendcon_id, PACKET_ID_LOSSY_CONFERENCE,
+            g->peers[to_send].group_number, data, length)) {
         ++sent;
     }
 
-    unsigned int to_send_other = 0;
+    aint to_send_other = -1;
     comp_val_old = ~0;
 
-    for (i = 0; i < num_connected_closest; ++i) {
-        uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
-        uint8_t dht_temp_pk[crypto_box_PUBLICKEYBYTES];
-        get_friendcon_public_keys(real_pk, dht_temp_pk, g_c->fr_c, g->close[connected_closest[i]].number);
-        uint64_t comp_val = calculate_comp_value(real_pk, g->real_pk);
+    for (i = 0; i < DESIRED_CLOSE_CONNECTIONS; ++i) {
+
+        if (!CLOSEST(i)) {
+            continue;
+        }
+
+        aint peer_index = g->closest_peers[i];
+
+        if (peer_index == receiver) {
+            continue;
+        }
+
+        Group_Peer *peer = g->peers + peer_index;
+
+        if (!really_connected(peer)) {
+            continue;
+        }
+
+        uint64_t comp_val = calculate_comp_value(peer->real_pk, g->real_pk);
 
         if (comp_val < comp_val_old) {
-            to_send_other = connected_closest[i];
+            to_send_other = peer_index;
             comp_val_old = comp_val;
         }
     }
@@ -1867,15 +2669,14 @@ static unsigned int send_lossy_all_close(const Group_Chats *g_c, int groupnumber
         return sent;
     }
 
-    if (send_lossy_group_peer(g_c->fr_c, g->close[to_send_other].number, PACKET_ID_LOSSY_CONFERENCE,
-                              g->close[to_send_other].group_number, data, length)) {
+    if (to_send_other >= 0
+            && send_lossy_group_peer(g_c->fr_c, g->peers[to_send_other].friendcon_id, PACKET_ID_LOSSY_CONFERENCE,
+                                     g->peers[to_send_other].group_number, data, length)) {
         ++sent;
     }
 
     return sent;
 }
-
-#define MAX_GROUP_MESSAGE_DATA_LEN (MAX_CRYPTO_DATA_SIZE - (1 + MIN_MESSAGE_PACKET_LEN))
 
 /* Send data of len with message_id to groupnumber.
  *
@@ -1885,26 +2686,25 @@ static unsigned int send_lossy_all_close(const Group_Chats *g_c, int groupnumber
  * return -3 if we are not connected to the group.
  * reutrn -4 if message failed to send.
  */
-static int send_message_group(const Group_Chats *g_c, int groupnumber, uint8_t message_id, const uint8_t *data,
-                              uint16_t len)
+static aint send_message_group(const Group_Chats *g_c, aint groupnumber, uint8_t message_id, const uint8_t *data,
+                               aint len)
 {
+
+    if (len > MAX_GROUP_MESSAGE_DATA_LEN) {
+        return -2;
+    }
+
     Group_c *g = get_group_c(g_c, groupnumber);
 
     if (!g) {
         return -1;
     }
 
-    if (len > MAX_GROUP_MESSAGE_DATA_LEN) {
-        return -2;
-    }
+    int source_peer_gid = get_self_peer_gid(g);
 
-    if (g->status != GROUPCHAT_STATUS_CONNECTED) {
+    if (source_peer_gid < 0) {
         return -3;
     }
-
-    uint8_t packet[sizeof(uint16_t) + sizeof(uint32_t) + 1 + len];
-    uint16_t peer_num = htons(g->peer_number);
-    memcpy(packet, &peer_num, sizeof(peer_num));
 
     ++g->message_number;
 
@@ -1912,7 +2712,14 @@ static int send_message_group(const Group_Chats *g_c, int groupnumber, uint8_t m
         ++g->message_number;
     }
 
-    uint32_t message_num = htonl(g->message_number);
+    uint32_t msgnum = g->message_number;
+
+    uint8_t packet[MAX_GROUP_MESSAGE_DATA_LEN + sizeof(uint16_t) + sizeof(uint32_t) + 1];
+    size_t packet_len = sizeof(uint16_t) + sizeof(uint32_t) + 1 + len;
+    uint16_t peer_gid = htons(source_peer_gid);
+    memcpy(packet, &peer_gid, sizeof(peer_gid));
+
+    uint32_t message_num = htonl(msgnum);
     memcpy(packet + sizeof(uint16_t), &message_num, sizeof(message_num));
 
     packet[sizeof(uint16_t) + sizeof(uint32_t)] = message_id;
@@ -1921,7 +2728,7 @@ static int send_message_group(const Group_Chats *g_c, int groupnumber, uint8_t m
         memcpy(packet + sizeof(uint16_t) + sizeof(uint32_t) + 1, data, len);
     }
 
-    unsigned int ret = send_message_all_close(g_c, groupnumber, packet, sizeof(packet), -1);
+    aint ret = send_message_all_close(g_c, groupnumber, packet, (uint16_t)packet_len, -1);
 
     return (ret == 0) ? -4 : ret;
 }
@@ -1932,13 +2739,13 @@ static int send_message_group(const Group_Chats *g_c, int groupnumber, uint8_t m
  */
 int group_message_send(const Group_Chats *g_c, int groupnumber, const uint8_t *message, uint16_t length)
 {
-    int ret = send_message_group(g_c, groupnumber, PACKET_ID_MESSAGE, message, length);
+    aint ret = send_message_group(g_c, groupnumber, PACKET_ID_MESSAGE, message, length);
 
     if (ret > 0) {
         return 0;
     }
 
-    return ret;
+    return (int)ret;
 }
 
 /* send a group action
@@ -1947,13 +2754,13 @@ int group_message_send(const Group_Chats *g_c, int groupnumber, const uint8_t *m
  */
 int group_action_send(const Group_Chats *g_c, int groupnumber, const uint8_t *action, uint16_t length)
 {
-    int ret = send_message_group(g_c, groupnumber, PACKET_ID_ACTION, action, length);
+    aint ret = send_message_group(g_c, groupnumber, PACKET_ID_ACTION, action, length);
 
     if (ret > 0) {
         return 0;
     }
 
-    return ret;
+    return (int)ret;
 }
 
 /* High level function to send custom lossy packets.
@@ -1963,21 +2770,28 @@ int group_action_send(const Group_Chats *g_c, int groupnumber, const uint8_t *ac
  */
 int send_group_lossy_packet(const Group_Chats *g_c, int groupnumber, const uint8_t *data, uint16_t length)
 {
-    // TODO(irungentoo): length check here?
     Group_c *g = get_group_c(g_c, groupnumber);
 
     if (!g) {
         return -1;
     }
 
-    uint8_t packet[sizeof(uint16_t) * 2 + length];
-    uint16_t peer_number = htons(g->peer_number);
-    memcpy(packet, &peer_number, sizeof(uint16_t));
+    uint8_t packet[MAX_CRYPTO_DATA_SIZE];
+    size_t plen = sizeof(uint16_t) * 2 + length;
+
+    int self_peer_gid = get_self_peer_gid(g);
+
+    if (self_peer_gid < 0) {
+        return -1;
+    }
+
+    uint16_t peer_gid = htons((uint16_t)self_peer_gid);
+    memcpy(packet, &peer_gid, sizeof(uint16_t));
     uint16_t message_num = htons(g->lossy_message_number);
     memcpy(packet + sizeof(uint16_t), &message_num, sizeof(uint16_t));
     memcpy(packet + sizeof(uint16_t) * 2, data, length);
 
-    if (send_lossy_all_close(g_c, groupnumber, packet, sizeof(packet), -1) == 0) {
+    if (send_lossy_all_close(g_c, groupnumber, packet, (uint16_t)plen, -1) == 0) {
         return -1;
     }
 
@@ -1986,7 +2800,7 @@ int send_group_lossy_packet(const Group_Chats *g_c, int groupnumber, const uint8
 }
 
 static void handle_message_packet_group(Group_Chats *g_c, int groupnumber, const uint8_t *data, uint16_t length,
-                                        int close_index, void *userdata)
+                                        aint peer_index_from, void *userdata)
 {
     if (length < sizeof(uint16_t) + sizeof(uint32_t) + 1) {
         return;
@@ -1998,61 +2812,146 @@ static void handle_message_packet_group(Group_Chats *g_c, int groupnumber, const
         return;
     }
 
-    uint16_t peer_number;
-    memcpy(&peer_number, data, sizeof(uint16_t));
-    peer_number = ntohs(peer_number);
+    uint16_t from_peer_gid = ntohs(*(uint16_t *)data);
+    aint index = get_peer_index(g, from_peer_gid);
 
-    int index = get_peer_index(g, peer_number);
+    uint8_t msg_id = data[sizeof(uint16_t) + sizeof(uint32_t)];
+
+    size_t pindex;
+
+    switch (msg_id) {
+        case GROUP_MESSAGE_PING_ID:
+            pindex = 0;
+            break;
+
+        case GROUP_MESSAGE_UNSUBSCRIBE:
+            pindex = 1;
+            break;
+
+        case GROUP_MESSAGE_NEW_PEER_ID:
+            pindex = 2;
+            break;
+
+        case GROUP_MESSAGE_KILL_PEER_ID:
+            pindex = 3;
+            break;
+
+        case GROUP_MESSAGE_NAME_ID:
+            pindex = 4;
+            break;
+
+        case GROUP_MESSAGE_TITLE_ID:
+            pindex = 5;
+            break;
+
+        case PACKET_ID_MESSAGE:
+            pindex = 6;
+            break;
+
+        case PACKET_ID_ACTION:
+            pindex = 7;
+            break;
+
+        default:
+            return;
+    }
 
     if (index == -1) {
-        /* We don't know the peer this packet came from so we query the list of peers from that peer.
-          (They would not have relayed it if they didn't know the peer.) */
-        send_peer_query(g_c, g->close[close_index].number, g->close[close_index].group_number);
-        return;
+
+        if (really_connected(g->peers + peer_index_from)) {
+            send_peer_query(g_c, g->peers[peer_index_from].friendcon_id, g->peers[peer_index_from].group_number);
+        }
+
+        if (msg_id != GROUP_MESSAGE_NEW_PEER_ID) {
+            return; /* this packet is very important to autojoin and compatibility, so we proceed id even no source peer known */
+        }
     }
 
-    uint32_t message_number;
-    memcpy(&message_number, data + sizeof(uint16_t), sizeof(message_number));
-    message_number = ntohl(message_number);
+    bool allow_resend = false;
 
-    if (g->group[index].last_message_number == 0) {
-        g->group[index].last_message_number = message_number;
-    } else if (message_number - g->group[index].last_message_number > 64 ||
-               message_number == g->group[index].last_message_number) {
-        return;
+    if (index >= 0) {
+
+        if (!id_equal(g->real_pk, g->peers[index].real_pk)) {
+            allow_resend = true;
+        }
+
+        uint32_t message_number;
+        memcpy(&message_number, data + sizeof(uint16_t), sizeof(message_number));
+        message_number = ntohl(message_number);
+
+        if (g->peers[index].last_message_number[pindex] > 0 && message_number == g->peers[index].last_message_number[pindex]) {
+            return;
+        }
+
+        g->peers[index].last_message_number[pindex] = message_number;
     }
 
-    g->group[index].last_message_number = message_number;
+    const uint8_t *msg_data = data + sizeof(uint16_t) + sizeof(uint32_t) + 1;
+    uint16_t msg_data_len = length - (sizeof(uint16_t) + sizeof(uint32_t) + 1);
 
-    uint8_t message_id = data[sizeof(uint16_t) + sizeof(message_number)];
-    const uint8_t *msg_data = data + sizeof(uint16_t) + sizeof(message_number) + 1;
-    uint16_t msg_data_len = length - (sizeof(uint16_t) + sizeof(message_number) + 1);
-
-    switch (message_id) {
+    switch (msg_id) {
         case GROUP_MESSAGE_PING_ID: {
-            if (msg_data_len != 0) {
+            /* absolutely no matter size of ping packet */
+            Group_Peer *peer = g->peers + index;
+            peer->last_recv = unix_time();
+
+            if (peer->keep_connection) {
+                --peer->keep_connection;
+            }
+        }
+        break;
+
+        case GROUP_MESSAGE_UNSUBSCRIBE: {
+
+            if (msg_data_len < (GROUP_IDENTIFIER_LENGTH + crypto_box_PUBLICKEYBYTES)) {
                 return;
             }
 
-            g->group[index].last_recv = unix_time();
+            unsubscribe_peer(g_c, msg_data + 1, msg_data + GROUP_IDENTIFIER_LENGTH, (Unsubscribe)msg_data[0]);
         }
         break;
 
         case GROUP_MESSAGE_NEW_PEER_ID: {
-            if (msg_data_len != GROUP_MESSAGE_NEW_PEER_LENGTH) {
+
+            if (msg_data_len < GROUP_MESSAGE_NEW_PEER_LENGTH) {
                 return;
             }
 
-            uint16_t new_peer_number;
-            memcpy(&new_peer_number, msg_data, sizeof(uint16_t));
-            new_peer_number = ntohs(new_peer_number);
-            addpeer(g_c, groupnumber, msg_data + sizeof(uint16_t), msg_data + sizeof(uint16_t) + crypto_box_PUBLICKEYBYTES,
-                    new_peer_number, userdata, true);
+            uint16_t new_peer_gid;
+            memcpy(&new_peer_gid, msg_data, sizeof(uint16_t));
+            new_peer_gid = ntohs(new_peer_gid);
+
+            if (from_peer_gid == new_peer_gid) {
+                allow_resend = false;
+            }
+
+            const uint8_t *real_pk = msg_data + sizeof(uint16_t);
+            const uint8_t *temp_pk = real_pk + crypto_box_PUBLICKEYBYTES;
+
+            if (id_equal(g->real_pk, real_pk)) {
+
+                allow_resend = false;
+                g->need_send_name = true;
+                g->keep_leave = false;
+                g->disable_auto_join = false;
+                g->join_mode = false;
+            }
+
+            aint peer_index = addpeer(g, groupnumber, real_pk, temp_pk, new_peer_gid);
+
+            int self_peer_gid = get_self_peer_gid(g);
+
+            if (self_peer_gid >= 0 && self_peer_gid_collision(g)) {
+                self_peer_gid = find_new_peer_gid(g);
+                change_self_peer_gid(g_c, groupnumber, self_peer_gid);
+                group_new_peer_send(g_c, groupnumber, (uint16_t)self_peer_gid, g->real_pk, g_c->m->dht->self_public_key);
+            }
         }
         break;
 
         case GROUP_MESSAGE_KILL_PEER_ID: {
-            if (msg_data_len != GROUP_MESSAGE_KILL_PEER_LENGTH) {
+
+            if (msg_data_len < GROUP_MESSAGE_KILL_PEER_LENGTH) {
                 return;
             }
 
@@ -2060,24 +2959,28 @@ static void handle_message_packet_group(Group_Chats *g_c, int groupnumber, const
             memcpy(&kill_peer_number, msg_data, sizeof(uint16_t));
             kill_peer_number = ntohs(kill_peer_number);
 
-            if (peer_number == kill_peer_number) {
-                delpeer(g_c, groupnumber, index, userdata);
-            } else {
-                return;
-                // TODO(irungentoo):
+            if (kill_peer_number == from_peer_gid) {
+
+                Group_c *g = get_group_c(g_c, groupnumber);
+
+                if (g) {
+                    unsubscribe_peer(g_c, g->identifier + 1, g->peers[index].real_pk, UNS_TEMP);
+                }
+
+                delpeer(g_c, groupnumber, index);
             }
         }
         break;
 
         case GROUP_MESSAGE_NAME_ID: {
-            if (setnick(g_c, groupnumber, index, msg_data, msg_data_len, userdata, true) == -1) {
+            if (setnick(g, index, msg_data, msg_data_len) == -1) {
                 return;
             }
         }
         break;
 
         case GROUP_MESSAGE_TITLE_ID: {
-            if (settitle(g_c, groupnumber, index, msg_data, msg_data_len, userdata) == -1) {
+            if (settitle(g, index, msg_data, msg_data_len) == -1) {
                 return;
             }
         }
@@ -2088,13 +2991,17 @@ static void handle_message_packet_group(Group_Chats *g_c, int groupnumber, const
                 return;
             }
 
-            uint8_t newmsg[msg_data_len + 1];
+            uint8_t newmsg[MAX_CRYPTO_DATA_SIZE];
             memcpy(newmsg, msg_data, msg_data_len);
             newmsg[msg_data_len] = 0;
 
-            // TODO(irungentoo):
             if (g_c->message_callback) {
-                g_c->message_callback(g_c->m, groupnumber, index, 0, newmsg, msg_data_len, userdata);
+
+                int index_in_list = find_peer_index_in_list(g, index);
+
+                if (index_in_list >= 0) {
+                    g_c->message_callback(g_c->m, (uint32_t)groupnumber, (uint32_t)index_in_list, 0, newmsg, msg_data_len, userdata);
+                }
             }
 
             break;
@@ -2105,13 +3012,16 @@ static void handle_message_packet_group(Group_Chats *g_c, int groupnumber, const
                 return;
             }
 
-            uint8_t newmsg[msg_data_len + 1];
+            uint8_t newmsg[MAX_CRYPTO_DATA_SIZE];
             memcpy(newmsg, msg_data, msg_data_len);
             newmsg[msg_data_len] = 0;
 
-            // TODO(irungentoo):
             if (g_c->message_callback) {
-                g_c->message_callback(g_c->m, groupnumber, index, 1, newmsg, msg_data_len, userdata);
+                int index_in_list = find_peer_index_in_list(g, index);
+
+                if (index_in_list >= 0) {
+                    g_c->message_callback(g_c->m, (uint32_t)groupnumber, (uint32_t)index_in_list, 1, newmsg, msg_data_len, userdata);
+                }
             }
 
             break;
@@ -2121,7 +3031,10 @@ static void handle_message_packet_group(Group_Chats *g_c, int groupnumber, const
             return;
     }
 
-    send_message_all_close(g_c, groupnumber, data, length, -1/* TODO(irungentoo) close_index */);
+    if (allow_resend) {
+        send_message_all_close(g_c, groupnumber, data, length, msg_id == PACKET_ID_MESSAGE
+                               || msg_id == PACKET_ID_ACTION ? -1 : peer_index_from);
+    }
 }
 
 static int handle_packet(void *object, int friendcon_id, const uint8_t *data, uint16_t length, void *userdata)
@@ -2149,20 +3062,27 @@ static int handle_packet(void *object, int friendcon_id, const uint8_t *data, ui
         return -1;
     }
 
-    int index = friend_in_close(g, friendcon_id);
+    aint peer_index = -1, i;
 
-    if (index == -1) {
+    for (i = 0; i < g->numpeers; ++i) {
+        if (g->peers[i].friendcon_id == friendcon_id) {
+            peer_index = i;
+            break;
+        }
+    }
+
+    if (peer_index == -1) {
         return -1;
     }
 
     switch (data[0]) {
         case PACKET_ID_DIRECT_CONFERENCE: {
-            handle_direct_packet(g_c, groupnumber, data + 1 + sizeof(uint16_t), length - (1 + sizeof(uint16_t)), index, userdata);
+            handle_direct_packet(g_c, groupnumber, data + 1 + sizeof(uint16_t), length - (1 + sizeof(uint16_t)), peer_index);
             break;
         }
 
         case PACKET_ID_MESSAGE_CONFERENCE: {
-            handle_message_packet_group(g_c, groupnumber, data + 1 + sizeof(uint16_t), length - (1 + sizeof(uint16_t)), index,
+            handle_message_packet_group(g_c, groupnumber, data + 1 + sizeof(uint16_t), length - (1 + sizeof(uint16_t)), peer_index,
                                         userdata);
             break;
         }
@@ -2183,53 +3103,61 @@ static int handle_packet(void *object, int friendcon_id, const uint8_t *data, ui
  *
  * TODO(irungentoo): test this
  */
-static unsigned int lossy_packet_not_received(Group_c *g, int peer_index, uint16_t message_number)
+static aint lossy_packet_not_received(Group_c *g, aint peer_index, uint16_t message_number)
 {
     if (peer_index == -1) {
         return -1;
     }
 
-    if (g->group[peer_index].bottom_lossy_number == g->group[peer_index].top_lossy_number) {
-        g->group[peer_index].top_lossy_number = message_number;
-        g->group[peer_index].bottom_lossy_number = (message_number - MAX_LOSSY_COUNT) + 1;
-        g->group[peer_index].recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
+    Group_Peer *peer = g->peers + peer_index;
+    Group_Peer_Lossy *lossy = peer->lossy;
+
+    if (!lossy) {
+        lossy = (Group_Peer_Lossy *)calloc(1, sizeof(Group_Peer_Lossy));
+        peer->lossy = lossy;
+    }
+
+    if (lossy->bottom_lossy_number == lossy->top_lossy_number) {
+        lossy->top_lossy_number = message_number;
+        lossy->bottom_lossy_number = (message_number - MAX_LOSSY_COUNT) + 1;
+        lossy->recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
         return 0;
     }
 
-    if ((uint16_t)(message_number - g->group[peer_index].bottom_lossy_number) < MAX_LOSSY_COUNT) {
-        if (g->group[peer_index].recv_lossy[message_number % MAX_LOSSY_COUNT]) {
+    if ((uint16_t)(message_number - lossy->bottom_lossy_number) < MAX_LOSSY_COUNT) {
+        if (lossy->recv_lossy[message_number % MAX_LOSSY_COUNT]) {
             return 1;
         }
 
-        g->group[peer_index].recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
+        lossy->recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
         return 0;
     }
 
-    if ((uint16_t)(message_number - g->group[peer_index].bottom_lossy_number) > (1 << 15)) {
+    if ((uint16_t)(message_number - lossy->bottom_lossy_number) > (1 << 15)) {
         return -1;
     }
 
-    uint16_t top_distance = message_number - g->group[peer_index].top_lossy_number;
+    uint16_t top_distance = message_number - lossy->top_lossy_number;
 
     if (top_distance >= MAX_LOSSY_COUNT) {
-        sodium_memzero(g->group[peer_index].recv_lossy, sizeof(g->group[peer_index].recv_lossy));
-        g->group[peer_index].top_lossy_number = message_number;
-        g->group[peer_index].bottom_lossy_number = (message_number - MAX_LOSSY_COUNT) + 1;
-        g->group[peer_index].recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
+        sodium_memzero(lossy->recv_lossy, sizeof(lossy->recv_lossy));
+        lossy->top_lossy_number = message_number;
+        lossy->bottom_lossy_number = (message_number - MAX_LOSSY_COUNT) + 1;
+        lossy->recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
         return 0;
     }
 
     if (top_distance < MAX_LOSSY_COUNT) {
-        unsigned int i;
+        size_t i;
 
-        for (i = g->group[peer_index].bottom_lossy_number; i != (g->group[peer_index].bottom_lossy_number + top_distance);
+        for (i = lossy->bottom_lossy_number; i != (lossy->bottom_lossy_number + top_distance);
                 ++i) {
-            g->group[peer_index].recv_lossy[i % MAX_LOSSY_COUNT] = 0;
+            lossy->recv_lossy[i % MAX_LOSSY_COUNT] = 0;
         }
 
-        g->group[peer_index].top_lossy_number = message_number;
-        g->group[peer_index].bottom_lossy_number = (message_number - MAX_LOSSY_COUNT) + 1;
-        g->group[peer_index].recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
+        lossy->top_lossy_number = message_number;
+        lossy->bottom_lossy_number = (message_number - MAX_LOSSY_COUNT) + 1;
+        lossy->recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
         return 0;
     }
 
@@ -2248,12 +3176,12 @@ static int handle_lossy(void *object, int friendcon_id, const uint8_t *data, uin
         return -1;
     }
 
-    uint16_t groupnumber, peer_number, message_number;
+    uint16_t groupnumber, peer_gid, message_number;
     memcpy(&groupnumber, data + 1, sizeof(uint16_t));
-    memcpy(&peer_number, data + 1 + sizeof(uint16_t), sizeof(uint16_t));
+    memcpy(&peer_gid, data + 1 + sizeof(uint16_t), sizeof(uint16_t));
     memcpy(&message_number, data + 1 + sizeof(uint16_t) * 2, sizeof(uint16_t));
     groupnumber = ntohs(groupnumber);
-    peer_number = ntohs(peer_number);
+    peer_gid = ntohs(peer_gid);
     message_number = ntohs(message_number);
 
     Group_c *g = get_group_c(g_c, groupnumber);
@@ -2262,17 +3190,24 @@ static int handle_lossy(void *object, int friendcon_id, const uint8_t *data, uin
         return -1;
     }
 
-    int index = friend_in_close(g, friendcon_id);
+    aint peer_index_from = -1, i;
 
-    if (index == -1) {
+    for (i = 0; i < g->numpeers; ++i) {
+        if (g->peers[i].friendcon_id == friendcon_id) {
+            peer_index_from = i;
+            break;
+        }
+    }
+
+    if (peer_index_from == -1) {
         return -1;
     }
 
-    if (peer_number == g->peer_number) {
+    if ((int)peer_gid == get_self_peer_gid(g)) {
         return -1;
     }
 
-    int peer_index = get_peer_index(g, peer_number);
+    aint peer_index = get_peer_index(g, peer_gid);
 
     if (peer_index == -1) {
         return -1;
@@ -2288,16 +3223,34 @@ static int handle_lossy(void *object, int friendcon_id, const uint8_t *data, uin
     ++lossy_data;
     --lossy_length;
 
+    int index_in_list = find_peer_index_in_list(g, peer_index);
+
+    if (index_in_list < 0) {
+        return -1;
+    }
+
+    /*
     if (g_c->lossy_packethandlers[message_id].function) {
-        if (g_c->lossy_packethandlers[message_id].function(g->object, groupnumber, peer_index, g->group[peer_index].object,
+        if (g_c->lossy_packethandlers[message_id].function(g->object, (int)groupnumber, index_in_list, g->peers[peer_index].object,
                 lossy_data, lossy_length) == -1) {
             return -1;
         }
     } else {
         return -1;
     }
+    */
 
-    send_lossy_all_close(g_c, groupnumber, data + 1 + sizeof(uint16_t), length - (1 + sizeof(uint16_t)), index);
+    if (192 /*GROUP_AUDIO_PACKET_ID*/ == message_id && g_c->lossy_packethandler) {
+        if (g_c->lossy_packethandler(g->object, (int)groupnumber, index_in_list, g->peers[peer_index].object,
+                                     lossy_data, lossy_length) == -1) {
+            return -1;
+        }
+    } else {
+        return -1;
+    }
+
+
+    send_lossy_all_close(g_c, groupnumber, data + 1 + sizeof(uint16_t), length - (1 + sizeof(uint16_t)), peer_index_from);
     return 0;
 }
 
@@ -2335,7 +3288,11 @@ int group_peer_set_object(const Group_Chats *g_c, int groupnumber, int peernumbe
         return -1;
     }
 
-    g->group[peernumber].object = object;
+    if (g->peers[peernumber].object && g->peer_on_leave) {
+        g->peer_on_leave(g->object, groupnumber, g->peers[peernumber].object);
+    }
+
+    g->peers[peernumber].object = object;
     return 0;
 }
 
@@ -2372,11 +3329,254 @@ void *group_peer_get_object(const Group_Chats *g_c, int groupnumber, int peernum
         return NULL;
     }
 
-    return g->group[peernumber].object;
+    return g->peers[peernumber].object;
 }
 
-/* Interval in seconds to send ping messages */
-#define GROUP_PING_INTERVAL 20
+static int64_t deltatime(uint64_t t1, uint64_t t2)
+{
+    return (int64_t)(t1 - t2);
+}
+
+static bool possible_groupnum(Group_Chats *g_c, int groupnumber, uint16_t gn, const uint8_t *for_pk)
+{
+    size_t i;
+
+    for (i = 0; i < g_c->num_chats; ++i) {
+
+        if (i == groupnumber) {
+            continue;
+        }
+
+        Group_c *g = get_group_c(g_c, i);
+
+        if (g) {
+
+            aint peer_index = peer_in_chat(g, for_pk);
+
+            if (peer_index >= 0 && g->peers[peer_index].group_number == gn) {
+                /* same peer already in gn group, so, current group has other gn value */
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+static bool already_joining(Group_Chats *g_c, Group_c *curgroup, const uint8_t *pk, aint gn)
+{
+    size_t i, j;
+
+    for (i = 0; i < g_c->num_chats; ++i) {
+        Group_c *g = get_group_c(g_c, i);
+
+        if (g) {
+            if (curgroup == g || !g->join_mode) {
+                continue;
+            }
+
+            for (j = 0; j < g->numjoinpeers; ++j) {
+                if (id_equal(g->joinpeers[j].real_pk, pk)) {
+                    if (g->joinpeers[j].joingn == gn) {
+                        return true;
+                    }
+                }
+            }
+
+        }
+    }
+
+    return false;
+}
+
+static void restore_conference(Group_Chats *g_c, int groupnumber)
+{
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (!g) {
+        return;
+    }
+
+    if (g->disable_auto_join || g->numjoinpeers == 0) {
+        return;
+    }
+
+    uint64_t ct = current_time_monotonic();
+
+    if (deltatime(ct, g->next_join_check_time) < 0) {
+        return;
+    }
+
+    bool force_restore_now = false;
+    Group_Join_Peer *jd = NULL;
+
+    if (g->keep_join_index >= 0) {
+
+        if (g->keep_join_index >= (int)g->numjoinpeers) {
+            g->keep_join_index = 0;
+        }
+
+        int next_time = 333;
+        jd = g->joinpeers + g->keep_join_index;
+
+        int friend_index = getfriend_id(g_c->m, jd->real_pk);
+
+        if (friend_index >= 0 && !jd->unsubscribed) {
+            int cs = m_get_friend_connectionstatus(g_c->m, friend_index);
+
+            if (CONNECTION_TCP == cs || CONNECTION_UDP == cs) {
+                next_time = 5000;
+
+                int mcount = g->numpeers; /* 1 - me */
+
+                bool present = false;
+                int m = 0;
+
+                for (; m < mcount; ++m) {
+                    if (id_equal(g->peers[m].real_pk, jd->real_pk)) {
+                        next_time = 1000;
+                        present = true;
+                        break;
+                    }
+                }
+
+                if (!present) {
+                    /* wow, member is online, but not in conference? restore! */
+                    if (jd->fails >= MAX_FAILED_JOIN_ATTEMPTS) {
+                        jd->fails = 0;
+                        jd->joingn = -1;
+                        jd->online = true;
+                    }
+
+                    jd->next_try_time = ct;
+                    force_restore_now = true;
+                }
+            }
+        }
+
+        g->next_join_check_time = ct + next_time;
+
+        if (!force_restore_now) {
+            ++g->keep_join_index;
+            return;
+        }
+    }
+
+    if (NULL == jd) {
+        int minnum = MAX_FAILED_JOIN_ATTEMPTS;
+        size_t i, nummax = 0;
+
+        for (i = 0; i < g->numjoinpeers; ++i) {
+            Group_Join_Peer *jp = g->joinpeers + i;
+
+            if (jp->fails == MAX_FAILED_JOIN_ATTEMPTS) {
+                ++nummax;
+                continue;
+            }
+
+            if (deltatime(ct, jp->next_try_time) < 0) {
+                continue;
+            }
+
+            if (jp->fails < minnum) {
+                jd = jp;
+                minnum = jp->fails;
+            }
+        }
+
+        if (g->join_mode && jd == NULL) {
+
+            if (nummax == g->numjoinpeers) {
+
+                /* now restart join process */
+                size_t i;
+
+                for (i = 0; i < g->numjoinpeers; ++i) {
+
+                    Group_Join_Peer *j = g->joinpeers + i;
+                    j->online = false;
+                    j->unsubscribed = false;
+                    j->fails = 0;
+                    j->joingn = -1;
+                    j->next_try_time = ct;
+                }
+            }
+
+            g->next_join_check_time = ct + 333;
+            return;
+        }
+
+    }
+
+    if (NULL == jd) {
+
+        g->keep_join_index = g->join_mode ? -1 : 0;
+        g->next_join_check_time = ct + 6000;
+        return;
+    }
+
+    if (!force_restore_now && !g->join_mode) {
+        return;
+    }
+
+    int friend_index = jd->unsubscribed ? -1 : getfriend_id(g_c->m, jd->real_pk);
+
+    if (friend_index >= 0) {
+        int cs = m_get_friend_connectionstatus(g_c->m, friend_index);
+
+        if (CONNECTION_TCP == cs || CONNECTION_UDP == cs) {
+
+            if (!jd->online) {
+                jd->online = true;
+                jd->fails = 0;
+                jd->joingn = -1;
+                jd->next_try_time = ct + 3000;
+                g->next_join_check_time = ct + 333;
+                return;
+            }
+
+            while (!possible_groupnum(g_c, groupnumber, jd->fails, jd->real_pk)) {
+                ++jd->fails;
+            };
+
+            jd->joingn = -1;
+
+            /* due brute force group numbers
+               we cant try join to different groups through same peer, using same group numbers */
+            if (already_joining(g_c, g, jd->real_pk, jd->fails)) {
+
+                jd->next_try_time = ct + 3000;
+                g->next_join_check_time = ct + 333;
+                return;
+            }
+
+            jd->joingn = jd->fails;
+
+            uint8_t invite_data[GROUP_IDENTIFIER_LENGTH + sizeof(uint16_t)];
+            *(uint16_t *)invite_data = htons(jd->fails);
+            memcpy(invite_data + 2, g->identifier, GROUP_IDENTIFIER_LENGTH);
+
+            g->auto_join = true;
+            join_groupchat(g_c, friend_index, g->identifier[0], invite_data, sizeof(invite_data));
+            g->auto_join = false;
+
+            ++jd->fails;
+
+            jd->next_try_time = ct + 20000; /* next try in 20 sec!!! It is important to wait for answer to this try */
+        } else {
+            jd->online = false;
+            ++jd->fails;
+            jd->joingn = -1;
+        }
+    } else {
+        jd->fails = MAX_FAILED_JOIN_ATTEMPTS;
+        jd->joingn = -1;
+        restore_conference(g_c, groupnumber);   /* hope to optimize tail recursion */
+        return;
+    }
+
+    g->next_join_check_time = ct + 333;
+}
 
 static int ping_groupchat(Group_Chats *g_c, int groupnumber)
 {
@@ -2389,51 +3589,59 @@ static int ping_groupchat(Group_Chats *g_c, int groupnumber)
     if (is_timeout(g->last_sent_ping, GROUP_PING_INTERVAL)) {
         if (group_ping_send(g_c, groupnumber) != -1) { /* Ping */
             g->last_sent_ping = unix_time();
+        } else {
+            /* no peers to ping */
+            g->last_sent_ping = unix_time() - GROUP_PING_INTERVAL + 2;
         }
+
     }
 
     return 0;
 }
 
-static int groupchat_clear_timedout(Group_Chats *g_c, int groupnumber, void *userdata)
+static void groupchat_clear_timedout(Group_Chats *g_c, int groupnumber, void *userdata)
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
     if (!g) {
-        return -1;
+        return;
     }
 
-    uint32_t i;
+    size_t i, opc = 0, dp = 0;
 
     for (i = 0; i < g->numpeers; ++i) {
-        if (g->peer_number != g->group[i].peer_number && is_timeout(g->group[i].last_recv, GROUP_PING_INTERVAL * 3)) {
-            delpeer(g_c, groupnumber, i, userdata);
+
+        if (g->peers[i].friendcon_id == -2 || id_equal(g->peers[i].real_pk, g->real_pk)) {
+            continue;
         }
 
-        if (g->group == NULL || i >= g->numpeers) {
-            break;
+        ++opc;
+
+        if (is_timeout(g->peers[i].last_recv, GROUP_PING_INTERVAL * 3)) {
+            delpeer(g_c, groupnumber, i);
+            ++dp;
         }
     }
 
-    return 0;
+    if (opc == dp && opc) {
+        /* looks like lost connection to other peers */
+        on_offline(g);
+    }
+
 }
 
 /* Send current name (set in messenger) to all online groups.
  */
 void send_name_all_groups(Group_Chats *g_c)
 {
-    unsigned int i;
+    size_t i;
 
     for (i = 0; i < g_c->num_chats; ++i) {
-        Group_c *g = get_group_c(g_c, i);
 
-        if (!g) {
-            continue;
-        }
-
-        if (g->status == GROUPCHAT_STATUS_CONNECTED) {
+        if (is_groupnumber_valid(g_c, i)) {
             group_name_send(g_c, i, g_c->m->name, g_c->m->name_length);
         }
+
     }
 }
 
@@ -2461,32 +3669,60 @@ Group_Chats *new_groupchats(Messenger *m)
 /* main groupchats loop. */
 void do_groupchats(Group_Chats *g_c, void *userdata)
 {
-    unsigned int i;
+    unsigned i;
+    bool is_online = onion_connection_status(g_c->m->onion_c) != 0;
 
-    for (i = 0; i < g_c->num_chats; ++i) {
-        Group_c *g = get_group_c(g_c, i);
+    if (!is_online && g_c->is_online) {
+        /* to offline */
 
-        if (!g) {
-            continue;
-        }
+        for (i = 0; i < g_c->num_chats; ++i) {
 
-        if (g->status == GROUPCHAT_STATUS_CONNECTED) {
-            connect_to_closest(g_c, i, userdata);
-            ping_groupchat(g_c, i);
-            groupchat_clear_timedout(g_c, i, userdata);
+            Group_c *g = g_c->chats + i;
+
+            if (!g->live || g->disable_auto_join) {
+                continue;
+            }
+
+            disconnect_conference(g_c, i, UNS_NONE);
+            on_offline(g);
         }
     }
 
-    // TODO(irungentoo):
+    g_c->is_online = is_online;
+
+    if (!is_online) {
+        return;
+    }
+
+    for (i = 0; i < g_c->num_chats; ++i) {
+
+        Group_c *g = g_c->chats + i;
+
+        if (!g->live) {
+            continue;
+        }
+
+        if (g->disable_auto_join) {
+            groupchat_clear_timedout(g_c, i, userdata);
+            apply_changes_in_peers(g_c, i, userdata);
+            continue;
+        }
+
+        apply_changes_in_peers(g_c, i, userdata);
+        connect_to_closest(g_c, i, userdata);
+        ping_groupchat(g_c, i);
+        groupchat_clear_timedout(g_c, i, userdata);
+        restore_conference(g_c, i);   /* always do something to restore contacts */
+    }
 }
 
 /* Free everything related with group chats. */
 void kill_groupchats(Group_Chats *g_c)
 {
-    unsigned int i;
+    unsigned i;
 
     for (i = 0; i < g_c->num_chats; ++i) {
-        del_groupchat(g_c, i);
+        del_groupchat_internal(g_c, i, UNS_NONE);
     }
 
     m_callback_conference_invite(g_c->m, NULL);
@@ -2504,7 +3740,7 @@ uint32_t count_chatlist(Group_Chats *g_c)
     uint32_t i;
 
     for (i = 0; i < g_c->num_chats; i++) {
-        if (g_c->chats[i].status != GROUPCHAT_STATUS_NONE) {
+        if (g_c->chats[i].live) {
             ret++;
         }
     }
@@ -2534,11 +3770,174 @@ uint32_t copy_chatlist(Group_Chats *g_c, uint32_t *out_list, uint32_t list_size)
             break;  /* Abandon ship */
         }
 
-        if (g_c->chats[i].status > GROUPCHAT_STATUS_NONE) {
+        if (g_c->chats[i].live) {
             out_list[ret] = i;
             ret++;
         }
     }
 
     return ret;
+}
+
+uint32_t saved_oldgroups_size(const Messenger *m)
+{
+    Group_Chats *g_c = (Group_Chats *)m->conferences_object;
+
+    size_t sz = sizeof(uint16_t);   // size of number of groupchats
+    size_t i;
+
+    for (i = 0; i < g_c->num_chats; ++i) {
+
+        Group_c *g = g_c->chats + i;
+
+        if (!g->live) {
+            continue;
+        }
+
+        sz += GROUP_IDENTIFIER_LENGTH + 1 + 1 + sizeof(
+                  uint16_t); /* +1 byte for options, +1 byte for title len, +2 bytes for count of joinpeers */
+        sz += g->title_len; /* +1 byte for title len */
+        sz += g->numjoinpeers * crypto_box_PUBLICKEYBYTES;
+    }
+
+    return (uint32_t)sz;
+}
+
+#define put16(v) { *((uint16_t *)data) = host_tolendian16( (uint16_t)(v) ); data += sizeof( uint16_t ); }
+#define putbytes( p, sz ) {memcpy(data,p, sz); data += sz;}
+
+void oldgroups_save(const Messenger *m, uint8_t *data)
+{
+    Group_Chats *g_c = (Group_Chats *)m->conferences_object;
+
+    uint16_t *num = (uint16_t *)data;
+    *num = 0;
+    data += sizeof(uint16_t);
+
+    size_t i;
+
+    for (i = 0; i < g_c->num_chats; ++i) {
+
+        Group_c *g = g_c->chats + i;
+
+        if (!g->live) {
+            continue;
+        }
+
+        putbytes(g->identifier, GROUP_IDENTIFIER_LENGTH);
+
+        uint8_t options = 0;
+
+        if (g->keep_leave) {
+            options = 1;
+        }
+
+        *data = options;
+        ++data;
+
+        *data = g->title_len;
+        ++data;
+        putbytes(g->title, g->title_len);
+
+        put16(g->numjoinpeers);
+
+        size_t j;
+
+        for (j = 0; j < g->numjoinpeers; ++j) {
+            putbytes(g->joinpeers[j].real_pk, crypto_box_PUBLICKEYBYTES);
+        }
+
+        ++(*num);
+    }
+
+}
+
+int oldgroups_load(Messenger *m, const uint8_t *data, uint32_t length)
+{
+    if (length < sizeof(uint16_t)) {
+        return -1;
+    }
+
+    Group_Chats *g_c = (Group_Chats *)m->conferences_object;
+
+    uint32_t i;
+
+    for (i = 0; i < g_c->num_chats; ++i) {
+        del_groupchat_internal(g_c, i, UNS_NONE);
+    }
+
+    g_c->num_chats = 0;
+
+    size_t numgchats = lendian_to_host16(*(uint16_t *)data);
+    data += sizeof(uint16_t), length -= sizeof(uint16_t);
+
+    for (i = 0; i < numgchats; ++i) {
+
+        if (length < GROUP_IDENTIFIER_LENGTH + 4) {
+            return -1;
+        }
+
+        int grounumber = add_groupchat(g_c, *data, data + 1);
+        data += GROUP_IDENTIFIER_LENGTH;
+        length -= GROUP_IDENTIFIER_LENGTH;
+
+        Group_c *g = get_group_c(g_c, grounumber);
+
+        if (!g) {
+            return -1;
+        }
+
+        g->invite_called = false;
+
+        if (*data & 1) {
+            g->keep_leave = true;
+            g->disable_auto_join = true;
+        } else {
+            g->join_mode = true;
+        }
+
+
+        ++data;
+        --length;
+
+        if (*data > sizeof(g->title)) {
+            return -1;
+        }
+
+        g->title_len = *data;
+        ++data;
+        --length;
+
+        if (length < g->title_len) {
+            return -1;
+        }
+
+        memcpy(g->title, data, g->title_len);
+        data += g->title_len;
+        length -= g->title_len;
+
+        g->numjoinpeers = lendian_to_host16(*(uint16_t *)data);
+        data += sizeof(uint16_t);
+        length -= sizeof(uint16_t);
+
+        g->joinpeers = (Group_Join_Peer *)calloc(g->numjoinpeers, sizeof(Group_Join_Peer));
+
+        if (length < g->numjoinpeers * crypto_box_PUBLICKEYBYTES) {
+            return -1;
+        }
+
+        length -= g->numjoinpeers * crypto_box_PUBLICKEYBYTES;
+
+        uint64_t t = current_time_monotonic() + 5000;
+        size_t j;
+
+        for (j = 0; j < g->numjoinpeers; ++j) {
+            memcpy(g->joinpeers[j].real_pk, data, crypto_box_PUBLICKEYBYTES);
+            data += crypto_box_PUBLICKEYBYTES;
+            g->joinpeers[j].next_try_time = t;
+            g->joinpeers[j].joingn = -1;
+        }
+    }
+
+    return 0;
 }

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -548,7 +548,6 @@ static void apply_changes_in_peers(Group_Chats *g_c, aint groupnumber, void *use
         g->closest_peers_entry = 0;
 
         size_t np = g->numpeers;
-        uint64_t comp_d = 0;
 
         for (i = 0; i < np; ++i) {
 
@@ -906,7 +905,6 @@ static int delpeer(Group_Chats *g_c, aint groupnumber, aint peer_index)
 
 int find_peer_index_in_list(const Group_c *g, aint peer_index)
 {
-    aint index = -1;
     size_t i;
 
     for (i = 0; i < g->numpeers_in_list; ++i) {
@@ -2937,7 +2935,7 @@ static void handle_message_packet_group(Group_Chats *g_c, int groupnumber, const
                 g->join_mode = false;
             }
 
-            aint peer_index = addpeer(g, groupnumber, real_pk, temp_pk, new_peer_gid);
+            /*aint peer_index =*/ addpeer(g, groupnumber, real_pk, temp_pk, new_peer_gid);
 
             int self_peer_gid = get_self_peer_gid(g);
 

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -52,7 +52,7 @@ typedef struct {
 
     uint8_t     *nick;
 
-    uint32_t    last_message_number[8]; /* 8 - number of group messages */
+    uint32_t    last_message_number[9]; /* 9 - number of group messages */
     int         friendcon_id;
 
     signed      gid : 24; /* unique per-conference peer id */
@@ -71,7 +71,6 @@ typedef struct {
     uint64_t    next_try_time;
     uint8_t     real_pk[crypto_box_PUBLICKEYBYTES];
     int8_t      fails;
-    int8_t      joingn;
     unsigned    online : 1;
     unsigned    unsubscribed : 1;
 } Group_Join_Peer;
@@ -188,9 +187,8 @@ void g_callback_group_title(Group_Chats *g_c, void (*function)(Messenger *m, uin
  *  Function(Group_Chats *g_c, int groupnumber, int peernumber, TOX_CHAT_CHANGE change, void *userdata)
  */
 enum {
-    CHAT_CHANGE_OCCURRED = 0,
-    /* CHAT_CHANGE_PEER_DEL, */
-    CHAT_CHANGE_PEER_NAME = 2,
+    CHAT_CHANGE_OCCURRED,
+    CHAT_CHANGE_PEER_NAME,
 };
 void g_callback_group_namelistchange(Group_Chats *g_c, void (*function)(Messenger *m, int, int, uint8_t, void *));
 

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -92,6 +92,7 @@ typedef struct {
 
     uint64_t last_sent_ping;
     uint64_t next_join_check_time;
+    uint64_t last_close_check_time;
 
     uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
     uint8_t title[MAX_NAME_LENGTH];
@@ -187,9 +188,9 @@ void g_callback_group_title(Group_Chats *g_c, void (*function)(Messenger *m, uin
  *  Function(Group_Chats *g_c, int groupnumber, int peernumber, TOX_CHAT_CHANGE change, void *userdata)
  */
 enum {
-    CHAT_CHANGE_OCCURRED,
-    __UNUSED__CHAT_CHANGE_PEER_DEL,
-    CHAT_CHANGE_PEER_NAME,
+    CHAT_CHANGE_OCCURRED = 0,
+    /* CHAT_CHANGE_PEER_DEL, */
+    CHAT_CHANGE_PEER_NAME = 2,
 };
 void g_callback_group_namelistchange(Group_Chats *g_c, void (*function)(Messenger *m, int, int, uint8_t, void *));
 

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -28,12 +28,6 @@
 #include "Messenger.h"
 
 enum {
-    GROUPCHAT_STATUS_NONE,
-    GROUPCHAT_STATUS_VALID,
-    GROUPCHAT_STATUS_CONNECTED
-};
-
-enum {
     GROUPCHAT_TYPE_TEXT,
     GROUPCHAT_TYPE_AV
 };
@@ -41,90 +35,126 @@ enum {
 #define MAX_LOSSY_COUNT 256
 
 typedef struct {
+
+    uint8_t     recv_lossy[MAX_LOSSY_COUNT];
+    uint16_t    bottom_lossy_number, top_lossy_number;
+
+} Group_Peer_Lossy;
+
+typedef struct {
     uint8_t     real_pk[crypto_box_PUBLICKEYBYTES];
     uint8_t     temp_pk[crypto_box_PUBLICKEYBYTES];
 
-    uint64_t    last_recv;
-    uint32_t    last_message_number;
-
-    uint8_t     nick[MAX_NAME_LENGTH];
-    uint8_t     nick_len;
-
-    uint16_t peer_number;
-
-    uint8_t  recv_lossy[MAX_LOSSY_COUNT];
-    uint16_t bottom_lossy_number, top_lossy_number;
-
+    Group_Peer_Lossy *lossy; /* rare use */
     void *object;
+
+    uint64_t    last_recv;
+
+    uint8_t     *nick;
+
+    uint32_t    last_message_number[8]; /* 8 - number of group messages */
+    int         friendcon_id;
+
+    signed      gid : 24; /* unique per-conference peer id */
+    unsigned    nick_len : 8;
+    unsigned    group_number : 16;
+    unsigned    keep_connection : 8; /* keep connection even not in ring (count down every incoming ping packet) */
+    unsigned    nick_changed : 1;
+    unsigned    title_changed : 1;
+    unsigned    auto_join : 1;
+    unsigned    need_send_peers : 1;
+    unsigned    connected : 1;
+
 } Group_Peer;
 
+typedef struct {
+    uint64_t    next_try_time;
+    uint8_t     real_pk[crypto_box_PUBLICKEYBYTES];
+    int8_t      fails;
+    int8_t      joingn;
+    unsigned    online : 1;
+    unsigned    unsubscribed : 1;
+} Group_Join_Peer;
+
 #define DESIRED_CLOSE_CONNECTIONS 4
-#define MAX_GROUP_CONNECTIONS 16
 #define GROUP_IDENTIFIER_LENGTH (1 + crypto_box_KEYBYTES) /* type + crypto_box_KEYBYTES so we can use new_symmetric_key(...) to fill it */
 
-enum {
-    GROUPCHAT_CLOSE_NONE,
-    GROUPCHAT_CLOSE_CONNECTION,
-    GROUPCHAT_CLOSE_ONLINE
-};
-
 typedef struct {
-    uint8_t status;
+    Group_Peer *peers;
+    Group_Join_Peer *joinpeers;
+    uint16_t *peers_list;
+    void *object;
 
-    Group_Peer *group;
     uint32_t numpeers;
+    uint32_t numpeers_in_list;
+    uint32_t numjoinpeers;
+    uint32_t message_number;
 
-    struct {
-        uint8_t type; /* GROUPCHAT_CLOSE_* */
-        uint8_t closest;
-        uint32_t number;
-        uint16_t group_number;
-    } close[MAX_GROUP_CONNECTIONS];
+    uint64_t last_sent_ping;
+    uint64_t next_join_check_time;
 
     uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
-    struct {
-        uint8_t entry;
-        uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
-        uint8_t temp_pk[crypto_box_PUBLICKEYBYTES];
-    } closest_peers[DESIRED_CLOSE_CONNECTIONS];
-    uint8_t changed;
+    uint8_t title[MAX_NAME_LENGTH];
+    uint16_t closest_peers[DESIRED_CLOSE_CONNECTIONS];
+
+    void (*peer_on_join)(void *, int, int);
+    void (*peer_on_leave)(void *, int, void *);
+    void (*group_on_delete)(void *, int);
 
     uint8_t identifier[GROUP_IDENTIFIER_LENGTH];
 
-    uint8_t title[MAX_NAME_LENGTH];
-    uint8_t title_len;
+    unsigned closest_peers_entry : DESIRED_CLOSE_CONNECTIONS;
+    unsigned live : 1;
+    unsigned join_mode : 1;
+    unsigned fake_join : 1;
+    unsigned auto_join : 1;
 
-    uint32_t message_number;
-    uint16_t lossy_message_number;
-    uint16_t peer_number;
+    unsigned title_len : 8;
+    unsigned lossy_message_number : 16;
 
-    uint64_t last_sent_ping;
+    signed keep_join_index : 24;
 
-    int number_joined; /* friendcon_id of person that invited us to the chat. (-1 means none) */
+    unsigned need_send_name : 1;
+    unsigned dirty_list : 1;
+    unsigned title_changed : 1;
+    unsigned invite_called : 1;
+    unsigned keep_leave : 1;
+    unsigned disable_auto_join : 1;
+    unsigned nick_changed : 1;
 
-    void *object;
-
-    void (*peer_on_join)(void *, int, int);
-    void (*peer_on_leave)(void *, int, int, void *);
-    void (*group_on_delete)(void *, int);
 } Group_c;
 
 typedef struct {
     Messenger *m;
     Friend_Connections *fr_c;
 
+
     Group_c *chats;
-    uint32_t num_chats;
+    uint16_t num_chats;
+    unsigned is_online : 1;
+
 
     void (*invite_callback)(Messenger *m, uint32_t, int, const uint8_t *, size_t, void *);
     void (*message_callback)(Messenger *m, uint32_t, uint32_t, int, const uint8_t *, size_t, void *);
     void (*group_namelistchange)(Messenger *m, int, int, uint8_t, void *);
     void (*title_callback)(Messenger *m, uint32_t, uint32_t, const uint8_t *, size_t, void *);
 
+
+    /*
+    there is only one value currently used: 192 (GROUP_AUDIO_PACKET_ID)
+    no need to reserve 255 addition pointers to handlers never used
+    that is why irungentoo's array of pointers was replaced with only one ptr
+    if someone in future want to use another id of packet in addition to the 192
+    just return back this array... or write better code
+                                                            isotoxin.dev
     struct {
         int (*function)(void *, int, int, void *, const uint8_t *, uint16_t);
     } lossy_packethandlers[256];
+    */
+
+    int(*lossy_packethandler)(void *, int, int, void *, const uint8_t *, uint16_t);
 } Group_Chats;
+
 
 /* Set the callback for group invites.
  *
@@ -157,8 +187,8 @@ void g_callback_group_title(Group_Chats *g_c, void (*function)(Messenger *m, uin
  *  Function(Group_Chats *g_c, int groupnumber, int peernumber, TOX_CHAT_CHANGE change, void *userdata)
  */
 enum {
-    CHAT_CHANGE_PEER_ADD,
-    CHAT_CHANGE_PEER_DEL,
+    CHAT_CHANGE_OCCURRED,
+    __UNUSED__CHAT_CHANGE_PEER_DEL,
     CHAT_CHANGE_PEER_NAME,
 };
 void g_callback_group_namelistchange(Group_Chats *g_c, void (*function)(Messenger *m, int, int, uint8_t, void *));
@@ -170,7 +200,7 @@ void g_callback_group_namelistchange(Group_Chats *g_c, void (*function)(Messenge
  * return group number on success.
  * return -1 on failure.
  */
-int add_groupchat(Group_Chats *g_c, uint8_t type);
+int add_groupchat(Group_Chats *g_c, uint8_t type, const uint8_t *uid /*can be NULL*/);
 
 /* Delete a groupchat from the chats array.
  *
@@ -178,6 +208,9 @@ int add_groupchat(Group_Chats *g_c, uint8_t type);
  * return -1 if groupnumber is invalid.
  */
 int del_groupchat(Group_Chats *g_c, int groupnumber);
+
+int enter_conference(Group_Chats *g_c, int groupnumber);
+int leave_conference(Group_Chats *g_c, int groupnumber, bool keep_leave);
 
 /* Copy the public key of peernumber who is in groupnumber to pk.
  * pk must be crypto_box_PUBLICKEYBYTES long.
@@ -325,6 +358,15 @@ uint32_t copy_chatlist(Group_Chats *g_c, uint32_t *out_list, uint32_t list_size)
  */
 int group_get_type(const Group_Chats *g_c, int groupnumber);
 
+/* return the unique id of conference that groupnumber is.
+*
+* return -1 on failure.
+* return type on success.
+*/
+int conference_get_id(const Group_Chats *g_c, int groupnumber, uint8_t *uid);
+
+int conference_by_uid(const Group_Chats *g_c, const uint8_t *uid);
+
 /* Send current name (set in messenger) to all online groups.
  */
 void send_name_all_groups(Group_Chats *g_c);
@@ -373,7 +415,7 @@ int callback_groupchat_peer_new(const Group_Chats *g_c, int groupnumber, void (*
  * return 0 on success.
  * return -1 on failure.
  */
-int callback_groupchat_peer_delete(Group_Chats *g_c, int groupnumber, void (*function)(void *, int, int, void *));
+int callback_groupchat_peer_delete(Group_Chats *g_c, int groupnumber, void (*function)(void *, int, void *));
 
 /* Set a function to be called when the group chat is deleted.
  *

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -2098,14 +2098,10 @@ namespace conference {
    */
   enum class STATE_CHANGE {
     /**
-     * Some changes to list has occurred. Rebuild of list required.
+     * Some changes to list have occurred. Rebuild of list required.
      * peer_number is undefined (always 0 for api compatibility)
      */
     LIST_CHANGED,
-    /**
-     * Deprecated. Never occurred.
-     */
-    PEER_EXIT,
     /**
      * A peer has changed their name.
      */

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -2047,9 +2047,12 @@ namespace conference {
      * or exits the conference.
      *
      * @param friend_number The friend who invited us.
-     *  if friend_number == UINT32_MAX then autojoin
-     *  if client do not call tox_conference_join or toxav_join_av_groupchat immediately
-     *  conference will be deleted
+     *  if friend_number == UINT32_MAX then conference automatically joined.
+     *  On auto-join client must call tox_conference_join or toxav_join_av_groupchat
+     *  immediately in callback. For api compatibility reason, if client don't
+     *  call one these functions, conference will be deleted and toxcore
+     *  totally forget this conference.
+     *  
      * @param type The conference type (text only or audio/video).
      * @param cookie A piece of data of variable length required to join the
      *   conference.
@@ -2152,11 +2155,11 @@ namespace conference {
 
   /**
    * This function starts entering process.
+   * Call this function only if you leave conference using $leave.
+   * No need to call this function for just created conferences
    *
    * @param conference_number The conference number of the conference to be entered.
-   * conference_number can be obtained by tox_conference_by_uid
-   * Call this function only if you leave conference using tox_conference_leave.
-   * No need to call this function for just created conferences
+   * conference_number can be obtained by $by_uid
    *
    * @return true on success.
    */
@@ -2177,12 +2180,12 @@ namespace conference {
    * Even error TOX_ERR_CONFERENCE_LEAVE_ALREADY, new keep_leave flag will be applied to conference
    *
    * @param conference_number The conference number of the conference to be disconnected.
-   * conference_number can be obtained by tox_conference_by_uid.
+   * conference_number can be obtained by $by_uid.
    *
    * @param keep_leave Set true to keep in leave state
    * No one can invite you to this conference after you leave it with keep_leave is true.
    * Also keep_leave == true means conference will not try to connect to other peers after restart.
-   * Call tox_conference_enter to enable auto connect and invite.
+   * Call $enter to enable auto connect and invite.
    *
    * @return true on success.
    */
@@ -2443,7 +2446,7 @@ namespace conference {
   /**
    * Get the conference unique ID.
    *
-   * @param uid A memory region large enough to store TOX_CONFERENCE_UID_SIZE bytes
+   * @param uid A memory region large enough to store $CONFERENCE_UID_SIZE bytes
    *
    * @return true on success.
    */
@@ -2453,7 +2456,7 @@ namespace conference {
    * Return the conference number associated with that uid.
    *
    * @return the conference number on success, UINT32_MAX on failure.
-   * @param uid A byte array containing the conference id (TOX_CONFERENCE_UID_SIZE).
+   * @param uid A byte array containing the conference id ($CONFERENCE_UID_SIZE).
    */
   const uint32_t by_uid(const uint8_t[CONFERENCE_UID_SIZE] uid) {
     NULL,

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -69,6 +69,10 @@ typedef struct Messenger Tox;
 #error TOX_MAX_STATUS_MESSAGE_LENGTH is assumed to be equal to MAX_STATUSMESSAGE_LENGTH
 #endif
 
+#if TOX_CONFERENCE_UID_SIZE != (GROUP_IDENTIFIER_LENGTH-1)
+#error TOX_CONFERENCE_UID_SIZE is assumed to be equal to (GROUP_IDENTIFIER_LENGTH-1)
+#endif
+
 uint32_t tox_version_major(void)
 {
     return TOX_VERSION_MAJOR;

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1237,7 +1237,7 @@ void tox_callback_conference_namelist_change(Tox *tox, tox_conference_namelist_c
 uint32_t tox_conference_new(Tox *tox, TOX_ERR_CONFERENCE_NEW *error)
 {
     Messenger *m = tox;
-    int ret = add_groupchat((Group_Chats *)m->conferences_object, GROUPCHAT_TYPE_TEXT);
+    int ret = add_groupchat((Group_Chats *)m->conferences_object, GROUPCHAT_TYPE_TEXT, NULL);
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_NEW_INIT);
@@ -1259,6 +1259,44 @@ bool tox_conference_delete(Tox *tox, uint32_t conference_number, TOX_ERR_CONFERE
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_DELETE_OK);
+    return true;
+}
+
+bool tox_conference_enter(Tox *tox, uint32_t conference_number, TOX_ERR_CONFERENCE_ENTER *error)
+{
+    Messenger *m = tox;
+    int ret = enter_conference((Group_Chats *)m->conferences_object, conference_number);
+
+    if (ret == -1) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_ENTER_NOT_FOUND);
+        return false;
+    }
+
+    if (ret == -2) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_ENTER_ALREADY);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_ENTER_OK);
+    return true;
+}
+
+bool tox_conference_leave(Tox *tox, uint32_t conference_number, bool keep_leave, TOX_ERR_CONFERENCE_LEAVE *error)
+{
+    Messenger *m = tox;
+    int ret = leave_conference((Group_Chats *)m->conferences_object, conference_number, keep_leave);
+
+    if (ret == -1) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_LEAVE_NOT_FOUND);
+        return false;
+    }
+
+    if (ret == -2) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_LEAVE_ALREADY);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_LEAVE_OK);
     return true;
 }
 
@@ -1540,6 +1578,33 @@ TOX_CONFERENCE_TYPE tox_conference_get_type(const Tox *tox, uint32_t conference_
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_GET_TYPE_OK);
     return (TOX_CONFERENCE_TYPE)ret;
 }
+
+bool tox_conference_get_uid(Tox *tox, uint32_t conference_number, uint8_t *uid /* TOX_CONFERENCE_ID_SIZE bytes */)
+{
+    const Messenger *m = tox;
+    int ret = conference_get_id((Group_Chats *)m->conferences_object, conference_number, uid);
+    return ret >= 0;
+}
+
+uint32_t tox_conference_by_uid(const Tox *tox, const uint8_t *uid, TOX_ERR_CONFERENCE_BY_UID *error)
+{
+    if (!uid) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_BY_UID_NULL);
+        return UINT32_MAX;
+    }
+
+    const Messenger *m = tox;
+    int32_t ret = conference_by_uid((Group_Chats *)m->conferences_object, uid);
+
+    if (ret == -1) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_BY_UID_NOT_FOUND);
+        return UINT32_MAX;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_BY_UID_OK);
+    return ret;
+}
+
 
 static void set_custom_packet_error(int ret, TOX_ERR_FRIEND_CUSTOM_PACKET *error)
 {

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -2377,11 +2377,6 @@ typedef enum TOX_CONFERENCE_STATE_CHANGE {
     TOX_CONFERENCE_STATE_CHANGE_LIST_CHANGED,
 
     /**
-     * Deprecated. Never occurred.
-     */
-    TOX_CONFERENCE_STATE_CHANGE_PEER_EXIT,
-
-    /**
      * A peer has changed their name.
      */
     TOX_CONFERENCE_STATE_CHANGE_PEER_NAME_CHANGE,

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -2306,9 +2306,12 @@ typedef enum TOX_CONFERENCE_TYPE {
  * or exits the conference.
  *
  * @param friend_number The friend who invited us.
- *  if friend_number == UINT32_MAX then autojoin
- *  if client do not call tox_conference_join or toxav_join_av_groupchat immediately
- *  conference will be deleted
+ *  if friend_number == UINT32_MAX then conference automatically joined.
+ *  On auto-join client must call tox_conference_join or toxav_join_av_groupchat
+ *  immediately in callback. For api compatibility reason, if client don't
+ *  call one these functions, conference will be deleted and toxcore
+ *  totally forget this conference.
+ *
  * @param type The conference type (text only or audio/video).
  * @param cookie A piece of data of variable length required to join the
  *   conference.
@@ -2472,11 +2475,11 @@ typedef enum TOX_ERR_CONFERENCE_ENTER {
 
 /**
  * This function starts entering process.
+ * Call this function only if you leave conference using tox_conference_leave.
+ * No need to call this function for just created conferences
  *
  * @param conference_number The conference number of the conference to be entered.
  * conference_number can be obtained by tox_conference_by_uid
- * Call this function only if you leave conference using tox_conference_leave.
- * No need to call this function for just created conferences
  *
  * @return true on success.
  */


### PR DESCRIPTION
This is not new groupchats. This is just upgrade to old groupchats with some advatages:
- Groupchats are now saved into tox_save
- Client can get groupchat unique id to save message log
- Auto restore groupchats after restart even your friend uses non-upgraded version

API compatibility: almost 100%
see changes at tox_conference_invite_cb and TOX_CONFERENCE_STATE_CHANGE

Protocol compatibility: 100%, except rare incorrect behaviour of non-upgraded clients due bug in old groupchats code.

**group.c** totally refactored

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/263)
<!-- Reviewable:end -->
