### PR TITLE
Added missing includes: <netinet/in.h> and <sys/socket.h>

### DIFF
--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -31,7 +31,6 @@
 
 /* Used for get_broadcast(). */
 #ifdef __linux
-#include <arpa/inet.h>
 #include <linux/netdevice.h>
 #include <sys/ioctl.h>
 #endif

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -52,14 +52,11 @@
 
 #if !(defined(_WIN32) || defined(__WIN32__) || defined(WIN32))
 
-#include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
-#include <netinet/in.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 
 #else
 

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -58,8 +58,10 @@
 #include <windows.h>
 #include <ws2tcpip.h>
 
-#else // Linux includes
+#else // UNIX includes
 
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <unistd.h>


### PR DESCRIPTION
Found these missing includes while compiling on FreeBSD 11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/473)
<!-- Reviewable:end -->
