### PR TITLE
Add aspcud for Opam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ addons:
     - libsndfile1-dev       # For av_test.
     - libvpx-dev            # For toxav.
     - opam                  # For apidsl and Frama-C.
+    - aspcud                # For Opam
     - portaudio19-dev       # For av_test.
     - texinfo               # For libconfig.
 


### PR DESCRIPTION
This fixes `opam init` crashing due to a stack overflow.
https://travis-ci.org/TokTok/c-toxcore/jobs/313905019#L1152-L1164

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/631)
<!-- Reviewable:end -->
