### PR TITLE
Make BUILD files more finely-grained.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,9 @@
 genrule(
     name = "copy_headers",
     srcs = [
-        "//c-toxcore/toxav:public",
-        "//c-toxcore/toxcore:public",
-        "//c-toxcore/toxencryptsave:public",
+        "//c-toxcore/toxav:public_headers",
+        "//c-toxcore/toxcore:public_headers",
+        "//c-toxcore/toxencryptsave:public_headers",
     ],
     outs = [
         "tox/toxav.h",
@@ -11,9 +11,9 @@ genrule(
         "tox/toxencryptsave.h",
     ],
     cmd = """
-        cp $(location //c-toxcore/toxav:public) $(GENDIR)/c-toxcore/tox/toxav.h
-        cp $(location //c-toxcore/toxcore:public) $(GENDIR)/c-toxcore/tox/tox.h
-        cp $(location //c-toxcore/toxencryptsave:public) $(GENDIR)/c-toxcore/tox/toxencryptsave.h
+        cp $(location //c-toxcore/toxav:public_headers) $(GENDIR)/c-toxcore/tox/toxav.h
+        cp $(location //c-toxcore/toxcore:public_headers) $(GENDIR)/c-toxcore/tox/tox.h
+        cp $(location //c-toxcore/toxencryptsave:public_headers) $(GENDIR)/c-toxcore/tox/toxencryptsave.h
     """,
 )
 

--- a/auto_tests/BUILD
+++ b/auto_tests/BUILD
@@ -1,3 +1,5 @@
+load("//tools:no_undefined.bzl", "cc_library")
+
 cc_library(
     name = "helpers",
     testonly = True,
@@ -12,7 +14,6 @@ cc_library(
     size = "small",
     srcs = [src],
     copts = [
-        "-std=c99",
         "-Wno-parentheses",
     ],
     deps = [
@@ -21,6 +22,7 @@ cc_library(
         "//c-toxcore/testing:misc_tools",
         "//c-toxcore/toxav",
         "//c-toxcore/toxcore",
+        "//c-toxcore/toxencryptsave",
         "@check",
     ],
 ) for src in glob(["*_test.c"])]

--- a/other/BUILD
+++ b/other/BUILD
@@ -1,3 +1,5 @@
+load("//tools:no_undefined.bzl", "cc_library")
+
 cc_library(
     name = "monolith",
     hdrs = ["monolith.h"],
@@ -14,7 +16,7 @@ cc_library(
     srcs = ["bootstrap_node_packets.c"],
     hdrs = ["bootstrap_node_packets.h"],
     visibility = ["//c-toxcore/other/bootstrap_daemon:__pkg__"],
-    deps = ["//c-toxcore/toxcore"],
+    deps = ["//c-toxcore/toxcore:network"],
 )
 
 cc_binary(

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,3 +1,5 @@
+load("//tools:no_undefined.bzl", "cc_library")
+
 cc_library(
     name = "misc_tools",
     hdrs = [

--- a/toxav/BUILD
+++ b/toxav/BUILD
@@ -1,41 +1,94 @@
+load("//tools:no_undefined.bzl", "cc_library")
+
 filegroup(
-    name = "public",
+    name = "public_headers",
     srcs = ["toxav.h"],
-    visibility = ["//visibility:public"],
+    visibility = ["//c-toxcore:__pkg__"],
+)
+
+cc_library(
+    name = "public",
+    hdrs = [":public_headers"],
+)
+
+cc_library(
+    name = "ring_buffer",
+    srcs = ["ring_buffer.c"],
+    hdrs = ["ring_buffer.h"],
+)
+
+cc_library(
+    name = "bwcontroller",
+    srcs = ["bwcontroller.c"],
+    hdrs = ["bwcontroller.h"],
+    deps = [
+        ":ring_buffer",
+        "//c-toxcore/toxcore:Messenger",
+    ],
+)
+
+cc_library(
+    name = "rtp",
+    srcs = ["rtp.c"],
+    hdrs = ["rtp.h"],
+    deps = [":bwcontroller"],
+)
+
+cc_library(
+    name = "audio",
+    srcs = ["audio.c"],
+    hdrs = ["audio.h"],
+    deps = [
+        ":public",
+        ":rtp",
+        "//c-toxcore/toxcore:network",
+        "@opus",
+    ],
+)
+
+cc_library(
+    name = "video",
+    srcs = [
+        "msi.c",
+        "video.c",
+    ],
+    hdrs = [
+        "msi.h",
+        "video.h",
+    ],
+    deps = [
+        ":audio",
+        ":public",
+        "//c-toxcore/toxcore:network",
+        "@libvpx",
+    ],
+)
+
+cc_library(
+    name = "groupav",
+    srcs = ["groupav.c"],
+    hdrs = ["groupav.h"],
+    deps = [
+        "//c-toxcore/toxcore:group",
+        "@opus",
+    ],
 )
 
 cc_library(
     name = "toxav",
     srcs = [
-        "audio.c",
-        "bwcontroller.c",
-        "groupav.c",
-        "msi.c",
-        "ring_buffer.c",
-        "rtp.c",
         "toxav.c",
         "toxav_old.c",
-        "video.c",
     ],
     hdrs = [
-        "audio.h",
-        "bwcontroller.h",
-        "groupav.h",
-        "msi.h",
-        "ring_buffer.h",
-        "rtp.h",
         "toxav.api.h",
         "toxav.h",
-        "video.h",
-    ],
-    copts = [
-        "-std=c99",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":groupav",
+        ":video",
         "//c-toxcore/toxcore",
-        "@libvpx",
-        "@opus",
     ],
 )
 
@@ -48,5 +101,10 @@ cc_library(
     visibility = [
         "//c-toxcore/other:__pkg__",
         "//c-toxcore/testing:__pkg__",
+    ],
+    deps = [
+        "//c-toxcore/toxcore",
+        "@libvpx",
+        "@opus",
     ],
 )

--- a/toxcore/BUILD
+++ b/toxcore/BUILD
@@ -1,15 +1,14 @@
+load("//tools:no_undefined.bzl", "cc_library")
+
 filegroup(
-    name = "public",
+    name = "public_headers",
     srcs = ["tox.h"],
-    visibility = ["//visibility:public"],
+    visibility = ["//c-toxcore:__pkg__"],
 )
 
 cc_library(
     name = "ccompat",
-    hdrs = [
-        "ccompat.h",
-    ],
-    visibility = ["//visibility:public"],
+    hdrs = ["ccompat.h"],
 )
 
 cc_library(
@@ -21,7 +20,7 @@ cc_library(
     hdrs = [
         "crypto_core.h",
     ],
-    visibility = ["//c-toxcore:__subpackages__"],
+    visibility = ["//c-toxcore/toxencryptsave:__pkg__"],
     deps = [
         ":ccompat",
         "@libsodium",
@@ -29,60 +28,170 @@ cc_library(
 )
 
 cc_library(
-    name = "toxcore",
+    name = "list",
+    srcs = ["list.c"],
+    hdrs = ["list.h"],
+)
+
+cc_library(
+    name = "logger",
+    srcs = ["logger.c"],
+    hdrs = ["logger.h"],
+)
+
+cc_library(
+    name = "network",
     srcs = [
-        "DHT.c",
-        "DHT.h",
-        "LAN_discovery.c",
-        "LAN_discovery.h",
-        "Messenger.c",
-        "Messenger.h",
-        "TCP_client.c",
-        "TCP_client.h",
-        "TCP_connection.c",
-        "TCP_connection.h",
-        "TCP_server.c",
-        "TCP_server.h",
-        "friend_connection.c",
-        "friend_connection.h",
-        "friend_requests.c",
-        "friend_requests.h",
-        "group.c",
-        "group.h",
-        "list.c",
-        "list.h",
-        "logger.c",
-        "logger.h",
-        "net_crypto.c",
-        "net_crypto.h",
         "network.c",
-        "network.h",
-        "onion.c",
-        "onion.h",
-        "onion_announce.c",
-        "onion_announce.h",
-        "onion_client.c",
-        "onion_client.h",
-        "ping.c",
-        "ping.h",
-        "ping_array.c",
-        "ping_array.h",
-        "tox.c",
-        "tox.h",
-        "tox_api.c",
         "util.c",
+    ],
+    hdrs = [
+        "network.h",
         "util.h",
     ],
-    copts = [
-        "-std=c99",
-        "-Wno-parentheses",
-    ],
     linkopts = ["-lpthread"],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//c-toxcore/other:__pkg__",
+        "//c-toxcore/toxav:__pkg__",
+    ],
     deps = [
         ":ccompat",
         ":crypto_core",
-        "//c-toxcore/toxencryptsave",
+        ":logger",
+    ],
+)
+
+cc_library(
+    name = "ping_array",
+    srcs = ["ping_array.c"],
+    hdrs = ["ping_array.h"],
+    deps = [":network"],
+)
+
+cc_library(
+    name = "DHT",
+    srcs = [
+        "DHT.c",
+        "LAN_discovery.c",
+        "ping.c",
+    ],
+    hdrs = [
+        "DHT.h",
+        "LAN_discovery.h",
+        "ping.h",
+    ],
+    copts = [
+        "-Wno-parentheses",
+    ],
+    visibility = ["//c-toxcore/other/bootstrap_daemon:__pkg__"],
+    deps = [
+        ":crypto_core",
+        ":logger",
+        ":ping_array",
+    ],
+)
+
+cc_library(
+    name = "onion",
+    srcs = ["onion.c"],
+    hdrs = ["onion.h"],
+    deps = [":DHT"],
+)
+
+cc_library(
+    name = "TCP_connection",
+    srcs = [
+        "TCP_client.c",
+        "TCP_connection.c",
+        "TCP_server.c",
+    ],
+    hdrs = [
+        "TCP_client.h",
+        "TCP_connection.h",
+        "TCP_server.h",
+    ],
+    deps = [
+        ":crypto_core",
+        ":list",
+        ":onion",
+    ],
+)
+
+cc_library(
+    name = "net_crypto",
+    srcs = ["net_crypto.c"],
+    hdrs = ["net_crypto.h"],
+    deps = [
+        ":DHT",
+        ":TCP_connection",
+    ],
+)
+
+cc_library(
+    name = "onion_announce",
+    srcs = ["onion_announce.c"],
+    hdrs = ["onion_announce.h"],
+    deps = [":onion"],
+)
+
+cc_library(
+    name = "onion_client",
+    srcs = ["onion_client.c"],
+    hdrs = ["onion_client.h"],
+    deps = [
+        ":net_crypto",
+        ":onion_announce",
+    ],
+)
+
+cc_library(
+    name = "friend_connection",
+    srcs = ["friend_connection.c"],
+    hdrs = ["friend_connection.h"],
+    deps = [
+        ":DHT",
+        ":net_crypto",
+        ":onion_client",
+    ],
+)
+
+cc_library(
+    name = "friend_requests",
+    srcs = ["friend_requests.c"],
+    hdrs = ["friend_requests.h"],
+    deps = [":friend_connection"],
+)
+
+cc_library(
+    name = "Messenger",
+    srcs = ["Messenger.c"],
+    hdrs = ["Messenger.h"],
+    visibility = ["//c-toxcore/toxav:__pkg__"],
+    deps = [":friend_requests"],
+)
+
+cc_library(
+    name = "group",
+    srcs = ["group.c"],
+    hdrs = ["group.h"],
+    visibility = ["//c-toxcore/toxav:__pkg__"],
+    deps = [":Messenger"],
+)
+
+cc_library(
+    name = "toxcore",
+    srcs = [
+        "tox.c",
+        "tox.h",
+        "tox_api.c",
+    ],
+    copts = [
+        "-Wno-parentheses",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":group",
+        "//c-toxcore/toxencryptsave:defines",
     ],
 )
 
@@ -92,5 +201,13 @@ cc_library(
         "*.c",
         "*.h",
     ]),
+    copts = [
+        "-Wno-parentheses",
+    ],
+    linkopts = ["-lpthread"],
     visibility = ["//c-toxcore/other:__pkg__"],
+    deps = [
+        "//c-toxcore/toxencryptsave:defines",
+        "@libsodium",
+    ],
 )

--- a/toxencryptsave/BUILD
+++ b/toxencryptsave/BUILD
@@ -1,25 +1,24 @@
+load("//tools:no_undefined.bzl", "cc_library")
+
 filegroup(
-    name = "public",
+    name = "public_headers",
     srcs = ["toxencryptsave.h"],
-    visibility = ["//visibility:public"],
+    visibility = ["//c-toxcore:__pkg__"],
+)
+
+cc_library(
+    name = "defines",
+    hdrs = ["defines.h"],
+    visibility = ["//c-toxcore/toxcore:__pkg__"],
 )
 
 cc_library(
     name = "toxencryptsave",
-    srcs = [
-        "toxencryptsave.c",
-    ],
-    hdrs = [
-        "defines.h",
-        "toxencryptsave.h",
-    ],
-    copts = [
-        "-std=c99",
-    ],
-    visibility = [
-        "//visibility:public",
-    ],
+    srcs = ["toxencryptsave.c"],
+    hdrs = ["toxencryptsave.h"],
+    visibility = ["//visibility:public"],
     deps = [
+        ":defines",
         "//c-toxcore/toxcore:crypto_core",
     ],
 )
@@ -31,4 +30,5 @@ cc_library(
         "*.h",
     ]),
     visibility = ["//c-toxcore/other:__pkg__"],
+    deps = ["//c-toxcore/toxcore:crypto_core"],
 )


### PR DESCRIPTION
This allows us to precisely see which libraries depend on which and lets
us split them up more, if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/714)
<!-- Reviewable:end -->
