### PR TITLE
Add error code for tox_new to reject proxy+udp.

### DIFF
--- a/auto_tests/invalid_proxy_test.c
+++ b/auto_tests/invalid_proxy_test.c
@@ -1,17 +1,10 @@
-// Test that if UDP is enabled, and an invalid proxy is provided, then we get a
-// UDP connection only.
+// Test that if UDP is enabled, and a invalid proxy is provided, we reject the
+// configuration.
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
 #endif
 
 #include "helpers.h"
-
-static uint8_t const key[] = {
-    0x15, 0xE9, 0xC3, 0x09, 0xCF, 0xCB, 0x79, 0xFD,
-    0xDF, 0x0E, 0xBA, 0x05, 0x7D, 0xAB, 0xB4, 0x9F,
-    0xE1, 0x5F, 0x38, 0x03, 0xB1, 0xBF, 0xF0, 0x65,
-    0x36, 0xAE, 0x2E, 0x5B, 0xA5, 0xE4, 0x69, 0x0E,
-};
 
 int main(void)
 {
@@ -22,25 +15,12 @@ int main(void)
     tox_options_set_proxy_type(opts, TOX_PROXY_TYPE_SOCKS5);
     tox_options_set_proxy_host(opts, "localhost");
     tox_options_set_proxy_port(opts, 51724);
-    Tox *tox = tox_new_log(opts, nullptr, nullptr);
+    TOX_ERR_NEW err;
+    Tox *tox = tox_new_log(opts, &err, nullptr);
     tox_options_free(opts);
 
-    tox_add_tcp_relay(tox, "tox.ngc.zone", 33445, key, nullptr);
-    tox_bootstrap(tox, "tox.ngc.zone", 33445, key, nullptr);
+    assert(tox == nullptr);
+    assert(err == TOX_ERR_NEW_PROXY_WITH_UDP);
 
-    printf("Waiting for connection");
-
-    while (tox_self_get_connection_status(tox) == TOX_CONNECTION_NONE) {
-        printf(".");
-        fflush(stdout);
-
-        tox_iterate(tox, nullptr);
-        c_sleep(ITERATION_INTERVAL);
-    }
-
-    assert(tox_self_get_connection_status(tox) == TOX_CONNECTION_UDP);
-    printf("Connection (UDP): %d\n", tox_self_get_connection_status(tox));
-
-    tox_kill(tox);
     return 0;
 }

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -697,6 +697,13 @@ static this new(const options_t *options) {
      */
     BAD_FORMAT,
   }
+
+  /**
+   * UDP was enabled together with a proxy. This is a security issue, because
+   * UDP connections are never proxied. You must disable UDP in order to use a
+   * proxy.
+   */
+  PROXY_WITH_UDP,
 }
 
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -89,6 +89,11 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
     if (options == nullptr) {
         m_options.ipv6enabled = TOX_ENABLE_IPV6_DEFAULT;
     } else {
+        if (tox_options_get_udp_enabled(options) && tox_options_get_proxy_type(options) != TOX_PROXY_TYPE_NONE) {
+            SET_ERROR_PARAMETER(error, TOX_ERR_NEW_PROXY_WITH_UDP);
+            return nullptr;
+        }
+
         if (tox_options_get_savedata_type(options) != TOX_SAVEDATA_TYPE_NONE) {
             if (tox_options_get_savedata_data(options) == nullptr || tox_options_get_savedata_length(options) == 0) {
                 SET_ERROR_PARAMETER(error, TOX_ERR_NEW_LOAD_BAD_FORMAT);

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -822,6 +822,13 @@ typedef enum TOX_ERR_NEW {
      */
     TOX_ERR_NEW_LOAD_BAD_FORMAT,
 
+    /**
+     * UDP was enabled together with a proxy. This is a security issue, because
+     * UDP connections are never proxied. You must disable UDP in order to use a
+     * proxy.
+     */
+    TOX_ERR_NEW_PROXY_WITH_UDP,
+
 } TOX_ERR_NEW;
 
 


### PR DESCRIPTION
See https://github.com/qTox/qTox/issues/5174.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/929)
<!-- Reviewable:end -->
