### PR TITLE
Proposal: Make arg `host` understand clearly.

### DIFF
--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -756,7 +756,7 @@ uint8_t[size] savedata {
  * This function will attempt to connect to the node using UDP. You must use
  * this function even if ${options.this.udp_enabled} was set to false.
  *
- * @param address The hostname or IP address (IPv4 or IPv6) of the node. Must be
+ * @param host The hostname or IP address (IPv4 or IPv6) of the node. Must be
  *   at most $MAX_HOSTNAME_LENGTH chars, including the NUL byte.
  * @param port The port on the host on which the bootstrap Tox instance is
  *   listening.
@@ -764,10 +764,10 @@ uint8_t[size] savedata {
  *   ($PUBLIC_KEY_SIZE bytes).
  * @return true on success.
  */
-bool bootstrap(string address, uint16_t port, const uint8_t[PUBLIC_KEY_SIZE] public_key) {
+bool bootstrap(string host, uint16_t port, const uint8_t[PUBLIC_KEY_SIZE] public_key) {
   NULL,
   /**
-   * The address could not be resolved to an IP address, or the IP address
+   * The hostname could not be resolved to an IP address, or the IP address
    * passed was invalid.
    */
   BAD_HOST,
@@ -785,13 +785,13 @@ bool bootstrap(string address, uint16_t port, const uint8_t[PUBLIC_KEY_SIZE] pub
  * the same bootstrap node, or to add TCP relays without using them as
  * bootstrap nodes.
  *
- * @param address The hostname or IP address (IPv4 or IPv6) of the TCP relay.
+ * @param host The hostname or IP address (IPv4 or IPv6) of the TCP relay.
  * @param port The port on the host on which the TCP relay is listening.
  * @param public_key The long term public key of the TCP relay
  *   ($PUBLIC_KEY_SIZE bytes).
  * @return true on success.
  */
-bool add_tcp_relay(string address, uint16_t port, const uint8_t[PUBLIC_KEY_SIZE] public_key)
+bool add_tcp_relay(string host, uint16_t port, const uint8_t[PUBLIC_KEY_SIZE] public_key)
     with error for bootstrap;
 
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -248,9 +248,9 @@ void tox_get_savedata(const Tox *tox, uint8_t *savedata)
     }
 }
 
-bool tox_bootstrap(Tox *tox, const char *address, uint16_t port, const uint8_t *public_key, TOX_ERR_BOOTSTRAP *error)
+bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key, TOX_ERR_BOOTSTRAP *error)
 {
-    if (!address || !public_key) {
+    if (!host || !public_key) {
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_NULL);
         return 0;
     }
@@ -262,7 +262,7 @@ bool tox_bootstrap(Tox *tox, const char *address, uint16_t port, const uint8_t *
 
     IP_Port *root;
 
-    int32_t count = net_getipport(address, &root, TOX_SOCK_DGRAM);
+    int32_t count = net_getipport(host, &root, TOX_SOCK_DGRAM);
 
     if (count == -1) {
         net_freeipport(root);
@@ -291,10 +291,10 @@ bool tox_bootstrap(Tox *tox, const char *address, uint16_t port, const uint8_t *
     return 0;
 }
 
-bool tox_add_tcp_relay(Tox *tox, const char *address, uint16_t port, const uint8_t *public_key,
+bool tox_add_tcp_relay(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key,
                        TOX_ERR_BOOTSTRAP *error)
 {
-    if (!address || !public_key) {
+    if (!host || !public_key) {
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_NULL);
         return 0;
     }
@@ -306,7 +306,7 @@ bool tox_add_tcp_relay(Tox *tox, const char *address, uint16_t port, const uint8
 
     IP_Port *root;
 
-    int32_t count = net_getipport(address, &root, TOX_SOCK_STREAM);
+    int32_t count = net_getipport(host, &root, TOX_SOCK_STREAM);
 
     if (count == -1) {
         net_freeipport(root);

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -905,7 +905,7 @@ typedef enum TOX_ERR_BOOTSTRAP {
     TOX_ERR_BOOTSTRAP_NULL,
 
     /**
-     * The address could not be resolved to an IP address, or the IP address
+     * The hostname could not be resolved to an IP address, or the IP address
      * passed was invalid.
      */
     TOX_ERR_BOOTSTRAP_BAD_HOST,
@@ -925,7 +925,7 @@ typedef enum TOX_ERR_BOOTSTRAP {
  * This function will attempt to connect to the node using UDP. You must use
  * this function even if Tox_Options.udp_enabled was set to false.
  *
- * @param address The hostname or IP address (IPv4 or IPv6) of the node. Must be
+ * @param host The hostname or IP address (IPv4 or IPv6) of the node. Must be
  *   at most TOX_MAX_HOSTNAME_LENGTH chars, including the NUL byte.
  * @param port The port on the host on which the bootstrap Tox instance is
  *   listening.
@@ -933,7 +933,7 @@ typedef enum TOX_ERR_BOOTSTRAP {
  *   (TOX_PUBLIC_KEY_SIZE bytes).
  * @return true on success.
  */
-bool tox_bootstrap(Tox *tox, const char *address, uint16_t port, const uint8_t *public_key, TOX_ERR_BOOTSTRAP *error);
+bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key, TOX_ERR_BOOTSTRAP *error);
 
 /**
  * Adds additional host:port pair as TCP relay.
@@ -942,14 +942,13 @@ bool tox_bootstrap(Tox *tox, const char *address, uint16_t port, const uint8_t *
  * the same bootstrap node, or to add TCP relays without using them as
  * bootstrap nodes.
  *
- * @param address The hostname or IP address (IPv4 or IPv6) of the TCP relay.
+ * @param host The hostname or IP address (IPv4 or IPv6) of the TCP relay.
  * @param port The port on the host on which the TCP relay is listening.
  * @param public_key The long term public key of the TCP relay
  *   (TOX_PUBLIC_KEY_SIZE bytes).
  * @return true on success.
  */
-bool tox_add_tcp_relay(Tox *tox, const char *address, uint16_t port, const uint8_t *public_key,
-                       TOX_ERR_BOOTSTRAP *error);
+bool tox_add_tcp_relay(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key, TOX_ERR_BOOTSTRAP *error);
 
 /**
  * Protocols that can be used to connect to the network or friends.


### PR DESCRIPTION
Rename args `host:port` from `address:port`.

The *address* is well known as *Tox Address* in this project. Then we
should reserve *addres* to it, and use *host* to express the hostname or
IP address in TCP domain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/954)
<!-- Reviewable:end -->
