### PR TITLE
Improve network error reporting on Windows

### DIFF
--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -38,7 +38,10 @@ START_TEST(test_addr_resolv_localhost)
 
     int res = addr_resolve(localhost, &ip, nullptr);
 
-    ck_assert_msg(res > 0, "Resolver failed: %u, %s", errno, strerror(errno));
+    int error = net_error();
+    const char *strerror = net_new_strerror(error);
+    ck_assert_msg(res > 0, "Resolver failed: %d, %s", error, strerror);
+    net_kill_strerror(strerror);
 
     char ip_str[IP_NTOA_LEN];
     ck_assert_msg(ip.family == TOX_AF_INET, "Expected family TOX_AF_INET, got %u.", ip.family);
@@ -54,7 +57,10 @@ START_TEST(test_addr_resolv_localhost)
         localhost_split = 1;
     }
 
-    ck_assert_msg(res > 0, "Resolver failed: %u, %s", errno, strerror(errno));
+    error = net_error();
+    strerror = net_new_strerror(error);
+    ck_assert_msg(res > 0, "Resolver failed: %d, %s", error, strerror);
+    net_kill_strerror(strerror);
 
     ck_assert_msg(ip.family == TOX_AF_INET6, "Expected family TOX_AF_INET6 (%u), got %u.", TOX_AF_INET6, ip.family);
     IP6 ip6_loopback = get_ip6_loopback();
@@ -71,7 +77,10 @@ START_TEST(test_addr_resolv_localhost)
     IP extra;
     ip_reset(&extra);
     res = addr_resolve(localhost, &ip, &extra);
-    ck_assert_msg(res > 0, "Resolver failed: %u, %s", errno, strerror(errno));
+    error = net_error();
+    strerror = net_new_strerror(error);
+    ck_assert_msg(res > 0, "Resolver failed: %d, %s", error, strerror);
+    net_kill_strerror(strerror);
 
 #if USE_IPV6
     ck_assert_msg(ip.family == TOX_AF_INET6, "Expected family TOX_AF_INET6 (%u), got %u.", TOX_AF_INET6, ip.family);
