### PR TITLE
Fix toxav use after free caused by premature MSI destruction

### DIFF
--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -188,6 +188,7 @@ void toxav_kill(ToxAV *av)
 
         while (it) {
             call_kill_transmission(it);
+            it->msi_call = NULL; /* msi_kill() frees the call's msi_call handle; which causes #278 */
             it = call_remove(it); /* This will eventually free av->calls */
         }
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/353)
<!-- Reviewable:end -->
