### PR TITLE
CMake: install bootstrapd if it is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,7 @@ if(BOOTSTRAP_DAEMON)
       other/bootstrap_node_packets.c
       other/bootstrap_node_packets.h)
     target_link_modules(tox-bootstrapd toxnetcrypto ${LIBCONFIG_LIBRARIES})
+    install(TARGETS tox-bootstrapd RUNTIME DESTINATION bin)
   endif()
 endif()
 


### PR DESCRIPTION
if bootstrapd option is enabled the binary should be
installed on `make install`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/504)
<!-- Reviewable:end -->
