### PR TITLE
Add compatibility pkg-config modules: libtoxcore, libtoxav.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,7 +551,20 @@ configure_file(
   @ONLY
 )
 
+configure_file(
+  "${CMAKE_SOURCE_DIR}/other/pkgconfig/libtoxcore.pc.in"
+  "${CMAKE_BINARY_DIR}/libtoxcore.pc"
+  @ONLY
+)
+
+configure_file(
+  "${CMAKE_SOURCE_DIR}/other/pkgconfig/libtoxav.pc.in"
+  "${CMAKE_BINARY_DIR}/libtoxav.pc"
+  @ONLY
+)
+
 install(FILES
+  ${CMAKE_BINARY_DIR}/libtoxcore.pc
   ${CMAKE_BINARY_DIR}/toxcore.pc
   ${CMAKE_BINARY_DIR}/toxdns.pc
   ${CMAKE_BINARY_DIR}/toxencryptsave.pc
@@ -564,6 +577,7 @@ install(FILES
 
 if(BUILD_TOXAV)
   install(FILES
+    ${CMAKE_BINARY_DIR}/libtoxav.pc
     ${CMAKE_BINARY_DIR}/toxav.pc
     DESTINATION "lib/pkgconfig")
   install(FILES

--- a/other/pkgconfig/libtoxav.pc.in
+++ b/other/pkgconfig/libtoxav.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libtoxav
+Description: Tox A/V library - compatibility module (use toxav instead)
+Requires: toxav
+Version: @PROJECT_VERSION@

--- a/other/pkgconfig/libtoxcore.pc.in
+++ b/other/pkgconfig/libtoxcore.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libtoxcore
+Description: Tox protocol library - compatibility module (use toxcore, toxdns, and toxencryptsave instead)
+Requires: toxcore toxdns toxencryptsave
+Version: @PROJECT_VERSION@


### PR DESCRIPTION
These were generated by the autotools build. Some clients may depend on
these files instead of the newer split pkg-config files. New clients
should be using the toxcore, toxav, toxencryptsave, and toxdns modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/322)
<!-- Reviewable:end -->
