### PR TITLE
Fix FreeBSD build on Travis

### DIFF
--- a/other/travis/freebsd-install
+++ b/other/travis/freebsd-install
@@ -21,6 +21,7 @@
 # package updates, and we do incremental system and package updates on every
 # change to the list of git tags (i.e. on every toxcore release, presumably).
 
+sudo apt-get update
 sudo apt-get install -y qemu
 
 OLD_PWD="$PWD"


### PR DESCRIPTION
FreeBSD build on Travis-CI has been failing lately:

```
+sudo apt-get install -y qemu
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
The following packages have unmet dependencies:
 qemu : Depends: qemu-system (>= 2.0.0+dfsg-2ubuntu1.36)
        Depends: qemu-utils (>= 2.0.0+dfsg-2ubuntu1.36)
E: Unable to correct problems, you have held broken packages.
```

This probably has to do with the next following new message popping up:

```
Running apt-get update by default has been disabled.
You can opt into running apt-get update by setting this in your .travis.yml file:
  addons:
    apt:
      update: true
```

So let's try running `apt-get update` and see if it fixes things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/887)
<!-- Reviewable:end -->
