### PR TITLE
Make bootstrap daemon use toxcore's version

### DIFF
--- a/other/bootstrap_daemon/src/global.h
+++ b/other/bootstrap_daemon/src/global.h
@@ -25,8 +25,33 @@
 #ifndef GLOBAL_H
 #define GLOBAL_H
 
+#include "../../../toxcore/tox.h"
+
 #define DAEMON_NAME "tox-bootstrapd"
-#define DAEMON_VERSION_NUMBER 2016010100UL // yyyymmmddvv format: yyyy year, mm month, dd day, vv version change count for that day
+
+#define DAEMON_VERSION_MAJOR TOX_VERSION_MAJOR
+#define DAEMON_VERSION_MINOR TOX_VERSION_MINOR
+#define DAEMON_VERSION_PATCH TOX_VERSION_PATCH
+
+// Make sure versions are within the limit
+#define VERSION_IS_OK(NUM) ( NUM >= 0 && NUM <= 999 )
+#if !VERSION_IS_OK(DAEMON_VERSION_MAJOR) || !VERSION_IS_OK(DAEMON_VERSION_MINOR) || !VERSION_IS_OK(DAEMON_VERSION_PATCH)
+#error "At least one of major, minor or patch parts of the version is out of bounds of [0, 999]. Current version: " DAEMON_VERSION_MAJOR "." DAEMON_VERSION_MINOR "." DAEMON_VERSION_PATCH
+#endif
+#undef VERSION_IS_OK
+
+// New version scheme of 1AAABBBCCC, where A B and C are major, minor and patch
+// versions of toxcore. The leading 1 is there just to keep the leading zeros,
+// so that it would be easier to read the version when printed as a number.
+// The version is in a visual decimal format rather than in any other format,
+// because the original version was using a similar format, it was using
+// YYYYMMDDVV date-based format for the version, with VV being an incremental
+// counter in case more than one version was released at that day. Due to this
+// some tools started showing the version to users as a plain number, rather
+// than some binary format that needs to be parsed before being shown to users
+// so we decided to keep this display format compatibility and adopted this
+// weird scheme with a leading 1.
+#define DAEMON_VERSION_NUMBER 1000000000UL + DAEMON_VERSION_MAJOR*1000000UL + DAEMON_VERSION_MINOR*1000UL + DAEMON_VERSION_PATCH*1UL
 
 #define MIN_ALLOWED_PORT 1
 #define MAX_ALLOWED_PORT 65535


### PR DESCRIPTION
I have wanted to make the daemon report toxcore's version for quite a bit now, and here I finally I got around to doing this. The main motivation for this was the onion vulnerability https://github.com/TokTok/c-toxcore/issues/873. To fix the vulnerability, all DHT nodes should be updated to the new upcoming toxcore version. Reporting toxcore version in the bootstrap daemon would enable us to see at the very least if the bootstrap nodes are updated, my main interest being the the nodes that are listed on the https://nodes.tox.chat page which displays the daemon version of the nodes.

The daemon version is just a `uint32_t`, there is not much you can encode in 4 bytes. I have been thinking of packing the toxcore version into that `uint32_t`, 1 byte for major, 1 byte for minor, 1 byte for patch and 1 byte for misc: bit indicating that this is a new version scheme, a bit indicating that the daemon was build using a release checkpoint of toxcore rather than an in-development (there might be big differences between 2.x.y release and the same 2.x.y right before the version bump, containing all the changes for the next version). Such version encoding would be inconsistent with the previous one of `YYYYMMDD`, which you could print out as an number to show the version to the user, which is what nodes.tox.chat and a few other scrips do. With the packed version encoding the version would need to be decoded first, if you print the `uint32_t` as it is, it won't make sense. So to keep the compatibility with the way the daemon version is being printed by others I settled on a `1AAABBBCCC` format, where `AAA` is the major version, `BBB` is the minor version and `CCC` is the patch version, all capped at 999. The leading 1 is just so that the leading zeros wouldn't get removed when printing it as a number, e.g. instead of `0.2.1` being printed as `2001`, it would be printed as `1000002001`, i.e. 000.002.001.