### PR TITLE
Implement the "persistent conference" callback changes as new functions.

### DIFF
--- a/auto_tests/monolith_test.cpp
+++ b/auto_tests/monolith_test.cpp
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
     CHECK_SIZE(Friend_Requests, 1080);
     // toxcore/group
     CHECK_SIZE(Group_c, 728);
-    CHECK_SIZE(Group_Chats, 2112);
+    CHECK_SIZE(Group_Chats, 2128);
     CHECK_SIZE(Group_Peer, 480);
     // toxcore/list
     CHECK_SIZE(BS_LIST, 32);

--- a/other/astyle/format-source
+++ b/other/astyle/format-source
@@ -35,10 +35,12 @@ apidsl_curl() {
 }
 
 # Check if apidsl generated sources are up to date.
-$APIDSL toxcore/crypto_core.api.h > toxcore/crypto_core.h
-$APIDSL toxcore/tox.api.h > toxcore/tox.h
-$APIDSL toxav/toxav.api.h > toxav/toxav.h
-$APIDSL toxencryptsave/toxencryptsave.api.h > toxencryptsave/toxencryptsave.h
+$APIDSL toxcore/crypto_core.api.h > toxcore/crypto_core.h &
+$APIDSL toxcore/tox.api.h > toxcore/tox.h &
+$APIDSL toxav/toxav.api.h > toxav/toxav.h &
+$APIDSL toxencryptsave/toxencryptsave.api.h > toxencryptsave/toxencryptsave.h &
+
+wait; wait; wait; wait
 
 if grep '<unresolved>' */*.h; then
   echo "error: some apidsl references were unresolved"

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -117,7 +117,9 @@ typedef struct {
 
     void (*invite_callback)(Messenger *m, uint32_t, int, const uint8_t *, size_t, void *);
     void (*message_callback)(Messenger *m, uint32_t, uint32_t, int, const uint8_t *, size_t, void *);
-    void (*group_namelistchange)(Messenger *m, uint32_t, uint32_t, uint8_t, void *);
+    void (*peer_name_callback)(Messenger *m, uint32_t, uint32_t, const uint8_t *, size_t, void *);
+    void (*peer_list_changed_callback)(Messenger *m, uint32_t, void *);
+    void (*group_namelistchange)(Messenger *m, uint32_t, uint32_t, int, void *);
     void (*title_callback)(Messenger *m, uint32_t, uint32_t, const uint8_t *, size_t, void *);
 
     struct {
@@ -150,17 +152,32 @@ void g_callback_group_message(Group_Chats *g_c, void (*function)(Messenger *m, u
 void g_callback_group_title(Group_Chats *g_c, void (*function)(Messenger *m, uint32_t, uint32_t, const uint8_t *,
                             size_t, void *));
 
+/* Set callback function for peer nickname changes.
+ *
+ * It gets called every time a peer changes their nickname.
+ *  Function(Group_Chats *g_c, uint32_t groupnumber, uint32_t peernumber, const uint8_t *nick, size_t nick_len, void *userdata)
+ */
+void g_callback_peer_name(Group_Chats *g_c, void (*function)(Messenger *m, uint32_t, uint32_t, const uint8_t *,
+                          size_t, void *));
+
+/* Set callback function for peer list changes.
+ *
+ * It gets called every time the name list changes(new peer, deleted peer)
+ *  Function(Group_Chats *g_c, uint32_t groupnumber, void *userdata)
+ */
+void g_callback_peer_list_changed(Group_Chats *g_c, void (*function)(Messenger *m, uint32_t, void *));
+
 /* Set callback function for peer name list changes.
  *
  * It gets called every time the name list changes(new peer/name, deleted peer)
- *  Function(Group_Chats *g_c, int groupnumber, int peernumber, TOX_CHAT_CHANGE change, void *userdata)
+ *  Function(Group_Chats *g_c, uint32_t groupnumber, uint32_t peernumber, TOX_CHAT_CHANGE change, void *userdata)
  */
 enum {
-    CHAT_CHANGE_OCCURRED,
+    CHAT_CHANGE_PEER_ADD,
+    CHAT_CHANGE_PEER_DEL,
     CHAT_CHANGE_PEER_NAME,
 };
