### PR TITLE
Don't build nTox by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,8 +483,8 @@ if(NOT WIN32
   endif()
 endif()
 
-option(BUILD_NTOX "Build nTox client" ON)
-if(NOT WIN32 AND BUILD_NTOX)
+option(BUILD_NTOX "Build nTox client" OFF)
+if(BUILD_NTOX AND NOT WIN32)
   add_c_executable(nTox testing/nTox.c)
   target_link_modules(nTox toxcore ${NCURSES_LIBRARIES})
 endif()

--- a/other/travis/env.sh
+++ b/other/travis/env.sh
@@ -7,7 +7,7 @@ export LD_LIBRARY_PATH=$CACHE_DIR/lib
 export PKG_CONFIG_PATH=$CACHE_DIR/lib/pkgconfig
 export ASTYLE=$CACHE_DIR/astyle/build/gcc/bin/astyle
 export CFLAGS="-O3 -DTRAVIS_ENV=1"
-export CMAKE_EXTRA_FLAGS="-DERROR_ON_WARNING=ON"
+export CMAKE_EXTRA_FLAGS="-DERROR_ON_WARNING=ON -DBUILD_NTOX=ON"
 
 BUILD_DIR=_build
 


### PR DESCRIPTION
Build it on Travis. It won't be built on the windows builds regardless
of having it enabled globally.

Fixes #292.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/303)
<!-- Reviewable:end -->
