### PR TITLE
Fix markdown formatting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,31 +1,29 @@
-#Install Instructions
+# Install Instructions
 
 - [Installation](#installation)
-  - [Unix like](#unix)
+  - [Unix like](#most-unix-like-oses)
     - [Quick install](#quick-install)
     - [Build manually](#build-manually)
       - [Compile toxcore](#compile-toxcore)
-  - [OS X](#osx)
+  - [OS X](#os-x)
     - [Homebrew](#homebrew)
     - [Non-Homebrew](#non-homebrew)
   - [Windows](#windows)
-    - [Cross-Compile](#windows-cross-compile)
-      - [Setting up a VM](#windows-cross-compile-vm)
-      - [Setting up the environment](#windows-cross-compile-environment)
-      - [Compiling](#windows-cross-compile-compiling)
-    - [Native](#windows-native)
+    - [Cross-Compile](#cross-compile)
+      - [Setting up a VM](#setting-up-a-vm)
+      - [Setting up the environment](#setting-up-the-environment)
+      - [Compiling](#compiling)
+    - [Native](#native)
 - [Additional](#additional)
-  - [Advanced configure options](#aconf)
-  - [A/V support](#av)
+  - [Advanced configure options](#advanced-configure-options)
+  - [A/V support](#av-support)
     - [libtoxav](#libtoxav)
-  - [Bootstrap daemon](#bootstrapd)
-  - [nTox](#ntox)
+  - [Bootstrap daemon](#bootstrap-daemon)
+  - [nTox](#ntox-test-cli)
 
-<a name="installation" />
-##Installation
+## Installation
 
-<a name="unix" />
-###Most Unix like OSes:
+### Most Unix like OSes:
 
 #### Quick install:
 
@@ -131,17 +129,16 @@ sudo make install
 ```
 
 
-<a name="osx" />
-###OS X:
+### OS X:
 
 You need the latest XCode with the Developer Tools (Preferences -> Downloads -> Command Line Tools).
 The following libraries are required along with libsodium and cmake for Mountain Lion and XCode 4.6.3 install libtool, automake and autoconf. You can download them with Homebrew, or install them manually.
 
 **Note: OS X users can also install Toxcore using [osx_build_script_toxcore.sh](other/osx_build_script_toxcore.sh)**
 
-There are no binaries/executables going to /bin/ or /usr/bin/ now. Everything is compiled and ran from the inside your local branch. See [Usage](#usage) below.
-<a name="homebrew" />
-####Homebrew:
+There are no binaries/executables going to /bin/ or /usr/bin/ now. Everything is compiled and ran from the inside your local branch.
+
+#### Homebrew:
 To install from the formula:
 ```bash
 brew tap Tox/tox
@@ -177,8 +174,7 @@ make install
 ```
 
 
-<a name="non-homebrew" />
-####Non-homebrew:
+#### Non-homebrew:
 
 Grab the following packages:
   * https://gnu.org/software/libtool/
@@ -267,17 +263,13 @@ If there is a problem with opus (for A/V) and you don't get a libtoxav, then try
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ```
 
-<a name="windows" />
-###Windows:
+### Windows:
 
-<a name="windows-cross-compile" />
-
-####Cross-compile
+#### Cross-compile
 
 It's a bit challenging to build Tox and all of its dependencies nativly on Windows, so we will show an easier, less error and headache prone method of building it -- cross-compiling.
 
-<a name="windows-cross-compile-vm" />
-#####Setting up a VM
+##### Setting up a VM
 
 We will assume that you don't have any VM running Linux around and will guide you from the ground up.
 
@@ -324,8 +316,7 @@ After the system is booted, go to **Devices** -> **Shared Clipboard** and select
 
 Now that the virtual machine is all set up, let's move to getting build dependencies and setting up environment variables.
 
-<a name="windows-cross-compile-environment" />
-#####Setting up the environment
+##### Setting up the environment
 
 First we will install all tools that we would need for building:
 ```bash
@@ -365,8 +356,7 @@ mkdir build
 cd build
 ```
 
-<a name="windows-cross-compile-compiling" />
-#####Compiling
+##### Compiling
 
 Now we will build libraries needed for audio/video: VPX and Opus.
 
@@ -439,8 +429,7 @@ cp -r ../include/tox /media/sf_toxbuild/release/include
 
 That's it. Now you should have `release/bin/libtox.dll`, `release/bin/libtox.dll.a` and `release/include/tox/<headers>` in your `toxbuild` directory on the Windows system.
 
-<a name="windows-native" />
-####Native
+#### Native
 
 Note that the Native instructions are incomplete, in a sense that they miss instructions needed for adding audio/video support to Tox. You also might stumble upon some unknown MinGW+msys issues while trying to build it.
 
@@ -475,21 +464,10 @@ make
 make install
 ```
 
-<a name="Clients" />
-####Clients:
-While [Toxic](https://github.com/tox/toxic) is no longer in core, a list of Tox clients are located in our [wiki](https://wiki.tox.chat/doku.php?id=clients)
 
+## Additional
 
-
-
-
-<a name="additional" />
-##Additional
-
-
-
-<a name="aconf" />
-###Advanced configure options:
+### Advanced configure options:
 
   - --prefix=/where/to/install
   - --with-libsodium-headers=/path/to/libsodium/include/
@@ -499,17 +477,14 @@ While [Toxic](https://github.com/tox/toxic) is no longer in core, a list of Tox 
   - --disable-tests build unit tests (default: auto)
   - --disable-av disable A/V support (default: auto) see: [libtoxav](#libtoxav)
   - --enable-ntox build nTox client (default: no) see: [nTox](#ntox)
-  - --enable-daemon build DHT bootstrap daemon (default=no) see: [Bootstrap daemon](#bootstrapd)
+  - --enable-daemon build DHT bootstrap daemon (default=no) see: [Bootstrap daemon](#bootstrap-daemon)
   - --enable-dht-bootstrap build DHT bootstrap utility (default=disabled)
   - --enable-shared[=PKGS]  build shared libraries [default=yes]
   - --enable-static[=PKGS]  build static libraries [default=yes]
 
+### A/V support:
 
-<a name="av" />
-###A/V support:
-
-<a name="libtoxav" />
-####libtoxav:
+#### libtoxav:
 
 'libtoxav' is needed for A/V support and it's enabled by default. You can disable it by adding --disable-av argument to ./configure script like so:
 ```bash
@@ -555,8 +530,7 @@ sudo make install
 cd ..
 ```
 
-<a name="bootstrapd" />
-###Bootstrap daemon:
+### Bootstrap daemon:
 
 Daemon is disabled by default. You can enable it by adding --enable-daemon argument to ./configure script like so:
 ```bash
@@ -584,8 +558,7 @@ Grab the following [package](http://www.hyperrealm.com/libconfig/), uncompress a
 See this [readme](other/bootstrap_daemon/README.md) on how to set up the bootstrap daemon.
 
 
-<a name="ntox" />
-###nTox test cli:
+### nTox test cli:
 
 nTox is disabled by default. You can enable it by adding --enable-ntox argument to ./configure script like so:
 ```bash

--- a/docs/av_api.md
+++ b/docs/av_api.md
@@ -1,8 +1,8 @@
-#A/V API reference
+# A/V API reference
 
-##Take toxmsi/phone.c as a reference
+## Take toxmsi/phone.c as a reference
 
-###Initialization:
+### Initialization:
 
 ```
 phone_t* initPhone(uint16_t _listen_port, uint16_t _send_port);
@@ -31,7 +31,7 @@ const uint8_t* _user_agent - string describing phone client version.
 Return value:
 msi_session_t* - pointer to a newly created msi session handler.
 
-###msi_session_t reference:
+### msi_session_t reference:
 
 How to handle msi session:
 Controlling is done via callbacks and action handlers.
@@ -91,7 +91,7 @@ int msi_reject ( msi_session_t* _session );
 Reject incomming call.
 
 
-###Now for rtp:
+### Now for rtp:
 
 You will need 2 sessions; one for audio one for video.
 You start them with:
@@ -110,7 +110,7 @@ Return value:
 rtp_session_t* - pointer to a newly created rtp session handler.
 ```
 
-###How to handle rtp session:
+### How to handle rtp session:
 Take a look at
 ```
 void* phone_handle_media_transport_poll ( void* _hmtc_args_p ) in phone.c
@@ -139,7 +139,7 @@ int rtp_send_msg ( rtp_session_t* _session, struct rtp_msg_s* _msg, void* _core_
 _core_handler is the same network handler as in msi_session_s struct.
 
 
-##A/V initialization:
+## A/V initialization:
 ```
 int init_receive_audio(codec_state *cs);
 int init_receive_video(codec_state *cs);
@@ -157,7 +157,7 @@ The variable bps is the required bitrate in bits per second.
 ```
 
 
-###A/V encoding/decoding:
+### A/V encoding/decoding:
 ```
 void *encode_video_thread(void *arg);
 ```

--- a/other/bootstrap_daemon/README.md
+++ b/other/bootstrap_daemon/README.md
@@ -1,29 +1,25 @@
-#Instructions
+# Instructions
 
-- [For `systemd` users](#systemd)
-  - [Setting up](#systemd-setting-up)
-  - [Updating](#systemd-updating)
-  - [Troubleshooting](#systemd-troubleshooting)
-<br>
-- [For `SysVinit` users](#sysvinit)
-  - [Setting up](#sysvinit-setting-up)
-  - [Updating](#sysvinit-updating)
-  - [Troubleshooting](#sysvinit-troubleshooting)
-<br>
-- [For `Docker` users](#docker)
-  - [Setting up](#docker-setting-up)
-  - [Updating](#docker-updating)
-  - [Troubleshooting](#docker-troubleshooting)
+- [For `systemd` users](#for-systemd-users)
+  - [Setting up](#setting-up)
+  - [Updating](#updating)
+  - [Troubleshooting](#troubleshooting)
+- [For `SysVinit` users](#for-sysvinit-users)
+  - [Setting up](#setting-up-1)
+  - [Updating](#updating-1)
+  - [Troubleshooting](#troubleshooting-1)
+- [For `Docker` users](#for-docker-users)
+  - [Setting up](#setting-up-2)
+  - [Updating](#updating-2)
+  - [Troubleshooting](#troubleshooting-2)
 
 
 These instructions are primarily tested on Debian Linux, Wheezy for SysVinit and Jessie for systemd, but they should work on other POSIX-compliant systems too.
 
 
-<a name="systemd" />
-##For `systemd` users
+## For `systemd` users
 
-<a name="systemd-setting-up" />
-###Setting up
+### Setting up
 
 For security reasons we run the daemon under its own user.
 
@@ -68,8 +64,7 @@ Get your public key and check that the daemon initialized correctly:
 sudo grep "tox-bootstrapd" /var/log/syslog
 ```
 
-<a name="systemd-updating" />
-###Updating
+### Updating
 
 You want to make sure that the daemon uses the newest toxcore, as there might have been some changes done to the DHT, so it's advised to update the daemon at least once every month.
 
@@ -91,8 +86,8 @@ sudo systemctl start tox-bootstrapd.service
 
 Note that `tox-bootstrapd.service` file might
 
-<a name="systemd-troubleshooting" />
-###Troubleshooting
+
+### Troubleshooting
 
 - Check daemon's status:
 ```sh
@@ -115,11 +110,11 @@ sudo journalctl -f _SYSTEMD_UNIT=tox-bootstrapd.service
 - Make sure tox-bootstrapd location matches its path in tox-bootstrapd.service file.
 
 
-<a name="sysvinit" />
-##For `SysVinit` users
 
-<a name="sysvinit-setting-up" />
-###Setting up
+## For `SysVinit` users
+
+
+### Setting up
 
 For security reasons we run the daemon under its own user.
 
@@ -170,8 +165,8 @@ Get your public key and check that the daemon initialized correctly:
 sudo grep "tox-bootstrapd" /var/log/syslog
 ```
 
-<a name="sysvinit-updating" />
-###Updating
+
+### Updating
 
 You want to make sure that the daemon uses the newest toxcore, as there might have been some changes done to the DHT, so it's advised to update the daemon at least once every month.
 
@@ -191,8 +186,7 @@ After all of this is done, simply start the daemon back again:
 sudo service tox-bootstrapd start
 ```
 
-<a name="sysvinit-troubleshooting" />
-###Troubleshooting
+### Troubleshooting
 
 - Check daemon's status:
 ```sh
@@ -213,11 +207,9 @@ sudo grep "tox-bootstrapd" /var/log/syslog
 - Make sure tox-bootstrapd location matches its path in the `/etc/init.d/tox-bootstrapd` init script.
 
 
-<a name="docker" />
-##For `Docker` users:
+## For `Docker` users:
 
-<a name="docker-setting-up" />
-###Setting up
+### Setting up
 
 If you are familiar with Docker and would rather run the daemon in a Docker container, run the following from this directory:
 
@@ -239,8 +231,7 @@ sudo docker logs tox-bootstrapd
 
 Note that the Docker container runs a script which pulls a list of bootstrap nodes off https://nodes.tox.chat/ and adds them in the config file.
 
-<a name="docker-updating" />
-###Updating
+### Updating
 
 You want to make sure that the daemon uses the newest toxcore, as there might have been some changes done to the DHT, so it's advised to update the daemon at least once every month.
 
@@ -259,8 +250,7 @@ sudo docker build -t tox-bootstrapd docker/
 sudo docker run -d --name tox-bootstrapd --restart always -v /var/lib/tox-bootstrapd/:/var/lib/tox-bootstrapd/ -p 443:443 -p 3389:3389 -p 33445:33445 -p 33445:33445/udp tox-bootstrapd
 ```
 
-<a name="docker-troubleshooting" />
-###Troubleshooting
+### Troubleshooting
 
 - Check if the container is running:
 ```sh


### PR DESCRIPTION
[GitHub changed how their Markdown parser works](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown) in non-backwards-compatible way, breaking custom anchors and `#Headings` (it's now required to have a space after `#`).

There are lines with `#######` in https://github.com/TokTok/c-toxcore/blob/master/docs/updates/Symmetric-NAT-Transversal.md. Not sure if they were rendered to anything, but they are not being rendered right now, which seems fine to me, so I haven't done anything about them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/534)
<!-- Reviewable:end -->
