### PR TITLE
feat: add Rust toxencryptsave

### DIFF
--- a/other/travis/env.sh
+++ b/other/travis/env.sh
@@ -7,6 +7,7 @@ export LD_LIBRARY_PATH=$CACHE_DIR/lib
 export PKG_CONFIG_PATH=$CACHE_DIR/lib/pkgconfig
 export ASTYLE=$CACHE_DIR/astyle/build/gcc/bin/astyle
 export CFLAGS="-O3 -DTRAVIS_ENV=1"
+export PATH="$PATH:$HOME/rust/bin"
 
 BUILD_DIR=_build
 

--- a/other/travis/toxcore-linux-install
+++ b/other/travis/toxcore-linux-install
@@ -51,3 +51,6 @@ pip install --user cpp-coveralls
   make install -j$NPROC
   cd - # popd
 }
+
+# build zetox and its CAPI
+other/travis/zetox

--- a/other/travis/toxcore-osx-install
+++ b/other/travis/toxcore-osx-install
@@ -1,3 +1,6 @@
 #!/bin/sh
 
 brew install libsodium libvpx opus libconfig check astyle
+
+# build zetox and its CAPI
+other/travis/zetox

--- a/other/travis/zetox
+++ b/other/travis/zetox
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Install Rust for toxencryptsave
+curl -sSf https://static.rust-lang.org/rustup.sh > rustup.sh
+mkdir ~/rust
+sh rustup.sh --prefix=~/rust --disable-sudo --spec=stable -y >/dev/null
+
+# Clone & compile tox-capi for toxencryptsave
+git clone https://github.com/ze-tox/tox-capi tox-capi
+cd tox-capi/toxencryptsave
+cargo build --release


### PR DESCRIPTION
As inquired by @iphydf.

---

Not integrated with CMake and not actually used by c-toxcore.
Someone who wants to play with CMake should integrate it.

Once integrated, ~whole `toxencryptsave` dir (spare for the `.h`) can be removed.

`.h` also will be possible to remove once Rust binding generator will provide 100% features set. This could be achieved right now with a work-around, but IMO there's no reason to use a work-around when there's a fully functional `.h` already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/288)
<!-- Reviewable:end -->
