### PR TITLE
Add option to disable local peer discovery

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1954,7 +1954,7 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
     m->onion = new_onion(m->dht);
     m->onion_a = new_onion_announce(m->dht);
     m->onion_c =  new_onion_client(m->net_crypto);
-    m->fr_c = new_friend_connections(m->onion_c);
+    m->fr_c = new_friend_connections(m->onion_c, options->local_discovery_enabled);
 
     if (!(m->onion && m->onion_a && m->onion_c)) {
         kill_friend_connections(m->fr_c);

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -78,6 +78,7 @@ typedef struct {
     uint16_t tcp_server_port;
 
     uint8_t hole_punching_enabled;
+    bool local_discovery_enabled;
 
     logger_cb *log_callback;
     void *log_user_data;

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -811,7 +811,7 @@ int send_friend_request_packet(Friend_Connections *fr_c, int friendcon_id, uint3
 }
 
 /* Create new friend_connections instance. */
-Friend_Connections *new_friend_connections(Onion_Client *onion_c)
+Friend_Connections *new_friend_connections(Onion_Client *onion_c, bool local_discovery_enabled)
 {
     if (!onion_c) {
         return NULL;
@@ -826,9 +826,13 @@ Friend_Connections *new_friend_connections(Onion_Client *onion_c)
     temp->dht = onion_c->dht;
     temp->net_crypto = onion_c->c;
     temp->onion_c = onion_c;
+    temp->local_discovery_enabled = local_discovery_enabled;
 
     new_connection_handler(temp->net_crypto, &handle_new_connections, temp);
-    LANdiscovery_init(temp->dht);
+
+    if (temp->local_discovery_enabled) {
+        LANdiscovery_init(temp->dht);
+    }
 
     return temp;
 }
@@ -889,7 +893,9 @@ void do_friend_connections(Friend_Connections *fr_c, void *userdata)
         }
     }
 
-    LANdiscovery(fr_c);
+    if (fr_c->local_discovery_enabled) {
+        LANdiscovery(fr_c);
+    }
 }
 
 /* Free everything related with friend_connections. */
@@ -905,6 +911,9 @@ void kill_friend_connections(Friend_Connections *fr_c)
         kill_friend_connection(fr_c, i);
     }
 
-    LANdiscovery_kill(fr_c->dht);
+    if (fr_c->local_discovery_enabled) {
+        LANdiscovery_kill(fr_c->dht);
+    }
+
     free(fr_c);
 }

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -108,6 +108,8 @@ typedef struct {
     void *fr_request_object;
 
     uint64_t last_LANdiscovery;
+
+    bool local_discovery_enabled;
 } Friend_Connections;
 
 /* return friendcon_id corresponding to the real public key on success.
@@ -197,7 +199,7 @@ void set_friend_request_callback(Friend_Connections *fr_c, int (*fr_request_call
                                  const uint8_t *, uint16_t, void *), void *object);
 
 /* Create new friend_connections instance. */
-Friend_Connections *new_friend_connections(Onion_Client *onion_c);
+Friend_Connections *new_friend_connections(Onion_Client *onion_c, bool local_discovery_enabled);
 
 /* main friend_connections loop. */
 void do_friend_connections(Friend_Connections *fr_c, void *userdata);

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -469,6 +469,13 @@ static class options {
      */
     bool udp_enabled;
 
+    /**
+     * Enable local network peer discovery.
+     *
+     * Disabling this will cause Tox to not look for peers on the local network.
+     */
+    bool local_discovery_enabled;
+
     namespace proxy {
       /**
        * Pass communications through a proxy.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -132,6 +132,7 @@ ACCESSORS(TOX_SAVEDATA_TYPE, savedata_, type)
 ACCESSORS(size_t, savedata_, length)
 ACCESSORS(tox_log_cb *, log_, callback)
 ACCESSORS(void *, log_, user_data)
+ACCESSORS(bool, , local_discovery_enabled)
 
 const uint8_t *tox_options_get_savedata_data(const struct Tox_Options *options)
 {
@@ -153,6 +154,7 @@ void tox_options_default(struct Tox_Options *options)
         options->udp_enabled = 1;
         options->proxy_type = TOX_PROXY_TYPE_NONE;
         options->hole_punching_enabled = true;
+        options->local_discovery_enabled = true;
     }
 }
 
@@ -218,6 +220,7 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
         m_options.port_range[1] = options->end_port;
         m_options.tcp_server_port = options->tcp_port;
         m_options.hole_punching_enabled = options->hole_punching_enabled;
+        m_options.local_discovery_enabled = options->local_discovery_enabled;
 
         m_options.log_callback = (logger_cb *)options->log_callback;
         m_options.log_user_data = options->log_user_data;

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -522,6 +522,14 @@ struct Tox_Options {
 
 
     /**
+     * Enable local network peer discovery.
+     *
+     * Disabling this will cause Tox to not look for peers on the local network.
+     */
+    bool local_discovery_enabled;
+
+
+    /**
      * Pass communications through a proxy.
      */
     TOX_PROXY_TYPE proxy_type;
@@ -634,6 +642,10 @@ void tox_options_set_ipv6_enabled(struct Tox_Options *options, bool ipv6_enabled
 bool tox_options_get_udp_enabled(const struct Tox_Options *options);
 
 void tox_options_set_udp_enabled(struct Tox_Options *options, bool udp_enabled);
+
+bool tox_options_get_local_discovery_enabled(const struct Tox_Options *options);
+
+void tox_options_set_local_discovery_enabled(struct Tox_Options *options, bool local_discovery_enabled);
 
 TOX_PROXY_TYPE tox_options_get_proxy_type(const struct Tox_Options *options);
 


### PR DESCRIPTION
#296 was storing local peer discovery option in DHT, when it should be local to friend connections, as friend connections are the only ones who use LAN discovery.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/306)
<!-- Reviewable:end -->
