### PR TITLE
 lan_discovery_test and version_test cleanup

### DIFF
--- a/auto_tests/lan_discovery_test.c
+++ b/auto_tests/lan_discovery_test.c
@@ -10,7 +10,7 @@ int main(void)
     Tox *tox1 = tox_new_log_lan(nullptr, nullptr, nullptr, /* lan_discovery */true);
     Tox *tox2 = tox_new_log_lan(nullptr, nullptr, nullptr, /* lan_discovery */true);
 
-    printf("Waiting for LAN discovery");
+    printf("Waiting for LAN discovery. This loop will attempt to run until successful.");
 
     while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
             tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE) {

--- a/auto_tests/version_test.c
+++ b/auto_tests/version_test.c
@@ -1,4 +1,5 @@
 #include "../toxcore/tox.h"
+#include "check_compat.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -6,20 +7,16 @@
 #define check(major, minor, patch, expected)                            \
   do_check(TOX_VERSION_MAJOR, TOX_VERSION_MINOR, TOX_VERSION_PATCH,     \
            major, minor, patch,                                         \
-           TOX_VERSION_IS_API_COMPATIBLE(major, minor, patch), expected,\
-           &result)
+           TOX_VERSION_IS_API_COMPATIBLE(major, minor, patch), expected)
 
 static void do_check(int lib_major, int lib_minor, int lib_patch,
                      int cli_major, int cli_minor, int cli_patch,
-                     bool actual, bool expected,
-                     int *result)
+                     bool actual, bool expected)
 {
-    if (actual != expected) {
-        printf("Client version %d.%d.%d is%s compatible with library version %d.%d.%d, but it should%s be\n",
-               cli_major, cli_minor, cli_patch, actual ? "" : " not",
-               lib_major, lib_minor, lib_patch, expected ? "" : " not");
-        *result = EXIT_FAILURE;
-    }
+    ck_assert_msg(actual == expected,
+                  "Client version %d.%d.%d is%s compatible with library version %d.%d.%d, but it should%s be\n",
+                  cli_major, cli_minor, cli_patch, actual ? "" : " not",
+                  lib_major, lib_minor, lib_patch, expected ? "" : " not");
 }
 
 #undef TOX_VERSION_MAJOR
@@ -28,11 +25,12 @@ static void do_check(int lib_major, int lib_minor, int lib_patch,
 
 int main(void)
 {
-    int result = 0;
 #define TOX_VERSION_MAJOR 0
 #define TOX_VERSION_MINOR 0
 #define TOX_VERSION_PATCH 4
+    // Tox versions from 0.0.* are only compatible with themselves.
     check(0, 0, 0, false);
+    check(0, 0, 3, false);
     check(0, 0, 4, true);
     check(0, 0, 5, false);
     check(1, 0, 4, false);
@@ -43,6 +41,7 @@ int main(void)
 #define TOX_VERSION_MAJOR 0
 #define TOX_VERSION_MINOR 1
 #define TOX_VERSION_PATCH 4
+    // Tox versions from 0.1.* are only compatible with themselves or 0.1.<*
     check(0, 0, 0, false);
     check(0, 0, 4, false);
     check(0, 0, 5, false);
@@ -55,6 +54,7 @@ int main(void)
     check(1, 0, 0, false);
     check(1, 0, 4, false);
     check(1, 0, 5, false);
+    check(1, 1, 4, false);
 #undef TOX_VERSION_MAJOR
 #undef TOX_VERSION_MINOR
 #undef TOX_VERSION_PATCH
@@ -62,11 +62,15 @@ int main(void)
 #define TOX_VERSION_MAJOR 1
 #define TOX_VERSION_MINOR 0
 #define TOX_VERSION_PATCH 4
+    // Beyond 0.*.* Tox is comfortable with any lower version within their major
+    check(0, 0, 4, false);
     check(1, 0, 0, true);
     check(1, 0, 1, true);
     check(1, 0, 4, true);
     check(1, 0, 5, false);
     check(1, 1, 0, false);
+    check(2, 0, 0, false);
+    check(2, 0, 4, false);
 #undef TOX_VERSION_MAJOR
 #undef TOX_VERSION_MINOR
 #undef TOX_VERSION_PATCH
@@ -74,6 +78,7 @@ int main(void)
 #define TOX_VERSION_MAJOR 1
 #define TOX_VERSION_MINOR 1
 #define TOX_VERSION_PATCH 4
+    check(0, 0, 4, false);
     check(1, 0, 0, true);
     check(1, 0, 4, true);
     check(1, 0, 5, true);
@@ -85,9 +90,10 @@ int main(void)
     check(1, 2, 4, false);
     check(1, 2, 5, false);
     check(2, 0, 0, false);
+    check(2, 1, 4, false);
 #undef TOX_VERSION_MAJOR
 #undef TOX_VERSION_MINOR
 #undef TOX_VERSION_PATCH
 
-    return result;
+    return 0;
 }


### PR DESCRIPTION
Another minor unit test PR. Big one coming up soon.

Removed a pointless declaration of a function in lan_discovery_test
and cleaned up the one error message there. Did an entire restructuring
of the version_test using macros that resulted in fewer lines of code but more
thorough testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/967)
<!-- Reviewable:end -->