@@ -156,6 +165,8 @@ END_TEST
 static Suite *network_suite(void)
 {
     Suite *s = suite_create("Network");
+
+    networking_at_startup();
 
     DEFTESTCASE(addr_resolv_localhost);
     DEFTESTCASE(ip_equal);

--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -64,7 +64,6 @@ extern "C" {
 #include <opencv/highgui.h>
 
 #include <assert.h>
-#include <errno.h>
 #include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -145,8 +145,10 @@ void send_update(BWController *bwc)
             msg->recv = net_htonl(bwc->cycle.recv);
 
             if (-1 == m_send_custom_lossy_packet(bwc->m, bwc->friend_number, bwc_packet, sizeof(bwc_packet))) {
-                LOGGER_WARNING(bwc->m->log, "BWC send failed (len: %u)! std error: %s",
-                               (unsigned)sizeof(bwc_packet), strerror(errno));
+                const char *netstrerror = net_new_strerror(net_error());
+                LOGGER_WARNING(bwc->m->log, "BWC send failed (len: %u)! std error: %s, net error %s",
+                               (unsigned)sizeof(bwc_packet), strerror(errno), netstrerror);
+                net_kill_strerror(netstrerror);
             }
         }
 

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -802,8 +802,10 @@ int rtp_send_data(RTPSession *session, const uint8_t *data, uint32_t length,
         memcpy(rdata + 1 + RTP_HEADER_SIZE, data, length);
 
         if (-1 == m_send_custom_lossy_packet(session->m, session->friend_number, rdata, SIZEOF_VLA(rdata))) {
-            LOGGER_WARNING(session->m->log, "RTP send failed (len: %u)! std error: %s",
-                           (unsigned)SIZEOF_VLA(rdata), strerror(errno));
+            const char *netstrerror = net_new_strerror(net_error());
+            LOGGER_WARNING(session->m->log, "RTP send failed (len: %u)! std error: %s, net error: %s",
+                           (unsigned)SIZEOF_VLA(rdata), strerror(errno), netstrerror);
+            net_kill_strerror(netstrerror);
         }
     } else {
         /**
@@ -819,8 +821,10 @@ int rtp_send_data(RTPSession *session, const uint8_t *data, uint32_t length,
 
             if (-1 == m_send_custom_lossy_packet(session->m, session->friend_number,
                                                  rdata, piece + RTP_HEADER_SIZE + 1)) {
-                LOGGER_WARNING(session->m->log, "RTP send failed (len: %d)! std error: %s",
-                               piece + RTP_HEADER_SIZE + 1, strerror(errno));
+                const char *netstrerror = net_new_strerror(net_error());
+                LOGGER_WARNING(session->m->log, "RTP send failed (len: %d)! std error: %s, net error: %s",
+                               piece + RTP_HEADER_SIZE + 1, strerror(errno), netstrerror);
+                net_kill_strerror(netstrerror);
             }
 
             sent += piece;
@@ -837,8 +841,10 @@ int rtp_send_data(RTPSession *session, const uint8_t *data, uint32_t length,
 
             if (-1 == m_send_custom_lossy_packet(session->m, session->friend_number, rdata,
                                                  piece + RTP_HEADER_SIZE + 1)) {
-                LOGGER_WARNING(session->m->log, "RTP send failed (len: %d)! std error: %s",
-                               piece + RTP_HEADER_SIZE + 1, strerror(errno));
+                const char *netstrerror = net_new_strerror(net_error());
+                LOGGER_WARNING(session->m->log, "RTP send failed (len: %d)! std error: %s, net error: %s",
+                               piece + RTP_HEADER_SIZE + 1, strerror(errno), netstrerror);
+                net_kill_strerror(netstrerror);
             }
         }
     }

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -404,6 +404,34 @@ void net_freeipport(IP_Port *ip_ports);
  */
 int bind_to_port(Socket sock, int family, uint16_t port);
 
+/* Get the last networking error code.
+ *
+ * Similar to Unix's errno, but cross-platform, as not all platforms use errno
+ * to indicate networking errors.
+ *
+ * Note that different platforms may return different codes for the same error,
+ * so you likely shouldn't be checking the value returned by this function
+ * unless you know what you are doing, you likely just want to use it in
+ * combination with net_new_strerror() to print the error.
+ *
+ * return platform-dependent network error code, if any.
+ */
+int net_error(void);
+
+/* Get a text explanation for the error code from net_error().
+ *
+ * return NULL on failure.
+ * return pointer to a NULL-terminated string describing the error code on
+ * success. The returned string must be freed using net_kill_strerror().
+ */
+const char *net_new_strerror(int error);
+
+/* Frees the string returned by net_new_strerror().
+ * It's valid to pass NULL as the argument, the function does nothing in this
+ * case.
+ */
+void net_kill_strerror(const char *strerror);
+
 /* Initialize networking.
  * bind to ip and port.
  * ip must be in network order EX: 127.0.0.1 = (7F000001).


### PR DESCRIPTION
Windows doesn't report network errors though errno, it has its own facilities.

Not sure if the `new` and `kill` are the correct words here, toxcore seems to use them for `alloc` and `free`, so I'm just following the pattern.

This should fix the `Unexpected error reading from socket: 0, No error` error on Windows, which someone on IRC supposedly got 60000 times in 10 seconds. The issue was in

```C
int fail_or_len = recvfrom(sock, (char *) data, MAX_UDP_PACKET_SIZE, 0, (struct sockaddr *)&addr, &addrlen);
if (fail_or_len < 0 && errno != EWOULDBLOCK) {
    LOGGER_ERROR(log, "Unexpected error reading from socket: %u, %s", errno, strerror(errno));
}
```

Because Windows doesn't use `errno` for error reporting, Windows was reporting  `EWOULDBLOCK` through `WSAGetLastError()` instead of `errno`, resulting in the logger being called when it shouldn't had been.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/867)
<!-- Reviewable:end -->
