### PR TITLE
Avoid accessing uninitialised memory in `net_crypto`.

### DIFF
--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -463,8 +463,7 @@ static int add_ip_port_connection(Net_Crypto *c, int crypt_connection_id, IP_Por
  */
 static IP_Port return_ip_port_connection(Net_Crypto *c, int crypt_connection_id)
 {
-    IP_Port empty;
-    empty.ip.family = 0;
+    const IP_Port empty = {{0}};
 
     Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);
 


### PR DESCRIPTION
On x86 and x86_64, this change has no effect. On IA64, this fixes a
potential hardware exception. A function returned a partially initialised
value of aggregate type. The only caller of this function checks that the
value is valid before accessing it by testing the one definitely
initialised member. Therefore on x86 and derived architectures, there is
no uninitialised memory access. On IA64, with the regular calling
convention, the struct is allocated on the caller stack and passed as a
pointer, so there the uninitialised memory is also never accessed.
However, on calling conventions where one or more struct members past the
first byte are passed in registers or copied in memory, this call can
cause undefined behaviour.

Specifically, the value can contain a trap representation of the integers
(at the very least the 16 bit port) and cause a hardware exception and
SIGFPE in userland.

Regardless of the explanation above, this change fixes an instance of
undefined behaviour that just happened to be OK on all systems we tested
on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/386)
<!-- Reviewable:end -->
