### PR TITLE
Fix LAN discovery when UDP is disabled

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1989,11 +1989,12 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
 
     unsigned int net_err = 0;
 
+    IP ip;
+    ip_init(&ip, options->ipv6enabled);
+
     if (options->udp_disabled) {
-        m->net = new_networking_no_udp(m->log);
+        m->net = new_networking_no_udp(m->log, ip);
     } else {
-        IP ip;
-        ip_init(&ip, options->ipv6enabled);
         m->net = new_networking_ex(m->log, ip, options->port_range[0], options->port_range[1], &net_err);
     }
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -839,7 +839,7 @@ Networking_Core *new_networking_ex(Logger *log, IP ip, uint16_t port_from, uint1
     return nullptr;
 }
 
-Networking_Core *new_networking_no_udp(Logger *log)
+Networking_Core *new_networking_no_udp(Logger *log, IP ip)
 {
     /* this is the easiest way to completely disable UDP without changing too much code. */
     Networking_Core *net = (Networking_Core *)calloc(1, sizeof(Networking_Core));
@@ -848,7 +848,13 @@ Networking_Core *new_networking_no_udp(Logger *log)
         return nullptr;
     }
 
+    if (ip.family != TOX_AF_INET && ip.family != TOX_AF_INET6) {
+        LOGGER_ERROR(log, "Invalid address family: %u\n", ip.family);
+        return nullptr;
+    }
+
     net->log = log;
+    net->family = ip.family;
 
     return net;
 }

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -416,7 +416,7 @@ int bind_to_port(Socket sock, int family, uint16_t port);
  */
 Networking_Core *new_networking(Logger *log, IP ip, uint16_t port);
 Networking_Core *new_networking_ex(Logger *log, IP ip, uint16_t port_from, uint16_t port_to, unsigned int *error);
-Networking_Core *new_networking_no_udp(Logger *log);
+Networking_Core *new_networking_no_udp(Logger *log, IP ip);
 
 /* Function to cleanup networking stuff (doesn't do much right now). */
 void kill_networking(Networking_Core *net);


### PR DESCRIPTION
Before, LAN discovery could not send broadcast packets when UDP was disabled, because INET family was not set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/866)
<!-- Reviewable:end -->
