### PR TITLE
Optionally use newer cmake features.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.1.0)
-cmake_policy(VERSION 3.1.0)
+cmake_minimum_required(VERSION 2.8.12)
+cmake_policy(VERSION 2.8.12)
 project(toxcore)
 
 set(CMAKE_MODULE_PATH ${toxcore_SOURCE_DIR}/cmake)
@@ -66,14 +66,19 @@ enable_testing()
 
 set(CMAKE_MACOSX_RPATH ON)
 
-# Set standard version for compiler.
-set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_C_EXTENSIONS OFF)
-set(CMAKE_CXX_EXTENSIONS OFF)
+if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
+  add_cflag("-std=c99")
+  add_cxxflag("-std=c++11")
+else()
+  # Set standard version for compiler.
+  set(CMAKE_C_STANDARD 99)
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_C_EXTENSIONS OFF)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 
-message(STATUS "Supported C compiler features = ${CMAKE_C_COMPILE_FEATURES}")
-message(STATUS "Supported C++ compiler features = ${CMAKE_CXX_COMPILE_FEATURES}")
+  message(STATUS "Supported C compiler features = ${CMAKE_C_COMPILE_FEATURES}")
+  message(STATUS "Supported C++ compiler features = ${CMAKE_CXX_COMPILE_FEATURES}")
+endif()
 
 if(NOT MSVC)
   # Warn on non-ISO C.


### PR DESCRIPTION
So we can keep supporting cmake 2.8.12, which is the version on ubuntu
trusty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/776)
<!-- Reviewable:end -->
