### PR TITLE
Add CMake knobs to suppress building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,7 +463,10 @@ endif()
 #
 ################################################################################
 
-if(NOT WIN32 AND BUILD_TOXAV AND SNDFILE_FOUND AND PORTAUDIO_FOUND AND OPENCV_FOUND)
+option(BUILD_AV_TEST "Build toxav test" ON)
+if(NOT WIN32
+   AND BUILD_AV_TEST AND BUILD_TOXAV
+   AND SNDFILE_FOUND AND PORTAUDIO_FOUND AND OPENCV_FOUND)
   add_c_executable(av_test testing/av_test.c)
   target_link_modules(av_test
     toxav

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,7 +480,8 @@ if(NOT WIN32
   endif()
 endif()
 
-if(NOT WIN32)
+option(BUILD_NTOX "Build nTox client" ON)
+if(NOT WIN32 AND BUILD_NTOX)
   add_c_executable(nTox testing/nTox.c)
   target_link_modules(nTox toxcore ${NCURSES_LIBRARIES})
 endif()


### PR DESCRIPTION
* BUILD_NTOX for nTox
* BUILD_AV_TEST for the toxav test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/287)
<!-- Reviewable:end -->
