### PR TITLE
WIP: Adopt the API change for persistent conferences.

### DIFF
--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -455,7 +455,7 @@ static int addpeer(Group_Chats *g_c, int groupnumber, const uint8_t *real_pk, co
     add_to_closest(g_c, groupnumber, real_pk, temp_pk);
 
     if (do_gc_callback && g_c->group_namelistchange) {
-        g_c->group_namelistchange(g_c->m, groupnumber, g->numpeers - 1, CHAT_CHANGE_PEER_ADD, userdata);
+        g_c->group_namelistchange(g_c->m, groupnumber, g->numpeers - 1, CHAT_CHANGE_OCCURRED, userdata);
     }
 
     if (g->peer_on_join) {
@@ -543,7 +543,7 @@ static int delpeer(Group_Chats *g_c, int groupnumber, int peer_index, void *user
     }
 
     if (g_c->group_namelistchange) {
-        g_c->group_namelistchange(g_c->m, groupnumber, peer_index, CHAT_CHANGE_PEER_DEL, userdata);
+        g_c->group_namelistchange(g_c->m, groupnumber, peer_index, CHAT_CHANGE_OCCURRED, userdata);
     }
 
     if (g->peer_on_leave) {

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -156,8 +156,7 @@ void g_callback_group_title(Group_Chats *g_c, void (*function)(Messenger *m, uin
  *  Function(Group_Chats *g_c, int groupnumber, int peernumber, TOX_CHAT_CHANGE change, void *userdata)
  */
 enum {
-    CHAT_CHANGE_PEER_ADD,
-    CHAT_CHANGE_PEER_DEL,
+    CHAT_CHANGE_OCCURRED,
     CHAT_CHANGE_PEER_NAME,
 };
 void g_callback_group_namelistchange(Group_Chats *g_c, void (*function)(Messenger *m, int, int, uint8_t, void *));

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -2110,13 +2110,10 @@ namespace conference {
    */
   enum class STATE_CHANGE {
     /**
-     * A peer has joined the conference.
+     * Some changes to list have occurred. Rebuild of list required.
+     * peer_number is undefined (always 0 for api compatibility).
      */
-    PEER_JOIN,
-    /**
-     * A peer has exited the conference.
-     */
-    PEER_EXIT,
+    LIST_CHANGED,
     /**
      * A peer has changed their name.
      */

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -2393,14 +2393,10 @@ void tox_callback_conference_title(Tox *tox, tox_conference_title_cb *callback);
 typedef enum TOX_CONFERENCE_STATE_CHANGE {
 
     /**
-     * A peer has joined the conference.
+     * Some changes to list have occurred. Rebuild of list required.
+     * peer_number is undefined (always 0 for api compatibility).
      */
-    TOX_CONFERENCE_STATE_CHANGE_PEER_JOIN,
-
-    /**
-     * A peer has exited the conference.
-     */
-    TOX_CONFERENCE_STATE_CHANGE_PEER_EXIT,
+    TOX_CONFERENCE_STATE_CHANGE_LIST_CHANGED,
 
     /**
      * A peer has changed their name.


### PR DESCRIPTION
This allows clients to make the necessary changes before we actually have
persistent conferences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/683)
<!-- Reviewable:end -->
