### PR TITLE
Add gtest include directory to -I flags if found.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,7 @@ if(EXISTS "/usr/src/gtest/src/gtest-all.cc")
   add_library(gtest
     /usr/src/gtest/src/gtest-all.cc
     /usr/src/gtest/src/gtest_main.cc)
+  include_directories(/usr/src/gtest/include)
   target_include_directories(gtest PRIVATE /usr/src/gtest)
   check_cxx_compiler_flag("-w" HAVE_CXX_W QUIET)
   check_cxx_compiler_flag("-Wno-global-constructors" HAVE_CXX_W_NO_GLOBAL_CONSTRUCTORS QUIET)


### PR DESCRIPTION
Otherwise it won't be found when cross-compiling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/773)
<!-- Reviewable:end -->
