### PR TITLE
Remove .cabal-sandbox option from tox-spectest find line.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,9 +357,7 @@ target_link_modules(toxencryptsave toxcore)
 #
 ################################################################################
 
-find_program(SPECTEST NAMES
-  tox-spectest
-  ${CMAKE_SOURCE_DIR}/../.cabal-sandbox/bin/tox-spectest)
+find_program(SPECTEST NAMES tox-spectest)
 
 if(SPECTEST AND MSGPACK_FOUND)
   add_c_executable(toxcore-sut


### PR DESCRIPTION
This was just for finding it in toktok-stack, which now uses
haskell-stack, and thus no longer has a .cabal-sandbox. We'll just assume
that the Makefile properly sets up the path such that tox-spectest is
available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/362)
<!-- Reviewable:end -->
