### PR TITLE
Fix network malloc(0) bug

### DIFF
--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -389,7 +389,8 @@ int net_connect(Socket sock, IP_Port ip_port);
  * Skip all addresses with socktype != type (use type = -1 to get all addresses)
  * To correctly deallocate array memory use net_freeipport()
  *
- * return number of elements in res array.
+ * return number of elements in res array
+ * and -1 on error.
  */
 int32_t net_getipport(const char *node, IP_Port **res, int type);
 


### PR DESCRIPTION
Thanks @nurupo for the report
From IRC:
> \<nurupo> Diadlo: are you here? there is an issue with the networking code
> \<nurupo> Diadlo: the "Unix API" one on this page. click on Details https://build.tox.chat/job/libtoxcore-toktok_analyze_scan-build/115/clangScanBuildBugs/
> \<nurupo> Diadlo: malloc(0) is undefined behaviour, so you should guard the malloc call with an if-statement checking for 0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/509)
<!-- Reviewable:end -->
