### PR TITLE
Fix a memory leak in hstox interface

### DIFF
--- a/testing/hstox/methods.c
+++ b/testing/hstox/methods.c
@@ -143,5 +143,9 @@ int method_cmp(char const *ptr, char const *expected, size_t max_size)
         }
     }
 
-    return memcmp(transformed, expected, max_size);
+    int result = memcmp(transformed, expected, max_size);
+
+    free(transformed);
+
+    return result;
 }


### PR DESCRIPTION
`transformed` is leaking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/277)
<!-- Reviewable:end -->
