### PR TITLE
CMake: Add soversion to library files to generate proper symlinks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,6 +610,11 @@ endif()
 #
 # :: Strict ABI
 #
+# Enabling the STRICT_ABI flag will generate and use an LD version script.
+# It ensures that the dynamic libraries (libtoxcore.so, libtoxav.so) only
+# export the symbols that are defined in their public API (tox.h and toxav.h,
+# respectively).
+#
 ################################################################################
 
 function(make_version_script header ns lib)

--- a/cmake/ModulePackage.cmake
+++ b/cmake/ModulePackage.cmake
@@ -54,7 +54,13 @@ function(add_module lib)
 
   if(ENABLE_SHARED)
     add_library(${lib}_shared SHARED ${ARGN})
-    set_target_properties(${lib}_shared PROPERTIES OUTPUT_NAME ${lib})
+    set_target_properties(${lib}_shared PROPERTIES
+      OUTPUT_NAME ${lib}
+      VERSION ${PROJECT_VERSION}
+      # While on 0.x, the x behaves like the major version. 0.2 will be
+      # incompatible with 0.1. Change this, when releasing 1.0!
+      SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    )
     install(TARGETS ${lib}_shared DESTINATION "lib")
   endif()
   if(ENABLE_STATIC)


### PR DESCRIPTION
As mentioned in https://github.com/TokTok/c-toxcore/issues/359#issuecomment-270710463
the current CMake build does not generate version symlinks for library .so files.
This is because the version is not specified for library targets.

See
- https://cmake.org/cmake/help/v3.0/prop_tgt/SOVERSION.html#prop_tgt:SOVERSION
- https://cmake.org/cmake/help/v3.0/prop_tgt/VERSION.html#prop_tgt:VERSION

~~I have used `VERSION` instead of `SOVERSION` as this seems to be
compatible with windows according to the docs linked above.~~ updated: changed this, see comments below.

I have compared installed files with autotools build vs. cmake:

autotools:

```
$ find . | sort
.
./bin
./include
./include/tox
./include/tox/toxav.h
./include/tox/toxdns.h
./include/tox/toxencryptsave.h
./include/tox/tox.h
./lib
./lib/libtoxav.a
./lib/libtoxav.la
./lib/libtoxav.so
./lib/libtoxav.so.0
./lib/libtoxav.so.0.0.0
./lib/libtoxcore.a
./lib/libtoxcore.la
./lib/libtoxcore.so
./lib/libtoxcore.so.0
./lib/libtoxcore.so.0.0.0
./lib/libtoxdns.a
./lib/libtoxdns.la
./lib/libtoxdns.so
./lib/libtoxdns.so.0
./lib/libtoxdns.so.0.0.0
./lib/libtoxencryptsave.a
./lib/libtoxencryptsave.la
./lib/libtoxencryptsave.so
./lib/libtoxencryptsave.so.0
./lib/libtoxencryptsave.so.0.0.0
./lib/pkgconfig
./lib/pkgconfig/libtoxav.pc
./lib/pkgconfig/libtoxcore.pc
```

cmake:

```
$ find . | sort
.
./include
./include/tox
./include/tox/toxav.h
./include/tox/toxdns.h
./include/tox/toxencryptsave.h
./include/tox/tox.h
./lib
./lib/libtoxav.a
./lib/libtoxav.so
./lib/libtoxav.so.0.1.2
./lib/libtoxcore.a
./lib/libtoxcore.so
./lib/libtoxcore.so.0.1.2
./lib/libtoxcrypto.a
./lib/libtoxcrypto.so
./lib/libtoxcrypto.so.0.1.2
./lib/libtoxdht.a
./lib/libtoxdht.so
./lib/libtoxdht.so.0.1.2
./lib/libtoxdns.a
./lib/libtoxdns.so
./lib/libtoxdns.so.0.1.2
./lib/libtoxencryptsave.a
./lib/libtoxencryptsave.so
./lib/libtoxencryptsave.so.0.1.2
./lib/libtoxfriends.a
./lib/libtoxfriends.so
./lib/libtoxfriends.so.0.1.2
./lib/libtoxgroup.a
./lib/libtoxgroup.so
./lib/libtoxgroup.so.0.1.2
./lib/libtoxmessenger.a
./lib/libtoxmessenger.so
./lib/libtoxmessenger.so.0.1.2
./lib/libtoxnetcrypto.a
./lib/libtoxnetcrypto.so
./lib/libtoxnetcrypto.so.0.1.2
./lib/libtoxnetwork.a
./lib/libtoxnetwork.so
./lib/libtoxnetwork.so.0.1.2
./lib/pkgconfig
./lib/pkgconfig/libtoxav.pc
./lib/pkgconfig/libtoxcore.pc
./lib/pkgconfig/toxav.pc
./lib/pkgconfig/toxcore.pc
./lib/pkgconfig/toxdns.pc
./lib/pkgconfig/toxencryptsave.pc
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/394)
<!-- Reviewable:end -->
