### PR TITLE
Run fewer Travis jobs during Pull Requests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+# For Pull Requests, we build only the first three jobs: autotools on Linux,
+# cmake on Linux, and cmake on Windows 32 bit.
+#
+# For branch builds and cron builds (once a day), we build all the jobs. This
+# is achieved using the "if: type IN (push, api, cron)" fields in the matrix.
+
 language: c
 
 matrix:
@@ -14,27 +20,32 @@ matrix:
     services:
     - docker
   - stage: "Stage 1"
+    if: type IN (push, api, cron)
     env: JOB=toxcore ENV=windows ARCH=x86_64
     group: deprecated-2017Q4
     services:
     - docker
   - stage: "Stage 1"
+    if: type IN (push, api, cron)
     env: JOB=toxcore ENV=freebsd
     dist: trusty
     sudo: required
     install:       other/travis/phase $JOB $ENV install       stage1
     script:        other/travis/phase $JOB $ENV script        stage1
   - stage: "Stage 1"
+    if: type IN (push, api, cron)
     env: JOB=tox-bootstrapd-docker ENV=linux
     services:
     - docker
     sudo: required
   - stage: "Stage 2"
+    if: type IN (push, api, cron)
     env: JOB=toxcore ENV=freebsd
     dist: trusty
     sudo: required
     install:       other/travis/phase $JOB $ENV install       stage2
   - stage: "Stage 2"
+    if: type IN (push, api, cron)
     env: JOB=toxcore ENV=osx RUN_TESTS=true
     os: osx
   fast_finish: true


### PR DESCRIPTION
Still run all the jobs during cron and regular push to branch. We
disabled build for push to branch, so cron is the only place where all
builds are run. This also means we need to worry less about spending time
in nightly builds, because they occur only once a day.

See https://github.com/travis-ci/travis-ci/issues/9071

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/690)
<!-- Reviewable:end -->