### PR TITLE
Don't set RTP_LARGE_FRAME on rtp audio packets

### DIFF
--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -770,7 +770,9 @@ int rtp_send_data(RTPSession *session, const uint8_t *data, uint32_t length,
     // here the highest bits gets stripped anyway, no need to do keyframe bit magic here!
     header.data_length_lower = length;
 
-    header.flags = RTP_LARGE_FRAME;
+    if (session->payload_type == rtp_TypeVideo) {
+        header.flags = RTP_LARGE_FRAME;
+    }
 
     uint16_t length_safe = (uint16_t)length;
 


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is <img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/832)
<!-- Reviewable:end -->

From @zoff99's code.
See discussion in #812.