### PR TITLE
Lift libconfig to v1.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ addons:
     - libsndfile1-dev       # For av_test.
     - libvpx-dev            # For toxav.
     - opam                  # For apidsl and Frama-C.
+    - aspcud                # For Opam
     - portaudio19-dev       # For av_test.
     - texinfo               # For libconfig.
 

--- a/other/travis/toxcore-linux-install
+++ b/other/travis/toxcore-linux-install
@@ -62,7 +62,7 @@ sed -i -e '/^import sys$/a import urllib3.contrib.pyopenssl\nurllib3.contrib.pyo
 
 # Install libconfig (version in ubuntu-precise too old).
 [ -f $CACHE_DIR/lib/libconfig.a ] || {
-  git clone --depth=1 --branch=REL1_6_STABLE https://github.com/hyperrealm/libconfig ../libconfig
+  git clone --depth=1 --branch=v1.7.1 https://github.com/hyperrealm/libconfig ../libconfig
   cd ../libconfig # pushd
   autoreconf -fi
   ./configure --prefix=$CACHE_DIR


### PR DESCRIPTION
https://github.com/hyperrealm/libconfig has deleted the branches for releases and switched to using tags instead, so the previous method of choosing a release is now broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/632)
<!-- Reviewable:end -->
