### PR TITLE
bugfix build error on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,11 @@ if(ASAN)
 else()
   # Forbid undefined symbols in shared libraries. This is incompatible with
   # asan, so it's in the else branch here.
-  add_dllflag("-Wl,-z,defs")
+  if(APPLE)
+    add_dllflag("-undefined error")
+  else()
+    add_dllflag("-Wl,-z,defs")
+  endif()
 endif()
 
 option(USE_IPV6 "Use IPv6 in tests" ON)


### PR DESCRIPTION
this pr fix the error when `make` on macosx:

> mkdir _builds && cd _builds
> cmake ..
> make
 
get
> ld: unknown option: -z
> clang: error: linker command failed with exit code 1 (use -v to see invocation)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/852)
<!-- Reviewable:end -->
