### PR TITLE
Disable asan, since it seems to break on travis.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,7 +37,7 @@ compile:
   ### ------- get libsodium -------
 
 ##### ------------ BUILD ------------
-  - cmake -DWARNINGS=OFF .
+  - cmake -DASAN=ON -DDEBUG=ON -DSTRICT_ABI=ON -DTRACE=ON -DWARNINGS=OFF .
   #- cmake .
   - make
   - sudo make install
@@ -121,4 +121,4 @@ compile:
 
 test:
   override:
-  - make VERBOSE=1 test || make VERBOSE=1 ARGS="--rerun-failed" test
+  - make VERBOSE=1 test || make VERBOSE=1 ARGS="--rerun-failed" test || make VERBOSE=1 ARGS="--rerun-failed" test || make VERBOSE=1 ARGS="--rerun-failed" test

--- a/other/travis/env-linux.sh
+++ b/other/travis/env-linux.sh
@@ -5,6 +5,9 @@ export PATH=$HOME/.cabal/bin:$PATH
 
 CMAKE=cmake
 CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DFORMAT_TEST=ON"
+# Asan is disabled because it's currently broken on Travis.
+# See https://github.com/travis-ci/travis-ci/issues/9033.
+CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DASAN=OFF"
 NPROC=`nproc`
 CURDIR=$PWD
 RUN_TESTS=true


### PR DESCRIPTION
But enable it on circle ci, so at least we have one asan build.

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/661)
<!-- Reviewable:end -->
