### PR TITLE
Fix a memory leak in GroupAV

### DIFF
--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -346,6 +346,7 @@ static int decode_audio_packet(Group_AV *group_av, Group_Peer_AV *peer_av, int g
         free(pk);
 
         if (out_audio_samples <= 0) {
+            free(out_audio);
             return -1;
         }
 
@@ -369,6 +370,7 @@ static int decode_audio_packet(Group_AV *group_av, Group_Peer_AV *peer_av, int g
         out_audio_samples = opus_decode(peer_av->audio_decoder, NULL, 0, out_audio, peer_av->last_packet_samples, 1);
 
         if (out_audio_samples <= 0) {
+            free(out_audio);
             return -1;
         }
     }


### PR DESCRIPTION
[Clang's scan-build has identified two potential memory leaks in `groupav.c`](https://build.tox.chat/view/libtoxcore/job/libtoxcore-toktok_analyze_scan-build/21/clangScanBuildBugs/). Looks like there were cases when the `decode_audio_packet()` function would return without freeing the allocated memory, which is fixed by this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/275)
<!-- Reviewable:end -->
