### PR TITLE
Fix NULL pointer dereference in log calls

### DIFF
--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -134,10 +134,10 @@ MSISession *msi_new(Messenger *m)
     LOGGER_DEBUG(m->log, "New msi session: %p ", retu);
     return retu;
 }
-int msi_kill(MSISession *session)
+int msi_kill(MSISession *session, Logger *log)
 {
     if (session == NULL) {
-        LOGGER_ERROR(session->messenger->log, "Tried to terminate non-existing session");
+        LOGGER_ERROR(log, "Tried to terminate non-existing session");
         return -1;
     }
 

--- a/toxav/msi.h
+++ b/toxav/msi.h
@@ -26,6 +26,7 @@
 #include "video.h"
 
 #include "../toxcore/Messenger.h"
+#include "../toxcore/logger.h"
 
 #include <inttypes.h>
 #include <pthread.h>
@@ -127,7 +128,7 @@ MSISession *msi_new(Messenger *m);
 /**
  * Terminate control session. NOTE: all calls will be freed
  */
-int msi_kill(MSISession *session);
+int msi_kill(MSISession *session, Logger *log);
 /**
  * Callback setter.
  */

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -110,10 +110,10 @@ int rtp_stop_receiving(RTPSession *session)
     LOGGER_DEBUG(session->m->log, "Stopped receiving on session: %p", session);
     return 0;
 }
-int rtp_send_data(RTPSession *session, const uint8_t *data, uint16_t length)
+int rtp_send_data(RTPSession *session, const uint8_t *data, uint16_t length, Logger *log)
 {
     if (!session) {
-        LOGGER_WARNING(session->m->log, "No session!");
+        LOGGER_ERROR(log, "No session!");
         return -1;
     }
 

--- a/toxav/rtp.h
+++ b/toxav/rtp.h
@@ -25,6 +25,7 @@
 #include "bwcontroller.h"
 
 #include "../toxcore/Messenger.h"
+#include "../toxcore/logger.h"
 
 #include <stdbool.h>
 
@@ -106,6 +107,6 @@ RTPSession *rtp_new(int payload_type, Messenger *m, uint32_t friendnumber,
 void rtp_kill(RTPSession *session);
 int rtp_allow_receiving(RTPSession *session);
 int rtp_stop_receiving(RTPSession *session);
-int rtp_send_data(RTPSession *session, const uint8_t *data, uint16_t length);
+int rtp_send_data(RTPSession *session, const uint8_t *data, uint16_t length, Logger *log);
 
 #endif /* RTP_H */

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -177,7 +177,7 @@ void toxav_kill(ToxAV *av)
     pthread_mutex_lock(av->mutex);
 
     /* To avoid possible deadlocks */
-    while (av->msi && msi_kill(av->msi) != 0) {
+    while (av->msi && msi_kill(av->msi, av->m->log) != 0) {
         pthread_mutex_unlock(av->mutex);
         pthread_mutex_lock(av->mutex);
     }
@@ -718,7 +718,7 @@ bool toxav_audio_send_frame(ToxAV *av, uint32_t friend_number, const int16_t *pc
             goto END;
         }
 
-        if (rtp_send_data(call->audio.first, dest, vrc + sizeof(sampling_rate)) != 0) {
+        if (rtp_send_data(call->audio.first, dest, vrc + sizeof(sampling_rate), av->m->log) != 0) {
             LOGGER_WARNING(av->m->log, "Failed to send audio packet");
             rc = TOXAV_ERR_SEND_FRAME_RTP_FAILED;
         }
@@ -815,7 +815,7 @@ bool toxav_video_send_frame(ToxAV *av, uint32_t friend_number, uint16_t width, u
 
         while ((pkt = vpx_codec_get_cx_data(call->video.second->encoder, &iter))) {
             if (pkt->kind == VPX_CODEC_CX_FRAME_PKT &&
-                    rtp_send_data(call->video.first, (const uint8_t *)pkt->data.frame.buf, pkt->data.frame.sz) < 0) {
+                    rtp_send_data(call->video.first, (const uint8_t *)pkt->data.frame.buf, pkt->data.frame.sz, av->m->log) < 0) {
 
                 pthread_mutex_unlock(call->mutex_video);
                 LOGGER_WARNING(av->m->log, "Could not send video frame: %s\n", strerror(errno));


### PR DESCRIPTION
Dereferencing `session` right after making sure that it's NULL is probably not a very good idea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/276)
<!-- Reviewable:end -->
