### PR TITLE
Update rpm spec and use variables in cmake instead of hardcoded paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 CMakeCache.txt
 CMakeFiles
 Makefile
+!/other/rpm/Makefile
 cmake_install.cmake
 install_manifest.txt
 tags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,13 @@ message("SOVERSION: ${SOVERSION}")
 
 include(AddCompilerFlag)
 include(ApiDsl)
-include(MacRpath)
 include(ModulePackage)
 include(StrictAbi)
+include(GNUInstallDirs)
+
+if(APPLE)
+  include(MacRpath)
+endif()
 
 enable_testing()
 
@@ -374,9 +378,9 @@ endforeach()
 # Make version script (on systems that support it) to limit symbol visibility.
 make_version_script(toxcore ${toxcore_API_HEADERS})
 
-# Generate pkg-config file, install library to "lib" and install headers to
-# "include/tox".
-install_module(toxcore DESTINATION "include/tox")
+# Generate pkg-config file, install library to "${CMAKE_INSTALL_LIBDIR}" and install headers to
+# "${CMAKE_INSTALL_INCLUDEDIR}/tox".
+install_module(toxcore DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tox)
 
 ################################################################################
 #

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,8 @@ dependencies:
   - sudo bash -c "echo '::1             localhost ipv6-localhost ipv6-loopback' >> /etc/hosts" # ipv6 localhost entry
 # ------------ network_test requires that "localhost" resolves to ::1 ------------
 
+  - sudo bash -c "echo /usr/local/lib/x86_64-linux-gnu > /etc/ld.so.conf.d/fix685519.conf" # fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=685519 
+
   - java -version ; exit 0
   - gcc --version ; exit 0
   - clang --version ; exit 0

--- a/cmake/ModulePackage.cmake
+++ b/cmake/ModulePackage.cmake
@@ -89,10 +89,10 @@ function(install_module lib)
       VERSION ${SOVERSION}
       SOVERSION ${SOVERSION_MAJOR}
     )
