### PR TITLE
Reset hole-punching parameters after not punching for a while

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -46,6 +46,9 @@
 /* Interval in seconds between punching attempts*/
 #define PUNCH_INTERVAL 3
 
+/* Time in seconds after which punching parameters will be reset */
+#define PUNCH_RESET_TIME 40
+
 #define MAX_NORMAL_PUNCHING_TRIES 5
 
 #define NAT_PING_REQUEST    0
@@ -2127,6 +2130,12 @@ static void do_NAT(DHT *dht)
 
             if (!ip_isset(&ip)) {
                 continue;
+            }
+
+            if (dht->friends_list[i].nat.punching_timestamp + PUNCH_RESET_TIME < temp_time) {
+                dht->friends_list[i].nat.tries = 0;
+                dht->friends_list[i].nat.punching_index = 0;
+                dht->friends_list[i].nat.punching_index2 = 0;
             }
 
             uint16_t port_list[MAX_FRIEND_CLIENTS];


### PR DESCRIPTION
This is an attempt to fix #237, based on a wild guess as to what might be going
on. Currently, if a friend goes offline and we try to reconnect to them, we
will continue the holepunching as if our initial attempt failed. It seems
likely that for many routers the first attempt, which tries ports close to
those which the friend's DHT neighbours report, is the one most likely to
succeed.

If this change does help with that issue, we should probably also tweak the
hole-punching algorithm to occasionally try close ports even if the first
attempt with them fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/574)
<!-- Reviewable:end -->
