### PR TITLE
Explicitly check if compiler supports C99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -295,7 +295,12 @@ if test "x$WANT_NACL" = "xyes"; then
 fi
 
 # Checks for programs.
-AC_PROG_CC
+AC_PROG_CC_C99
+
+if test "x$ac_cv_prog_cc_c99" = "xno" ; then
+    AC_MSG_ERROR([c-toxcore requires a C99 compatible compiler])
+fi
+
 AM_PROG_CC_C_O
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AC_LIBTOOL_WIN32_DLL


### PR DESCRIPTION
c-tocxocre will start using C99 code, so check if the compiler supports
it and abort in configure with an error if it does not.

closes #413

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/414)
<!-- Reviewable:end -->
