### PR TITLE
Reduce ctest timeout to 2 minutes from 5 minutes.

### DIFF
--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -30,7 +30,7 @@ RUN $CMAKE                                      \
   -DASAN=ON                                     \
   -DDEBUG=ON                                    \
   -DSTRICT_ABI=ON                               \
-  -DTEST_TIMEOUT_SECONDS=300                    \
+  -DTEST_TIMEOUT_SECONDS=120                    \
   -DTRACE=ON                                    \
   $CMAKE_EXTRA_FLAGS
 


### PR DESCRIPTION
Fixes #411.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/524)
<!-- Reviewable:end -->
