### PR TITLE
Use more ubuntu packages; remove hstox for now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,22 +15,18 @@ matrix:
       apt: &apt-dependencies
         sources:
         - avsm
-        - hvr-ghc
         packages:
-        - alex-3.1.7            # For hstox.
-        - cabal-install-1.18    # For hstox.
+        - aspcud                # For Opam
         - check                 # For tests.
-        - ghc-7.8.4             # For hstox.
-        - happy-1.19.5          # For hstox.
+        - libconfig-dev         # For tox-bootstrapd.
         - libcv-dev             # For av_test.
         - libhighgui-dev        # For av_test.
         - libopencv-contrib-dev # For av_test.
+        - libopus-dev           # For toxav.
         - libsndfile1-dev       # For av_test.
         - libvpx-dev            # For toxav.
         - opam                  # For apidsl and Frama-C.
-        - aspcud                # For Opam
         - portaudio19-dev       # For av_test.
-        - texinfo               # For libconfig.
   - stage: "Stage 1"
     if: type IN (push, api, cron)
     env: JOB=autotools ENV=linux
@@ -86,13 +82,6 @@ matrix:
 
 cache:
   directories:
-  # Although Travis documentation says not to rely on the value of $HOME, we
-  # rely on it here because cabal installs its packages there by default. If
-  # that ever changes, these values need to be updated.
-  # Note that we can't use shell expressions in these paths, so we can't ask
-  # cabal where its data is stored.
-  - $HOME/.cabal
-  - $HOME/.ghc
   - $HOME/cache
   - /opt/freebsd/cache
 
@@ -108,7 +97,3 @@ notifications:
     template:
     - "%{result} %{repository_name} %{build_url}"
     - "#%{build_number} changes: %{compare_url}"
-
-branches:
-  only:
-  - master

--- a/other/travis/toxcore-linux-install
+++ b/other/travis/toxcore-linux-install
@@ -21,7 +21,7 @@ sed -i -e '/^import sys$/a import urllib3.contrib.pyopenssl\nurllib3.contrib.pyo
 
 # Install astyle (version in ubuntu-precise too old).
 [ -f $ASTYLE ] || {
-  wget -O ../astyle.tar.gz https://launchpad.net/ubuntu/+archive/primary/+files/astyle_2.05.1.orig.tar.gz
+  wget -O ../astyle.tar.gz http://http.debian.net/debian/pool/main/a/astyle/astyle_2.06.orig.tar.gz
   tar -xf ../astyle.tar.gz -C $CACHE_DIR
   make -C $CACHE_DIR/astyle/build/gcc -j$NPROC
 }
@@ -35,61 +35,3 @@ sed -i -e '/^import sys$/a import urllib3.contrib.pyopenssl\nurllib3.contrib.pyo
   make install -j$NPROC
   cd - # popd
 }
