### PR TITLE
Fixed attempt to join detached threads (fixes toxav test crash)

### DIFF
--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -202,6 +202,7 @@ START_TEST(test_AV_three_calls)
     uint32_t index[] = { 1, 2, 3, 4, 5 };
     Tox *Alice, *bootstrap, *Bobs[3];
     ToxAV *AliceAV, *BobsAV[3];
+    void *retval;
 
     CallControl AliceCC[3], BobsCC[3];
 
@@ -300,10 +301,6 @@ START_TEST(test_AV_three_calls)
     (void) pthread_create(tids + 1, NULL, call_thread, tds + 1);
     (void) pthread_create(tids + 2, NULL, call_thread, tds + 2);
 
-    (void) pthread_detach(tids[0]);
-    (void) pthread_detach(tids[1]);
-    (void) pthread_detach(tids[2]);
-
     time_t start_time = time(NULL);
 
     while (time(NULL) - start_time < 5) {
@@ -314,9 +311,14 @@ START_TEST(test_AV_three_calls)
         c_sleep(20);
     }
 
-    (void) pthread_join(tids[0], NULL);
-    (void) pthread_join(tids[1], NULL);
-    (void) pthread_join(tids[2], NULL);
+    ck_assert(pthread_join(tids[0], &retval) == 0);
+    ck_assert(retval == NULL);
+
+    ck_assert(pthread_join(tids[1], &retval) == 0);
+    ck_assert(retval == NULL);
+
+    ck_assert(pthread_join(tids[2], &retval) == 0);
+    ck_assert(retval == NULL);
 
     printf("Killing all instances\n");
     toxav_kill(BobsAV[0]);


### PR DESCRIPTION
Fixed race condition in the case when we already called toxav_kill but concurrent thread is actually still alive and is accessing its ToxAV instance. #278

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/309)
<!-- Reviewable:end -->
