### PR TITLE
Improve LAN discovery

### DIFF
--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -354,6 +354,10 @@ static int handle_LANdiscovery(void *object, IP_Port source, const uint8_t *pack
         return 1;
     }
 
+    char ip_str[IP_NTOA_LEN] = { 0 };
+    ip_ntoa(&source.ip, ip_str, sizeof(ip_str));
+    LOGGER_INFO(dht->log, "Found node in LAN: %s", ip_str);
+
     DHT_bootstrap(dht, source, packet + 1);
     return 0;
 }

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -107,6 +107,7 @@ typedef struct {
     void *fr_request_object;
 
     uint64_t last_LANdiscovery;
+    uint16_t next_LANport;
 
     bool local_discovery_enabled;
 } Friend_Connections;


### PR DESCRIPTION
Issue: If another tox instance started on the not default port, LAN
discovery will be failed.

Now tox will iterate though all possible ports to find another tox
instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/586)
<!-- Reviewable:end -->
