### PR TITLE
pkg-config .pc files: added .private versions of Libs and Required to prevent top-level linking of all libraries.

### DIFF
--- a/other/pkgconfig/toxav.pc.in
+++ b/other/pkgconfig/toxav.pc.in
@@ -4,7 +4,8 @@ includedir=${prefix}/include
 
 Name: toxav
 Description: Tox A/V library
-Requires: opus toxcore vpx
+Requires.private: opus toxcore vpx
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} @toxav_PKGCONFIG_LIBS@ -ltoxav
+Libs: -L${libdir} -ltoxav
+Libs.private: @toxav_PKGCONFIG_LIBS@
 Cflags: -I${includedir}

--- a/other/pkgconfig/toxcore.pc.in
+++ b/other/pkgconfig/toxcore.pc.in
@@ -4,7 +4,8 @@ includedir=${prefix}/include
 
 Name: toxcore
 Description: Tox protocol library
-Requires: libsodium
+Requires.private: libsodium
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} -ltoxcore @toxcore_PKGCONFIG_LIBS@ -ltoxcrypto -ltoxnetwork -ltoxdht -ltoxnetcrypto -ltoxfriends -ltoxmessenger -ltoxgroup
+Libs: -L${libdir} -ltoxcore
+Libs.private: @toxcore_PKGCONFIG_LIBS@ -ltoxcrypto -ltoxnetwork -ltoxdht -ltoxnetcrypto -ltoxfriends -ltoxmessenger -ltoxgroup
 Cflags: -I${includedir}

--- a/other/pkgconfig/toxdns.pc.in
+++ b/other/pkgconfig/toxdns.pc.in
@@ -4,7 +4,8 @@ includedir=${prefix}/include
 
 Name: toxdns
 Description: Tox DNS3 library
-Requires: toxcore
+Requires.private: toxcore
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} @toxdns_PKGCONFIG_LIBS@ -ltoxdns
+Libs: -L${libdir} -ltoxdns
+Libs.private: @toxdns_PKGCONFIG_LIBS@
 Cflags: -I${includedir}

--- a/other/pkgconfig/toxencryptsave.pc.in
+++ b/other/pkgconfig/toxencryptsave.pc.in
@@ -4,7 +4,8 @@ includedir=${prefix}/include
 
 Name: toxencryptsave
 Description: Tox block encryption library
-Requires: toxcore
+Requires.private: toxcore
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} @toxencryptsave_PKGCONFIG_LIBS@ -ltoxencryptsave
+Libs: -L${libdir} -ltoxencryptsave
+Libs.private: @toxencryptsave_PKGCONFIG_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Problem: ```pkg-config --libs toxcore``` returns all libraries that are required by all libtox*.so libraries. This is wrong because for a dynamically linked executable only top-level libraries need to be supplied. ```pkg-config --libs --static toxcore``` should return all libraries for the statically linked executable.

For example, the ToxBot https://github.com/JFreegman/ToxBot executable uses pkg-config and is linked with the opus library, which is wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/533)
<!-- Reviewable:end -->
