### PR TITLE
Don't allocate or dereference Tox_Options in tests.

### DIFF
--- a/auto_tests/file_saving_test.c
+++ b/auto_tests/file_saving_test.c
@@ -34,9 +34,9 @@ static const char *pphrase = "bar", *name = "foo", *savefile = "./save";
 
 static void save_data_encrypted(void)
 {
-    struct Tox_Options options;
-    tox_options_default(&options);
-    Tox *t = tox_new(&options, NULL);
+    struct Tox_Options *options = tox_options_new(NULL);
+    Tox *t = tox_new(options, NULL);
+    tox_options_free(options);
 
     tox_self_set_name(t, (const uint8_t *)name, strlen(name), NULL);
 
@@ -87,17 +87,17 @@ static void load_data_decrypted(void)
         exit(3);
     }
 
-    struct Tox_Options options;
+    struct Tox_Options *options = tox_options_new(NULL);
 
-    tox_options_default(&options);
+    tox_options_set_savedata_type(options, TOX_SAVEDATA_TYPE_TOX_SAVE);
 
-    tox_options_set_savedata_type(&options, TOX_SAVEDATA_TYPE_TOX_SAVE);
-
-    tox_options_set_savedata_data(&options, clear, size);
+    tox_options_set_savedata_data(options, clear, size);
 
     TOX_ERR_NEW err;
 
-    Tox *t = tox_new(&options, &err);
+    Tox *t = tox_new(options, &err);
+
+    tox_options_free(options);
 
     if (t == NULL) {
         fprintf(stderr, "error: tox_new returned the error value %d\n", err);

--- a/auto_tests/self_conference_title_change_test.c
+++ b/auto_tests/self_conference_title_change_test.c
@@ -47,13 +47,13 @@ static void cbtitlechange(Tox *tox, uint32_t conference_number, uint32_t peer_nu
 int main(void)
 {
     uint32_t conference_number;
-    struct Tox_Options to;
+    struct Tox_Options *to = tox_options_new(NULL);
     Tox *t;
     TOX_ERR_CONFERENCE_NEW conference_err;
     TOX_ERR_CONFERENCE_TITLE title_err;
 
-    tox_options_default(&to);
-    t = tox_new(&to, NULL);
+    t = tox_new(to, NULL);
+    tox_options_free(to);
 
     tox_callback_conference_title(t, &cbtitlechange);
 

--- a/auto_tests/selfname_change_conference_test.c
+++ b/auto_tests/selfname_change_conference_test.c
@@ -57,13 +57,13 @@ static void cbconfmembers(Tox *tox, uint32_t conference_number, uint32_t peer_nu
 
 int main(void)
 {
-    struct Tox_Options to;
+    struct Tox_Options *to = tox_options_new(NULL);
     Tox *t;
     TOX_ERR_CONFERENCE_NEW conference_err;
     TOX_ERR_SET_INFO name_err;
 
-    tox_options_default(&to);
-    t = tox_new(&to, NULL);
+    t = tox_new(to, NULL);
+    tox_options_free(to);
 
     tox_callback_conference_namelist_change(t, cbconfmembers);
 

--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -231,27 +231,29 @@ static void initialize_tox(Tox **bootstrap, ToxAV **AliceAV, CallControl *AliceC
     Tox *Alice;
     Tox *Bob;
 
-    struct Tox_Options opts;
-    tox_options_default(&opts);
+    struct Tox_Options *opts = tox_options_new(NULL);
+    assert(opts != NULL);
 
-    opts.end_port = 0;
-    opts.ipv6_enabled = false;
+    tox_options_set_end_port(opts, 0);
+    tox_options_set_ipv6_enabled(opts, false);
 
     {
         TOX_ERR_NEW error;
 
-        opts.start_port = 33445;
+        tox_options_set_start_port(opts, 33445);
         *bootstrap = tox_new(&opts, &error);
         assert(error == TOX_ERR_NEW_OK);
 
-        opts.start_port = 33455;
+        tox_options_set_start_port(opts, 33455);
         Alice = tox_new(&opts, &error);
         assert(error == TOX_ERR_NEW_OK);
 
-        opts.start_port = 33465;
+        tox_options_set_start_port(opts, 33465);
         Bob = tox_new(&opts, &error);
         assert(error == TOX_ERR_NEW_OK);
     }
+
+    tox_options_free(opts);
 
     printf("Created 3 instances of Tox\n");
     printf("Preparing network...\n");


### PR DESCRIPTION
This struct will soon become opaque.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/710)
<!-- Reviewable:end -->
