### PR TITLE
forget DHT pubkey of offline friend after DHT timeout

### DIFF
--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -878,6 +878,7 @@ void do_friend_connections(Friend_Connections *fr_c, void *userdata)
                     if (friend_con->dht_lock) {
                         DHT_delfriend(fr_c->dht, friend_con->dht_temp_pk, friend_con->dht_lock);
                         friend_con->dht_lock = 0;
+                        memset(friend_con->dht_temp_pk, 0, CRYPTO_PUBLIC_KEY_SIZE);
                     }
                 }
 


### PR DESCRIPTION
According to my tests, this fixes #240. I expect it also fixes #237.

The problem was as follows: if a friend goes offline for long enough, we stop
searching for them on the DHT, but then if they come back with the same DHT key
(as will be the case if the network connection was interrupted but their client
wasn't restarted), prior to this patch we didn't initiate a new search.

The reason that it took two disconnections for this to cause a problem is that
we keep information on their ip address and tcp relays, and attempt to reuse
after a disconnect if there's still a DHT search ongoing. So if the first
disconnect lasted for at least 122s, the DHT search was deleted, but we could
still connect back using the old details once they reconnected; but then on a
subsequent disconnect, the old details wouldn't be used and nor would a DHT
search start up, so we'd never reconnect to the friend.

This PR zeroes out the friend's DHT PK when we delete them from the DHT, so the
next dhtpk packet we get from them will trigger us to add them back to the DHT
search list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/615)
<!-- Reviewable:end -->
