### PR TITLE
Remove some static variables

### DIFF
--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -36,7 +36,8 @@ START_TEST(test_addr_resolv_localhost)
 
     if (res > 0) {
         ck_assert_msg(ip.family == AF_INET, "Expected family AF_INET, got %u.", ip.family);
-        ck_assert_msg(ip.ip4.uint32 == htonl(0x7F000001), "Expected 127.0.0.1, got %s.", inet_ntoa(ip.ip4.in_addr));
+        ck_assert_msg(ip.ip4.uint32 == htonl(0x7F000001), "Expected 127.0.0.1, got %s.",
+                      inet_ntoa(ip.ip4.in_addr));
     }
 
     ip_init(&ip, 1); // ipv6enabled = 1
@@ -50,8 +51,10 @@ START_TEST(test_addr_resolv_localhost)
     ck_assert_msg(res > 0, "Resolver failed: %u, %s (%x, %x)", errno, strerror(errno));
 
     if (res > 0) {
+        char ip_str[IP_NTOA_LEN];
         ck_assert_msg(ip.family == AF_INET6, "Expected family AF_INET6 (%u), got %u.", AF_INET6, ip.family);
-        ck_assert_msg(!memcmp(&ip.ip6, &in6addr_loopback, sizeof(IP6)), "Expected ::1, got %s.", ip_ntoa(&ip));
+        ck_assert_msg(!memcmp(&ip.ip6, &in6addr_loopback, sizeof(IP6)), "Expected ::1, got %s.",
+                      ip_ntoa(&ip, ip_str, sizeof(ip_str)));
     }
 
     if (!localhost_split) {
@@ -63,8 +66,10 @@ START_TEST(test_addr_resolv_localhost)
         ck_assert_msg(res > 0, "Resolver failed: %u, %s (%x, %x)", errno, strerror(errno));
 
         if (res > 0) {
+            char ip_str[IP_NTOA_LEN];
             ck_assert_msg(ip.family == AF_INET6, "Expected family AF_INET6 (%u), got %u.", AF_INET6, ip.family);
-            ck_assert_msg(!memcmp(&ip.ip6, &in6addr_loopback, sizeof(IP6)), "Expected ::1, got %s.", ip_ntoa(&ip));
+            ck_assert_msg(!memcmp(&ip.ip6, &in6addr_loopback, sizeof(IP6)), "Expected ::1, got %s.",
+                          ip_ntoa(&ip, ip_str, sizeof(ip_str)));
 
             ck_assert_msg(extra.family == AF_INET, "Expected family AF_INET (%u), got %u.", AF_INET, extra.family);
             ck_assert_msg(extra.ip4.uint32 == htonl(0x7F000001), "Expected 127.0.0.1, got %s.", inet_ntoa(extra.ip4.in_addr));

--- a/testing/DHT_test.c
+++ b/testing/DHT_test.c
@@ -87,16 +87,17 @@ static void print_hardening(Hardening *h)
 static void print_assoc(IPPTsPng *assoc, uint8_t ours)
 {
     IP_Port *ipp = &assoc->ip_port;
-    printf("\nIP: %s Port: %u", ip_ntoa(&ipp->ip), ntohs(ipp->port));
+    char ip_str[IP_NTOA_LEN];
+    printf("\nIP: %s Port: %u", ip_ntoa(&ipp->ip, ip_str, sizeof(ip_str)), ntohs(ipp->port));
     printf("\nTimestamp: %llu", (long long unsigned int) assoc->timestamp);
     printf("\nLast pinged: %llu\n", (long long unsigned int) assoc->last_pinged);
 
     ipp = &assoc->ret_ip_port;
 
     if (ours) {
-        printf("OUR IP: %s Port: %u\n", ip_ntoa(&ipp->ip), ntohs(ipp->port));
+        printf("OUR IP: %s Port: %u\n", ip_ntoa(&ipp->ip, ip_str, sizeof(ip_str)), ntohs(ipp->port));
     } else {
-        printf("RET IP: %s Port: %u\n", ip_ntoa(&ipp->ip), ntohs(ipp->port));
+        printf("RET IP: %s Port: %u\n", ip_ntoa(&ipp->ip, ip_str, sizeof(ip_str)), ntohs(ipp->port));
     }
 
     printf("Timestamp: %llu\n", (long long unsigned int) assoc->ret_timestamp);
@@ -136,7 +137,8 @@ static void print_friendlist(DHT *dht)
         print_client_id(dht->friends_list[k].public_key);
 
         int friendok = DHT_getfriendip(dht, dht->friends_list[k].public_key, &p_ip);
-        printf("\nIP: %s:%u (%d)", ip_ntoa(&p_ip.ip), ntohs(p_ip.port), friendok);
+        char ip_str[IP_NTOA_LEN];
+        printf("\nIP: %s:%u (%d)", ip_ntoa(&p_ip.ip, ip_str, sizeof(ip_str)), ntohs(p_ip.port), friendok);
 
         printf("\nCLIENTS IN LIST:\n\n");
 

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -39,8 +39,10 @@
 #define MAX_INTERFACES 16
 
 
+/* TODO: multiple threads might concurrently try to set these, and it isn't clear that this couldn't lead to undesirable
+ * behaviour. Consider storing the data in per-instance variables instead. */
 static int     broadcast_count = -1;
-static IP_Port broadcast_ip_port[MAX_INTERFACES];
+static IP_Port broadcast_ip_ports[MAX_INTERFACES];
 
 #if defined(_WIN32) || defined(__WIN32__) || defined (WIN32)
 
@@ -48,8 +50,6 @@ static IP_Port broadcast_ip_port[MAX_INTERFACES];
 
 static void fetch_broadcast_info(uint16_t port)
 {
-    broadcast_count = 0;
-
     IP_ADAPTER_INFO *pAdapterInfo = (IP_ADAPTER_INFO *)malloc(sizeof(IP_ADAPTER_INFO));
     unsigned long ulOutBufLen = sizeof(IP_ADAPTER_INFO);
 
@@ -66,6 +66,13 @@ static void fetch_broadcast_info(uint16_t port)
         }
     }
 
+    /* We copy these to the static variables broadcast_* only at the end of fetch_broadcast_info().
+     * The intention is to ensure that even if multiple threads enter fetch_broadcast_info() concurrently, only valid
+     * interfaces will be set to be broadcast to.
+     * */
+    int count = 0;
+    IP_Port ip_ports[MAX_INTERFACES];
+
     int ret;
 
     if ((ret = GetAdaptersInfo(pAdapterInfo, &ulOutBufLen)) == NO_ERROR) {
@@ -77,16 +84,16 @@ static void fetch_broadcast_info(uint16_t port)
             if (addr_parse_ip(pAdapter->IpAddressList.IpMask.String, &subnet_mask)
                     && addr_parse_ip(pAdapter->GatewayList.IpAddress.String, &gateway)) {
                 if (gateway.family == AF_INET && subnet_mask.family == AF_INET) {
-                    IP_Port *ip_port = &broadcast_ip_port[broadcast_count];
+                    IP_Port *ip_port = &ip_ports[count];
                     ip_port->ip.family = AF_INET;
                     uint32_t gateway_ip = ntohl(gateway.ip4.uint32), subnet_ip = ntohl(subnet_mask.ip4.uint32);
                     uint32_t broadcast_ip = gateway_ip + ~subnet_ip - 1;
                     ip_port->ip.ip4.uint32 = htonl(broadcast_ip);
                     ip_port->port = port;
-                    broadcast_count++;
+                    count++;
 
-                    if (broadcast_count >= MAX_INTERFACES) {
-                        return;
+                    if (count >= MAX_INTERFACES) {
+                        break;
                     }
                 }
             }
@@ -98,6 +105,12 @@ static void fetch_broadcast_info(uint16_t port)
     if (pAdapterInfo) {
         free(pAdapterInfo);
     }
+
+    broadcast_count = count;
+
+    for (uint32_t i = 0; i < count; i++) {
+        broadcast_ip_ports[i] = ip_ports[i];
+    }
 }
 
 #elif defined(__linux__)
@@ -108,7 +121,6 @@ static void fetch_broadcast_info(uint16_t port)
      * so it's wrapped in __linux for now.
      * Definitely won't work like this on Windows...
      */
-    broadcast_count = 0;
     sock_t sock = 0;
 
     if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
@@ -128,14 +140,21 @@ static void fetch_broadcast_info(uint16_t port)
         return;
     }
 
+    /* We copy these to the static variables broadcast_* only at the end of fetch_broadcast_info().
+     * The intention is to ensure that even if multiple threads enter fetch_broadcast_info() concurrently, only valid
+     * interfaces will be set to be broadcast to.
+     * */
+    int count = 0;
+    IP_Port ip_ports[MAX_INTERFACES];
+
     /* ifconf.ifc_len is set by the ioctl() to the actual length used;
      * on usage of the complete array the call should be repeated with
      * a larger array, not done (640kB and 16 interfaces shall be
      * enough, for everybody!)
      */
-    int i, count = ifconf.ifc_len / sizeof(struct ifreq);
+    int i, n = ifconf.ifc_len / sizeof(struct ifreq);
 
-    for (i = 0; i < count; i++) {
+    for (i = 0; i < n; i++) {
         /* there are interfaces with are incapable of broadcast */
         if (ioctl(sock, SIOCGIFBRDADDR, &i_faces[i]) < 0) {
             continue;
@@ -148,12 +167,11 @@ static void fetch_broadcast_info(uint16_t port)
 
         struct sockaddr_in *sock4 = (struct sockaddr_in *)&i_faces[i].ifr_broadaddr;
 
-        if (broadcast_count >= MAX_INTERFACES) {
-            close(sock);
-            return;
+        if (count >= MAX_INTERFACES) {
+            break;
         }
 
-        IP_Port *ip_port = &broadcast_ip_port[broadcast_count];
+        IP_Port *ip_port = &ip_ports[count];
         ip_port->ip.family = AF_INET;
         ip_port->ip.ip4.in_addr = sock4->sin_addr;
 
@@ -162,10 +180,16 @@ static void fetch_broadcast_info(uint16_t port)
         }
 
         ip_port->port = port;
-        broadcast_count++;
+        count++;
     }
 
     close(sock);
+
+    broadcast_count = count;
+
+    for (uint32_t i = 0; i < count; i++) {
+        broadcast_ip_ports[i] = ip_ports[i];
+    }
 }
 
 #else // TODO(irungentoo): Other platforms?
@@ -196,7 +220,7 @@ static uint32_t send_broadcasts(Networking_Core *net, uint16_t port, const uint8
     int i;
 
     for (i = 0; i < broadcast_count; i++) {
-        sendpacket(net, broadcast_ip_port[i], data, length);
+        sendpacket(net, broadcast_ip_ports[i], data, length);
     }
 
     return 1;

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -240,6 +240,8 @@ struct Messenger {
     Friend *friendlist;
     uint32_t numfriends;
 
+    time_t lastdump;
+
     uint8_t has_added_relays; // If the first connection has occurred in do_messenger
     Node_format loaded_relays[NUM_SAVED_TCP_RELAYS]; // Relays loaded from config
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -242,11 +242,16 @@ uint64_t current_time_monotonic(void)
 {
     uint64_t time;
 #if defined(_WIN32) || defined(__WIN32__) || defined (WIN32)
+    uint64_t old_add_monotime = add_monotime;
     time = (uint64_t)GetTickCount() + add_monotime;
 
-    if (time < last_monotime) { /* Prevent time from ever decreasing because of 32 bit wrap. */
+    /* Check if time has decreased because of 32 bit wrap from GetTickCount(), while avoiding false positives from race
+     * conditions when multiple threads call this function at once */
+    if (time + 0x10000 < last_monotime) {
         uint32_t add = ~0;
-        add_monotime += add;
+        /* use old_add_monotime rather than simply incrementing add_monotime, to handle the case that many threads
+         * simultaneously detect an overflow */
+        add_monotime = old_add_monotime + add;
         time += add;
     }
 
@@ -285,21 +290,23 @@ static uint32_t data_1(uint16_t buflen, const uint8_t *buffer)
 static void loglogdata(Logger *log, const char *message, const uint8_t *buffer,
                        uint16_t buflen, IP_Port ip_port, int res)
 {
+    char ip_str[IP_NTOA_LEN];
+
     if (res < 0) { /* Windows doesn't necessarily know %zu */
         LOGGER_TRACE(log, "[%2u] %s %3hu%c %s:%hu (%u: %s) | %04x%04x",
                      buffer[0], message, (buflen < 999 ? (uint16_t)buflen : 999), 'E',
-                     ip_ntoa(&ip_port.ip), ntohs(ip_port.port), errno, strerror(errno), data_0(buflen, buffer),
-                     data_1(buflen, buffer));
+                     ip_ntoa(&ip_port.ip, ip_str, sizeof(ip_str)), ntohs(ip_port.port), errno,
+                     strerror(errno), data_0(buflen, buffer), data_1(buflen, buffer));
     } else if ((res > 0) && ((size_t)res <= buflen)) {
         LOGGER_TRACE(log, "[%2u] %s %3zu%c %s:%hu (%u: %s) | %04x%04x",
                      buffer[0], message, (res < 999 ? (size_t)res : 999), ((size_t)res < buflen ? '<' : '='),
-                     ip_ntoa(&ip_port.ip), ntohs(ip_port.port), 0, "OK", data_0(buflen, buffer), data_1(buflen,
-                             buffer));
+                     ip_ntoa(&ip_port.ip, ip_str, sizeof(ip_str)), ntohs(ip_port.port), 0, "OK",
+                     data_0(buflen, buffer), data_1(buflen, buffer));
     } else { /* empty or overwrite */
         LOGGER_TRACE(log, "[%2u] %s %zu%c%zu %s:%hu (%u: %s) | %04x%04x",
                      buffer[0], message, (size_t)res, (!res ? '!' : '>'), buflen,
-                     ip_ntoa(&ip_port.ip), ntohs(ip_port.port), 0, "OK", data_0(buflen, buffer), data_1(buflen,
-                             buffer));
+                     ip_ntoa(&ip_port.ip, ip_str, sizeof(ip_str)), ntohs(ip_port.port), 0, "OK",
+                     data_0(buflen, buffer), data_1(buflen, buffer));
     }
 }
 
@@ -690,7 +697,9 @@ Networking_Core *new_networking_ex(Logger *log, IP ip, uint16_t port_from, uint1
         if (!res) {
             temp->port = *portptr;
 
-            LOGGER_DEBUG(log, "Bound successfully to %s:%u", ip_ntoa(&ip), ntohs(temp->port));
+            char ip_str[IP_NTOA_LEN];
+            LOGGER_DEBUG(log, "Bound successfully to %s:%u", ip_ntoa(&ip, ip_str, sizeof(ip_str)),
+                         ntohs(temp->port));
 
             /* errno isn't reset on success, only set on failure, the failed
              * binds with parallel clients yield a -EPERM to the outside if
@@ -715,8 +724,9 @@ Networking_Core *new_networking_ex(Logger *log, IP ip, uint16_t port_from, uint1
         *portptr = htons(port_to_try);
     }
 
+    char ip_str[IP_NTOA_LEN];
     LOGGER_ERROR(log, "Failed to bind socket: %u, %s IP: %s port_from: %u port_to: %u", errno, strerror(errno),
-                 ip_ntoa(&ip), port_from, port_to);
+                 ip_ntoa(&ip, ip_str, sizeof(ip_str)), port_from, port_to);
 
     kill_networking(temp);
 
@@ -867,41 +877,46 @@ void ipport_copy(IP_Port *target, const IP_Port *source)
 
 /* ip_ntoa
  *   converts ip into a string
- *   uses a static buffer, so mustn't used multiple times in the same output
+ *   ip_str must be of length at least IP_NTOA_LEN
  *
  *   IPv6 addresses are enclosed into square brackets, i.e. "[IPv6]"
  *   writes error message into the buffer on error
+ *
+ *   returns ip_str
  */
-/* there would be INET6_ADDRSTRLEN, but it might be too short for the error message */
-static char addresstext[96]; // TODO(irungentoo): magic number. Why not INET6_ADDRSTRLEN ?
-const char *ip_ntoa(const IP *ip)
+const char *ip_ntoa(const IP *ip, char *ip_str, size_t length)
 {
+    if (length < IP_NTOA_LEN) {
+        snprintf(ip_str, length, "Bad buf length");
+        return ip_str;
+    }
+
     if (ip) {
         if (ip->family == AF_INET) {
             /* returns standard quad-dotted notation */
             const struct in_addr *addr = (const struct in_addr *)&ip->ip4;
 
-            addresstext[0] = 0;
-            inet_ntop(ip->family, addr, addresstext, sizeof(addresstext));
+            ip_str[0] = 0;
+            inet_ntop(ip->family, addr, ip_str, length);
         } else if (ip->family == AF_INET6) {
             /* returns hex-groups enclosed into square brackets */
             const struct in6_addr *addr = (const struct in6_addr *)&ip->ip6;
 
-            addresstext[0] = '[';
-            inet_ntop(ip->family, addr, &addresstext[1], sizeof(addresstext) - 3);
-            size_t len = strlen(addresstext);
-            addresstext[len] = ']';
-            addresstext[len + 1] = 0;
+            ip_str[0] = '[';
+            inet_ntop(ip->family, addr, &ip_str[1], length - 3);
+            size_t len = strlen(ip_str);
+            ip_str[len] = ']';
+            ip_str[len + 1] = 0;
         } else {
-            snprintf(addresstext, sizeof(addresstext), "(IP invalid, family %u)", ip->family);
+            snprintf(ip_str, length, "(IP invalid, family %u)", ip->family);
         }
     } else {
-        snprintf(addresstext, sizeof(addresstext), "(IP invalid: NULL)");
+        snprintf(ip_str, length, "(IP invalid: NULL)");
     }
 
     /* brute force protection against lacking termination */
-    addresstext[sizeof(addresstext) - 1] = 0;
-    return addresstext;
+    ip_str[length - 1] = 0;
+    return ip_str;
 }
 
 /*

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -193,12 +193,16 @@ IP_Port;
 
 /* ip_ntoa
  *   converts ip into a string
- *   uses a static buffer, so mustn't used multiple times in the same output
+ *   ip_str must be of length at least IP_NTOA_LEN
  *
  *   IPv6 addresses are enclosed into square brackets, i.e. "[IPv6]"
  *   writes error message into the buffer on error
+ *
+ *   returns ip_str
  */
-const char *ip_ntoa(const IP *ip);
+/* this would be INET6_ADDRSTRLEN, but it might be too short for the error message */
+#define IP_NTOA_LEN 96 // TODO(irungentoo): magic number. Why not INET6_ADDRSTRLEN ?
+const char *ip_ntoa(const IP *ip, char *ip_str, size_t length);
 
 /*
  * ip_parse_addr

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -41,6 +41,8 @@
 static uint64_t unix_time_value;
 static uint64_t unix_base_time_value;
 
+/* XXX: note that this is not thread-safe; if multiple threads call unix_time_update() concurrently, the return value of
+ * unix_time() may fail to increase monotonically with increasing time */
 void unix_time_update(void)
 {
     if (unix_base_time_value == 0) {


### PR DESCRIPTION
This partially implements #405, reworking ip_ntoa(), ID2String() and cmp_dht_entry() to avoid the use of the global static variables 'addresstext', 'IDString', 'cmp_public_key', and moving 'lastdump' into the Messenger struct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/432)
<!-- Reviewable:end -->
