### PR TITLE
Collect `PACKET_ID*` constants in `net_crypto.h`, cleanup their uses

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1856,6 +1856,13 @@ int m_callback_rtp_packet(Messenger *m, int32_t friendnumber, uint8_t byte, m_lo
 }
 
 
+/* TODO(oxij): this name is confusing, because this function sends both av and custom lossy packets.
+ * Meanwhile, m_handle_lossy_packet routes custom packets to custom_lossy_packet_registerhandler
+ * as you would expect from its name.
+ *
+ * I.e. custom_lossy_packet_registerhandler's "custom lossy packet" and this "custom lossy packet"
+ * are not the same set of packets.
+ */
 int m_send_custom_lossy_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint32_t length)
 {
     if (friend_not_valid(m, friendnumber)) {
@@ -1866,6 +1873,7 @@ int m_send_custom_lossy_packet(const Messenger *m, int32_t friendnumber, const u
         return -2;
     }
 
+    // TODO(oxij): send_lossy_cryptpacket makes this check already, similarly for other similar places
     if (data[0] < PACKET_ID_RANGE_LOSSY_START || data[0] > PACKET_ID_RANGE_LOSSY_END) {
         return -3;
     }

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -172,8 +172,8 @@ static int send_offline_packet(Messenger *m, int friendcon_id)
 
 static int m_handle_status(void *object, int i, uint8_t status, void *userdata);
 static int m_handle_packet(void *object, int i, const uint8_t *temp, uint16_t len, void *userdata);
-static int m_handle_custom_lossy_packet(void *object, int friend_num, const uint8_t *packet, uint16_t length,
-                                        void *userdata);
+static int m_handle_lossy_packet(void *object, int friend_num, const uint8_t *packet, uint16_t length,
+                                 void *userdata);
 
 static int32_t init_new_friend(Messenger *m, const uint8_t *real_pk, uint8_t status)
 {
@@ -203,7 +203,7 @@ static int32_t init_new_friend(Messenger *m, const uint8_t *real_pk, uint8_t sta
             m->friendlist[i].is_typing = 0;
             m->friendlist[i].message_id = 0;
             friend_connection_callbacks(m->fr_c, friendcon_id, MESSENGER_CALLBACK_INDEX, &m_handle_status, &m_handle_packet,
-                                        &m_handle_custom_lossy_packet, m, i);
+                                        &m_handle_lossy_packet, m, i);
 
             if (m->numfriends == i) {
                 ++m->numfriends;
@@ -1807,8 +1807,8 @@ int m_msi_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, 
     return write_cryptpacket_id(m, friendnumber, PACKET_ID_MSI, data, length, 0);
 }
 
-static int m_handle_custom_lossy_packet(void *object, int friend_num, const uint8_t *packet, uint16_t length,
-                                        void *userdata)
+static int m_handle_lossy_packet(void *object, int friend_num, const uint8_t *packet, uint16_t length,
+                                 void *userdata)
 {
     Messenger *m = (Messenger *)object;
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -28,6 +28,7 @@
 #include "friend_connection.h"
 #include "friend_requests.h"
 #include "logger.h"
+#include "net_crypto.h"
 
 #define MAX_NAME_LENGTH 128
 /* TODO(irungentoo): this must depend on other variable. */
@@ -48,30 +49,6 @@ typedef enum Message_Type {
     MESSAGE_NORMAL,
     MESSAGE_ACTION
 } Message_Type;
-
-/* NOTE: Packet ids below 24 must never be used. */
-#define PACKET_ID_ONLINE 24
-#define PACKET_ID_OFFLINE 25
-#define PACKET_ID_NICKNAME 48
-#define PACKET_ID_STATUSMESSAGE 49
-#define PACKET_ID_USERSTATUS 50
-#define PACKET_ID_TYPING 51
-#define PACKET_ID_MESSAGE 64
-#define PACKET_ID_ACTION (PACKET_ID_MESSAGE + MESSAGE_ACTION) // 65
-#define PACKET_ID_MSI 69
-#define PACKET_ID_FILE_SENDREQUEST 80
-#define PACKET_ID_FILE_CONTROL 81
-#define PACKET_ID_FILE_DATA 82
-#define PACKET_ID_INVITE_CONFERENCE 96
-#define PACKET_ID_ONLINE_PACKET 97
-#define PACKET_ID_DIRECT_CONFERENCE 98
-#define PACKET_ID_MESSAGE_CONFERENCE 99
-#define PACKET_ID_LOSSY_CONFERENCE 199
-
-/* All packets starting with a byte in this range can be used for anything. */
-#define PACKET_ID_LOSSLESS_RANGE_START 160
-#define PACKET_ID_LOSSLESS_RANGE_SIZE 32
-#define PACKET_LOSSY_AV_RESERVED 8 // Number of lossy packet types at start of range reserved for A/V.
 
 typedef struct Messenger_Options {
     bool ipv6enabled;
@@ -247,7 +224,7 @@ typedef struct Friend {
     uint32_t num_sending_files;
     struct File_Transfers file_receiving[MAX_CONCURRENT_FILE_PIPES];
 
-    RTP_Packet_Handler lossy_rtp_packethandlers[PACKET_LOSSY_AV_RESERVED];
+    RTP_Packet_Handler lossy_rtp_packethandlers[PACKET_ID_RANGE_LOSSY_AV_SIZE];
 
     struct Receipts *receipts_start;
     struct Receipts *receipts_end;

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -31,6 +31,57 @@
 
 #include <pthread.h>
 
+/*** Crypto payloads. ***/
+
+/** Ranges. **/
+
+/* Packets in this range are reserved for net_crypto internal use. */
+#define PACKET_ID_RANGE_RESERVED_START 0
+#define PACKET_ID_RANGE_RESERVED_END 15
+/* Packets in this range are reserved for Messenger use. */
+#define PACKET_ID_RANGE_LOSSLESS_START 16
+#define PACKET_ID_RANGE_LOSSLESS_NORMAL_START 16
+#define PACKET_ID_RANGE_LOSSLESS_NORMAL_END 159
+/* Packets in this range can be used for anything. */
+#define PACKET_ID_RANGE_LOSSLESS_CUSTOM_START 160
+#define PACKET_ID_RANGE_LOSSLESS_CUSTOM_END 191
+#define PACKET_ID_RANGE_LOSSLESS_END 191
+/* Packets in this range are reserved for AV use. */
+#define PACKET_ID_RANGE_LOSSY_START 192
+#define PACKET_ID_RANGE_LOSSY_AV_START 192
+#define PACKET_ID_RANGE_LOSSY_AV_SIZE 8
+#define PACKET_ID_RANGE_LOSSY_AV_END 199
+/* Packets in this range can be used for anything. */
+#define PACKET_ID_RANGE_LOSSY_CUSTOM_START 200
+#define PACKET_ID_RANGE_LOSSY_CUSTOM_END 254
+#define PACKET_ID_RANGE_LOSSY_END 254
+
+/** Messages. **/
+
+#define PACKET_ID_PADDING 0 /* Denotes padding */
+#define PACKET_ID_REQUEST 1 /* Used to request unreceived packets */
+#define PACKET_ID_KILL    2 /* Used to kill connection */
+
+#define PACKET_ID_ONLINE 24
+#define PACKET_ID_OFFLINE 25
+#define PACKET_ID_NICKNAME 48
+#define PACKET_ID_STATUSMESSAGE 49
+#define PACKET_ID_USERSTATUS 50
+#define PACKET_ID_TYPING 51
+#define PACKET_ID_MESSAGE 64
+#define PACKET_ID_ACTION 65 /* PACKET_ID_MESSAGE + MESSAGE_ACTION */
+#define PACKET_ID_MSI 69    /* Used by AV to setup calls and etc */
+#define PACKET_ID_FILE_SENDREQUEST 80
+#define PACKET_ID_FILE_CONTROL 81
+#define PACKET_ID_FILE_DATA 82
+#define PACKET_ID_INVITE_CONFERENCE 96
+#define PACKET_ID_ONLINE_PACKET 97
+#define PACKET_ID_DIRECT_CONFERENCE 98
+#define PACKET_ID_MESSAGE_CONFERENCE 99
+#define PACKET_ID_LOSSY_CONFERENCE 199
+
+/*** Crypto connections. ***/
+
 typedef enum Crypto_Conn_State {
     CRYPTO_CONN_NO_CONNECTION = 0,
     CRYPTO_CONN_COOKIE_REQUESTING = 1,  // send cookie request packets
@@ -66,19 +117,8 @@ typedef enum Crypto_Conn_State {
 /* The timeout of no received UDP packets before the direct UDP connection is considered dead. */
 #define UDP_DIRECT_TIMEOUT 8
 
-#define PACKET_ID_PADDING 0 /* Denotes padding */
-#define PACKET_ID_REQUEST 1 /* Used to request unreceived packets */
-#define PACKET_ID_KILL    2 /* Used to kill connection */
-
-/* Packet ids 0 to CRYPTO_RESERVED_PACKETS - 1 are reserved for use by net_crypto. */
-#define CRYPTO_RESERVED_PACKETS 16
-
 #define MAX_TCP_CONNECTIONS 64
 #define MAX_TCP_RELAYS_PEER 4
-
-/* All packets starting with a byte in this range are considered lossy packets. */
-#define PACKET_ID_LOSSY_RANGE_START 192
-#define PACKET_ID_LOSSY_RANGE_SIZE 63
 
 #define CRYPTO_MAX_PADDING 8 /* All packets will be padded a number of bytes based on this number. */
 
@@ -209,7 +249,7 @@ bool max_speed_reached(Net_Crypto *c, int crypt_connection_id);
  * return -1 if data could not be put in packet queue.
  * return positive packet number if data was put into the queue.
  *
- * The first byte of data must be in the CRYPTO_RESERVED_PACKETS to PACKET_ID_LOSSY_RANGE_START range.
+ * The first byte of data must be in the PACKET_ID_RANGE_LOSSLESS.
  *
  * congestion_control: should congestion control apply to this packet?
  */
@@ -225,10 +265,12 @@ int64_t write_cryptpacket(Net_Crypto *c, int crypt_connection_id, const uint8_t 
  */
 int cryptpacket_received(Net_Crypto *c, int crypt_connection_id, uint32_t packet_number);
 
-/* return -1 on failure.
+/* Sends a lossy cryptopacket.
+ *
+ * return -1 on failure.
  * return 0 on success.
  *
- * Sends a lossy cryptopacket. (first byte must in the PACKET_ID_LOSSY_RANGE_*)
+ * The first byte of data must be in the PACKET_ID_RANGE_LOSSY.
  */
 int send_lossy_cryptpacket(Net_Crypto *c, int crypt_connection_id, const uint8_t *data, uint16_t length);
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1522,7 +1522,7 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
         return 0;
     }
 
-    if (data[0] < (PACKET_ID_LOSSY_RANGE_START + PACKET_LOSSY_AV_RESERVED)) {
+    if (data[0] <= PACKET_ID_RANGE_LOSSY_AV_END) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_INVALID);
         return 0;
     }

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1522,6 +1522,8 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
         return 0;
     }
 
+    // TODO(oxij): this feels ugly, this is needed only because m_send_custom_lossy_packet in Messenger.c
+    // sends both AV and custom packets despite its name and this API hides those AV packets
     if (data[0] <= PACKET_ID_RANGE_LOSSY_AV_END) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_INVALID);
         return 0;


### PR DESCRIPTION
The result of me trying to understand how packet handling in tox works. This change is a noop, really.

I built `qtox`, `utox`, `toxic`, and `toxvpn` against this. All compile and, it seems, work as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/962)
<!-- Reviewable:end -->
