### PR TITLE
Bump toxcore version to 0.2.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ set(CMAKE_MODULE_PATH ${toxcore_SOURCE_DIR}/cmake)
 # This version is for the entire project. All libraries (core, av, ...) move in
 # versions in a synchronised way.
 set(PROJECT_VERSION_MAJOR "0")
-set(PROJECT_VERSION_MINOR "1")
-set(PROJECT_VERSION_PATCH "11")
+set(PROJECT_VERSION_MINOR "2")
+set(PROJECT_VERSION_PATCH "0")
 set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 # set .so library version / following libtool scheme

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.65])
-AC_INIT([tox], [0.1.11])
+AC_INIT([tox], [0.2.0])
 AC_CONFIG_AUX_DIR(configure_aux)
 AC_CONFIG_SRCDIR([toxcore/net_crypto.c])
 AC_CONFIG_HEADERS([config.h])

--- a/other/version-sync
+++ b/other/version-sync
@@ -62,7 +62,7 @@ update 'CMakeLists.txt' 's/\(PROJECT_VERSION_PATCH "\).*"/\1'$PATCH'"/'
 
 # the last major version number from the 0.x release cycle
 # this must be constant starting from the 1.0 release
-LAST_SOMAJOR=1
+LAST_SOMAJOR=2
 
 if [ $MAJOR -eq 0 ]; then
   SOMAJOR=$MINOR

--- a/so.version
+++ b/so.version
@@ -11,6 +11,6 @@
 # For a full reference see:
 # https://www.gnu.org/software/libtool/manual/libtool.html#Updating-version-info
 
-CURRENT=12
+CURRENT=2
 REVISION=0
-AGE=11
+AGE=0

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -173,13 +173,13 @@ const VERSION_MAJOR                = 0;
  * breaking the API or ABI. Set to 0 when the major version number is
  * incremented.
  */
-const VERSION_MINOR                = 1;
+const VERSION_MINOR                = 2;
 
 /**
  * The patch or revision number. Incremented when bugfixes are applied without
  * changing any functionality or API or ABI.
  */
-const VERSION_PATCH                = 11;
+const VERSION_PATCH                = 0;
 
 /**
  * A macro to check at preprocessing time whether the client code is compatible

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -172,7 +172,7 @@ uint32_t tox_version_major(void);
  * breaking the API or ABI. Set to 0 when the major version number is
  * incremented.
  */
-#define TOX_VERSION_MINOR              1
+#define TOX_VERSION_MINOR              2
 
 uint32_t tox_version_minor(void);
 
@@ -180,7 +180,7 @@ uint32_t tox_version_minor(void);
  * The patch or revision number. Incremented when bugfixes are applied without
  * changing any functionality or API or ABI.
  */
-#define TOX_VERSION_PATCH              11
+#define TOX_VERSION_PATCH              0
 
 uint32_t tox_version_patch(void);
 


### PR DESCRIPTION
We're not releasing yet, but projects preparing for the release will want
to build against this version in master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/654)
<!-- Reviewable:end -->
