### PR TITLE
Test for memberlist not changing after changing own name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,9 @@ auto_test(tox_many_tcp)
 auto_test(tox_one)
 auto_test(tox_strncasecmp)
 auto_test(version)
+# TODO(iphydf): This test is broken. The code needs to be fixed, as the test
+# itself is correct.
+#auto_test(selfname_change_conference)
 
 if(BUILD_TOXAV)
   auto_test(toxav_basic)

--- a/auto_tests/Makefile.inc
+++ b/auto_tests/Makefile.inc
@@ -75,6 +75,14 @@ dht_autotest_CFLAGS = $(AUTOTEST_CFLAGS)
 dht_autotest_LDADD = $(AUTOTEST_LDADD)
 
 
+# TODO(iphydf): This test is broken. The code needs to be fixed, as the test
+# itself is correct.
+#selfname_change_conference_SOURCE = ../auto_tests/selfname_change_conference_test.c
+#
+#selfname_change_conference_CFLAGS = $(AUTOTEST_CFLAGS)
+#
+#selfname_change_conference_LDADD = $(AUTOTEST_LDADD)
+
 if BUILD_AV
 toxav_basic_test_SOURCES = ../auto_tests/toxav_basic_test.c
 

--- a/auto_tests/selfname_change_conference_test.c
+++ b/auto_tests/selfname_change_conference_test.c
@@ -1,0 +1,97 @@
+/* selfname_change_conference_test.c
+ *
+ * Small test for checking if obtaining savedata, saving it to disk and using
+ * works correctly.
+ *
+ *  Copyright (C) 2017 Tox project All Rights Reserved.
+ *
+ *  This file is part of Tox.
+ *
+ *  Tox is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Tox is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "../toxcore/tox.h"
+#include "../toxencryptsave/toxencryptsave.h"
+
+static const char *newname = "chris";
+
+static void cbconfmembers(Tox *tox, uint32_t conference_number, uint32_t peer_number,
+                          TOX_CONFERENCE_STATE_CHANGE change,
+                          void *user_data)
+{
+    uint8_t new_peer_name[TOX_MAX_NAME_LENGTH + 1];
+
+    if (change != TOX_CONFERENCE_STATE_CHANGE_PEER_NAME_CHANGE) {
+        return;
+    }
+
+    if (!tox_conference_peer_get_name(tox, conference_number, peer_number, new_peer_name, NULL)) {
+        return;
+    }
+
+    if (!memcmp(newname, new_peer_name, tox_conference_peer_get_name_size(tox, conference_number, peer_number, NULL))) {
+        printf("success: own name was changed and updated in the conference");
+        exit(0);
+    }
+}
+
+int main(void)
+{
+    uint32_t conference_number;
+    struct timespec sleeptime;
+    struct Tox_Options to;
+    Tox *t;
+    TOX_ERR_CONFERENCE_NEW conference_err;
+    TOX_ERR_SET_INFO name_err;
+
+    tox_options_default(&to);
+    t = tox_new(&to, NULL);
+
+    tox_callback_conference_namelist_change(t, cbconfmembers);
+
+    if ((conference_number = tox_conference_new(t, &conference_err)) == UINT32_MAX) {
+        tox_kill(t);
+        fprintf(stderr, "error: could not create new conference, error code %d\n", conference_err);
+        return 2;
+    }
+
+    tox_iterate(t, NULL);
+
+    sleeptime.tv_sec = 0;
+    sleeptime.tv_nsec = tox_iteration_interval(t) * 1E6;
+
+    nanosleep(&sleeptime, NULL);
+
+    if (!tox_self_set_name(t, (const uint8_t *)newname, strlen(newname), &name_err)) {
+        tox_kill(t);
+        fprintf(stderr, "error: could not set own name, error code %d\n", name_err);
+        return 3;
+    }
+
+    tox_iterate(t, NULL);
+    nanosleep(&sleeptime, NULL);
+    tox_iterate(t, NULL);
+
+    fprintf(stderr, "error: name was not changed in callback. exiting.\n");
+
+    tox_kill(t);
+
+    return 1;
+}


### PR DESCRIPTION
The problem illustrated with this test is that the `tox_callback_conference_namelist_change()` is not invoked for A when A changes his name.

I assumed that this is also incorrect behaviour if the user is not connected to the network, but correct me if this is not the case.

I hope I haven't missed anything important.

Greetings,

pranomostro

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/468)
<!-- Reviewable:end -->
