### PR TITLE
Avoid conditional-uninitialised warning for tcp test.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -58,7 +58,7 @@ START_TEST(test_basic)
     ck_assert_msg(tcp_server_listen_count(tcp_s) == NUM_PORTS,
                   "Failed to bind a TCP relay server to all %d attempted ports.", NUM_PORTS);
 
-    Socket sock;
+    Socket sock = {0};
 
     // Check all opened ports for connectivity.
     for (uint8_t i = 0; i < NUM_PORTS; i++) {


### PR DESCRIPTION
The C compiler warns because the value is initialised in a loop and used
outside of it. In this case, it's always initialised, but changing the
value of `NUM_PORTS` can change that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/931)
<!-- Reviewable:end -->