-void g_callback_group_namelistchange(Group_Chats *g_c, void (*function)(Messenger *m, uint32_t, uint32_t, uint8_t,
-                                     void *));
+void g_callback_group_namelistchange(Group_Chats *g_c, void (*function)(Messenger *m, uint32_t, uint32_t, int, void *));
 
 /* Creates a new groupchat and puts it in the chats array.
  *

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -2105,15 +2105,47 @@ namespace conference {
     typedef void(uint32_t conference_number, uint32_t peer_number, const uint8_t[length] title);
   }
 
+  namespace peer {
+
+    /**
+     * This event is triggered when a peer changes their name.
+     */
+    event name const {
+      /**
+       * @param conference_number The conference number of the conference the
+       *   peer is in.
+       * @param peer_number The ID of the peer who changed their nickname.
+       * @param name A byte array containing the new nickname.
+       * @param length The size of the name byte array.
+       */
+      typedef void(uint32_t conference_number, uint32_t peer_number, const uint8_t[length] name);
+    }
+
+    /**
+     * This event is triggered when a peer joins or leaves the conference.
+     */
+    event list_changed const {
+      /**
+       * @param conference_number The conference number of the conference the
+       *   peer is in.
+       */
+      typedef void(uint32_t conference_number);
+    }
+
+  }
+
   /**
    * Peer list state change types.
    */
   enum class STATE_CHANGE {
     /**
-     * Some changes to list have occurred. Rebuild of list required.
-     * peer_number is undefined (always 0 for api compatibility)
+     * A peer has joined the conference.
      */
-    LIST_CHANGED,
+    PEER_JOIN,
+    /**
+     * A peer has exited the conference.
+     */
+    PEER_EXIT,
     /**
      * A peer has changed their name.
      */
@@ -2122,6 +2154,8 @@ namespace conference {
 
   /**
    * This event is triggered when the peer list changes (name change, peer join, peer exit).
+   *
+   * @deprecated Use the `${event peer.name}` and `${event peer.list_changed}` events, instead.
    */
   event namelist_change const {
     /**

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1103,12 +1103,23 @@ void tox_callback_conference_title(Tox *tox, tox_conference_title_cb *callback)
     g_callback_group_title((Group_Chats *)m->conferences_object, callback);
 }
 
+void tox_callback_conference_peer_name(Tox *tox, tox_conference_peer_name_cb *callback)
+{
+    Messenger *m = tox;
+    g_callback_peer_name((Group_Chats *)m->conferences_object, callback);
+}
+
+void tox_callback_conference_peer_list_changed(Tox *tox, tox_conference_peer_list_changed_cb *callback)
+{
+    Messenger *m = tox;
+    g_callback_peer_list_changed((Group_Chats *)m->conferences_object, callback);
+}
+
 void tox_callback_conference_namelist_change(Tox *tox, tox_conference_namelist_change_cb *callback)
 {
     Messenger *m = tox;
-    g_callback_group_namelistchange((Group_Chats *)m->conferences_object, (void (*)(struct Messenger *, uint32_t, uint32_t,
-                                    uint8_t,
-                                    void *))callback);
+    g_callback_group_namelistchange((Group_Chats *)m->conferences_object,
+                                    (void (*)(struct Messenger *, uint32_t, uint32_t, int, void *))callback);
 }
 
 uint32_t tox_conference_new(Tox *tox, TOX_ERR_CONFERENCE_NEW *error)

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -2388,15 +2388,51 @@ typedef void tox_conference_title_cb(Tox *tox, uint32_t conference_number, uint3
 void tox_callback_conference_title(Tox *tox, tox_conference_title_cb *callback);
 
 /**
+ * @param conference_number The conference number of the conference the
+ *   peer is in.
+ * @param peer_number The ID of the peer who changed their nickname.
+ * @param name A byte array containing the new nickname.
+ * @param length The size of the name byte array.
+ */
+typedef void tox_conference_peer_name_cb(Tox *tox, uint32_t conference_number, uint32_t peer_number,
+        const uint8_t *name, size_t length, void *user_data);
+
+
+/**
+ * Set the callback for the `conference_peer_name` event. Pass NULL to unset.
+ *
+ * This event is triggered when a peer changes their name.
+ */
+void tox_callback_conference_peer_name(Tox *tox, tox_conference_peer_name_cb *callback);
+
+/**
+ * @param conference_number The conference number of the conference the
+ *   peer is in.
+ */
+typedef void tox_conference_peer_list_changed_cb(Tox *tox, uint32_t conference_number, void *user_data);
+
+
+/**
+ * Set the callback for the `conference_peer_list_changed` event. Pass NULL to unset.
+ *
+ * This event is triggered when a peer joins or leaves the conference.
+ */
+void tox_callback_conference_peer_list_changed(Tox *tox, tox_conference_peer_list_changed_cb *callback);
+
+/**
  * Peer list state change types.
  */
 typedef enum TOX_CONFERENCE_STATE_CHANGE {
 
     /**
-     * Some changes to list have occurred. Rebuild of list required.
-     * peer_number is undefined (always 0 for api compatibility)
+     * A peer has joined the conference.
      */
-    TOX_CONFERENCE_STATE_CHANGE_LIST_CHANGED,
+    TOX_CONFERENCE_STATE_CHANGE_PEER_JOIN,
+
+    /**
+     * A peer has exited the conference.
+     */
+    TOX_CONFERENCE_STATE_CHANGE_PEER_EXIT,
 
     /**
      * A peer has changed their name.
@@ -2419,6 +2455,8 @@ typedef void tox_conference_namelist_change_cb(Tox *tox, uint32_t conference_num
  * Set the callback for the `conference_namelist_change` event. Pass NULL to unset.
  *
  * This event is triggered when the peer list changes (name change, peer join, peer exit).
+ *
+ * @deprecated Use the `conference_peer_name` and `conference_peer_list_changed` events, instead.
  */
 void tox_callback_conference_namelist_change(Tox *tox, tox_conference_namelist_change_cb *callback);
 


### PR DESCRIPTION
We can now revert the changes to the callbacks and keep supporting them
until clients have moved off them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/799)
<!-- Reviewable:end -->
