### PR TITLE
added CLion cmake build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Thumbs.db
 *.tmp
 
 # Make
+/cmake-build-*
 /_build
 /_install
 /tox-0.0.0*


### PR DESCRIPTION
Added `/cmake-build-*` to ignore directories created
by CLion IDE for cmake builds:

- `/cmake-build-debug`
- `/cmake-build-release`
- ...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/435)
<!-- Reviewable:end -->
