### PR TITLE
Fix Libs line in toxcore.pc pkg-config file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ target_link_modules(toxnetwork toxcrypto)
 
 if(CMAKE_THREAD_LIBS_INIT)
   target_link_modules(toxnetwork ${CMAKE_THREAD_LIBS_INIT})
-  set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} "-l${CMAKE_THREAD_LIBS_INIT}")
+  set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 if(RT_LIBRARIES)
@@ -524,6 +524,8 @@ endif()
 # :: Installation and pkg-config
 #
 ################################################################################
+
+string(REPLACE ";" " " toxcore_PKGCONFIG_LIBS "${toxcore_PKGCONFIG_LIBS}")
 
 if(BUILD_TOXAV)
   configure_file(


### PR DESCRIPTION
CMake lists are `;` separated and CMAKE_THREAD_LIBS_INIT contains
"-lpthread". This resulted in "-l-lpthread;-lrt" on Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/325)
<!-- Reviewable:end -->
