### PR TITLE
Add TOX_CONNECTION_UNKNOWN to enum

### DIFF
--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -961,6 +961,11 @@ typedef enum TOX_CONNECTION {
      * particular friend was built using direct UDP packets.
      */
     TOX_CONNECTION_UDP,
+    
+    /**
+     * For a friend, this means that friend is offline
+     */
+    TOX_CONNECTION_UNKNOWN,
 
 } TOX_CONNECTION;
 


### PR DESCRIPTION
`tox_friend_get_connection_status()` returns whatever [m_get_friend_connectionstatus](https://github.com/TokTok/c-toxcore/blob/master/toxcore/Messenger.c#L444) returns. When a friend is offline and you call `tox_friend_get_connection_status()`, it returns the value 3 (CONNECTION_UNKNOWN) which is not a valid [TOX_CONNECTION](https://github.com/TokTok/c-toxcore/blob/master/toxcore/tox.h#L939) value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/853)
<!-- Reviewable:end -->
