### PR TITLE
Disable -Wunused-but-set-variable compiler warning flag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ if(WARNINGS)
   add_cflag("-Wno-shadow")
   add_cflag("-Wno-shorten-64-to-32")
   add_cflag("-Wno-unreachable-code-return")
+  add_cflag("-Wno-unused-but-set-variable")
   add_cflag("-Wno-used-but-marked-unused")
 
   # Disable specific warning flags for C++.


### PR DESCRIPTION
This warning is triggered in `av_test.c`, where we have an open issue.
Silencing the warning locally would make the issue less visible. This
way, we will see the warning when we start removing the `-Wno-*` flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/265)
<!-- Reviewable:end -->
