### PR TITLE
Fix out of bounds read in error case in messenger_test.

### DIFF
--- a/auto_tests/messenger_test.c
+++ b/auto_tests/messenger_test.c
@@ -184,8 +184,8 @@ END_TEST
 START_TEST(test_getself_name)
 {
     const char *nickname = "testGallop";
-    int len = strlen(nickname);
-    VLA(char, nick_check, len);
+    size_t len = strlen(nickname);
+    char *nick_check = (char *)calloc(len + 1, 1);
 
     setname(m, (const uint8_t *)nickname, len);
     getself_name(m, (uint8_t *)nick_check);
@@ -193,6 +193,7 @@ START_TEST(test_getself_name)
     ck_assert_msg((memcmp(nickname, nick_check, len) == 0),
                   "getself_name failed to return the known name!\n"
                   "known name: %s\nreturned: %s\n", nickname, nick_check);
+    free(nick_check);
 }
 END_TEST
 

--- a/testing/irc_syncbot.c
+++ b/testing/irc_syncbot.c
@@ -300,8 +300,7 @@ int main(int argc, char *argv[])
         if (count > 0) {
             last_get = get_monotime_sec();
             ping_sent = 0;
-            VLA(uint8_t, data, count + 1);
-            data[count] = 0;
+            uint8_t *data = (uint8_t *)calloc(count + 1, 1);
             recv(sock, data, count, MSG_NOSIGNAL);
             printf("%s", data);
 
@@ -345,6 +344,8 @@ int main(int argc, char *argv[])
                     p_i = i + 1;
                 }
             }
+
+            free(data);
         }
 
         if (connected == 1) {


### PR DESCRIPTION
Also got rid of a VLA. They are overused a bit in toxcore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/730)
<!-- Reviewable:end -->
