### PR TITLE
Add links to Tox's Spectrum community

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![Project Tox](https://raw.github.com/TokTok/toxcore/master/other/tox.png "Project Tox")
 
-[![Build Status](https://travis-ci.org/TokTok/c-toxcore.svg?branch=master)](https://travis-ci.org/TokTok/c-toxcore) [![Coverage Status](https://coveralls.io/repos/github/TokTok/toxcore/badge.svg?branch=master)](https://coveralls.io/github/TokTok/toxcore?branch=master) [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/tox)
+[![Build Status](https://travis-ci.org/TokTok/c-toxcore.svg?branch=master)](https://travis-ci.org/TokTok/c-toxcore) [![Coverage Status](https://coveralls.io/repos/github/TokTok/toxcore/badge.svg?branch=master)](https://coveralls.io/github/TokTok/toxcore?branch=master) [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/tox) [![IRC Network](https://img.shields.io/badge/irc-freenode-blue.svg "IRC Freenode")](https://webchat.freenode.net/?channels=tox,toktok)
 
 [**Website**](https://tox.chat) **|** [**Wiki**](https://wiki.tox.chat/) **|** [**Blog**](https://blog.tox.chat/) **|** [**FAQ**](https://wiki.tox.chat/doku.php?id=users:faq) **|** [**Binaries/Downloads**](https://wiki.tox.chat/Binaries) **|** [**Clients**](https://wiki.tox.chat/doku.php?id=clients) **|** [**Compiling**](/INSTALL.md) **|** [**Toxcore's Projects**](https://github.com/TokTok/c-toxcore/projects)
 
@@ -33,8 +33,8 @@ describes what can happen if your secret key is stolen).
 The roadmap and changelog are generated from GitHub issues. You may view them
 on the website, where they are updated at least once every 24 hours:
 
--   Changelog: https://toktok.ltd/changelog/c-toxcore
--   Roadmap: https://toktok.ltd/roadmap/c-toxcore
+* Changelog: https://toktok.ltd/changelog/c-toxcore
+* Roadmap: https://toktok.ltd/roadmap/c-toxcore
 
 ## Installing toxcore
 
@@ -170,5 +170,5 @@ the API documentation in [toxcore/tox.h](toxcore/tox.h) for more information.
 
 ### Other resources
 
-- [Another echo bot](https://wiki.tox.chat/developers/client_examples/echo_bot)
-- [minitox](https://github.com/hqwrong/minitox) (A minimal tox client)
+* [Another echo bot](https://wiki.tox.chat/developers/client_examples/echo_bot)
+* [minitox](https://github.com/hqwrong/minitox) (A minimal tox client)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ![Project Tox](https://raw.github.com/TokTok/toxcore/master/other/tox.png "Project Tox")
 
-**Current build status:** [![Build Status](https://travis-ci.org/TokTok/c-toxcore.svg?branch=master)](https://travis-ci.org/TokTok/c-toxcore)
-**Current Coverage:** [![Coverage Status](https://coveralls.io/repos/github/TokTok/toxcore/badge.svg?branch=master)](https://coveralls.io/github/TokTok/toxcore?branch=master)
+[![Build Status](https://travis-ci.org/TokTok/c-toxcore.svg?branch=master)](https://travis-ci.org/TokTok/c-toxcore) [![Coverage Status](https://coveralls.io/repos/github/TokTok/toxcore/badge.svg?branch=master)](https://coveralls.io/github/TokTok/toxcore?branch=master) [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/tox)
 
 [**Website**](https://tox.chat) **|** [**Wiki**](https://wiki.tox.chat/) **|** [**Blog**](https://blog.tox.chat/) **|** [**FAQ**](https://wiki.tox.chat/doku.php?id=users:faq) **|** [**Binaries/Downloads**](https://wiki.tox.chat/Binaries) **|** [**Clients**](https://wiki.tox.chat/doku.php?id=clients) **|** [**Compiling**](/INSTALL.md) **|** [**Toxcore's Projects**](https://github.com/TokTok/c-toxcore/projects)
 
-**IRC Channels:** Users: [#tox@freenode](https://webchat.freenode.net/?channels=tox), Developers: [#toktok@freenode](https://webchat.freenode.net/?channels=toktok)
+**IRC Channels:** Users: [#tox@freenode](https://webchat.freenode.net/?channels=tox), Developers: [#toktok@freenode](https://webchat.freenode.net/?channels=toktok)  
+**Spectrum community:** https://spectrum.chat/tox
 
 ## What is Tox
 


### PR DESCRIPTION
I'm currently working very hard on Tox's rebranding, to make it more « sexy » and « appealing » and this is one of the steps required.

I tought it would be cool to have a sort of message board mixed with chat and found Spectrum that looks really interesting. I've always wanted to setup a forum/chat for Tox's community (@grayhatter too iirc) and finally made it!

This PR scope is adding badge + link to the community to make it more discoverable.
I'll open a PR on the toktok.ltd / tox.chat websites too.

IMHO, this doesn't duplicate IRC community and should allows non tech-savvy people to enter the great community that Tox is. The only thing required is to spread the wor(l)d about this new place to discuss Tox's stuff!

I hope you'll like this! :yum:

Oh and feel free to join us on Spectrum too! https://spectrum.chat/tox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/829)
<!-- Reviewable:end -->
