### PR TITLE
Remove statics used in onion comparison functions.

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -866,7 +866,7 @@ static unsigned int store_node_ok(const Client_data *client, const uint8_t *publ
 static void sort_client_list(Client_data *list, unsigned int length, const uint8_t *comp_public_key)
 {
     // Pass comp_public_key to qsort with each Client_data entry, so the
-    // comparison function cmp_dht_entry can use it as the base of comparison.
+    // comparison function can use it as the base of comparison.
     Cmp_data cmp_list[length];
 
     for (uint32_t i = 0; i < length; i++) {


### PR DESCRIPTION
I realised that in my previous (now merged) PR#432, I missed a couple of uses
of static variables. This fixes them. Both are entirely analogous to one which
was fixed by that PR in DHT.c, using a static variable to fix the base of
comparison used in a qsort. I've used the same solution. This involves some
unsightly code duplication, but I couldn't see a nice way around that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/471)
<!-- Reviewable:end -->
