### PR TITLE
Return big endian nospam in friend addresses.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,7 @@ if(BUILD_TOXAV)
   auto_test(toxav_basic)
   auto_test(toxav_many)
 endif()
+auto_test(util)
 
 ################################################################################
 #

--- a/auto_tests/util_test.c
+++ b/auto_tests/util_test.c
@@ -1,0 +1,45 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "../toxcore/util.h"
+
+#include <check.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+
+#include "helpers.h"
+
+START_TEST(test_byteswap_u32)
+{
+    ck_assert_msg(byteswap_u32(0xdeadbeef) == 0xefbeadde, "byteswap_u32 should swap endianness reliably");
+}
+END_TEST
+
+static Suite *crypto_suite(void)
+{
+    Suite *s = suite_create("Util");
+
+    DEFTESTCASE(byteswap_u32);
+
+    return s;
+}
+
+int main(int argc, char *argv[])
+{
+    srand((unsigned int) time(NULL));
+
+    Suite *crypto = crypto_suite();
+    SRunner *test_runner = srunner_create(crypto);
+    int number_failed = 0;
+
+    srunner_run_all(test_runner, CK_NORMAL);
+    number_failed = srunner_ntests_failed(test_runner);
+
+    srunner_free(test_runner);
+
+    return number_failed;
+}

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -144,7 +144,7 @@ static uint16_t address_checksum(const uint8_t *address, uint32_t len)
 void getaddress(const Messenger *m, uint8_t *address)
 {
     id_copy(address, m->net_crypto->self_public_key);
-    uint32_t nospam = get_nospam(&(m->fr));
+    uint32_t nospam = htonl(get_nospam(&(m->fr)));
     memcpy(address + crypto_box_PUBLICKEYBYTES, &nospam, sizeof(nospam));
     uint16_t checksum = address_checksum(address, FRIEND_ADDRESS_SIZE - sizeof(checksum));
     memcpy(address + crypto_box_PUBLICKEYBYTES + sizeof(nospam), &checksum, sizeof(checksum));

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -29,6 +29,9 @@
 
 #include "util.h"
 
+#include <assert.h>
+
+
 /* Set and get the nospam variable used to prevent one type of friend request spam. */
 void set_nospam(Friend_Requests *fr, uint32_t num)
 {
@@ -125,7 +128,11 @@ static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, co
         return 1;
     }
 
-    if (memcmp(packet, &fr->nospam, sizeof(fr->nospam)) != 0) {
+    uint32_t reversed_nospam = byteswap_u32(fr->nospam);
+    assert(sizeof reversed_nospam == sizeof fr->nospam);
+
+    if (memcmp(packet, &fr->nospam, sizeof(fr->nospam)) != 0
+            && memcmp(packet, &reversed_nospam, sizeof(reversed_nospam)) != 0) {
         return 1;
     }
 

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -193,3 +193,12 @@ int create_recursive_mutex(pthread_mutex_t *mutex)
 
     return 0;
 }
+
+uint32_t byteswap_u32(uint32_t v)
+{
+    return
+        ((v >> 24) & 0x000000ff) |
+        ((v >>  8) & 0x0000ff00) |
+        ((v <<  8) & 0x00ff0000) |
+        ((v << 24) & 0xff000000) ;
+}

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -58,4 +58,6 @@ int load_state(load_state_callback_func load_state_callback, void *outer,
 /* Returns -1 if failed or 0 if success */
 int create_recursive_mutex(pthread_mutex_t *mutex);
 
+uint32_t byteswap_u32(uint32_t v);
+
 #endif /* UTIL_H */


### PR DESCRIPTION
We now accept both big and little endian nospams in friend requests so
that regardless of how the nospam was presented to the user, we'll
accept it. This also fixes the bug that actual big endian systems could
never do a successful friend request to begin with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/269)
<!-- Reviewable:end -->
