### PR TITLE
Portability Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ install_manifest.txt
 tags
 Makefile.in
 CMakeLists.txt.user
+DartConfiguration.tcl
+CTestTestfile.cmake
+*.pc
 
 # Testing
 testing/data
@@ -40,6 +43,9 @@ testing/data
 *.app
 *.la
 
+# Libraries
+*.so
+
 # Misc (?)
 m4/*
 configure
@@ -51,8 +57,6 @@ config.log
 config.status
 stamp-h1
 autom4te.cache
-libtoxcore.pc
-libtoxav.pc
 libtool
 .deps
 .libs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,21 +56,20 @@ macro(add_flag flag)
   add_cflag(${flag})
   add_cxxflag(${flag})
 endmacro()
+  
+# Set standard version for compiler.
+add_cflag("-std=c99")
+add_cxxflag("-std=c++11")
+
+# Error on non-ISO C.
+add_cflag("-pedantic-errors")
 
 option(WARNINGS "Enable additional compiler warnings" ON)
 if(WARNINGS)
-  # Set standard version for compiler.
-  add_cflag("-std=gnu99")
-  add_cxxflag("-std=c++98")
-
   # Add all warning flags we can.
   add_flag("-Wall")
   add_flag("-Wextra")
   add_flag("-Weverything")
-
-  # -pedantic only for C, because in C++ we want to allow the GNU/C99 extension
-  # of having a comma at the end of an enumerator list.
-  add_cflag("-pedantic")
 
   # Disable specific warning flags for both C and C++.
   add_flag("-Wno-cast-align")

--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/auto_tests/conference_test.c
+++ b/auto_tests/conference_test.c
@@ -1,6 +1,8 @@
 /* Auto Tests: Conferences.
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -175,7 +177,7 @@ group_test_restart:
          * Either way in this case it's fine  */
         if (peer_count != NUM_GROUP_TOX) {
             ++test_run;
-            printf("\tError starting up the first group (peer_count %"PRIu32" != %d, test_run = %d)\n", peer_count, NUM_GROUP_TOX,
+            printf("\tError starting up the first group (peer_count %" PRIu32 " != %d, test_run = %d)\n", peer_count, NUM_GROUP_TOX,
                    test_run);
 
             for (j = 0; j < NUM_GROUP_TOX; ++j) {
@@ -194,7 +196,7 @@ group_test_restart:
          * important again.
          */
         ck_assert_msg(peer_count == NUM_GROUP_TOX, "\n\tBad number of group peers (pre check)."
-                      "\n\t\t\tExpected: %u but tox_instance(%u)  only has: %"PRIu32"\n\n",
+                      "\n\t\t\tExpected: %u but tox_instance(%u)  only has: %" PRIu32 "\n\n",
                       NUM_GROUP_TOX, i, peer_count);
 
         uint8_t title[2048];
@@ -241,7 +243,7 @@ group_test_restart:
         for (i = 0; i < (k - 1); ++i) {
             uint32_t peer_count = tox_conference_peer_count(toxes[i], 0, NULL);
             ck_assert_msg(peer_count == (k - 1), "\n\tBad number of group peers (post check)."
-                          "\n\t\t\tExpected: %u but tox_instance(%u)  only has: %"PRIu32"\n\n",
+                          "\n\t\t\tExpected: %u but tox_instance(%u)  only has: %" PRIu32 "\n\n",
                           (k - 1), i, peer_count);
         }
     }

--- a/auto_tests/dht_test.c
+++ b/auto_tests/dht_test.c
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -114,8 +114,8 @@ START_TEST(test_ip_equal)
     ip2.ip6.uint32[2] = htonl(0xFFFF);
     ip2.ip6.uint32[3] = htonl(0x7F000001);
 
-    ck_assert_msg(IN6_IS_ADDR_V4MAPPED(&ip2.ip6.in6_addr) != 0,
-                  "IN6_IS_ADDR_V4MAPPED(::ffff:127.0.0.1): expected != 0, got 0.");
+    ck_assert_msg(IPV6_IPV4_IN_V6(ip2.ip6) != 0,
+                  "IPV6_IPV4_IN_V6(::ffff:127.0.0.1): expected != 0, got 0.");
 
     res = ip_equal(&ip1, &ip2);
     ck_assert_msg(res != 0, "ip_equal( {AF_INET, 127.0.0.1}, {AF_INET6, ::ffff:127.0.0.1} ): expected result != 0, got 0.");

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/auto_tests/save_friend_test.c
+++ b/auto_tests/save_friend_test.c
@@ -1,7 +1,10 @@
 /* Auto Tests: Save and load friends.
  */
 
+#define _XOPEN_SOURCE 600
+
 #include "helpers.h"
+#include "../toxcore/tox.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/auto_tests/tox_many_tcp_test.c
+++ b/auto_tests/tox_many_tcp_test.c
@@ -1,6 +1,8 @@
 /* Auto Tests: Many TCP.
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/auto_tests/tox_many_test.c
+++ b/auto_tests/tox_many_test.c
@@ -1,6 +1,8 @@
 /* Auto Tests: Many clients.
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -10,6 +10,8 @@
  *
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/auto_tests/toxav_basic_test.c
+++ b/auto_tests/toxav_basic_test.c
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -22,6 +22,8 @@
  *
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/other/bootstrap_daemon/src/log.c
+++ b/other/bootstrap_daemon/src/log.c
@@ -26,8 +26,8 @@
 
 #include "global.h"
 
+#include <assert.h>
 #include <syslog.h>
-
 #include <stdarg.h>
 #include <stdio.h>
 
@@ -82,7 +82,22 @@ static int level_syslog(LOG_LEVEL level)
 
 static void log_syslog(LOG_LEVEL level, const char *format, va_list args)
 {
-    vsyslog(level_syslog(level), format, args);
+    va_list args2;
+
+    va_copy(args2, args);
+    int size = vsnprintf(NULL, 0, format, args2);
+    va_end(args2);
+
+    assert(size >= 0);
+
+    if (size < 0) {
+        return;
+    }
+
+    char buf[size + 1];
+    vsnprintf(buf, size + 1, format, args);
+
+    syslog(level_syslog(level), "%s", buf);
 }
 
 static FILE *level_stdout(LOG_LEVEL level)

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -22,6 +22,8 @@
  *
  */
 
+#define _XOPEN_SOURCE 600
+
 // system provided
 #include <sys/stat.h>
 #include <unistd.h>

--- a/testing/DHT_test.c
+++ b/testing/DHT_test.c
@@ -27,6 +27,8 @@
  *
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -37,6 +37,8 @@
  *
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -22,6 +22,8 @@
  *   -lopencv_highgui -lopencv_imgproc -lsndfile -pthread -lvpx -lopus -lsodium -lportaudio
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/testing/irc_syncbot.c
+++ b/testing/irc_syncbot.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 600
 
 #include <stdint.h>
 #include <stdio.h>
@@ -34,8 +35,8 @@ static uint16_t port = 6667;
 
 static int sock;
 
-#define SERVER_CONNECT "NICK "IRC_NAME"\nUSER "IRC_NAME" 8 * :"IRC_NAME"\n"
-#define CHANNEL_JOIN "JOIN "IRC_CHANNEL"\n"
+#define SERVER_CONNECT "NICK " IRC_NAME "\nUSER " IRC_NAME " 8 * :" IRC_NAME "\n"
+#define CHANNEL_JOIN "JOIN " IRC_CHANNEL "\n"
 
 /* In toxcore/network.c */
 uint64_t current_time_monotonic(void);
@@ -131,8 +132,8 @@ static void copy_groupmessage(Tox *tox, uint32_t groupnumber, uint32_t friendgro
     uint8_t sendbuf[2048];
     uint16_t send_len = 0;
 
-    memcpy(sendbuf, "PRIVMSG "IRC_CHANNEL" :", sizeof("PRIVMSG "IRC_CHANNEL" :"));
-    send_len += sizeof("PRIVMSG "IRC_CHANNEL" :") - 1;
+    memcpy(sendbuf, "PRIVMSG " IRC_CHANNEL " :", sizeof("PRIVMSG " IRC_CHANNEL " :"));
+    send_len += sizeof("PRIVMSG " IRC_CHANNEL " :") - 1;
     memcpy(sendbuf + send_len, name, namelen);
     send_len += namelen;
     sendbuf[send_len] = ':';

--- a/testing/misc_tools.c
+++ b/testing/misc_tools.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #ifdef TOX_DEBUG
 #include <assert.h>

--- a/testing/tox_shell.c
+++ b/testing/tox_shell.c
@@ -26,6 +26,8 @@
  *
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/testing/tox_sync.c
+++ b/testing/tox_sync.c
@@ -28,6 +28,8 @@
  *
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -42,6 +44,7 @@
 #include <dirent.h>
 #include <netinet/in.h>
 #include <stdio.h>
+#include <sys/stat.h>
 
 #define NUM_FILE_SENDERS 256
 typedef struct {
@@ -297,6 +300,7 @@ int main(int argc, char *argv[])
     memcpy(path, argv[argvoffset + 4], strlen(argv[argvoffset + 4]));
     DIR           *d;
     struct dirent *dir;
+    struct stat statbuf;
     uint8_t notconnected = 1;
 
     while (1) {
@@ -310,7 +314,12 @@ int main(int argc, char *argv[])
 
             if (d) {
                 while ((dir = readdir(d)) != NULL) {
-                    if (dir->d_type == DT_REG) {
+                    char filepath[strlen(path) + strlen(dir->d_name) + 1];
+                    memcpy(filepath, path, strlen(path));
+                    memcpy(filepath + strlen(path), dir->d_name, strlen(dir->d_name) + 1);
+                    stat(filepath, &statbuf);
+
+                    if (S_ISREG(statbuf.st_mode)) {
                         char fullpath[1024];
 
                         if (path[strlen(path) - 1] == '/') {

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -619,7 +619,7 @@ static int send_routing_response(TCP_Secure_Connection *con, uint8_t rpid, const
  */
 static int send_connect_notification(TCP_Secure_Connection *con, uint8_t id)
 {
-    uint8_t data[2] = {TCP_PACKET_CONNECTION_NOTIFICATION, id + NUM_RESERVED_PORTS};
+    uint8_t data[2] = {TCP_PACKET_CONNECTION_NOTIFICATION, (uint8_t)(id + NUM_RESERVED_PORTS)};
     return write_packet_TCP_secure_connection(con, data, sizeof(data), 1);
 }
 
@@ -629,7 +629,7 @@ static int send_connect_notification(TCP_Secure_Connection *con, uint8_t id)
  */
 static int send_disconnect_notification(TCP_Secure_Connection *con, uint8_t id)
 {
-    uint8_t data[2] = {TCP_PACKET_DISCONNECT_NOTIFICATION, id + NUM_RESERVED_PORTS};
+    uint8_t data[2] = {TCP_PACKET_DISCONNECT_NOTIFICATION, (uint8_t)(id + NUM_RESERVED_PORTS)};
     return write_packet_TCP_secure_connection(con, data, sizeof(data), 1);
 }
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -21,6 +21,9 @@
  *
  */
 
+#define _DARWIN_C_SOURCE
+#define _XOPEN_SOURCE 600
+
 #if defined(_WIN32) && _WIN32_WINNT >= _WIN32_WINNT_WINXP
 #define _WIN32_WINNT  0x501
 #endif

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -21,6 +21,8 @@
  *
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -22,6 +22,8 @@
  *  along with Tox.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define _XOPEN_SOURCE 600
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif


### PR DESCRIPTION
This reverts commit 59e2a844f04a8725e8079f854158aa86ef5988b2.

- CFLAG gnu99 was changed to c99.
- CXXFLAG c++98 was changed to c++11.
- CFLAG -pedantic-errors was added so that non-ISO C now throws errors.
- _XOPEN_SOURCE feature test macro added and set to 600 to expose SUSv3 and c99 definitions in modules that required them.
- Fixed tests (and bootstrap daemon logging) that were failing due to the altered build flags.
- Avoid string suffix misinterpretation; explicit narrowing conversion.
- Misc. additions to .gitignore to make sure build artifacts don't wind up in version control.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/398)
<!-- Reviewable:end -->
