### PR TITLE
Filter out annoying log statements in unit tests.

### DIFF
--- a/auto_tests/helpers.h
+++ b/auto_tests/helpers.h
@@ -51,6 +51,11 @@ static void print_debug_log(Tox *m, TOX_LOG_LEVEL level, const char *path, uint3
         return;
     }
 
+    if (strncmp(message, "Bound successfully to ", strlen("Bound successfully to ")) ||
+            strncmp(message, "Found node in LAN: ", strlen("Found node in LAN: "))) {
+        return;
+    }
+
     uint32_t index = user_data ? *(uint32_t *)user_data : 0;
     const char *file = strrchr(path, '/');
     file = file ? file + 1 : path;

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -356,7 +356,7 @@ static int handle_LANdiscovery(void *object, IP_Port source, const uint8_t *pack
 
     char ip_str[IP_NTOA_LEN] = { 0 };
     ip_ntoa(&source.ip, ip_str, sizeof(ip_str));
-    LOGGER_INFO(dht->log, "Found node in LAN: %s", ip_str);
+    LOGGER_DEBUG(dht->log, "Found node in LAN: %s", ip_str);
 
     DHT_bootstrap(dht, source, packet + 1);
     return 0;


### PR DESCRIPTION
These may be useful when debugging toxcore locally, but are not useful in
unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/680)
<!-- Reviewable:end -->
