### PR TITLE
Make some sizeof tests linux-only.

### DIFF
--- a/auto_tests/monolith_test.cpp
+++ b/auto_tests/monolith_test.cpp
@@ -207,8 +207,10 @@ int main(int argc, char *argv[])
     CHECK_SIZE(Messenger_Options, 72);
     CHECK_SIZE(Receipts, 16);
     // toxcore/net_crypto
+#ifdef __linux__
     CHECK_SIZE(Crypto_Connection, 525392);
     CHECK_SIZE(Net_Crypto, 272);
+#endif
     CHECK_SIZE(New_Connection, 168);
     CHECK_SIZE(Packet_Data, 1384);
     CHECK_SIZE(Packets_Array, 262152);


### PR DESCRIPTION
net_crypto has pthread types in its struct, so its size is system
dependent. In particular, the sizes are wrong on FreeBSD.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/796)
<!-- Reviewable:end -->
