### PR TITLE
Fix pthreads in AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,12 @@
 install:
-- curl https://download.libsodium.org/libsodium/releases/libsodium-1.0.11-msvc.zip -o libsodium-1.0.11-msvc.zip
-- unzip libsodium-1.0.11-msvc.zip
+- mkdir libsodium && cd libsodium
+- curl https://download.libsodium.org/libsodium/releases/libsodium-1.0.11-msvc.zip -o libsodium.zip
+- unzip libsodium.zip
+- cd ..
+- mkdir pthreads-win32 && cd pthreads-win32
+- curl ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip -o pthreads.zip
+- unzip pthreads.zip
+- cd ..
 
 before_build:
 - cmake . -DBOOTSTRAP_DAEMON=OFF -DENABLE_SHARED=OFF

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -52,6 +52,7 @@ if(NOT LIBSODIUM_FOUND)
   if(LIBSODIUM_LIBRARIES)
     set(LIBSODIUM_FOUND TRUE)
   endif()
+  add_definitions(-DSODIUM_STATIC)
   message("libsodium: ${LIBSODIUM_LIBRARIES}")
 endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -40,17 +40,30 @@ pkg_use_module(SNDFILE              sndfile      )
 ###############################################################################
 
 if(NOT LIBSODIUM_FOUND)
-  include_directories(include)
+  include_directories(libsodium/include)
   find_library(LIBSODIUM_LIBRARIES
     NAMES
       sodium
       libsodium
     PATHS
-      Win32/Release/v140/static
-      x64/Release/v140/static
+      libsodium/Win32/Release/v140/static
+      libsodium/x64/Release/v140/static
   )
   if(LIBSODIUM_LIBRARIES)
     set(LIBSODIUM_FOUND TRUE)
   endif()
   message("libsodium: ${LIBSODIUM_LIBRARIES}")
+endif()
+
+if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") AND CMAKE_USE_WIN32_THREADS_INIT)
+  include_directories(pthreads-win32/Pre-built.2/include)
+  find_library(CMAKE_THREAD_LIBS_INIT
+    NAMES
+      pthreadVC2
+    PATHS
+      pthreads-win32/Pre-built.2/lib/x86
+      pthreads-win32/Pre-built.2/lib/x64
+  )
+  add_definitions(-DHAVE_STRUCT_TIMESPEC)
+  message("libpthreads: ${CMAKE_THREAD_LIBS_INIT}")
 endif()


### PR DESCRIPTION
The AppVeyor MSVC build is failing because it can't find pthreads library. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/479)
<!-- Reviewable:end -->
