### PR TITLE
pkg-config .pc files: added .private versions of Libs and Required

### DIFF
--- a/other/pkgconfig/toxcore.pc.in
+++ b/other/pkgconfig/toxcore.pc.in
@@ -4,7 +4,8 @@ includedir=${prefix}/include
 
 Name: toxcore
 Description: Tox protocol library
-Requires: @toxcore_PKGCONFIG_REQUIRES@
+Requires.private: @toxcore_PKGCONFIG_REQUIRES@
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} -ltoxcore @toxcore_PKGCONFIG_LIBS@
+Libs: -L${libdir} -ltoxcore
+Libs.private: @toxcore_PKGCONFIG_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
To prevent top-level linking of all libraries.

Problem: ```pkg-config --libs toxcore``` returns all libraries that are
required by all libtox*.so libraries. This is wrong because for a
dynamically linked executable only top-level libraries need to be
supplied. ```pkg-config --libs --static toxcore``` should return all
libraries for the statically linked executable.

For example, the ToxBot https://github.com/JFreegman/ToxBot executable
uses pkg-config and is linked with the opus library, which is wrong.

Based on #533.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/667)
<!-- Reviewable:end -->
