### PR TITLE
Fix coveralls reporting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
   - stage: "Stage 1"
     env: JOB=toxcore ENV=linux
-    compiler: clang
+    compiler: gcc
     addons:
       apt: &apt-dependencies
         packages:
@@ -26,7 +26,7 @@ matrix:
   - stage: "Stage 1"
     if: type IN (push, api, cron)
     env: JOB=autotools ENV=linux
-    compiler: gcc
+    compiler: clang
     addons:
       apt: *apt-dependencies
   - stage: "Stage 1"

--- a/other/travis/toxcore-linux-install
+++ b/other/travis/toxcore-linux-install
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Install cpp-coveralls to upload test coverage results.
-pip install --user urllib3[secure] cpp-coveralls
+pip install --user ndg-httpsclient urllib3[secure] cpp-coveralls
 
 # Work around https://github.com/eddyxu/cpp-coveralls/issues/108 by manually
 # installing the pyOpenSSL module and injecting it into urllib3 as per


### PR DESCRIPTION
The new clang version makes gcov segfault. Also, coveralls needs another
package that it doesn't install the right version of by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/845)
<!-- Reviewable:end -->
