### PR TITLE
Split daemon's logging backends in separate modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,12 +455,16 @@ if(BOOTSTRAP_DAEMON)
       other/bootstrap_daemon/src/command_line_arguments.c
       other/bootstrap_daemon/src/command_line_arguments.h
       other/bootstrap_daemon/src/config.c
-      other/bootstrap_daemon/src/config_defaults.h
       other/bootstrap_daemon/src/config.h
+      other/bootstrap_daemon/src/config_defaults.h
+      other/bootstrap_daemon/src/global.h
       other/bootstrap_daemon/src/log.c
       other/bootstrap_daemon/src/log.h
+      other/bootstrap_daemon/src/log_backend_stdout.c
+      other/bootstrap_daemon/src/log_backend_stdout.h
+      other/bootstrap_daemon/src/log_backend_syslog.c
+      other/bootstrap_daemon/src/log_backend_syslog.h
       other/bootstrap_daemon/src/tox-bootstrapd.c
-      other/bootstrap_daemon/src/global.h
       other/bootstrap_node_packets.c
       other/bootstrap_node_packets.h)
     target_link_modules(tox-bootstrapd toxnetcrypto ${LIBCONFIG_LIBRARIES})

--- a/other/bootstrap_daemon/src/Makefile.inc
+++ b/other/bootstrap_daemon/src/Makefile.inc
@@ -6,10 +6,15 @@ tox_bootstrapd_SOURCES = \
                         ../other/bootstrap_daemon/src/command_line_arguments.c \
                         ../other/bootstrap_daemon/src/command_line_arguments.h \
                         ../other/bootstrap_daemon/src/config.c \
-                        ../other/bootstrap_daemon/src/config_defaults.h \
                         ../other/bootstrap_daemon/src/config.h \
+                        ../other/bootstrap_daemon/src/config_defaults.h \
+                        ../other/bootstrap_daemon/src/global.h \
                         ../other/bootstrap_daemon/src/log.c \
                         ../other/bootstrap_daemon/src/log.h \
+                        ../other/bootstrap_daemon/src/log_backend_stdout.c \
+                        ../other/bootstrap_daemon/src/log_backend_stdout.h \
+                        ../other/bootstrap_daemon/src/log_backend_syslog.c \
+                        ../other/bootstrap_daemon/src/log_backend_syslog.h \
                         ../other/bootstrap_daemon/src/tox-bootstrapd.c \
                         ../other/bootstrap_daemon/src/global.h \
                         ../other/bootstrap_node_packets.c \

--- a/other/bootstrap_daemon/src/command_line_arguments.c
+++ b/other/bootstrap_daemon/src/command_line_arguments.c
@@ -40,7 +40,7 @@ static void print_help(void)
     // 2 space ident
     // make sure all lines fit into 80 columns
     // make sure options are listed in alphabetical order