-
-# Install msgpack-c.
-[ -f $CACHE_DIR/lib/libmsgpackc.so ] || {
-  git clone --depth=1 https://github.com/msgpack/msgpack-c ../msgpack-c
-  $CC -shared -fPIC -O3 -I../msgpack-c/include ../msgpack-c/src/*.c -o $CACHE_DIR/lib/libmsgpackc.so
-  cp -a ../msgpack-c/include/* $CACHE_DIR/include/
-  sed -e "s|@prefix@|$CACHE_DIR|"            \
-      -e 's|@exec_prefix@|${prefix}|'        \
-      -e 's|@libdir@|${prefix}/lib|'         \
-      -e 's|@includedir@|${prefix}/include|' \
-      -e 's|@VERSION@|2.1.1|'                \
-      ../msgpack-c/msgpack.pc.in             \
-      > $CACHE_DIR/lib/pkgconfig/msgpack.pc
-  # TODO(iphydf): This doesn't work, because the cmake version on travis is too
-  # old. We're building it manually, instead.
-  # cd ../msgpack-c # pushd
-  # cmake . -DCMAKE_INSTALL_PREFIX:PATH=$CACHE_DIR \
-  #   -DMSGPACK_ENABLE_CXX=OFF                     \
-  #   -DMSGPACK_BUILD_EXAMPLES=OFF                 \
-  #   -DMSGPACK_BUILD_TESTS=OFF
-  # make -j$NPROC
-  # make install -j$NPROC
-  # cd - # popd
-}
-
-# Install libconfig (version in ubuntu-precise too old).
-[ -f $CACHE_DIR/lib/libconfig.a ] || {
-  git clone --depth=1 --branch=v1.7.1 https://github.com/hyperrealm/libconfig ../libconfig
-  cd ../libconfig # pushd
-  autoreconf -fi
-  ./configure --prefix=$CACHE_DIR
-  touch lib/scanner.l
-  make install -j$NPROC
-  cd - # popd
-}
-
-# Install libopus (not in ubuntu-precise).
-[ -f $CACHE_DIR/lib/libopus.a ] || {
-  git clone --depth=1 --branch=1.1.2 https://github.com/xiph/opus ../opus
-  cd ../opus # pushd
-  ./autogen.sh
-  ./configure --prefix=$CACHE_DIR
-  make install -j$NPROC
-  cd - # popd
-}
-
-if [ "$CC" = "clang" ]; then
-  # An initial update is required or the cabal cache will be empty and no packages
-  # can be installed.
-  cabal update
-
-  # Install the hstox test runner after installing libsodium.
-  CABAL_FLAGS="--disable-library-profiling"
-  CABAL_FLAGS="$CABAL_FLAGS --extra-include-dirs=$CACHE_DIR/include"
-  CABAL_FLAGS="$CABAL_FLAGS --extra-lib-dirs=$CACHE_DIR/lib"
-  git clone --recursive --depth=1 https://github.com/TokTok/hs-toxcore ../hs-toxcore
-  (cd ../hs-toxcore && cabal install $CABAL_FLAGS)
-fi

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -87,7 +87,7 @@ int create_announce_request(uint8_t *packet, uint16_t max_packet_length, const u
     }
 
     uint8_t plain[ONION_PING_ID_SIZE + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_PUBLIC_KEY_SIZE +
-                  ONION_ANNOUNCE_SENDBACK_DATA_LENGTH];
+                                     ONION_ANNOUNCE_SENDBACK_DATA_LENGTH];
     memcpy(plain, ping_id, ONION_PING_ID_SIZE);
     memcpy(plain + ONION_PING_ID_SIZE, client_id, CRYPTO_PUBLIC_KEY_SIZE);
     memcpy(plain + ONION_PING_ID_SIZE + CRYPTO_PUBLIC_KEY_SIZE, data_public_key, CRYPTO_PUBLIC_KEY_SIZE);
@@ -375,7 +375,7 @@ static int handle_announce_request(void *object, IP_Port source, const uint8_t *
     get_shared_key(&onion_a->shared_keys_recv, shared_key, dht_get_self_secret_key(onion_a->dht), packet_public_key);
 
     uint8_t plain[ONION_PING_ID_SIZE + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_PUBLIC_KEY_SIZE +
-                  ONION_ANNOUNCE_SENDBACK_DATA_LENGTH];
+                                     ONION_ANNOUNCE_SENDBACK_DATA_LENGTH];
     int len = decrypt_data_symmetric(shared_key, packet + 1, packet + 1 + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE,
                                      ONION_PING_ID_SIZE + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_PUBLIC_KEY_SIZE + ONION_ANNOUNCE_SENDBACK_DATA_LENGTH +
                                      CRYPTO_MAC_SIZE, plain);

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -40,20 +40,20 @@ void tox_options_set_##ns##name(struct Tox_Options *options, type name) \
     options->ns##name = name; \
 }
 
-ACCESSORS(bool, , ipv6_enabled)
-ACCESSORS(bool, , udp_enabled)
-ACCESSORS(TOX_PROXY_TYPE, proxy_ , type)
-ACCESSORS(const char *, proxy_ , host)
-ACCESSORS(uint16_t, proxy_ , port)
-ACCESSORS(uint16_t, , start_port)
-ACCESSORS(uint16_t, , end_port)
-ACCESSORS(uint16_t, , tcp_port)
-ACCESSORS(bool, , hole_punching_enabled)
+ACCESSORS(bool,, ipv6_enabled)
+ACCESSORS(bool,, udp_enabled)
+ACCESSORS(TOX_PROXY_TYPE, proxy_, type)
+ACCESSORS(const char *, proxy_, host)
+ACCESSORS(uint16_t, proxy_, port)
+ACCESSORS(uint16_t,, start_port)
+ACCESSORS(uint16_t,, end_port)
+ACCESSORS(uint16_t,, tcp_port)
+ACCESSORS(bool,, hole_punching_enabled)
 ACCESSORS(TOX_SAVEDATA_TYPE, savedata_, type)
 ACCESSORS(size_t, savedata_, length)
 ACCESSORS(tox_log_cb *, log_, callback)
 ACCESSORS(void *, log_, user_data)
-ACCESSORS(bool, , local_discovery_enabled)
+ACCESSORS(bool,, local_discovery_enabled)
 
 const uint8_t *tox_options_get_savedata_data(const struct Tox_Options *options)
 {


### PR DESCRIPTION
Since trusty has more up-to-date packages, we can remove some of the
custom install code. Also, we're not using hstox at the moment, so there
is no need to slow down the builds for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/759)
<!-- Reviewable:end -->
