### PR TITLE
Conditionally enable non-portable assert on LP64.

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2752,7 +2752,9 @@ static uint32_t friends_list_save(const Messenger *m, uint8_t *data)
             uint8_t *next_data = friend_save(&temp, cur_data);
 #ifdef TOX_DEBUG
             assert(next_data - cur_data == friend_size());
+#ifdef __LP64__
             assert(memcmp(cur_data, &temp, friend_size()) == 0);
+#endif
 #endif
             cur_data = next_data;
             num++;
@@ -2812,7 +2814,9 @@ static int friends_list_load(Messenger *m, const uint8_t *data, uint32_t length)
         const uint8_t *next_data = friend_load(&temp, cur_data);
 #ifdef TOX_DEBUG
         assert(next_data - cur_data == friend_size());
+#ifdef __LP64__
         assert(memcmp(&temp, cur_data, friend_size()) == 0);
+#endif
 #endif
         cur_data = next_data;
 


### PR DESCRIPTION
This only works on LP64. It may fail on Windows, which can be LLP64
(IL32P64).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/312)
<!-- Reviewable:end -->
