### PR TITLE
Add `-D__STDC_LIMIT_MACROS=1` for C++ code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,6 +467,7 @@ function(auto_test target)
 endfunction()
 
 if(BUILD_TOXAV)
+  add_definitions(-D__STDC_LIMIT_MACROS=1)
   add_executable(auto_monolith_test
     auto_tests/monolith_test.cpp
     ${ANDROID_CPU_FEATURES})


### PR DESCRIPTION
Without this, `UINT*_MAX` are not defined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/741)
<!-- Reviewable:end -->
