### PR TITLE
Fix file descriptor leak in hstox test.

### DIFF
--- a/testing/hstox/driver.c
+++ b/testing/hstox/driver.c
@@ -89,6 +89,7 @@ static int write_sample_input(msgpack_object req)
     msgpack_pack_object(&pk, req);
 
     check_return(E_WRITE, write(fd, sbuf.data, sbuf.size));
+    check_return(E_WRITE, close(fd));
 
     return E_OK;
 }

--- a/testing/hstox/driver.c
+++ b/testing/hstox/driver.c
@@ -80,7 +80,7 @@ static int write_sample_input(msgpack_object req)
 
     check_return(E_WRITE, ftruncate(fd, 0));
 
-    msgpack_sbuffer sbuf __attribute__((__cleanup__(msgpack_sbuffer_destroy)));
+    msgpack_sbuffer sbuf __attribute__((__cleanup__(msgpack_sbuffer_destroy))) = {0};
     msgpack_sbuffer_init(&sbuf);
 
     msgpack_packer pk;
@@ -101,7 +101,7 @@ static int handle_request(struct settings cfg, int write_fd, msgpack_object req)
         fprintf(stderr, "\n");
     }
 
-    msgpack_sbuffer sbuf __attribute__((__cleanup__(msgpack_sbuffer_destroy))); /* buffer */
+    msgpack_sbuffer sbuf __attribute__((__cleanup__(msgpack_sbuffer_destroy))) = {0}; /* buffer */
     msgpack_sbuffer_init(&sbuf); /* initialize buffer */
 
     msgpack_packer pk;                                      /* packer */
@@ -186,7 +186,7 @@ int communicate(struct settings cfg, int read_fd, int write_fd)
         memcpy(msgpack_unpacker_buffer(&unp), buf, size);
         msgpack_unpacker_buffer_consumed(&unp, size);
 
-        msgpack_unpacked req __attribute__((__cleanup__(msgpack_unpacked_destroy)));
+        msgpack_unpacked req __attribute__((__cleanup__(msgpack_unpacked_destroy))) = {0};
         msgpack_unpacked_init(&req);
 
         switch (msgpack_unpacker_next(&unp, &req)) {
@@ -225,7 +225,7 @@ static int run_tests(struct settings cfg, int port)
         1
     }, sizeof(int)));
 
-    struct sockaddr_in servaddr;
+    struct sockaddr_in servaddr = {0};
     servaddr.sin_family      = AF_INET;
     servaddr.sin_addr.s_addr = htons(INADDR_ANY);
     servaddr.sin_port        = htons(port);

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1273,12 +1273,14 @@ int32_t net_getipport(const char *node, IP_Port **res, int tox_type)
     assert(count <= MAX_COUNT);
 
     if (count == 0) {
+        freeaddrinfo(infos);
         return 0;
     }
 
     *res = (IP_Port *)malloc(sizeof(IP_Port) * count);
 
     if (*res == NULL) {
+        freeaddrinfo(infos);
         return -1;
     }
 


### PR DESCRIPTION
We return E_WRITE because closing only fails when an I/O error occurs,
which is likely an error from the write() call above. See close(2) for
details.

http://man7.org/linux/man-pages/man2/close.2.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/656)
<!-- Reviewable:end -->
