### PR TITLE
Fix SSL verification in coveralls.

### DIFF
--- a/other/travis/toxcore-linux-install
+++ b/other/travis/toxcore-linux-install
@@ -12,7 +12,12 @@ git clone --depth=1 https://github.com/TokTok/apidsl ../apidsl
 make -C ../apidsl -j$NPROC
 
 # Install cpp-coveralls to upload test coverage results.
-pip install --user cpp-coveralls
+pip install --user urllib3[secure] cpp-coveralls
+
+# Work around https://github.com/eddyxu/cpp-coveralls/issues/108 by manually
+# installing the pyOpenSSL module and injecting it into urllib3 as per
+# https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
+sed -i -e '/^import sys$/a import urllib3.contrib.pyopenssl\nurllib3.contrib.pyopenssl.inject_into_urllib3()' `which coveralls`
 
 # Install astyle (version in ubuntu-precise too old).
 [ -f $ASTYLE ] || {


### PR DESCRIPTION
We really don't care about coveralls doing its call to the right server.
The worst that can happen is that someone MITMs our coverage analysis,
which we already don't care about much at this point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/377)
<!-- Reviewable:end -->
