### PR TITLE
Clarify toxencryptsave documentation regarding buffer sizes

### DIFF
--- a/toxencryptsave/toxencryptsave.h
+++ b/toxencryptsave/toxencryptsave.h
@@ -203,6 +203,9 @@ bool tox_derive_key_with_salt(const uint8_t *passphrase, size_t pplength, const 
  * derive_key_with_salt to produce the same key as was previously used. Any encrpyted
  * data with this module can be used as input.
  *
+ * The data must be at least TOX_PASS_ENCRYPTION_EXTRA_LENGTH bytes in length.
+ * The salt must be TOX_PASS_SALT_LENGTH bytes in length.
+ *
  * returns true if magic number matches
  * success does not say anything about the validity of the data, only that data of
  * the appropriate size was copied
@@ -232,7 +235,11 @@ bool tox_pass_key_encrypt(const uint8_t *data, size_t data_len, const TOX_PASS_K
 bool tox_pass_key_decrypt(const uint8_t *data, size_t length, const TOX_PASS_KEY *key, uint8_t *out,
                           TOX_ERR_DECRYPTION *error);
 
-/* Determines whether or not the given data is encrypted (by checking the magic number)
+/* Determines whether or not the given data is encrypted (by checking the magic number).
+ *
+ * The data must be at least TOX_PASS_ENCRYPTION_EXTRA_LENGTH bytes in length.
+ *
+ * returns true on success
  */
 bool tox_is_data_encrypted(const uint8_t *data);
 


### PR DESCRIPTION
~~Fixes a possible buffer overrun by `memcpy()` in `tox_is_data_encrypted()` when the `data` is less than `TOX_ENC_SAVE_MAGIC_LENGTH`. There was the very same buffer overrun present in `tox_get_salt()`, which I replaced with a call to `tox_is_data_encrypted()`. I have also added some extra checks on function inputs.~~

TES seems to be somewhat poorely written, for example, the same `tox_get_salt()` function doesn't check if `salt` has enough space to store the entire salt, nor does the documentation to `tox_get_salt()` mention anything about the salt being `TOX_PASS_SALT_LENGTH` in size. We should really consider reviewing the TES module and porting its interface to APIDSL.

~~This PR breaks API.~~

**Edited:** Fixes a possible buffer overrun by `memcpy()` in `tox_is_data_encrypted()` when the `data` is less than `TOX_ENC_SAVE_MAGIC_LENGTH` by specifying the size requirement in the documentation to the `tox_is_data_encrypted()` function. `tox_get_salt()` had similar issue and was dealt with in the similar manner.

Instead of documentation fixes this PR had previously have size checks added in code, you can see the code changes I have precociously had in this PR in https://github.com/nurupo/InsertProjectNameHere/commit/74160214039cd163d41172e33ee67033026af9f7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/307)
<!-- Reviewable:end -->
