### PR TITLE
Make audio/video bit rates "properties"

### DIFF
--- a/auto_tests/toxav_basic_test.c
+++ b/auto_tests/toxav_basic_test.c
@@ -476,19 +476,19 @@ START_TEST(test_AV_flows)
 
         printf("Call started as audio only\n");
         printf("Turning on video for Alice...\n");
-        ck_assert(toxav_bit_rate_set_video(AliceAV, 0, 1000, NULL));
+        ck_assert(toxav_video_set_bit_rate(AliceAV, 0, 1000, NULL));
 
         iterate_tox(bootstrap, Alice, Bob);
         ck_assert(BobCC.state & TOXAV_FRIEND_CALL_STATE_SENDING_V);
 
         printf("Turning off video for Alice...\n");
-        ck_assert(toxav_bit_rate_set_video(AliceAV, 0, 0, NULL));
+        ck_assert(toxav_video_set_bit_rate(AliceAV, 0, 0, NULL));
 
         iterate_tox(bootstrap, Alice, Bob);
         ck_assert(!(BobCC.state & TOXAV_FRIEND_CALL_STATE_SENDING_V));
 
         printf("Turning off audio for Alice...\n");
-        ck_assert(toxav_bit_rate_set_audio(AliceAV, 0, 0, NULL));
+        ck_assert(toxav_audio_set_bit_rate(AliceAV, 0, 0, NULL));
 
         iterate_tox(bootstrap, Alice, Bob);
         ck_assert(!(BobCC.state & TOXAV_FRIEND_CALL_STATE_SENDING_A));

--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -210,11 +210,15 @@ static void t_toxav_receive_audio_frame_cb(ToxAV *av, uint32_t friend_number,
     free(rb_write(cc->arb, f));
     pthread_mutex_unlock(cc->arb_mutex);
 }
-static void t_toxav_bit_rate_status_cb(ToxAV *av, uint32_t friend_number,
-                                       uint32_t audio_bit_rate, uint32_t video_bit_rate,
-                                       void *user_data)
+static void t_toxav_audio_bit_rate_cb(ToxAV *av, uint32_t friend_number,
+                                      uint32_t audio_bit_rate, void *user_data)
 {
-    printf("Suggested bit rates: audio: %d video: %d\n", audio_bit_rate, video_bit_rate);
+    printf("Suggested bit rate: audio: %d\n", audio_bit_rate);
+}
+static void t_toxav_video_bit_rate_cb(ToxAV *av, uint32_t friend_number,
+                                      uint32_t video_bit_rate, void *user_data)
+{
+    printf("Suggested bit rate: video: %d\n", video_bit_rate);
 }
 static void t_accept_friend_request_cb(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length,
                                        void *userdata)
