### PR TITLE
Add bazel build scripts for c-toxcore.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,29 @@
+genrule(
+    name = "copy_headers",
+    srcs = [
+        "//c-toxcore/toxav:public",
+        "//c-toxcore/toxcore:public",
+        "//c-toxcore/toxencryptsave:public",
+    ],
+    outs = [
+        "tox/toxav.h",
+        "tox/tox.h",
+        "tox/toxencryptsave.h",
+    ],
+    cmd = """
+        cp $(location //c-toxcore/toxav:public) $(GENDIR)/c-toxcore/tox/toxav.h
+        cp $(location //c-toxcore/toxcore:public) $(GENDIR)/c-toxcore/tox/tox.h
+        cp $(location //c-toxcore/toxencryptsave:public) $(GENDIR)/c-toxcore/tox/toxencryptsave.h
+    """,
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [
+        "tox/tox.h",
+        "tox/toxav.h",
+        "tox/toxencryptsave.h",
+    ],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/auto_tests/BUILD
+++ b/auto_tests/BUILD
@@ -1,0 +1,25 @@
+cc_library(
+    name = "helpers",
+    testonly = True,
+    hdrs = [
+        "check_compat.h",
+        "helpers.h",
+    ],
+)
+
+[cc_test(
+    name = src[:-2],
+    size = "small",
+    srcs = [src],
+    copts = [
+        "-Wno-parentheses",
+    ],
+    deps = [
+        ":helpers",
+        "//c-toxcore/other:monolith",
+        "//c-toxcore/testing:misc_tools",
+        "//c-toxcore/toxav",
+        "//c-toxcore/toxcore",
+        "@check",
+    ],
+) for src in glob(["*_test.c"])]

--- a/auto_tests/helpers.h
+++ b/auto_tests/helpers.h
@@ -42,6 +42,8 @@ static const char *tox_log_level_name(TOX_LOG_LEVEL level)
         case TOX_LOG_LEVEL_ERROR:
             return "ERROR";
     }
+
+    return "<unknown>";
 }
 
 static void print_debug_log(Tox *m, TOX_LOG_LEVEL level, const char *path, uint32_t line, const char *func,

--- a/other/BUILD
+++ b/other/BUILD
@@ -1,0 +1,10 @@
+cc_library(
+    name = "monolith",
+    hdrs = ["monolith.h"],
+    visibility = ["//c-toxcore/auto_tests:__pkg__"],
+    deps = [
+        "//c-toxcore/toxav:monolith",
+        "//c-toxcore/toxcore:monolith",
+        "//c-toxcore/toxencryptsave:monolith",
+    ],
+)

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,0 +1,7 @@
+cc_library(
+    name = "misc_tools",
+    hdrs = [
+        "misc_tools.c",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/toxav/BUILD
+++ b/toxav/BUILD
@@ -1,0 +1,46 @@
+filegroup(
+    name = "public",
+    srcs = ["toxav.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "toxav",
+    srcs = [
+        "audio.c",
+        "bwcontroller.c",
+        "groupav.c",
+        "msi.c",
+        "ring_buffer.c",
+        "rtp.c",
+        "toxav.c",
+        "toxav_old.c",
+        "video.c",
+    ],
+    hdrs = [
+        "audio.h",
+        "bwcontroller.h",
+        "groupav.h",
+        "msi.h",
+        "ring_buffer.h",
+        "rtp.h",
+        "toxav.api.h",
+        "toxav.h",
+        "video.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//c-toxcore/toxcore",
+        "@libvpx",
+        "@opus",
+    ],
+)
+
+cc_library(
+    name = "monolith",
+    hdrs = glob([
+        "*.c",
+        "*.h",
+    ]),
+    visibility = ["//c-toxcore/other:__pkg__"],
+)

--- a/toxcore/BUILD
+++ b/toxcore/BUILD
@@ -1,0 +1,95 @@
+filegroup(
+    name = "public",
+    srcs = ["tox.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ccompat",
+    hdrs = [
+        "ccompat.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "crypto_core",
+    srcs = [
+        "crypto_core.c",
+        "crypto_core_mem.c",
+    ],
+    hdrs = [
+        "crypto_core.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ccompat",
+        "@libsodium",
+    ],
+)
+
+cc_library(
+    name = "toxcore",
+    srcs = [
+        "DHT.c",
+        "DHT.h",
+        "LAN_discovery.c",
+        "LAN_discovery.h",
+        "Messenger.c",
+        "Messenger.h",
+        "TCP_client.c",
+        "TCP_client.h",
+        "TCP_connection.c",
+        "TCP_connection.h",
+        "TCP_server.c",
+        "TCP_server.h",
+        "friend_connection.c",
+        "friend_connection.h",
+        "friend_requests.c",
+        "friend_requests.h",
+        "group.c",
+        "group.h",
+        "list.c",
+        "list.h",
+        "logger.c",
+        "logger.h",
+        "net_crypto.c",
+        "net_crypto.h",
+        "network.c",
+        "network.h",
+        "onion.c",
+        "onion.h",
+        "onion_announce.c",
+        "onion_announce.h",
+        "onion_client.c",
+        "onion_client.h",
+        "ping.c",
+        "ping.h",
+        "ping_array.c",
+        "ping_array.h",
+        "tox.c",
+        "tox.h",
+        "tox_api.c",
+        "util.c",
+        "util.h",
+    ],
+    copts = [
+        "-Wno-parentheses",
+    ],
+    linkopts = ["-lpthread"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ccompat",
+        ":crypto_core",
+        "//c-toxcore/toxencryptsave",
+    ],
+)
+
+cc_library(
+    name = "monolith",
+    hdrs = glob([
+        "*.c",
+        "*.h",
+    ]),
+    visibility = ["//c-toxcore/other:__pkg__"],
+)

--- a/toxencryptsave/BUILD
+++ b/toxencryptsave/BUILD
@@ -1,0 +1,31 @@
+filegroup(
+    name = "public",
+    srcs = ["toxencryptsave.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "toxencryptsave",
+    srcs = [
+        "toxencryptsave.c",
+    ],
+    hdrs = [
+        "defines.h",
+        "toxencryptsave.h",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//c-toxcore/toxcore:crypto_core",
+    ],
+)
+
+cc_library(
+    name = "monolith",
+    hdrs = glob([
+        "*.c",
+        "*.h",
+    ]),
+    visibility = ["//c-toxcore/other:__pkg__"],
+)


### PR DESCRIPTION
This allows us and users to reproducibly build verified versions of the
library with checksums. It will power the toktok-stack continuous build
with checked-in checksums at specific git revisions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/694)
<!-- Reviewable:end -->
