### PR TITLE
Save bandwidth by moderating onion pinging

### DIFF
--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -32,7 +32,7 @@
 #define MAX_ONION_CLIENTS 8
 #define MAX_ONION_CLIENTS_ANNOUNCE 12 /* Number of nodes to announce ourselves to. */
 #define ONION_NODE_PING_INTERVAL 15
-#define ONION_NODE_TIMEOUT (ONION_NODE_PING_INTERVAL * 3)
+#define ONION_NODE_TIMEOUT ONION_NODE_PING_INTERVAL
 
 /* The interval in seconds at which to tell our friends where we are */
 #define ONION_DHTPK_SEND_INTERVAL 30
@@ -50,12 +50,16 @@
 #define MAX_STORED_PINGED_NODES 9
 #define MIN_NODE_PING_TIME 10
 
+#define ONION_NODE_MAX_PINGS 3
+
 #define MAX_PATH_NODES 32
 
-/* If no packets are received within that interval tox will
- * be considered offline.
+/* If no announce response packets are received within this interval tox will
+ * be considered offline. We give time for a node to be pinged often enough
+ * that it times out, which leads to the network being thoroughly tested as it
+ * is replaced.
  */
-#define ONION_OFFLINE_TIMEOUT (ONION_NODE_PING_INTERVAL * 1.25)
+#define ONION_OFFLINE_TIMEOUT (ONION_NODE_PING_INTERVAL * (ONION_NODE_MAX_PINGS+2))
 
 /* Onion data packet ids. */
 #define ONION_DATA_FRIEND_REQ CRYPTO_PACKET_FRIEND_REQ
@@ -68,9 +72,13 @@ typedef struct {
     uint8_t     data_public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t     is_stored;
 
+    uint64_t    added_time;
+
     uint64_t    timestamp;
 
     uint64_t    last_pinged;
+
+    uint8_t     unsuccessful_pings;
 
     uint32_t    path_used;
 } Onion_Node;
@@ -100,6 +108,8 @@ typedef struct {
     Onion_Node clients_list[MAX_ONION_CLIENTS];
     uint8_t temp_public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t temp_secret_key[CRYPTO_SECRET_KEY_SIZE];
+
+    uint64_t last_reported_announced;
 
     uint64_t last_dht_pk_onion_sent;
     uint64_t last_dht_pk_dht_sent;
@@ -133,6 +143,7 @@ typedef struct {
     uint16_t       num_friends;
 
     Onion_Node clients_announce_list[MAX_ONION_CLIENTS_ANNOUNCE];
+    uint64_t last_announce;
 
     Onion_Client_Paths onion_paths_self;
     Onion_Client_Paths onion_paths_friends;


### PR DESCRIPTION
Currently, a large majority of the traffic in the tox network is generated by
pinging onion nodes with Onion Request packets, which a node does to keep
itself announced and to check for friends coming online. This PR significantly
reduces the rate at which such requests are sent.

In part this is by fixing some bugs; probably most significantly, previously
the nodes for friends were always considered timed out when we came to ping
them, since the timeout for announce nodes was used for the check rather than
that for friend nodes, leading to some extra traffic.

Then it implements two schemes for reducing unnecessary pinging. The first is
to start to trust slightly announce nodes and paths which have been alive for a
while, and not ping them so aggressively - while reverting to the old behaviour
at the first sign of failure. Based on my testing, this reducing announce
traffic by around a factor of 4, from around 2 packets per second to around
~0.5, with no discernable problems.

The second is to gradually reduce the rate of pinging we do to check on offline
friends when they've been offline for some time. Since some users typically
have many offline friends, this should result in a large reduction in traffic.

This last should be the only change which could cause any problems for users.
The principal effect is on friend requests: if we make a friend request
to an offline node, and it remains offline for some time while we stay online,
then when it comes online it may take longer for it to receive the friend
request. With the constants as I've set them, the extreme case is that they
stay offline for at least 1600 minutes, and then the request will take
something like 5 minutes on average to get through. The same delay applies to
established friends who come online after being offline for a while and who
somehow fail to find our announcement - that shouldn't happen, but possibly it
sometimes does (and an attacker can cause it by poisoning our announcement
neighbourhood).

Please note when testing this PR that you shouldn't expect to see a huge
bandwidth reduction - what you should see if you packet-sniff is a reduction
(after your node has been up for a while) in Onion Request packets (first byte
0x80), but it needs a large proportion of the network to adopt it before we'll
start to see actual significant bandwidth reduction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/542)
<!-- Reviewable:end -->
