### PR TITLE
Disable the autotools build in PR builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ language: c
 matrix:
   include:
   - stage: "Stage 1"
-    env: JOB=autotools ENV=linux
-    compiler: gcc
+    env: JOB=toxcore ENV=linux
+    compiler: clang
     addons:
       apt: &apt-dependencies
         sources:
@@ -32,8 +32,9 @@ matrix:
         - portaudio19-dev       # For av_test.
         - texinfo               # For libconfig.
   - stage: "Stage 1"
-    env: JOB=toxcore ENV=linux
-    compiler: clang
+    if: type IN (push, api, cron)
+    env: JOB=autotools ENV=linux
+    compiler: gcc
     addons:
       apt: *apt-dependencies
   - stage: "Stage 1"


### PR DESCRIPTION
We will only build this during the nightly build. It's very rare for the
autotools build to break when the cmake build does not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/728)
<!-- Reviewable:end -->