@@ -302,14 +306,16 @@ static void initialize_tox(Tox **bootstrap, ToxAV **AliceAV, CallControl *AliceC
     /* Alice */
     toxav_callback_call(*AliceAV, t_toxav_call_cb, AliceCC);
     toxav_callback_call_state(*AliceAV, t_toxav_call_state_cb, AliceCC);
-    toxav_callback_bit_rate_status(*AliceAV, t_toxav_bit_rate_status_cb, AliceCC);
+    toxav_callback_audio_bit_rate(*AliceAV, t_toxav_audio_bit_rate_cb, AliceCC);
+    toxav_callback_video_bit_rate(*AliceAV, t_toxav_video_bit_rate_cb, AliceCC);
     toxav_callback_video_receive_frame(*AliceAV, t_toxav_receive_video_frame_cb, AliceCC);
     toxav_callback_audio_receive_frame(*AliceAV, t_toxav_receive_audio_frame_cb, AliceCC);
 
     /* Bob */
     toxav_callback_call(*BobAV, t_toxav_call_cb, BobCC);
     toxav_callback_call_state(*BobAV, t_toxav_call_state_cb, BobCC);
-    toxav_callback_bit_rate_status(*BobAV, t_toxav_bit_rate_status_cb, BobCC);
+    toxav_callback_audio_bit_rate(*BobAV, t_toxav_audio_bit_rate_cb, BobCC);
+    toxav_callback_video_bit_rate(*BobAV, t_toxav_video_bit_rate_cb, BobCC);
     toxav_callback_video_receive_frame(*BobAV, t_toxav_receive_video_frame_cb, BobCC);
     toxav_callback_audio_receive_frame(*BobAV, t_toxav_receive_audio_frame_cb, BobCC);
 

--- a/toxav/toxav.api.h
+++ b/toxav/toxav.api.h
@@ -405,43 +405,6 @@ error for bit_rate_set {
   FRIEND_NOT_IN_CALL,
 }
 
-namespace bit_rate {
-  /**
-   * Set the bit rate to be used in subsequent audio frames.
-   *
-   * @param friend_number The friend number of the friend for which to set the
-   * bit rate.
-   * @param audio_bit_rate The new audio bit rate in Kb/sec. Set to 0 to disable.
-   *
-   */
-
-  bool set_audio(uint32_t friend_number, uint32_t audio_bit_rate) with error for bit_rate_set;
-  /**
-   * Set the bit rate to be used in subsequent video frames.
-   *
-   * @param friend_number The friend number of the friend for which to set the
-   * bit rate.
-   * @param video_bit_rate The new video bit rate in Kb/sec. Set to 0 to disable.
-   *
-   */
-  bool set_video(uint32_t friend_number, uint32_t video_bit_rate) with error for bit_rate_set;
-
-  event status {
-    /**
-     * The function type for the ${event status} callback. The event is triggered
-     * when the network becomes too saturated for current bit rates at which
-     * point core suggests new bit rates.
-     *
-     * @param friend_number The friend number of the friend for which to set the
-     * bit rate.
-     * @param audio_bit_rate Suggested maximum audio bit rate in Kb/sec.
-     * @param video_bit_rate Suggested maximum video bit rate in Kb/sec.
-     */
-    typedef void(uint32_t friend_number, uint32_t audio_bit_rate, uint32_t video_bit_rate);
-  }
-}
-
-
 /*******************************************************************************
  *
  * :: A/V sending
@@ -506,6 +469,32 @@ namespace audio {
    */
   bool send_frame(uint32_t friend_number, const int16_t *pcm, size_t sample_count,
                   uint8_t channels, uint32_t sampling_rate) with error for send_frame;
+
+  uint32_t bit_rate {
+    /**
+     * Set the bit rate to be used in subsequent video frames.
+     *
+     * @param friend_number The friend number of the friend for which to set the
+     * bit rate.
+     * @param bit_rate The new audio bit rate in Kb/sec. Set to 0 to disable.
+     *
+     * @return true on success.
+     */
+    set(uint32_t friend_number) with error for bit_rate_set;
+  }
+
+  event bit_rate {
+    /**
+     * The function type for the ${event bit_rate} callback. The event is triggered
+     * when the network becomes too saturated for current bit rates at which
+     * point core suggests new bit rates.
+     *
+     * @param friend_number The friend number of the friend for which to set the
+     * bit rate.
+     * @param audio_bit_rate Suggested maximum audio bit rate in Kb/sec.
+     */
+    typedef void(uint32_t friend_number, uint32_t audio_bit_rate);
+  }
 }
 
 namespace video {
@@ -526,6 +515,32 @@ namespace video {
    */
   bool send_frame(uint32_t friend_number, uint16_t width, uint16_t height,
                   const uint8_t *y, const uint8_t *u, const uint8_t *v) with error for send_frame;
+
+  uint32_t bit_rate {
+    /**
+     * Set the bit rate to be used in subsequent video frames.
+     *
+     * @param friend_number The friend number of the friend for which to set the
+     * bit rate.
+     * @param bit_rate The new video bit rate in Kb/sec. Set to 0 to disable.
+     *
+     * @return true on success.
+     */
+    set(uint32_t friend_number) with error for bit_rate_set;
+  }
+
+  event bit_rate {
+    /**
+     * The function type for the ${event bit_rate} callback. The event is triggered
+     * when the network becomes too saturated for current bit rates at which
+     * point core suggests new bit rates.
+     *
+     * @param friend_number The friend number of the friend for which to set the
+     * bit rate.
+     * @param video_bit_rate Suggested maximum video bit rate in Kb/sec.
+     */
+    typedef void(uint32_t friend_number, uint32_t video_bit_rate);
+  }
 }
 
 

--- a/toxav/toxav.h
+++ b/toxav/toxav.h
@@ -511,48 +511,6 @@ typedef enum TOXAV_ERR_BIT_RATE_SET {
 } TOXAV_ERR_BIT_RATE_SET;
 
 
-/**
- * Set the bit rate to be used in subsequent audio frames.
- *
- * @param friend_number The friend number of the friend for which to set the
- * bit rate.
- * @param audio_bit_rate The new audio bit rate in Kb/sec. Set to 0 to disable.
- *
- */
-bool toxav_bit_rate_set_audio(ToxAV *av, uint32_t friend_number, uint32_t audio_bit_rate,
-                              TOXAV_ERR_BIT_RATE_SET *error);
-
-/**
- * Set the bit rate to be used in subsequent video frames.
- *
- * @param friend_number The friend number of the friend for which to set the
- * bit rate.
- * @param video_bit_rate The new video bit rate in Kb/sec. Set to 0 to disable.
- *
- */
-bool toxav_bit_rate_set_video(ToxAV *av, uint32_t friend_number, uint32_t video_bit_rate,
-                              TOXAV_ERR_BIT_RATE_SET *error);
-
-/**
- * The function type for the bit_rate_status callback. The event is triggered
- * when the network becomes too saturated for current bit rates at which
- * point core suggests new bit rates.
- *
- * @param friend_number The friend number of the friend for which to set the
- * bit rate.
- * @param audio_bit_rate Suggested maximum audio bit rate in Kb/sec.
- * @param video_bit_rate Suggested maximum video bit rate in Kb/sec.
- */
-typedef void toxav_bit_rate_status_cb(ToxAV *av, uint32_t friend_number, uint32_t audio_bit_rate,
-                                      uint32_t video_bit_rate, void *user_data);
-
-
-/**
- * Set the callback for the `bit_rate_status` event. Pass NULL to unset.
- *
- */
-void toxav_callback_bit_rate_status(ToxAV *av, toxav_bit_rate_status_cb *callback, void *user_data);
-
 
 /*******************************************************************************
  *
@@ -634,6 +592,35 @@ bool toxav_audio_send_frame(ToxAV *av, uint32_t friend_number, const int16_t *pc
                             uint8_t channels, uint32_t sampling_rate, TOXAV_ERR_SEND_FRAME *error);
 
 /**
+ * Set the bit rate to be used in subsequent video frames.
+ *
+ * @param friend_number The friend number of the friend for which to set the
+ * bit rate.
+ * @param bit_rate The new audio bit rate in Kb/sec. Set to 0 to disable.
+ *
+ * @return true on success.
+ */
+bool toxav_audio_set_bit_rate(ToxAV *av, uint32_t friend_number, uint32_t bit_rate, TOXAV_ERR_BIT_RATE_SET *error);
+
+/**
+ * The function type for the audio_bit_rate callback. The event is triggered
+ * when the network becomes too saturated for current bit rates at which
+ * point core suggests new bit rates.
+ *
+ * @param friend_number The friend number of the friend for which to set the
+ * bit rate.
+ * @param audio_bit_rate Suggested maximum audio bit rate in Kb/sec.
+ */
+typedef void toxav_audio_bit_rate_cb(ToxAV *av, uint32_t friend_number, uint32_t audio_bit_rate, void *user_data);
+
+
+/**
+ * Set the callback for the `audio_bit_rate` event. Pass NULL to unset.
+ *
+ */
+void toxav_callback_audio_bit_rate(ToxAV *av, toxav_audio_bit_rate_cb *callback, void *user_data);
+
+/**
  * Send a video frame to a friend.
  *
  * Y - plane should be of size: height * width
@@ -650,6 +637,35 @@ bool toxav_audio_send_frame(ToxAV *av, uint32_t friend_number, const int16_t *pc
  */
 bool toxav_video_send_frame(ToxAV *av, uint32_t friend_number, uint16_t width, uint16_t height, const uint8_t *y,
                             const uint8_t *u, const uint8_t *v, TOXAV_ERR_SEND_FRAME *error);
+
+/**
+ * Set the bit rate to be used in subsequent video frames.
+ *
+ * @param friend_number The friend number of the friend for which to set the
+ * bit rate.
+ * @param bit_rate The new video bit rate in Kb/sec. Set to 0 to disable.
+ *
+ * @return true on success.
+ */
+bool toxav_video_set_bit_rate(ToxAV *av, uint32_t friend_number, uint32_t bit_rate, TOXAV_ERR_BIT_RATE_SET *error);
+
+/**
+ * The function type for the video_bit_rate callback. The event is triggered
+ * when the network becomes too saturated for current bit rates at which
+ * point core suggests new bit rates.
+ *
+ * @param friend_number The friend number of the friend for which to set the
+ * bit rate.
+ * @param video_bit_rate Suggested maximum video bit rate in Kb/sec.
+ */
+typedef void toxav_video_bit_rate_cb(ToxAV *av, uint32_t friend_number, uint32_t video_bit_rate, void *user_data);
+
+
+/**
+ * Set the callback for the `video_bit_rate` event. Pass NULL to unset.
+ *
+ */
+void toxav_callback_video_bit_rate(ToxAV *av, toxav_video_bit_rate_cb *callback, void *user_data);
 
 
 /*******************************************************************************


### PR DESCRIPTION
follow TokTok#731. This commit
completely removed all things in namespace bit_rate, and deprecated
functions are to be added back in another commit. set_xxx() is treadted
as a property of namespace audio&video, same as bit_rate change event.

toxav_basic_test is fixed, either.

As for adding legacy functions back, it should be finished in https://github.com/TokTok/c-toxcore/pull/732.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/734)
<!-- Reviewable:end -->
