### PR TITLE
Fix version compatibility test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,8 @@ auto_test(tox)
 auto_test(tox_many)
 auto_test(tox_many_tcp)
 auto_test(tox_one)
+auto_test(version)
+
 if(BUILD_TOXAV)
   auto_test(toxav_basic)
   auto_test(toxav_many)

--- a/auto_tests/version_test.c
+++ b/auto_tests/version_test.c
@@ -1,0 +1,93 @@
+#include "../toxcore/tox.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define check(major, minor, patch, expected)                            \
+  do_check(TOX_VERSION_MAJOR, TOX_VERSION_MINOR, TOX_VERSION_PATCH,     \
+           major, minor, patch,                                         \
+           TOX_VERSION_IS_API_COMPATIBLE(major, minor, patch), expected,\
+           &result)
+
+static void do_check(int lib_major, int lib_minor, int lib_patch,
+                     int cli_major, int cli_minor, int cli_patch,
+                     bool actual, bool expected,
+                     int *result)
+{
+    if (actual != expected) {
+        printf("Client version %d.%d.%d is%s compatible with library version %d.%d.%d, but it should%s be\n",
+               cli_major, cli_minor, cli_patch, actual ? "" : " not",
+               lib_major, lib_minor, lib_patch, expected ? "" : " not");
+        *result = EXIT_FAILURE;
+    }
+}
+
+#undef TOX_VERSION_MAJOR
+#undef TOX_VERSION_MINOR
+#undef TOX_VERSION_PATCH
+
+int main(void)
+{
+    int result = 0;
+#define TOX_VERSION_MAJOR 0
+#define TOX_VERSION_MINOR 0
+#define TOX_VERSION_PATCH 4
+    check(0, 0, 0, false);
+    check(0, 0, 4, true);
+    check(0, 0, 5, false);
+    check(1, 0, 4, false);
+#undef TOX_VERSION_MAJOR
+#undef TOX_VERSION_MINOR
+#undef TOX_VERSION_PATCH
+
+#define TOX_VERSION_MAJOR 0
+#define TOX_VERSION_MINOR 1
+#define TOX_VERSION_PATCH 4
+    check(0, 0, 0, false);
+    check(0, 0, 4, false);
+    check(0, 0, 5, false);
+    check(0, 1, 0, true);
+    check(0, 1, 4, true);
+    check(0, 1, 5, false);
+    check(0, 2, 0, false);
+    check(0, 2, 4, false);
+    check(0, 2, 5, false);
+    check(1, 0, 0, false);
+    check(1, 0, 4, false);
+    check(1, 0, 5, false);
+#undef TOX_VERSION_MAJOR
+#undef TOX_VERSION_MINOR
+#undef TOX_VERSION_PATCH
+
+#define TOX_VERSION_MAJOR 1
+#define TOX_VERSION_MINOR 0
+#define TOX_VERSION_PATCH 4
+    check(1, 0, 0, true);
+    check(1, 0, 1, true);
+    check(1, 0, 4, true);
+    check(1, 0, 5, false);
+    check(1, 1, 0, false);
+#undef TOX_VERSION_MAJOR
+#undef TOX_VERSION_MINOR
+#undef TOX_VERSION_PATCH
+
+#define TOX_VERSION_MAJOR 1
+#define TOX_VERSION_MINOR 1
+#define TOX_VERSION_PATCH 4
+    check(1, 0, 0, true);
+    check(1, 0, 4, true);
+    check(1, 0, 5, true);
+    check(1, 1, 0, true);
+    check(1, 1, 1, true);
+    check(1, 1, 4, true);
+    check(1, 1, 5, false);
+    check(1, 2, 0, false);
+    check(1, 2, 4, false);
+    check(1, 2, 5, false);
+    check(2, 0, 0, false);
+#undef TOX_VERSION_MAJOR
+#undef TOX_VERSION_MINOR
+#undef TOX_VERSION_PATCH
+
+    return result;
+}

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -183,13 +183,24 @@ const VERSION_PATCH                = 5;
 
 /**
  * A macro to check at preprocessing time whether the client code is compatible
- * with the installed version of Tox.
+ * with the installed version of Tox. Leading zeros in the version number are 
+ * ignored. E.g. 0.1.5 is to 0.1.4 what 1.5 is to 1.4, that is: it can add new
+ * features, but can't break the API.
  */
