### PR TITLE
Fixed the FreeBSD build failure due to the undefined MSG_NOSIGNAL.

### DIFF
--- a/testing/irc_syncbot.c
+++ b/testing/irc_syncbot.c
@@ -23,6 +23,10 @@
 #define MSG_NOSIGNAL 0
 #endif
 
+#if defined(__FreeBSD__) && !defined(MSG_NOSIGNAL)
+#define       MSG_NOSIGNAL    0x20000 // only defined on FreeBSD for some __POSIX_VISIBLE, causes compilation failures
+#endif
+
 //IRC name and channel.
 #define IRC_NAME "Tox_syncbot"
 #define IRC_CHANNEL "#tox-real-ontopic"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/424)
<!-- Reviewable:end -->
