### PR TITLE
Call freeaddrinfo on error paths in net_getipport.

### DIFF
--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1273,12 +1273,14 @@ int32_t net_getipport(const char *node, IP_Port **res, int tox_type)
     assert(count <= MAX_COUNT);
 
     if (count == 0) {
+        freeaddrinfo(infos);
         return 0;
     }
 
     *res = (IP_Port *)malloc(sizeof(IP_Port) * count);
 
     if (*res == NULL) {
+        freeaddrinfo(infos);
         return -1;
     }
 


### PR DESCRIPTION
Without these, we'll have a memory leak on error paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/658)
<!-- Reviewable:end -->
