### PR TITLE
Use latest version of cpp-coveralls.

### DIFF
--- a/other/travis/toxcore-linux-install
+++ b/other/travis/toxcore-linux-install
@@ -12,6 +12,7 @@ git clone --depth=1 https://github.com/TokTok/apidsl ../apidsl
 make -C ../apidsl -j$NPROC
 
 # Install cpp-coveralls to upload test coverage results.
+pip install --upgrade --user pip
 pip install git+git@github.com:eddyxu/cpp-coveralls.git
 
 # Install astyle (version in ubuntu-precise too old).

--- a/other/travis/toxcore-linux-install
+++ b/other/travis/toxcore-linux-install
@@ -12,12 +12,7 @@ git clone --depth=1 https://github.com/TokTok/apidsl ../apidsl
 make -C ../apidsl -j$NPROC
 
 # Install cpp-coveralls to upload test coverage results.
-pip install --user urllib3[secure] cpp-coveralls
-
-# Work around https://github.com/eddyxu/cpp-coveralls/issues/108 by manually
-# installing the pyOpenSSL module and injecting it into urllib3 as per
-# https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
-sed -i -e '/^import sys$/a import urllib3.contrib.pyopenssl\nurllib3.contrib.pyopenssl.inject_into_urllib3()' `which coveralls`
+pip install git+git@github.com:eddyxu/cpp-coveralls.git
 
 # Install astyle (version in ubuntu-precise too old).
 [ -f $ASTYLE ] || {


### PR DESCRIPTION
This may have fixed the urllib issue. See
https://github.com/eddyxu/cpp-coveralls/issues/108#issuecomment-271068923

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/406)
<!-- Reviewable:end -->