-#define TOX_VERSION_IS_API_COMPATIBLE(MAJOR, MINOR, PATCH)      \
-  (TOX_VERSION_MAJOR == MAJOR &&                                \
-   (TOX_VERSION_MINOR > MINOR ||                                \
-    (TOX_VERSION_MINOR == MINOR &&                              \
-     TOX_VERSION_PATCH >= PATCH)))
+#define TOX_VERSION_IS_API_COMPATIBLE(MAJOR, MINOR, PATCH)              \
+  (TOX_VERSION_MAJOR > 0 && TOX_VERSION_MAJOR == MAJOR) && (            \
+    /* 1.x.x, 2.x.x, etc. with matching major version. */               \
+    TOX_VERSION_MINOR > MINOR ||                                        \
+    TOX_VERSION_MINOR == MINOR && TOX_VERSION_PATCH >= PATCH            \
+  ) || (TOX_VERSION_MAJOR == 0 && MAJOR == 0) && (                      \
+    /* 0.x.x makes minor behave like major above. */                    \
+    (TOX_VERSION_MINOR > 0 && TOX_VERSION_MINOR == MINOR) && (          \
+      TOX_VERSION_PATCH >= PATCH                                        \
+    ) || (TOX_VERSION_MINOR == 0 && MINOR == 0) && (                    \
+      /* 0.0.x and 0.0.y are only compatible if x == y. */              \
+      TOX_VERSION_PATCH == PATCH                                        \
+    )                                                                   \
+  )
 
 /**
  * A macro to make compilation fail if the client code is not compatible with

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -86,11 +86,7 @@ uint32_t tox_version_patch(void)
 
 bool tox_version_is_compatible(uint32_t major, uint32_t minor, uint32_t patch)
 {
-    return (TOX_VERSION_MAJOR == major && /* Force the major version */
-            (TOX_VERSION_MINOR > minor || /* Current minor version must be newer than requested -- or -- */
-             (TOX_VERSION_MINOR == minor && TOX_VERSION_PATCH >= patch) /* the patch must be the same or newer */
-            )
-           );
+    return TOX_VERSION_IS_API_COMPATIBLE(major, minor, patch);
 }
 
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -186,13 +186,24 @@ uint32_t tox_version_patch(void);
 
 /**
  * A macro to check at preprocessing time whether the client code is compatible
- * with the installed version of Tox.
+ * with the installed version of Tox. Leading zeros in the version number are
+ * ignored. E.g. 0.1.5 is to 0.1.4 what 1.5 is to 1.4, that is: it can add new
+ * features, but can't break the API.
  */
-#define TOX_VERSION_IS_API_COMPATIBLE(MAJOR, MINOR, PATCH)      \
-  (TOX_VERSION_MAJOR == MAJOR &&                                \
-   (TOX_VERSION_MINOR > MINOR ||                                \
-    (TOX_VERSION_MINOR == MINOR &&                              \
-     TOX_VERSION_PATCH >= PATCH)))
+#define TOX_VERSION_IS_API_COMPATIBLE(MAJOR, MINOR, PATCH)              \
+  (TOX_VERSION_MAJOR > 0 && TOX_VERSION_MAJOR == MAJOR) && (            \
+    /* 1.x.x, 2.x.x, etc. with matching major version. */               \
+    TOX_VERSION_MINOR > MINOR ||                                        \
+    TOX_VERSION_MINOR == MINOR && TOX_VERSION_PATCH >= PATCH            \
+  ) || (TOX_VERSION_MAJOR == 0 && MAJOR == 0) && (                      \
+    /* 0.x.x makes minor behave like major above. */                    \
+    (TOX_VERSION_MINOR > 0 && TOX_VERSION_MINOR == MINOR) && (          \
+      TOX_VERSION_PATCH >= PATCH                                        \
+    ) || (TOX_VERSION_MINOR == 0 && MINOR == 0) && (                    \
+      /* 0.0.x and 0.0.y are only compatible if x == y. */              \
+      TOX_VERSION_PATCH == PATCH                                        \
+    )                                                                   \
+  )
 
 /**
  * A macro to make compilation fail if the client code is not compatible with


### PR DESCRIPTION
When the version number has trailing zeros, a change of the first non-zero number means a break in API compatibility. eg. 0.0.1 to 0.0.2 means a break, 0.3.0 to 0.4.0 means a break, but 0.3.0 to 0.3.1 means not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/315)
<!-- Reviewable:end -->
