### PR TITLE
Disable UDP when proxy is enabled.

### DIFF
--- a/auto_tests/invalid_proxy_test.c
+++ b/auto_tests/invalid_proxy_test.c
@@ -1,5 +1,5 @@
-// Test that if UDP is enabled, and an invalid proxy is provided, then we get a
-// UDP connection only.
+// Test that if UDP is enabled, and a proxy is provided that does not support
+// UDP proxying, we disable UDP.
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
 #endif
@@ -12,6 +12,9 @@ static uint8_t const key[] = {
     0xE1, 0x5F, 0x38, 0x03, 0xB1, 0xBF, 0xF0, 0x65,
     0x36, 0xAE, 0x2E, 0x5B, 0xA5, 0xE4, 0x69, 0x0E,
 };
+
+// Try to bootstrap for 30 seconds.
+#define NUM_ITERATIONS (unsigned)(30.0 / (ITERATION_INTERVAL / 1000.0))
 
 int main(void)
 {
@@ -30,16 +33,12 @@ int main(void)
 
     printf("Waiting for connection");
 
-    while (tox_self_get_connection_status(tox) == TOX_CONNECTION_NONE) {
-        printf(".");
-        fflush(stdout);
-
+    for (unsigned i = 0; i < NUM_ITERATIONS; i++) {
         tox_iterate(tox, nullptr);
         c_sleep(ITERATION_INTERVAL);
+        // None of the iterations should have a connection.
+        assert(tox_self_get_connection_status(tox) == TOX_CONNECTION_NONE);
     }
-
-    assert(tox_self_get_connection_status(tox) == TOX_CONNECTION_UDP);
-    printf("Connection (UDP): %d\n", tox_self_get_connection_status(tox));
 
     tox_kill(tox);
     return 0;

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1993,6 +1993,12 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
 
     unsigned int net_err = 0;
 
+    if (!options->udp_disabled && options->proxy_info.proxy_type != TCP_PROXY_NONE) {
+        // We don't currently support UDP over proxy.
+        LOGGER_WARNING(m->log, "UDP enabled and proxy set: disabling UDP");
+        options->udp_disabled = true;
+    }
+
     if (options->udp_disabled) {
         m->net = new_networking_no_udp(m->log);
     } else {

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -473,7 +473,9 @@ static class options {
      *
      * Setting this to false will force Tox to use TCP only. Communications will
      * need to be relayed through a TCP relay node, potentially slowing them down.
-     * Disabling UDP support is necessary when using anonymous proxies or Tor.
+     *
+     * If a proxy is enabled, UDP will be disabled if either toxcore or the
+     * proxy don't support proxying UDP messages.
      */
     bool udp_enabled;
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -526,7 +526,9 @@ struct Tox_Options {
      *
      * Setting this to false will force Tox to use TCP only. Communications will
      * need to be relayed through a TCP relay node, potentially slowing them down.
-     * Disabling UDP support is necessary when using anonymous proxies or Tor.
+     *
+     * If a proxy is enabled, UDP will be disabled if either toxcore or the
+     * proxy don't support proxying UDP messages.
      */
     bool udp_enabled;
 


### PR DESCRIPTION
Currently, toxcore does not support UDP over proxies. In the future, we
can relax this by disabling UDP only if the proxy doesn't support it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/930)
<!-- Reviewable:end -->
