### PR TITLE
Remove the format test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,19 +450,6 @@ unit_test(toxcore util)
 
 set(TEST_TIMEOUT_SECONDS "" CACHE STRING "Limit runtime of each test to the number of seconds specified")
 
-option(FORMAT_TEST "Require the format_test to be executed; fail cmake if it can't" OFF)
-
-if(ASTYLE)
-  add_test(
-    NAME format_test
-    COMMAND ${toxcore_SOURCE_DIR}/other/astyle/format-source
-      "${toxcore_SOURCE_DIR}"
-      "${ASTYLE}")
-  set_tests_properties(format_test PROPERTIES TIMEOUT "${TEST_TIMEOUT_SECONDS}")
-elseif(FORMAT_TEST)
-  message(FATAL_ERROR "format_test can not be run, because ASTYLE (${ASTYLE}) could not be found")
-endif()
-
 if(ANDROID_CPU_FEATURES)
   # We need to compile cpufeatures.c as many times as there are executables,
   # because libvpx doesn't include it although it depends on it. We can't get

--- a/other/travis/env-linux.sh
+++ b/other/travis/env-linux.sh
@@ -4,7 +4,6 @@ export PATH=/opt/ghc/7.8.4/bin:/opt/cabal/1.18/bin:/opt/alex/3.1.7/bin:/opt/happ
 export PATH=$HOME/.cabal/bin:$PATH
 
 CMAKE=cmake
-CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DFORMAT_TEST=ON"
 # Asan is disabled because it's currently broken on Travis.
 # See https://github.com/travis-ci/travis-ci/issues/9033.
 CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DASAN=OFF"

--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -43,3 +43,5 @@ RUN $MAKE -C$BUILD_DIR -j$NPROC -k install
 if $RUN_TESTS; then
   TESTS $MAX_TEST_RETRIES $MAKE -C$BUILD_DIR -j$NPROC test ARGS="-j50 --rerun-failed" CTEST_OUTPUT_ON_FAILURE="$CTEST_OUTPUT_ON_FAILURE"
 fi
+
+other/astyle/format-source . $ASTYLE


### PR DESCRIPTION
It's annoying to have a test touch every source file. It causes a
recompile of everything after every test run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/947)
<!-- Reviewable:end -->
