### PR TITLE
Feature bootstrap trace/debug log output

### DIFF
--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -94,6 +94,40 @@ static void manage_keys(DHT *dht)
     fclose(keys_file);
 }
 
+static void print_log(void *context, Logger_Level level, const char *file, int line,
+                      const char *func, const char *message, void *userdata)
+{
+    char *strlevel;
+
+    switch (level) {
+        case LOGGER_LEVEL_TRACE:
+            strlevel = "TRACE";
+            break;
+
+        case LOGGER_LEVEL_DEBUG:
+            strlevel = "DEBUG";
+            break;
+
+        case LOGGER_LEVEL_INFO:
+            strlevel = "INFO";
+            break;
+
+        case LOGGER_LEVEL_WARNING:
+            strlevel = "WARNING";
+            break;
+
+        case LOGGER_LEVEL_ERROR:
+            strlevel = "ERROR";
+            break;
+
+        default:
+            strlevel = "<unknown>";
+            break;
+    }
+
+    fprintf(stderr, "[%s] %s:%d(%s) %s\n", strlevel, file, line, func, message);
+}
+
 int main(int argc, char *argv[])
 {
     if (argc == 2 && !tox_strncasecmp(argv[1], "-h", 3)) {
@@ -116,6 +150,11 @@ int main(int argc, char *argv[])
     ip_init(&ip, ipv6enabled);
 
     Logger *logger = logger_new();
+
+    if (MIN_LOGGER_LEVEL == LOGGER_LEVEL_TRACE || MIN_LOGGER_LEVEL == LOGGER_LEVEL_DEBUG) {
+        logger_callback_log(logger, print_log, nullptr, nullptr);
+    }
+
     Mono_Time *mono_time = mono_time_new();
     DHT *dht = new_dht(logger, mono_time, new_networking(logger, ip, PORT), true);
     Onion *onion = new_onion(mono_time, dht);

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -97,7 +97,7 @@ static void manage_keys(DHT *dht)
 static void print_log(void *context, Logger_Level level, const char *file, int line,
                       const char *func, const char *message, void *userdata)
 {
-    char *strlevel;
+    const char *strlevel;
 
     switch (level) {
         case LOGGER_LEVEL_TRACE:

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -178,6 +178,44 @@ static void daemonize(LOG_BACKEND log_backend, char *pid_file_path)
     }
 }
 
+void print_log(void *context, LOGGER_LEVEL level, const char *file, int line,
+               const char *func, const char *message, void *userdata)
+{
+    if (MIN_LOGGER_LEVEL != LOG_TRACE && MIN_LOGGER_LEVEL != LOG_DEBUG) {
+        return;
+    }
+
+    char *strlevel;
+
+    switch (level) {
+        case LOG_TRACE:
+            strlevel = "TRACE";
+            break;
+
+        case LOG_DEBUG:
+            strlevel = "DEBUG";
+            break;
+
+        case LOG_INFO:
+            strlevel = "INFO";
+            break;
+
+        case LOG_WARNING:
+            strlevel = "WARNING";
+            break;
+
+        case LOG_ERROR:
+            strlevel = "ERROR";
+            break;
+
+        default:
+            strlevel = "<unknown>";
+            break;
+    }
+
+    fprintf(stderr, "[%s] %s:%d(%s) %s\n", strlevel, file, line, func, message);
+}
+
 int main(int argc, char *argv[])
 {
     umask(077);
@@ -231,6 +269,7 @@ int main(int argc, char *argv[])
     ip_init(&ip, enable_ipv6);
 
     Logger *logger = logger_new();
+    logger_callback_log(logger, print_log, nullptr, nullptr);
 
     Networking_Core *net = new_networking(logger, ip, port);
 

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -178,42 +178,40 @@ static void daemonize(LOG_BACKEND log_backend, char *pid_file_path)
     }
 }
 
-void print_log(void *context, LOGGER_LEVEL level, const char *file, int line,
-               const char *func, const char *message, void *userdata)
-{
-    if (MIN_LOGGER_LEVEL != LOG_TRACE && MIN_LOGGER_LEVEL != LOG_DEBUG) {
-        return;
-    }
+// Logs toxcore logger message using our logger facility
 
-    char *strlevel;
+static void toxcore_logger_callback(void *context, Logger_Level level, const char *file, int line,
+                                    const char *func, const char *message, void *userdata)
+{
+    LOG_LEVEL log_level;
 
     switch (level) {
-        case LOG_TRACE:
-            strlevel = "TRACE";
+        case LOGGER_LEVEL_TRACE:
+            log_level = LOG_LEVEL_INFO;
             break;
 
-        case LOG_DEBUG:
-            strlevel = "DEBUG";
+        case LOGGER_LEVEL_DEBUG:
+            log_level = LOG_LEVEL_INFO;
             break;
 
-        case LOG_INFO:
-            strlevel = "INFO";
+        case LOGGER_LEVEL_INFO:
+            log_level = LOG_LEVEL_INFO;
             break;
 
-        case LOG_WARNING:
-            strlevel = "WARNING";
+        case LOGGER_LEVEL_WARNING:
+            log_level = LOG_LEVEL_WARNING;
             break;
 
-        case LOG_ERROR:
-            strlevel = "ERROR";
+        case LOGGER_LEVEL_ERROR:
+            log_level = LOG_LEVEL_ERROR;
             break;
 
         default:
-            strlevel = "<unknown>";
+            log_level = LOG_LEVEL_INFO;
             break;
     }
 
-    fprintf(stderr, "[%s] %s:%d(%s) %s\n", strlevel, file, line, func, message);
+    log_write(log_level, "%s:%d(%s) %s\n", file, line, func, message);
 }
 
 int main(int argc, char *argv[])
@@ -269,7 +267,10 @@ int main(int argc, char *argv[])
     ip_init(&ip, enable_ipv6);
 
     Logger *logger = logger_new();
-    logger_callback_log(logger, print_log, nullptr, nullptr);
+
+    if (MIN_LOGGER_LEVEL == LOGGER_LEVEL_TRACE || MIN_LOGGER_LEVEL == LOGGER_LEVEL_DEBUG) {
+        logger_callback_log(logger, toxcore_logger_callback, nullptr, nullptr);
+    }
 
     Networking_Core *net = new_networking(logger, ip, port);
 


### PR DESCRIPTION
A meanful logger for bootstrap. It outputs trace or debug log only.

* Build with default options, the bootstrap outputs nothing more.

* Build with `DEBUG=ON`, `tox-bootstrapd` outputs as,

    ```
    Running "tox-bootstrapd" version 2016010100.
    Successfully read:
    ...
    General config read successfully
    [DEBUG] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:959(new_networking_ex) Bound successfully to 0.0.0.0:33445
    Set MOTD successfully.
    Keys are managed successfully.
    Initialized Tox TCP server successfully.
    Successfully added bootstrap node #0: node.tox.biribiri.org:33445 F404ABAA1C99A9D37D61AB54898F56793E1DEF8BD46B1038B9D822E8460FAB67
    List of bootstrap nodes read successfully.
    Public Key: F5B0095E6C4AD95A3C1B87C452DF6427C3CB2D2A12135B9EBDDE1A979668811E
    Initialized LAN discovery successfully.
    Connected to another bootstrap node successfully.
    [ERROR] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:562(sendpacket) attempted to send message with network family 0 (probably IPv6) on IPv4 socket
    [ERROR] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:562(sendpacket) attempted to send message with network family 0 (probably IPv6) on IPv4 socket
    [ERROR] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:562(sendpacket) attempted to send message with network family 0 (probably IPv6) on IPv4 socket
    ...
    ```

* Build with `TRACE=ON`, `tox-bootstrapd` outputs as,

    ```
    Running "tox-bootstrapd" version 2016010100.
    Successfully read:
    ...
    General config read successfully
    [DEBUG] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:959(new_networking_ex) Bound successfully to 0.0.0.0:33445
    Set MOTD successfully.
    Keys are managed successfully.
    Initialized Tox TCP server successfully.
    [TRACE] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:515(loglogdata) [ 2] O=> 113= 67.215.253.85:33445 (0: OK) | f5b0095e6c4ad95a
    Successfully added bootstrap node #0: node.tox.biribiri.org:33445 F404ABAA1C99A9D37D61AB54898F56793E1DEF8BD46B1038B9D822E8460FAB67
    List of bootstrap nodes read successfully.
    Public Key: F5B0095E6C4AD95A3C1B87C452DF6427C3CB2D2A12135B9EBDDE1A979668811E
    Initialized LAN discovery successfully.
    [TRACE] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:515(loglogdata) [33] O=>  33= 192.168.0.255:33445 (0: OK) | f5b0095e6c4ad95a
    [TRACE] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:515(loglogdata) [33] O=>  33= 172.17.255.255:33445 (0: OK) | f5b0095e6c4ad95a
    [TRACE] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:515(loglogdata) [33] O=>  33= 192.168.100.255:33445 (0: OK) | f5b0095e6c4ad95a
    [TRACE] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:515(loglogdata) [33] O=>  33= 192.168.122.255:33445 (0: OK) | f5b0095e6c4ad95a
    [TRACE] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:515(loglogdata) [33] O=>  33= 255.255.255.255:33445 (0: OK) | f5b0095e6c4ad95a
    [TRACE] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:515(loglogdata) [33] =>O  33< 192.168.0.63:33445 (0: OK) | f5b0095e6c4ad95a
    [TRACE] /home/cotox/tox-stuff/c-toxcore/toxcore/network.c:515(loglogdata) [33] =>O  33< 172.17.0.1:33445 (0: OK) | f5b0095e6c4ad95a
    ...
    ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/895)
<!-- Reviewable:end -->
