### PR TITLE
Correct check for net_crypto packet index.

### DIFF
--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -727,7 +727,7 @@ static uint32_t num_packets_array(const Packets_Array *array)
  */
 static int add_data_to_buffer(const Logger *log, Packets_Array *array, uint32_t number, const Packet_Data *data)
 {
-    if (number - array->buffer_start > CRYPTO_PACKET_BUFFER_SIZE) {
+    if (number - array->buffer_start >= CRYPTO_PACKET_BUFFER_SIZE) {
         return -1;
     }
 


### PR DESCRIPTION
Current check allows to write one more packet than it should. Noticed this when implemented `net_crypto` module for [tox-rs](https://github.com/tox-rs/tox).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/943)
<!-- Reviewable:end -->
