### PR TITLE
Remove `TOX_DEBUG` and have asserts always enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,6 @@ endif()
 option(DEBUG "Enable assertions and other debugging facilities" OFF)
 if(DEBUG)
   set(MIN_LOGGER_LEVEL DEBUG)
-  add_definitions(-DTOX_DEBUG=1)
   add_cflag("-g3")
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,6 @@ BUILD_AV="yes"
 BUILD_TESTING="yes"
 
 TOX_LOGGER="no"
-TOX_DEBUG="no"
 
 NCURSES_FOUND="no"
 LIBCONFIG_FOUND="no"
@@ -89,17 +88,6 @@ AC_ARG_ENABLE([logging],
             TOX_LOGGER="yes"
 
             AC_DEFINE([MIN_LOGGER_LEVEL], [LOG_DEBUG], [LOG_LEVEL value])
-        fi
-    ]
-)
-
-AC_ARG_ENABLE([debug],
-    [AC_HELP_STRING([--enable-debug], [enable debugging (default: disabled)]) ],
-    [
-        if test "x$enableval" = "xyes"; then
-            TOX_DEBUG="yes"
-
-            AC_DEFINE([TOX_DEBUG], [], [If debugging enabled])
         fi
     ]
 )

--- a/testing/misc_tools.c
+++ b/testing/misc_tools.c
@@ -31,10 +31,6 @@
 #include <string.h>
 #include <strings.h>
 
-#ifdef TOX_DEBUG
-#include <assert.h>
-#endif // TOX_DEBUG
-
 // You are responsible for freeing the return value!
 uint8_t *hex_string_to_bin(const char *hex_string)
 {

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2813,13 +2813,10 @@ static int dht_load_state_callback(void *outer, const uint8_t *data, uint32_t le
 
             break;
 
-#ifdef TOX_DEBUG
-
         default:
-            fprintf(stderr, "Load state (DHT): contains unrecognized part (len %u, type %u)\n",
-                    length, type);
+            LOGGER_ERROR(dht->log, "Load state (DHT): contains unrecognized part (len %u, type %u)\n",
+                         length, type);
             break;
-#endif
     }
 
     return 0;
@@ -2839,7 +2836,7 @@ int DHT_load(DHT *dht, const uint8_t *data, uint32_t length)
         lendian_to_host32(&data32, data);
 
         if (data32 == DHT_STATE_COOKIE_GLOBAL) {
-            return load_state(dht_load_state_callback, dht, data + cookie_len,
+            return load_state(dht_load_state_callback, dht->log, dht, data + cookie_len,
                               length - cookie_len, DHT_STATE_COOKIE_TYPE);
         }
     }

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -550,9 +550,7 @@ Networking_Core *new_networking_ex(Logger *log, IP ip, uint16_t port_from, uint1
 
     /* maybe check for invalid IPs like 224+.x.y.z? if there is any IP set ever */
     if (ip.family != AF_INET && ip.family != AF_INET6) {
-#ifdef TOX_DEBUG
-        fprintf(stderr, "Invalid address family: %u\n", ip.family);
-#endif
+        LOGGER_ERROR(log, "Invalid address family: %u\n", ip.family);
         return NULL;
     }
 
@@ -576,9 +574,7 @@ Networking_Core *new_networking_ex(Logger *log, IP ip, uint16_t port_from, uint1
 
     /* Check for socket error. */
     if (!sock_valid(temp->sock)) {
-#ifdef TOX_DEBUG
-        fprintf(stderr, "Failed to get a socket?! %u, %s\n", errno, strerror(errno));
-#endif
+        LOGGER_ERROR(log, "Failed to get a socket?! %u, %s\n", errno, strerror(errno));
         free(temp);
 
         if (error) {

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -116,13 +116,11 @@ void lendian_to_host32(uint32_t *dest, const uint8_t *lendian)
 }
 
 /* state load/save */
-int load_state(load_state_callback_func load_state_callback, void *outer,
+int load_state(load_state_callback_func load_state_callback, Logger *log, void *outer,
                const uint8_t *data, uint32_t length, uint16_t cookie_inner)
 {
     if (!load_state_callback || !data) {
-#ifdef TOX_DEBUG
-        fprintf(stderr, "load_state() called with invalid args.\n");
-#endif
+        LOGGER_ERROR(log, "load_state() called with invalid args.\n");
         return -1;
     }
 
@@ -139,17 +137,13 @@ int load_state(load_state_callback_func load_state_callback, void *outer,
 
         if (length < length_sub) {
             /* file truncated */
-#ifdef TOX_DEBUG
-            fprintf(stderr, "state file too short: %u < %u\n", length, length_sub);
-#endif
+            LOGGER_ERROR(log, "state file too short: %u < %u\n", length, length_sub);
             return -1;
         }
 
         if (lendian_to_host16((cookie_type >> 16)) != cookie_inner) {
             /* something is not matching up in a bad way, give up */
-#ifdef DEBUG
-            fprintf(stderr, "state file garbled: %04x != %04x\n", (cookie_type >> 16), cookie_inner);
-#endif
+            LOGGER_ERROR(log, "state file garbled: %04x != %04x\n", (cookie_type >> 16), cookie_inner);
             return -1;
         }
 

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -29,6 +29,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "logger.h"
+
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define PAIR(TYPE1__, TYPE2__) struct { TYPE1__ first; TYPE2__ second; }
 
@@ -52,7 +54,7 @@ void lendian_to_host32(uint32_t *dest, const uint8_t *lendian);
 
 /* state load/save */
 typedef int (*load_state_callback_func)(void *outer, const uint8_t *data, uint32_t len, uint16_t type);
-int load_state(load_state_callback_func load_state_callback, void *outer,
+int load_state(load_state_callback_func load_state_callback, Logger *log, void *outer,
                const uint8_t *data, uint32_t length, uint16_t cookie_inner);
 
 /* Returns -1 if failed or 0 if success */


### PR DESCRIPTION
These are cheap asserts. I've also replaced the fprintf's with
`LOGGER_ERROR` calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/381)
<!-- Reviewable:end -->
