### PR TITLE
Remove dead return statement.

### DIFF
--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -2218,10 +2218,9 @@ static unsigned int lossy_packet_not_received(Group_c *g, int peer_index, uint16
         g->group[peer_index].top_lossy_number = message_number;
         g->group[peer_index].bottom_lossy_number = (message_number - MAX_LOSSY_COUNT) + 1;
         g->group[peer_index].recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
-        return 0;
-    }
 
-    if (top_distance < MAX_LOSSY_COUNT) {
+        return 0;
+    } else {  // top_distance < MAX_LOSSY_COUNT
         unsigned int i;
 
         for (i = g->group[peer_index].bottom_lossy_number; i != (g->group[peer_index].bottom_lossy_number + top_distance);
@@ -2232,10 +2231,9 @@ static unsigned int lossy_packet_not_received(Group_c *g, int peer_index, uint16
         g->group[peer_index].top_lossy_number = message_number;
         g->group[peer_index].bottom_lossy_number = (message_number - MAX_LOSSY_COUNT) + 1;
         g->group[peer_index].recv_lossy[message_number % MAX_LOSSY_COUNT] = 1;
+
         return 0;
     }
-
-    return -1;
 }
 
 static int handle_lossy(void *object, int friendcon_id, const uint8_t *data, uint16_t length, void *userdata)


### PR DESCRIPTION
Turning this code:
```c
if (cond) { ... return 0; }
if (!cond) { ... return 0; }
return -1;
```
into:
```c
if (cond) { ... return 0; }
else { ... return 0; }
```

The `return -1` in the first variant can never happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/729)
<!-- Reviewable:end -->
