### PR TITLE
Strengthen the note about ABI compatibility in tox.h.

### DIFF
--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -428,19 +428,17 @@ typedef void log_cb(LOG_LEVEL level, string file, uint32_t line, string func, st
 
 static class options {
   /**
-   * This struct contains all the startup options for Tox. You can either
-   * allocate this object yourself, and pass it to $default, or call $new to get
-   * a new default options object.
+   * This struct contains all the startup options for Tox. You must $new to
+   * allocate an object of this type.
    *
-   * If you allocate it yourself, be aware that your binary will rely on the
-   * memory layout of this struct. In particular, if additional fields are added
-   * in future versions of the API, code that allocates it itself will become
-   * incompatible.
+   * WARNING: Although this struct happens to be visible in the API, it is
+   * effectively private. Do not allocate this yourself or access members
+   * directly, as it *will* break binary compatibility frequently.
    *
    * @deprecated The memory layout of this struct (size, alignment, and field
    * order) is not part of the ABI. To remain compatible, prefer to use $new to
    * allocate the object and accessor functions to set the members. The struct
-   * will become opaque (i.e. the definition will become private) in v0.1.0.
+   * will become opaque (i.e. the definition will become private) in v0.2.0.
    */
   struct this [get, set] {
     /**

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -477,19 +477,17 @@ typedef void tox_log_cb(Tox *tox, TOX_LOG_LEVEL level, const char *file, uint32_
 
 
 /**
- * This struct contains all the startup options for Tox. You can either
- * allocate this object yourself, and pass it to tox_options_default, or call tox_options_new to get
- * a new default options object.
+ * This struct contains all the startup options for Tox. You must tox_options_new to
+ * allocate an object of this type.
  *
- * If you allocate it yourself, be aware that your binary will rely on the
- * memory layout of this struct. In particular, if additional fields are added
- * in future versions of the API, code that allocates it itself will become
- * incompatible.
+ * WARNING: Although this struct happens to be visible in the API, it is
+ * effectively private. Do not allocate this yourself or access members
+ * directly, as it *will* break binary compatibility frequently.
  *
  * @deprecated The memory layout of this struct (size, alignment, and field
  * order) is not part of the ABI. To remain compatible, prefer to use tox_options_new to
  * allocate the object and accessor functions to set the members. The struct
- * will become opaque (i.e. the definition will become private) in v0.1.0.
+ * will become opaque (i.e. the definition will become private) in v0.2.0.
  */
 struct Tox_Options {
 


### PR DESCRIPTION
We really want to get all clients off this struct. We won't actually
remove it until 0.2, but we're going to break ABI compatibility with this
in various 0.1.x releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/330)
<!-- Reviewable:end -->
