### PR TITLE
Update tox-bootstrapd Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ matrix:
     sudo: required
     install:       other/travis/phase $JOB $ENV install       stage1
     script:        other/travis/phase $JOB $ENV script        stage1
+  - stage: "Stage 1"
+    env: JOB=tox-bootstrapd-docker ENV=linux
+    services:
+    - docker
+    sudo: required
   - stage: "Stage 2"
     env: JOB=toxcore ENV=freebsd
     dist: trusty

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 WORKDIR /tmp/tox
 
@@ -16,12 +16,12 @@ RUN export BUILD_PACKAGES="\
       python3" && \
     export RUNTIME_PACKAGES="\
       libconfig9 \
-      libsodium13" && \
+      libsodium18" && \
 # get all deps
     apt-get update && apt-get install -y $BUILD_PACKAGES $RUNTIME_PACKAGES && \
 # install toxcore and daemon
-    git clone https://github.com/irungentoo/toxcore && \
-    cd toxcore && \
+    git clone https://github.com/TokTok/c-toxcore && \
+    cd c-toxcore && \
     ./autogen.sh && \
     ./configure --enable-daemon && \
     make -j`nproc` && \
@@ -39,9 +39,9 @@ RUN export BUILD_PACKAGES="\
 # add bootstrap nodes from https://nodes.tox.chat/
     python3 other/bootstrap_daemon/docker/get-nodes.py >> /etc/tox-bootstrapd.conf && \
 # perform cleanup
-    export AUTO_ADDED_PACKAGES="$(apt-mark showauto)" && \
-    apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES && \
+    apt-get remove --purge -y $BUILD_PACKAGES && \
     apt-get clean && \
+    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     cd / && \
     rm -rf /tmp/*

--- a/other/travis/tox-bootstrapd-docker-linux-script
+++ b/other/travis/tox-bootstrapd-docker-linux-script
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# Copy source code to other/bootstrap_daemon/docker/c-toxcore
+OLD_PWD=$PWD
+cd /tmp
+cp -a $OLD_PWD c-toxcore
+mv c-toxcore $OLD_PWD/other/bootstrap_daemon/docker
+cd $OLD_PWD
+ls -lbh other/bootstrap_daemon/docker
+ls -lbh other/bootstrap_daemon/docker/c-toxcore
+
+cd other/bootstrap_daemon
+
+# Make Docker container use our current source code instead of master branch
+sed -i "s|WORKDIR /tmp/tox|WORKDIR /tmp/tox\nADD /c-toxcore ./c-toxcore/|g" docker/Dockerfile
+sed -i '/git clone/d' docker/Dockerfile
+
+cat docker/Dockerfile
+
+sudo docker build -t tox-bootstrapd docker/
+sudo useradd --home-dir /var/lib/tox-bootstrapd --create-home --system --shell /sbin/nologin --comment "Account to run Tox's DHT bootstrap daemon" --user-group tox-bootstrapd
+sudo chmod 700 /var/lib/tox-bootstrapd
+sudo docker run -d --name tox-bootstrapd -v /var/lib/tox-bootstrapd/:/var/lib/tox-bootstrapd/ -p 443:443 -p 3389:3389 -p 33445:33445 -p 33445:33445/udp tox-bootstrapd
+
+sudo ls -lbh /var/lib/tox-bootstrapd
+
+if sudo [ ! -f /var/lib/tox-bootstrapd/keys ]; then
+  echo "Error: File /var/lib/tox-bootstrapd/keys doesn't exist"
+  exit 1
+fi
+
+COUNTER=0
+COUNTER_END=120
+while [ $COUNTER -lt $COUNTER_END ]; do
+  if sudo docker logs tox-bootstrapd | grep -q "Connected to another bootstrap node successfully" ; then
+    break
+  fi
+  sleep 1
+  COUNTER=$(($COUNTER+1))
+done
+
+sudo docker logs tox-bootstrapd
+
+if [ "$COUNTER" = "$COUNTER_END" ]; then
+  echo "Error: Didn't connect to any nodes"
+  exit 1
+fi
+
+# Wait a bit befrore testing if the container is still running
+sleep 30
+
+sudo docker ps -a
+
+if [ "`sudo docker inspect -f {{.State.Running}} tox-bootstrapd`" != "true" ]; then
+  echo "Error: Container is not running"
+  exit 1
+fi
+
+if ! python3 ../fun/bootstrap_node_info.py ipv4 localhost 33445 ; then
+  echo "Error: Unable to get bootstrap node info"
+  exit 1
+fi
+


### PR DESCRIPTION
New Debian stable came out this summer, so let's use that. Better yet, the `slim` version with manpages and other things removed. Also, didn't realize it was still pulling `irungentoo/toxcore`, I guess it wasn't updated since TokTok fork.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/637)
<!-- Reviewable:end -->
