### PR TITLE
Replace include(CTest) on enable_testing()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,10 @@ include(AddCompilerFlag)
 include(ApiDsl)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
-include(CTest)
 include(MacRpath)
 include(StrictAbi)
+
+enable_testing()
 
 set(CMAKE_MACOSX_RPATH ON)
 


### PR DESCRIPTION
CTest include generate a lot of unused targets

See [here](https://stackoverflow.com/questions/45169854/cmake-in-qtcreator-4-3-shows-many-automatic-targets-how-to-remove-hide-them)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/576)
<!-- Reviewable:end -->
