### PR TITLE
Fix Travis always succeeding despite tests failing

### DIFF
--- a/other/travis/env-linux.sh
+++ b/other/travis/env-linux.sh
@@ -15,6 +15,8 @@ TESTS() {
   "$@" || {
     if [ $COUNT -gt 1 ]; then
       TESTS `expr $COUNT - 1` "$@"
+    else
+      false
     fi
   }
 }

--- a/other/travis/env-osx.sh
+++ b/other/travis/env-osx.sh
@@ -14,6 +14,8 @@ TESTS() {
   "$@" || {
     if [ $COUNT -gt 1 ]; then
       TESTS `expr $COUNT - 1` "$@"
+    else
+      false
     fi
   }
 }

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -180,7 +180,7 @@ uint32_t tox_version_minor(void);
  * The patch or revision number. Incremented when bugfixes are applied without
  * changing any functionality or API or ABI.
  */
-#define TOX_VERSION_PATCH              5
+#define TOX_VERSION_PATCH              6
 
 uint32_t tox_version_patch(void);
 


### PR DESCRIPTION
This fixes (at least I believe it does, need to wait for the Travis report for this PR) Travis builds succeeding despite tests failing.

Travis always succeeding has caused the following things to be unnoticed:

- Version string "0.1.5" not being updated to "0.1.6" when releasing 0.1.6 version (https://github.com/TokTok/c-toxcore/issues/474)
- Missing formatting in PR code (https://github.com/TokTok/c-toxcore/issues/494)
- Heap buffer overflow (https://github.com/TokTok/c-toxcore/issues/495)

Failing Travis build on the test failure is the desired behavior and it was the behavior we had until some commit unintentionally broke it (I suspect https://github.com/TokTok/c-toxcore/commit/f58dbe250329aad0ac2d54789359c162f43de311).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/496)
<!-- Reviewable:end -->
