### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,12 +46,12 @@ Note: package fetching commands may vary by OS.
 On Ubuntu `< 15.04` / Debian `< 8`:
 
 ```bash
-sudo apt-get install build-essential libtool autotools-dev automake checkinstall check git yasm
+sudo apt-get install build-essential libtool autotools-dev automake checkinstall check git yasm libncurses5-dev
 ```
 
 On Ubuntu `>= 15.04` / Debian `>= 8`:
 ```bash
-sudo apt-get install build-essential libtool autotools-dev automake checkinstall check git yasm libsodium13 libsodium-dev
+sudo apt-get install build-essential libtool autotools-dev automake checkinstall check git yasm libncurses5-dev libsodium13 libsodium-dev
 ```
 
 On Fedora:


### PR DESCRIPTION
Added missing package `libncurses5-dev` to Debian/Ubuntu instructions. Otherwise cmake will fail complaining about the missing library:

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
NCURSES_LIBRARIES
    linked by target "nTox" in directory /home/cebe/dev/tox/c-toxcore

-- Configuring incomplete, errors occurred!
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/291)
<!-- Reviewable:end -->
