### PR TITLE
Add back JOIN/EXIT events for conferences.

### DIFF
--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -456,6 +456,7 @@ static int addpeer(Group_Chats *g_c, int groupnumber, const uint8_t *real_pk, co
 
     if (do_gc_callback && g_c->group_namelistchange) {
         g_c->group_namelistchange(g_c->m, groupnumber, 0, CHAT_CHANGE_OCCURRED, userdata);
+        g_c->group_namelistchange(g_c->m, groupnumber, g->numpeers - 1, CHAT_CHANGE_PEER_JOIN, userdata);
     }
 
     if (g->peer_on_join) {
@@ -544,6 +545,7 @@ static int delpeer(Group_Chats *g_c, int groupnumber, int peer_index, void *user
 
     if (g_c->group_namelistchange) {
         g_c->group_namelistchange(g_c->m, groupnumber, 0, CHAT_CHANGE_OCCURRED, userdata);
+        g_c->group_namelistchange(g_c->m, groupnumber, peer_index, CHAT_CHANGE_PEER_EXIT, userdata);
     }
 
     if (g->peer_on_leave) {

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -158,6 +158,8 @@ void g_callback_group_title(Group_Chats *g_c, void (*function)(Messenger *m, uin
 enum {
     CHAT_CHANGE_OCCURRED,
     CHAT_CHANGE_PEER_NAME,
+    CHAT_CHANGE_PEER_JOIN,
+    CHAT_CHANGE_PEER_EXIT,
 };
 void g_callback_group_namelistchange(Group_Chats *g_c, void (*function)(Messenger *m, int, int, uint8_t, void *));
 

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -2064,6 +2064,10 @@ namespace conference {
      * The invitation will remain valid until the inviting friend goes offline
      * or exits the conference.
      *
+     * The friend_number can be -1, which means this is a synthesised invite
+     * event coming from an already joined conference that is being re-joined
+     * after restart or reconnect.
+     *
      * @param friend_number The friend who invited us.
      * @param type The conference type (text only or audio/video).
      * @param cookie A piece of data of variable length required to join the
@@ -2118,6 +2122,20 @@ namespace conference {
      * A peer has changed their name.
      */
     PEER_NAME_CHANGE,
+    /**
+     * A peer has joined the conference.
+     *
+     * @deprecated Join/exit events are unreliable due to unstable peer numbers.
+     *   Prefer to listen for $LIST_CHANGED and rebuild the peer list from
+     *   scratch. This enumerator will be removed in v0.3.0.
+     */
+    PEER_JOIN,
+    /**
+     * A peer has left the conference.
+     *
+     * @deprecated See $PEER_JOIN.
+     */
+    PEER_EXIT,
   }
 
   /**

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -2333,6 +2333,10 @@ typedef enum TOX_CONFERENCE_TYPE {
  * The invitation will remain valid until the inviting friend goes offline
  * or exits the conference.
  *
+ * The friend_number can be -1, which means this is a synthesised invite
+ * event coming from an already joined conference that is being re-joined
+ * after restart or reconnect.
+ *
  * @param friend_number The friend who invited us.
  * @param type The conference type (text only or audio/video).
  * @param cookie A piece of data of variable length required to join the
@@ -2402,6 +2406,22 @@ typedef enum TOX_CONFERENCE_STATE_CHANGE {
      * A peer has changed their name.
      */
     TOX_CONFERENCE_STATE_CHANGE_PEER_NAME_CHANGE,
+
+    /**
+     * A peer has joined the conference.
+     *
+     * @deprecated Join/exit events are unreliable due to unstable peer numbers.
+     *   Prefer to listen for TOX_CONFERENCE_STATE_CHANGE_LIST_CHANGED and rebuild the peer list from
+     *   scratch. This enumerator will be removed in v0.3.0.
+     */
+    TOX_CONFERENCE_STATE_CHANGE_PEER_JOIN,
+
+    /**
+     * A peer has left the conference.
+     *
+     * @deprecated See TOX_CONFERENCE_STATE_CHANGE_PEER_JOIN.
+     */
+    TOX_CONFERENCE_STATE_CHANGE_PEER_EXIT,
 
 } TOX_CONFERENCE_STATE_CHANGE;
 


### PR DESCRIPTION
Apparently it's very hard for clients to adapt, so we're keeping the
events for now. They are now actively deprecated and should no longer be
used. The LIST_CHANGED event is the recommended way, but both events will
be emitted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/795)
<!-- Reviewable:end -->
