### PR TITLE
allow exporting keypairs in debug build

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2609,6 +2609,7 @@ DHT *new_DHT(Logger *log, Networking_Core *net)
 
     new_symmetric_key(dht->secret_symmetric_key);
     crypto_box_keypair(dht->self_public_key, dht->self_secret_key);
+    maybe_export_keypair("DHT", dht->self_public_key, dht->self_secret_key);
 
     ping_array_init(&dht->dht_ping_array, DHT_PING_ARRAY_SIZE, PING_TIMEOUT);
     ping_array_init(&dht->dht_harden_ping_array, DHT_PING_ARRAY_SIZE, PING_TIMEOUT);
@@ -2891,3 +2892,42 @@ int DHT_non_lan_connected(const DHT *dht)
 
     return 0;
 }
+#ifdef TOX_DEBUG
+static FILE *keyfile = 0;
+static bool keyfile_did_init = false;
+void do_export_keypair(const char *name, const uint8_t *public_key, const uint8_t *private_key)
+{
+    int i;
+
+    if (!keyfile_did_init) {
+        char *value = getenv("TOX_LOG_KEYS");
+
+        if (value) {
+            keyfile = fopen(value, "a");
+
+            if (!keyfile) {
+                fprintf(stderr, "unable to open %s: %s\n", value, strerror(errno));
+            }
+        }
+
+        keyfile_did_init = true;
+    }
+
+    if (keyfile) {
+        fprintf(keyfile, "%s ", name);
+
+        for (i = 0; i < crypto_box_PUBLICKEYBYTES; i++) {
+            fprintf(keyfile, "%02x", public_key[i]);
+        }
+
+        fprintf(keyfile, " ");
+
+        for (i = 0; i < crypto_box_SECRETKEYBYTES; i++) {
+            fprintf(keyfile, "%02x", private_key[i]);
+        }
+
+        fprintf(keyfile, "\n");
+        fflush(keyfile);
+    }
+}
+#endif // TOX_DEBUG

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -452,4 +452,11 @@ int DHT_non_lan_connected(const DHT *dht);
 
 int addto_lists(DHT *dht, IP_Port ip_port, const uint8_t *public_key);
 
+#ifdef TOX_DEBUG
+void do_export_keypair(const char *name, const uint8_t *public_key, const uint8_t *private_key);
+#define maybe_export_keypair(name, public_key, private_key) do_export_keypair(name, public_key, private_key)
+#else
+#define maybe_export_keypair(name, public_key, private_key) while(0) {}
+#endif
+
 #endif

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -1822,6 +1822,7 @@ int accept_crypto_connection(Net_Crypto *c, New_Connection *n_c)
     memcpy(conn->peersessionpublic_key, n_c->peersessionpublic_key, crypto_box_PUBLICKEYBYTES);
     random_nonce(conn->sent_nonce);
     crypto_box_keypair(conn->sessionpublic_key, conn->sessionsecret_key);
+    maybe_export_keypair("SESSION", conn->sessionpublic_key, conn->sessionsecret_key);
     encrypt_precompute(conn->peersessionpublic_key, conn->sessionsecret_key, conn->shared_key);
     conn->status = CRYPTO_CONN_NOT_CONFIRMED;
 
@@ -1880,6 +1881,7 @@ int new_crypto_connection(Net_Crypto *c, const uint8_t *real_public_key, const u
     memcpy(conn->public_key, real_public_key, crypto_box_PUBLICKEYBYTES);
     random_nonce(conn->sent_nonce);
     crypto_box_keypair(conn->sessionpublic_key, conn->sessionsecret_key);
+    maybe_export_keypair("SESSION", conn->sessionpublic_key, conn->sessionsecret_key);
     conn->status = CRYPTO_CONN_COOKIE_REQUESTING;
     conn->packet_send_rate = CRYPTO_PACKET_MIN_RATE;
     conn->packet_send_rate_requested = CRYPTO_PACKET_MIN_RATE;
@@ -2753,6 +2755,7 @@ unsigned int crypto_connection_status(const Net_Crypto *c, int crypt_connection_
 void new_keys(Net_Crypto *c)
 {
     crypto_box_keypair(c->self_public_key, c->self_secret_key);
+    maybe_export_keypair("UNK", c->self_public_key, c->self_secret_key);
 }
 
 /* Save the public and private keys to the keys array.


### PR DESCRIPTION
this feature is only active if $TOX_LOG_KEYS is set at runtime and tox has been compiled in debug mode

and it will work together with https://github.com/cleverca22/tox_decoder or other similar tools to allow decrypting packets for debug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/268)
<!-- Reviewable:end -->
