### PR TITLE
CMake warn if libconfig not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,7 +544,10 @@ if(BOOTSTRAP_DAEMON AND WIN32)
   set(BOOTSTRAP_DAEMON OFF)
 endif()
 if(BOOTSTRAP_DAEMON)
-  if(LIBCONFIG_FOUND)
+  if(NOT LIBCONFIG_FOUND)
+    message(WARNING "Option BOOTSTRAP_DAEMON is enabled but required library LIBCONFIG was not found.")
+    set(BOOTSTRAP_DAEMON OFF)
+  else()
     add_executable(tox-bootstrapd ${CPUFEATURES}
       other/bootstrap_daemon/src/command_line_arguments.c
       other/bootstrap_daemon/src/command_line_arguments.h


### PR DESCRIPTION
When configuring with CMake with enabled option `BUILD_TOXAV` it warns if required libraries are missing, so I can read logs and understand why something went wrong:

```
CMake Warning at CMakeLists.txt:202 (message):
  Option BUILD_TOXAV is enabled but required library OPUS was not found.
CMake Warning at CMakeLists.txt:206 (message):
  Option BUILD_TOXAV is enabled but required library VPX was not found.
```

When `libconfig` is missing and option `BOOTSTRAP_DAEMON` is enabled CMake silently succeeds configuration, but `tox-bootstrapd` will not be built. I spent a few hours to understand why I don't have `tox-bootstrapd` during my CI execution. I've changed CMakeLists to display the warning:

```
CMake Warning at CMakeLists.txt:548 (message):
  Option BOOTSTRAP_DAEMON is enabled but required library LIBCONFIG was not
  found.
```

I'm sure this small change is very useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/864)
<!-- Reviewable:end -->