-    install(TARGETS ${lib}_shared DESTINATION "lib")
+    install(TARGETS ${lib}_shared DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
   if(ENABLE_STATIC)
-    install(TARGETS ${lib}_static DESTINATION "lib")
+    install(TARGETS ${lib}_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
 
   string(REPLACE ";" " " ${lib}_PKGCONFIG_LIBS "${${lib}_PKGCONFIG_LIBS}")
@@ -104,9 +104,15 @@ function(install_module lib)
     @ONLY
   )
 
+  configure_file(
+    "${toxcore_SOURCE_DIR}/other/rpm/${lib}.spec.in"
+    "${CMAKE_BINARY_DIR}/${lib}.spec"
+    @ONLY
+  )
+
   install(FILES
     ${CMAKE_BINARY_DIR}/${lib}.pc
-    DESTINATION "lib/pkgconfig")
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
   foreach(sublib ${${lib}_API_HEADERS})
     string(REPLACE "^" ";" sublib ${sublib})

--- a/other/pkgconfig/toxcore.pc.in
+++ b/other/pkgconfig/toxcore.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/lib
-includedir=${prefix}/include
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: toxcore
 Description: Tox protocol library

--- a/other/rpm/Makefile
+++ b/other/rpm/Makefile
@@ -1,0 +1,32 @@
+PROJECT_NAME = toxcore
+PROJECT_FULL_NAME = c-$(PROJECT_NAME)
+PROJECT_VERSION = $(shell git describe | sed -e 's/^v//' -e 's/-/_/g')
+PROJECT_COMMIT_ID = $(shell git rev-parse HEAD)
+PROJECT_COMMIT_ID_SHORT = $(shell git rev-parse --short HEAD)
+PROJECT_GIT_ROOT = $(shell git rev-parse --show-toplevel)
+
+all:
+	@echo available targets: spec srpm clean
+
+spec: toxcore.spec
+
+toxcore.spec:
+	sed -r \
+	  -e 's#@PROJECT_NAME@#$(PROJECT_NAME)#g' \
+	  -e 's#@PROJECT_VERSION@#$(PROJECT_VERSION)#' \
+	  -e 's#^(%define commit )0$$#\1$(PROJECT_COMMIT_ID)#' \
+	  toxcore.spec.in > toxcore.spec
+
+$(PROJECT_FULL_NAME)-$(PROJECT_COMMIT_ID_SHORT).tar.gz:
+	( \
+	  cd $(PROJECT_GIT_ROOT); \
+	  git archive --prefix '$(PROJECT_FULL_NAME)-$(PROJECT_COMMIT_ID_SHORT)/' -o other/rpm/$(PROJECT_FULL_NAME)-$(PROJECT_COMMIT_ID_SHORT).tar.gz $(PROJECT_COMMIT_ID) \
+	)
+
+srpm: toxcore.spec $(PROJECT_FULL_NAME)-$(PROJECT_COMMIT_ID_SHORT).tar.gz
+	rpmbuild --define "_sourcedir ." --define "_srcrpmdir ." -bs toxcore.spec
+
+clean:
+	rm -f toxcore.spec *.tar.gz *.rpm
+
+.PHONY = clean srpm spec

--- a/other/rpm/tox-bootstrapd.service
+++ b/other/rpm/tox-bootstrapd.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Tox DHT Bootstrap Daemon
+After=network.target
+
+[Service]
+Type=forking
+RuntimeDirectory=tox-bootstrapd
+RuntimeDirectoryMode=750
+PIDFile=/var/run/tox-bootstrapd/tox-bootstrapd.pid
+WorkingDirectory=/var/lib/tox-bootstrapd
+ExecStart=/usr/bin/tox-bootstrapd --config /etc/tox-bootstrapd.conf
+User=tox-bootstrapd
+Group=tox-bootstrapd
+#CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/other/rpm/toxcore.spec.in
+++ b/other/rpm/toxcore.spec.in
@@ -1,0 +1,126 @@
+%define full_name c-@PROJECT_NAME@
+%define commit 0
+%if "${commit}" != "0"
+%define shortcommit %(c=%{commit}; echo ${c:0:7})
+%endif
+
+Name:           @PROJECT_NAME@
+Version:        @PROJECT_VERSION@
+Release:        1%{?dist}
+Summary:        All-in-one secure communication platform
+
+License:        GPLv3
+URL:            https://github.com/TokTok/%{full_name}
+%if "%{commit}" == "0"
+Source0:        https://github.com/TokTok/%{full_name}/archive/v%{version}.tar.gz
+%else
+Source0:        https://github.com/TokTok/%{full_name}/archive/%{commit}/%{full_name}-%{shortcommit}.tar.gz
+%endif
+
+BuildRequires:  cmake
+BuildRequires:  libvpx-devel
+BuildRequires:  opus-devel
+BuildRequires:  libsodium-devel
+BuildRequires:  libconfig-devel
+BuildRequires:  systemd-units
+
+%description
+With the rise of governmental monitoring programs, Tox, a FOSS initiative, aims
+to be an easy to use, all-in-one communication platform that ensures their users
+full privacy and secure message delivery.
+
+%package devel
+Summary:        Development files for @PROJECT_NAME@
+Requires:       %{name} = %{version}-%{release}
+
+%description devel
+Development package for @PROJECT_NAME@
+
+%package static
+Summary:        @PROJECT_NAME@ static libraries
+Requires:       %{name}-devel = %{version}-%{release}
+
+%description static
+@PROJECT_NAME@ static libraries
+
+%package -n tox-bootstrapd
+Summary:        Tox DHT bootstrap daemon.
+Requires:       %{name} = %{version}-%{release}
+Requires(pre):  shadow-utils
+Requires(post): systemd-units
+Requires(preun): systemd-units
+Requires(postun): systemd-units
+
+%description -n tox-bootstrapd
+Tox DHT bootstrap daemon.
+
+%prep
+%if "%{commit}" == "0"
+%setup -q -n %{full_name}-%{version}
+%else
+%setup -q -n %{full_name}-%{commit}
+%endif
+
+%build
+%cmake
+%{__make} %{?_smp_mflags}
+
+%install
+%make_install
+mkdir -p %{buildroot}%{_unitdir}
+install -m 0644 other/rpm/tox-bootstrapd.service %{buildroot}%{_unitdir}/tox-bootstrapd.service
+install -d "%{buildroot}%{_sharedstatedir}/tox-bootstrapd"
+mkdir -p %{buildroot}%{_sysconfdir}
+install -m 0644 other/bootstrap_daemon/tox-bootstrapd.conf %{buildroot}%{_sysconfdir}/tox-bootstrapd.conf
+
+%check
+%{__make} %{?_smp_mflags} test
+
+%pre -n tox-bootstrapd
+getent group tox-bootstrapd >/dev/null || groupadd -r tox-bootstrapd
+getent passwd tox-bootstrapd >/dev/null || \
+    useradd -r -g tox-bootstrapd -d /var/lib/tox-bootstrapd -s /sbin/nologin \
+    -c "Account to run Tox's DHT bootstrap daemon" tox-bootstrapd
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%post -n tox-bootstrapd
+%systemd_post tox-bootstrapd.service
+
+%postun -n tox-bootstrapd
+%systemd_postun_with_restart tox-bootstrapd.service
+
+%preun -n tox-bootstrapd
+%systemd_preun tox-bootstrapd.service
+
+%files
+%defattr(-, root, root)
+%doc COPYING README.md CHANGELOG.md
+%{_libdir}/libtoxcore.so*
+
+%files devel
+%defattr(-, root, root)
+%{_includedir}/tox/
+%{_libdir}/pkgconfig/toxcore.pc
+
+%files static
+%defattr(-, root, root)
+%{_libdir}/libtoxcore.a
+
+%files -n tox-bootstrapd
+%defattr(-, root, root)
+%{_bindir}/tox-bootstrapd
+%{_unitdir}/tox-bootstrapd.service
+%{_sharedstatedir}/tox-bootstrapd
+%attr(-,tox-bootstrapd,tox-bootstrapd) %{_sharedstatedir}/tox-bootstrapd/
+%config(noreplace) %{_sysconfdir}/tox-bootstrapd.conf
+
+
+%changelog
+* Sat Nov 25 2017 SmokedCheese <root@ubuntology.ru> - 0.0.0-2
+- Rewrite spec file
+
+* Tue Mar  3 2015 Sergey 'Jin' Bostandzhyan <jin@mediatomb.cc> - 0.0.0-1
+- initial package


### PR DESCRIPTION
Update rpm spec and use variables in cmake instead of hardcoded paths.

How to use:

0. `yum groupinstall -y 'Development Tools' && yum install -y epel-release rpm-build && rpmdev-setuptree`
1. `cmake ${TOXCORE_SOURCES}` to generate toxcore.spec from template
2. `spectool --get-files --sourcedir toxcore.spec` <- will not work before merge, use that from my branch: `git archive --prefix 'c-toxcore-0.1.10/' -o ~/rpmbuild/SOURCES/v0.1.10.tar.gz HEAD`
3. `rpmbuild -bb toxcore.spec`

Maybe setup autobuild on tags/commits?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/624)
<!-- Reviewable:end -->
