### PR TITLE
Fix theoretical memory leaks

### DIFF
--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -238,6 +238,7 @@ bool tox_bootstrap(Tox *tox, const char *address, uint16_t port, const uint8_t *
     int32_t count = net_getipport(address, &root, SOCK_DGRAM);
 
     if (count == -1) {
+        net_freeipport(root);
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_BAD_HOST);
         return 0;
     }
@@ -281,6 +282,7 @@ bool tox_add_tcp_relay(Tox *tox, const char *address, uint16_t port, const uint8
     int32_t count = net_getipport(address, &root, SOCK_STREAM);
 
     if (count == -1) {
+        net_freeipport(root);
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_BAD_HOST);
         return 0;
     }


### PR DESCRIPTION
[cppcheck complains](https://build.tox.chat/job/libtoxcore-toktok_analyze_cppcheck/132/cppcheckResult/) about possible memory leak in the case the return value of `net_getipport` overflowed to be -1, which in practice shouldn't happen, but let's guard against it and make cppcheck happy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/559)
<!-- Reviewable:end -->
