### PR TITLE
Fix static builds

### DIFF
--- a/libtoxcore.pc.in
+++ b/libtoxcore.pc.in
@@ -7,5 +7,5 @@ Name: libtoxcore
 Description: Tox protocol library
 Requires:
 Version: @PACKAGE_VERSION@
-Libs: @NACL_OBJECTS_PKGCONFIG@ -L${libdir} @NACL_LDFLAGS@ -ltoxdns -ltoxencryptsave -ltoxcore @NACL_LIBS@ @LIBS@ @MATH_LDFLAGS@ @PTHREAD_LDFLAGS@
+Libs: @NACL_OBJECTS_PKGCONFIG@ -L${libdir} -ltoxcore @NACL_LDFLAGS@ -ltoxdns -ltoxencryptsave @NACL_LIBS@ @LIBS@ @MATH_LDFLAGS@ @PTHREAD_LDFLAGS@
 Cflags: -I${includedir}

--- a/other/pkgconfig/toxcore.pc.in
+++ b/other/pkgconfig/toxcore.pc.in
@@ -6,5 +6,5 @@ Name: toxcore
 Description: Tox protocol library
 Requires: libsodium
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} @toxcore_PKGCONFIG_LIBS@ -ltoxcrypto -ltoxnetwork -ltoxdht -ltoxnetcrypto -ltoxfriends -ltoxmessenger -ltoxgroup -ltoxcore
+Libs: -L${libdir} -ltoxcore @toxcore_PKGCONFIG_LIBS@ -ltoxcrypto -ltoxnetwork -ltoxdht -ltoxnetcrypto -ltoxfriends -ltoxmessenger -ltoxgroup
 Cflags: -I${includedir}


### PR DESCRIPTION
I'm porting tuntox to work with TokTok c-toxcore and couldn't get it to link statically - dynamic linking works.

I'm not sure if the solution in this pull request is valid but it definitely makes the static linking work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/305)
<!-- Reviewable:end -->