-    write_log(LOG_LEVEL_INFO,
+    log_write(LOG_LEVEL_INFO,
               "Usage: tox-bootstrapd [OPTION]... --config=FILE_PATH\n"
               "\n"
               "Options:\n"
@@ -64,7 +64,7 @@ void handle_command_line_arguments(int argc, char *argv[], char **cfg_file_path,
                                    bool *run_in_foreground)
 {
     if (argc < 2) {
-        write_log(LOG_LEVEL_ERROR, "Error: No arguments provided.\n\n");
+        log_write(LOG_LEVEL_ERROR, "Error: No arguments provided.\n\n");
         print_help();
         exit(1);
     }
@@ -112,7 +112,7 @@ void handle_command_line_arguments(int argc, char *argv[], char **cfg_file_path,
                     *log_backend = LOG_BACKEND_STDOUT;
                     log_backend_set = true;
                 } else {
-                    write_log(LOG_LEVEL_ERROR, "Error: Invalid BACKEND value for --log-backend option passed: %s\n\n", optarg);
+                    log_write(LOG_LEVEL_ERROR, "Error: Invalid BACKEND value for --log-backend option passed: %s\n\n", optarg);
                     print_help();
                     exit(1);
                 }
@@ -120,16 +120,16 @@ void handle_command_line_arguments(int argc, char *argv[], char **cfg_file_path,
                 break;
 
             case 'v':
-                write_log(LOG_LEVEL_INFO, "Version: %lu\n", DAEMON_VERSION_NUMBER);
+                log_write(LOG_LEVEL_INFO, "Version: %lu\n", DAEMON_VERSION_NUMBER);
                 exit(0);
 
             case '?':
-                write_log(LOG_LEVEL_ERROR, "Error: Unrecognized option %s\n\n", argv[optind - 1]);
+                log_write(LOG_LEVEL_ERROR, "Error: Unrecognized option %s\n\n", argv[optind - 1]);
                 print_help();
                 exit(1);
 
             case ':':
-                write_log(LOG_LEVEL_ERROR, "Error: No argument provided for option %s\n\n", argv[optind - 1]);
+                log_write(LOG_LEVEL_ERROR, "Error: No argument provided for option %s\n\n", argv[optind - 1]);
                 print_help();
                 exit(1);
         }
@@ -140,7 +140,7 @@ void handle_command_line_arguments(int argc, char *argv[], char **cfg_file_path,
     }
 
     if (!cfg_file_path_set) {
-        write_log(LOG_LEVEL_ERROR, "Error: The required --config option wasn't specified\n\n");
+        log_write(LOG_LEVEL_ERROR, "Error: The required --config option wasn't specified\n\n");
         print_help();
         exit(1);
     }

--- a/other/bootstrap_daemon/src/config.c
+++ b/other/bootstrap_daemon/src/config.c
@@ -50,15 +50,15 @@ static void parse_tcp_relay_ports_config(config_t *cfg, uint16_t **tcp_relay_por
     config_setting_t *ports_array = config_lookup(cfg, NAME_TCP_RELAY_PORTS);
 
     if (ports_array == NULL) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in the configuration file.\n", NAME_TCP_RELAY_PORTS);
-        write_log(LOG_LEVEL_WARNING, "Using default '%s':\n", NAME_TCP_RELAY_PORTS);
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in the configuration file.\n", NAME_TCP_RELAY_PORTS);
+        log_write(LOG_LEVEL_WARNING, "Using default '%s':\n", NAME_TCP_RELAY_PORTS);
 
         uint16_t default_ports[DEFAULT_TCP_RELAY_PORTS_COUNT] = {DEFAULT_TCP_RELAY_PORTS};
 
         int i;
 
         for (i = 0; i < DEFAULT_TCP_RELAY_PORTS_COUNT; i ++) {
-            write_log(LOG_LEVEL_INFO, "Port #%d: %u\n", i, default_ports[i]);
+            log_write(LOG_LEVEL_INFO, "Port #%d: %u\n", i, default_ports[i]);
         }
 
         // similar procedure to the one of reading config file below
@@ -70,7 +70,7 @@ static void parse_tcp_relay_ports_config(config_t *cfg, uint16_t **tcp_relay_por
 
             if ((*tcp_relay_ports)[*tcp_relay_port_count] < MIN_ALLOWED_PORT
                     || (*tcp_relay_ports)[*tcp_relay_port_count] > MAX_ALLOWED_PORT) {
-                write_log(LOG_LEVEL_WARNING, "Port #%d: Invalid port: %u, should be in [%d, %d]. Skipping.\n", i,
+                log_write(LOG_LEVEL_WARNING, "Port #%d: Invalid port: %u, should be in [%d, %d]. Skipping.\n", i,
                           (*tcp_relay_ports)[*tcp_relay_port_count], MIN_ALLOWED_PORT, MAX_ALLOWED_PORT);
                 continue;
             }
@@ -90,7 +90,7 @@ static void parse_tcp_relay_ports_config(config_t *cfg, uint16_t **tcp_relay_por
     }
 
     if (config_setting_is_array(ports_array) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_ERROR, "'%s' setting should be an array. Array syntax: 'setting = [value1, value2, ...]'.\n",
+        log_write(LOG_LEVEL_ERROR, "'%s' setting should be an array. Array syntax: 'setting = [value1, value2, ...]'.\n",
                   NAME_TCP_RELAY_PORTS);
         return;
     }
@@ -98,7 +98,7 @@ static void parse_tcp_relay_ports_config(config_t *cfg, uint16_t **tcp_relay_por
     int config_port_count = config_setting_length(ports_array);
 
     if (config_port_count == 0) {
-        write_log(LOG_LEVEL_ERROR, "'%s' is empty.\n", NAME_TCP_RELAY_PORTS);
+        log_write(LOG_LEVEL_ERROR, "'%s' is empty.\n", NAME_TCP_RELAY_PORTS);
         return;
     }
 
@@ -111,12 +111,12 @@ static void parse_tcp_relay_ports_config(config_t *cfg, uint16_t **tcp_relay_por
 
         if (elem == NULL) {
             // it's NULL if `ports_array` is not an array (we have that check earlier) or if `i` is out of range, which should not be
-            write_log(LOG_LEVEL_WARNING, "Port #%d: Something went wrong while parsing the port. Stopping reading ports.\n", i);
+            log_write(LOG_LEVEL_WARNING, "Port #%d: Something went wrong while parsing the port. Stopping reading ports.\n", i);
             break;
         }
 
         if (config_setting_is_number(elem) == CONFIG_FALSE) {
-            write_log(LOG_LEVEL_WARNING, "Port #%d: Not a number. Skipping.\n", i);
+            log_write(LOG_LEVEL_WARNING, "Port #%d: Not a number. Skipping.\n", i);
             continue;
         }
 
@@ -124,7 +124,7 @@ static void parse_tcp_relay_ports_config(config_t *cfg, uint16_t **tcp_relay_por
 
         if ((*tcp_relay_ports)[*tcp_relay_port_count] < MIN_ALLOWED_PORT
                 || (*tcp_relay_ports)[*tcp_relay_port_count] > MAX_ALLOWED_PORT) {
-            write_log(LOG_LEVEL_WARNING, "Port #%d: Invalid port: %u, should be in [%d, %d]. Skipping.\n", i,
+            log_write(LOG_LEVEL_WARNING, "Port #%d: Invalid port: %u, should be in [%d, %d]. Skipping.\n", i,
                       (*tcp_relay_ports)[*tcp_relay_port_count], MIN_ALLOWED_PORT, MAX_ALLOWED_PORT);
             continue;
         }
@@ -161,15 +161,15 @@ int get_general_config(const char *cfg_file_path, char **pid_file_path, char **k
 
     // Read the file. If there is an error, report it and exit.
     if (config_read_file(&cfg, cfg_file_path) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_ERROR, "%s:%d - %s\n", config_error_file(&cfg), config_error_line(&cfg), config_error_text(&cfg));
+        log_write(LOG_LEVEL_ERROR, "%s:%d - %s\n", config_error_file(&cfg), config_error_line(&cfg), config_error_text(&cfg));
         config_destroy(&cfg);
         return 0;
     }
 
     // Get port
     if (config_lookup_int(&cfg, NAME_PORT, port) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_PORT);
-        write_log(LOG_LEVEL_WARNING, "Using default '%s': %d\n", NAME_PORT, DEFAULT_PORT);
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_PORT);
+        log_write(LOG_LEVEL_WARNING, "Using default '%s': %d\n", NAME_PORT, DEFAULT_PORT);
         *port = DEFAULT_PORT;
     }
 
@@ -177,8 +177,8 @@ int get_general_config(const char *cfg_file_path, char **pid_file_path, char **k
     const char *tmp_pid_file;
 
     if (config_lookup_string(&cfg, NAME_PID_FILE_PATH, &tmp_pid_file) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_PID_FILE_PATH);
-        write_log(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_PID_FILE_PATH, DEFAULT_PID_FILE_PATH);
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_PID_FILE_PATH);
+        log_write(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_PID_FILE_PATH, DEFAULT_PID_FILE_PATH);
         tmp_pid_file = DEFAULT_PID_FILE_PATH;
     }
 
@@ -189,8 +189,8 @@ int get_general_config(const char *cfg_file_path, char **pid_file_path, char **k
     const char *tmp_keys_file;
 
     if (config_lookup_string(&cfg, NAME_KEYS_FILE_PATH, &tmp_keys_file) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_KEYS_FILE_PATH);
-        write_log(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_KEYS_FILE_PATH, DEFAULT_KEYS_FILE_PATH);
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_KEYS_FILE_PATH);
+        log_write(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_KEYS_FILE_PATH, DEFAULT_KEYS_FILE_PATH);
         tmp_keys_file = DEFAULT_KEYS_FILE_PATH;
     }
 
@@ -199,31 +199,31 @@ int get_general_config(const char *cfg_file_path, char **pid_file_path, char **k
 
     // Get IPv6 option
     if (config_lookup_bool(&cfg, NAME_ENABLE_IPV6, enable_ipv6) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_IPV6);
-        write_log(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_IPV6, DEFAULT_ENABLE_IPV6 ? "true" : "false");
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_IPV6);
+        log_write(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_IPV6, DEFAULT_ENABLE_IPV6 ? "true" : "false");
         *enable_ipv6 = DEFAULT_ENABLE_IPV6;
     }
 
     // Get IPv4 fallback option
     if (config_lookup_bool(&cfg, NAME_ENABLE_IPV4_FALLBACK, enable_ipv4_fallback) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_IPV4_FALLBACK);
-        write_log(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_IPV4_FALLBACK,
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_IPV4_FALLBACK);
+        log_write(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_IPV4_FALLBACK,
                   DEFAULT_ENABLE_IPV4_FALLBACK ? "true" : "false");
         *enable_ipv4_fallback = DEFAULT_ENABLE_IPV4_FALLBACK;
     }
 
     // Get LAN discovery option
     if (config_lookup_bool(&cfg, NAME_ENABLE_LAN_DISCOVERY, enable_lan_discovery) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_LAN_DISCOVERY);
-        write_log(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_LAN_DISCOVERY,
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_LAN_DISCOVERY);
+        log_write(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_LAN_DISCOVERY,
                   DEFAULT_ENABLE_LAN_DISCOVERY ? "true" : "false");
         *enable_lan_discovery = DEFAULT_ENABLE_LAN_DISCOVERY;
     }
 
     // Get TCP relay option
     if (config_lookup_bool(&cfg, NAME_ENABLE_TCP_RELAY, enable_tcp_relay) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_TCP_RELAY);
-        write_log(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_TCP_RELAY,
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_TCP_RELAY);
+        log_write(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_TCP_RELAY,
                   DEFAULT_ENABLE_TCP_RELAY ? "true" : "false");
         *enable_tcp_relay = DEFAULT_ENABLE_TCP_RELAY;
     }
@@ -236,8 +236,8 @@ int get_general_config(const char *cfg_file_path, char **pid_file_path, char **k
 
     // Get MOTD option
     if (config_lookup_bool(&cfg, NAME_ENABLE_MOTD, enable_motd) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_MOTD);
-        write_log(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_MOTD,
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_ENABLE_MOTD);
+        log_write(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_ENABLE_MOTD,
                   DEFAULT_ENABLE_MOTD ? "true" : "false");
         *enable_motd = DEFAULT_ENABLE_MOTD;
     }
@@ -247,8 +247,8 @@ int get_general_config(const char *cfg_file_path, char **pid_file_path, char **k
         const char *tmp_motd;
 
         if (config_lookup_string(&cfg, NAME_MOTD, &tmp_motd) == CONFIG_FALSE) {
-            write_log(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_MOTD);
-            write_log(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_MOTD, DEFAULT_MOTD);
+            log_write(LOG_LEVEL_WARNING, "No '%s' setting in configuration file.\n", NAME_MOTD);
+            log_write(LOG_LEVEL_WARNING, "Using default '%s': %s\n", NAME_MOTD, DEFAULT_MOTD);
             tmp_motd = DEFAULT_MOTD;
         }
 
@@ -261,34 +261,34 @@ int get_general_config(const char *cfg_file_path, char **pid_file_path, char **k
 
     config_destroy(&cfg);
 
-    write_log(LOG_LEVEL_INFO, "Successfully read:\n");
-    write_log(LOG_LEVEL_INFO, "'%s': %s\n", NAME_PID_FILE_PATH,        *pid_file_path);
-    write_log(LOG_LEVEL_INFO, "'%s': %s\n", NAME_KEYS_FILE_PATH,       *keys_file_path);
-    write_log(LOG_LEVEL_INFO, "'%s': %d\n", NAME_PORT,                 *port);
-    write_log(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_IPV6,          *enable_ipv6          ? "true" : "false");
-    write_log(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_IPV4_FALLBACK, *enable_ipv4_fallback ? "true" : "false");
-    write_log(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_LAN_DISCOVERY, *enable_lan_discovery ? "true" : "false");
+    log_write(LOG_LEVEL_INFO, "Successfully read:\n");
+    log_write(LOG_LEVEL_INFO, "'%s': %s\n", NAME_PID_FILE_PATH,        *pid_file_path);
+    log_write(LOG_LEVEL_INFO, "'%s': %s\n", NAME_KEYS_FILE_PATH,       *keys_file_path);
+    log_write(LOG_LEVEL_INFO, "'%s': %d\n", NAME_PORT,                 *port);
+    log_write(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_IPV6,          *enable_ipv6          ? "true" : "false");
+    log_write(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_IPV4_FALLBACK, *enable_ipv4_fallback ? "true" : "false");
+    log_write(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_LAN_DISCOVERY, *enable_lan_discovery ? "true" : "false");
 
-    write_log(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_TCP_RELAY,     *enable_tcp_relay     ? "true" : "false");
+    log_write(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_TCP_RELAY,     *enable_tcp_relay     ? "true" : "false");
 
     // show info about tcp ports only if tcp relay is enabled
     if (*enable_tcp_relay) {
         if (*tcp_relay_port_count == 0) {
-            write_log(LOG_LEVEL_ERROR, "No TCP ports could be read.\n");
+            log_write(LOG_LEVEL_ERROR, "No TCP ports could be read.\n");
         } else {
-            write_log(LOG_LEVEL_INFO, "Read %d TCP ports:\n", *tcp_relay_port_count);
+            log_write(LOG_LEVEL_INFO, "Read %d TCP ports:\n", *tcp_relay_port_count);
             int i;
 
             for (i = 0; i < *tcp_relay_port_count; i ++) {
-                write_log(LOG_LEVEL_INFO, "Port #%d: %u\n", i, (*tcp_relay_ports)[i]);
+                log_write(LOG_LEVEL_INFO, "Port #%d: %u\n", i, (*tcp_relay_ports)[i]);
             }
         }
     }
 
-    write_log(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_MOTD,          *enable_motd          ? "true" : "false");
+    log_write(LOG_LEVEL_INFO, "'%s': %s\n", NAME_ENABLE_MOTD,          *enable_motd          ? "true" : "false");
 
     if (*enable_motd) {
-        write_log(LOG_LEVEL_INFO, "'%s': %s\n", NAME_MOTD, *motd);
+        log_write(LOG_LEVEL_INFO, "'%s': %s\n", NAME_MOTD, *motd);
     }
 
     return 1;
@@ -335,7 +335,7 @@ int bootstrap_from_config(const char *cfg_file_path, DHT *dht, int enable_ipv6)
     config_init(&cfg);
 
     if (config_read_file(&cfg, cfg_file_path) == CONFIG_FALSE) {
-        write_log(LOG_LEVEL_ERROR, "%s:%d - %s\n", config_error_file(&cfg), config_error_line(&cfg), config_error_text(&cfg));
+        log_write(LOG_LEVEL_ERROR, "%s:%d - %s\n", config_error_file(&cfg), config_error_line(&cfg), config_error_text(&cfg));
         config_destroy(&cfg);
         return 0;
     }
@@ -343,14 +343,14 @@ int bootstrap_from_config(const char *cfg_file_path, DHT *dht, int enable_ipv6)
     config_setting_t *node_list = config_lookup(&cfg, NAME_BOOTSTRAP_NODES);
 
     if (node_list == NULL) {
-        write_log(LOG_LEVEL_WARNING, "No '%s' setting in the configuration file. Skipping bootstrapping.\n",
+        log_write(LOG_LEVEL_WARNING, "No '%s' setting in the configuration file. Skipping bootstrapping.\n",
                   NAME_BOOTSTRAP_NODES);
         config_destroy(&cfg);
         return 1;
     }
 
     if (config_setting_length(node_list) == 0) {
-        write_log(LOG_LEVEL_WARNING, "No bootstrap nodes found. Skipping bootstrapping.\n");
+        log_write(LOG_LEVEL_WARNING, "No bootstrap nodes found. Skipping bootstrapping.\n");
         config_destroy(&cfg);
         return 1;
     }
@@ -376,30 +376,30 @@ int bootstrap_from_config(const char *cfg_file_path, DHT *dht, int enable_ipv6)
 
         // Check that all settings are present
         if (config_setting_lookup_string(node, NAME_PUBLIC_KEY, &bs_public_key) == CONFIG_FALSE) {
-            write_log(LOG_LEVEL_WARNING, "Bootstrap node #%d: Couldn't find '%s' setting. Skipping the node.\n", i,
+            log_write(LOG_LEVEL_WARNING, "Bootstrap node #%d: Couldn't find '%s' setting. Skipping the node.\n", i,
                       NAME_PUBLIC_KEY);
             goto next;
         }
 
         if (config_setting_lookup_int(node, NAME_PORT, &bs_port) == CONFIG_FALSE) {
-            write_log(LOG_LEVEL_WARNING, "Bootstrap node #%d: Couldn't find '%s' setting. Skipping the node.\n", i, NAME_PORT);
+            log_write(LOG_LEVEL_WARNING, "Bootstrap node #%d: Couldn't find '%s' setting. Skipping the node.\n", i, NAME_PORT);
             goto next;
         }
 
         if (config_setting_lookup_string(node, NAME_ADDRESS, &bs_address) == CONFIG_FALSE) {
-            write_log(LOG_LEVEL_WARNING, "Bootstrap node #%d: Couldn't find '%s' setting. Skipping the node.\n", i, NAME_ADDRESS);
+            log_write(LOG_LEVEL_WARNING, "Bootstrap node #%d: Couldn't find '%s' setting. Skipping the node.\n", i, NAME_ADDRESS);
             goto next;
         }
 
         // Process settings
         if (strlen(bs_public_key) != CRYPTO_PUBLIC_KEY_SIZE * 2) {
-            write_log(LOG_LEVEL_WARNING, "Bootstrap node #%d: Invalid '%s': %s. Skipping the node.\n", i, NAME_PUBLIC_KEY,
+            log_write(LOG_LEVEL_WARNING, "Bootstrap node #%d: Invalid '%s': %s. Skipping the node.\n", i, NAME_PUBLIC_KEY,
                       bs_public_key);
             goto next;
         }
 
         if (bs_port < MIN_ALLOWED_PORT || bs_port > MAX_ALLOWED_PORT) {
-            write_log(LOG_LEVEL_WARNING, "Bootstrap node #%d: Invalid '%s': %d, should be in [%d, %d]. Skipping the node.\n", i,
+            log_write(LOG_LEVEL_WARNING, "Bootstrap node #%d: Invalid '%s': %d, should be in [%d, %d]. Skipping the node.\n", i,
                       NAME_PORT,
                       bs_port, MIN_ALLOWED_PORT, MAX_ALLOWED_PORT);
             goto next;
@@ -411,11 +411,11 @@ int bootstrap_from_config(const char *cfg_file_path, DHT *dht, int enable_ipv6)
         free(bs_public_key_bin);
 
         if (!address_resolved) {
-            write_log(LOG_LEVEL_WARNING, "Bootstrap node #%d: Invalid '%s': %s. Skipping the node.\n", i, NAME_ADDRESS, bs_address);
+            log_write(LOG_LEVEL_WARNING, "Bootstrap node #%d: Invalid '%s': %s. Skipping the node.\n", i, NAME_ADDRESS, bs_address);
             goto next;
         }
 
-        write_log(LOG_LEVEL_INFO, "Successfully added bootstrap node #%d: %s:%d %s\n", i, bs_address, bs_port, bs_public_key);
+        log_write(LOG_LEVEL_INFO, "Successfully added bootstrap node #%d: %s:%d %s\n", i, bs_address, bs_port, bs_public_key);
 
 next:
         // config_setting_lookup_string() allocates string inside and doesn't allow us to free it direcly

--- a/other/bootstrap_daemon/src/log.h
+++ b/other/bootstrap_daemon/src/log.h
@@ -28,8 +28,8 @@
 #include <stdbool.h>
 
 typedef enum LOG_BACKEND {
-    LOG_BACKEND_SYSLOG,
-    LOG_BACKEND_STDOUT
+    LOG_BACKEND_STDOUT,
+    LOG_BACKEND_SYSLOG
 } LOG_BACKEND;
 
 typedef enum LOG_LEVEL {
@@ -43,13 +43,13 @@ typedef enum LOG_LEVEL {
  * @param backend Specifies which backend to use.
  * @return true on success, flase if log is already opened.
  */
-bool open_log(LOG_BACKEND backend);
+bool log_open(LOG_BACKEND backend);
 
 /**
  * Releases all used resources by the logger.
  * @return true on success, flase if log is already closed.
  */
-bool close_log(void);
+bool log_close(void);
 
 /**
  * Writes a message to the log.
@@ -58,7 +58,7 @@ bool close_log(void);
  * @param ... Zero or more arguments, similar to printf function.
  * @return true on success, flase if log is closed.
  */
-bool write_log(LOG_LEVEL level, const char *format, ...);
+bool log_write(LOG_LEVEL level, const char *format, ...);
 
 
 #endif // LOG_H

--- a/other/bootstrap_daemon/src/log_backend_stdout.c
+++ b/other/bootstrap_daemon/src/log_backend_stdout.c
@@ -1,0 +1,47 @@
+/*
+ * Tox DHT bootstrap daemon.
+ * Stdout logging backend.
+ */
+
+/*
+ * Copyright © 2016-2017 The TokTok team.
+ * Copyright © 2015-2016 Tox project.
+ *
+ * This file is part of Tox, the free peer to peer instant messenger.
+ *
+ * Tox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "log_backend_stdout.h"
+
+#include <stdio.h>
+
+static FILE *log_backend_stdout_level(LOG_LEVEL level)
+{
+    switch (level) {
+        case LOG_LEVEL_INFO:
+            return stdout;
+
+        case LOG_LEVEL_WARNING: // intentional fallthrough
+        case LOG_LEVEL_ERROR:
+            return stderr;
+    }
+
+    return stdout;
+}
+
+void log_backend_stdout_write(LOG_LEVEL level, const char *format, va_list args)
+{
+    vfprintf(log_backend_stdout_level(level), format, args);
+    fflush(log_backend_stdout_level(level));
+}

--- a/other/bootstrap_daemon/src/log_backend_stdout.h
+++ b/other/bootstrap_daemon/src/log_backend_stdout.h
@@ -1,0 +1,34 @@
+/*
+ * Tox DHT bootstrap daemon.
+ * Stdout logging backend.
+ */
+
+/*
+ * Copyright © 2016-2017 The TokTok team.
+ * Copyright © 2015-2016 Tox project.
+ *
+ * This file is part of Tox, the free peer to peer instant messenger.
+ *
+ * Tox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LOG_STDOUT_H
+#define LOG_STDOUT_H
+
+#include "log.h"
+
+#include <stdarg.h>
+
+void log_backend_stdout_write(LOG_LEVEL level, const char *format, va_list args);
+
+#endif // LOG_BACKEND_STDOUT_H

--- a/other/bootstrap_daemon/src/log_backend_syslog.c
+++ b/other/bootstrap_daemon/src/log_backend_syslog.c
@@ -1,0 +1,79 @@
+/*
+ * Tox DHT bootstrap daemon.
+ * Syslog logging backend.
+ */
+
+/*
+ * Copyright © 2016-2017 The TokTok team.
+ * Copyright © 2015-2016 Tox project.
+ *
+ * This file is part of Tox, the free peer to peer instant messenger.
+ *
+ * Tox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "log_backend_syslog.h"
+
+#include "global.h"
+
+#include "../../../toxcore/ccompat.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <syslog.h>
+
+void log_backend_syslog_open(void)
+{
+    openlog(DAEMON_NAME, LOG_NOWAIT | LOG_PID, LOG_DAEMON);
+}
+
+void log_backend_syslog_close(void)
+{
+    closelog();
+}
+
+static int log_backend_syslog_level(LOG_LEVEL level)
+{
+    switch (level) {
+        case LOG_LEVEL_INFO:
+            return LOG_INFO;
+
+        case LOG_LEVEL_WARNING:
+            return LOG_WARNING;
+
+        case LOG_LEVEL_ERROR:
+            return LOG_ERR;
+    }
+
+    return LOG_INFO;
+}
+
+void log_backend_syslog_write(LOG_LEVEL level, const char *format, va_list args)
+{
+    va_list args2;
+
+    va_copy(args2, args);
+    int size = vsnprintf(NULL, 0, format, args2);
+    va_end(args2);
+
+    assert(size >= 0);
+
+    if (size < 0) {
+        return;
+    }
+
+    VLA(char, buf, size + 1);
+    vsnprintf(buf, size + 1, format, args);
+
+    syslog(log_backend_syslog_level(level), "%s", buf);
+}

--- a/other/bootstrap_daemon/src/log_backend_syslog.h
+++ b/other/bootstrap_daemon/src/log_backend_syslog.h
@@ -1,0 +1,36 @@
+/*
+ * Tox DHT bootstrap daemon.
+ * Syslog logging backend.
+ */
+
+/*
+ * Copyright © 2016-2017 The TokTok team.
+ * Copyright © 2015-2016 Tox project.
+ *
+ * This file is part of Tox, the free peer to peer instant messenger.
+ *
+ * Tox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LOG_BACKEND_SYSLOG_H
+#define LOG_BACKEND_SYSLOG_H
+
+#include "log.h"
+
+#include <stdarg.h>
+
+void log_backend_syslog_open(void);
+void log_backend_syslog_close(void);
+void log_backend_syslog_write(LOG_LEVEL level, const char *format, va_list args);
+
+#endif // LOG_BACKEND_SYSLOG_H


### PR DESCRIPTION
- `log_backend.h` defines an interface for logging back-ends, which `log_backend_[stdout|syslog].[h|c]` implement. These implementations are then put together into a `BACKENDS` array in `log.c`, which is indexed by the `LOG_BACKEND` enum. Haven't really done any such modular implementations in C before, so any corrections are welcome.

- Renamed
  - `open_log()` --> `log_open()`
  - `close_log()` --> `log_close()`
  - `write_log()` --> `log_write()`

  Should probably have been a separate commit/PR, but I happened to do the renaming and modularization at the same time, so there we go.

I meant to make logging modular from the beginning, but at the time of writing it I thought that maybe it's simpler to keep all logging backends relatively separate in `log.c` as there is so little code, instead of scattering them in multiple files and adding this struct with function pointers glue, at least until there is more code for the logging that would warrant the splitting, but there was some confusion as to why I want to keep backends relatively separate

>[The part I don't understand is the "keeping backends separate". You still have explicit knowledge of every backend in this function. What is the advantage of having `my_foo(...)` instead of `foo(...)`?](https://github.com/TokTok/c-toxcore/pull/297#issuecomment-267774183)
> -- @iphydf 

, so this PR should remove this confusion now that the logging backends are truly separate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/487)
<!-- Reviewable:end -->
