### PR TITLE
Call the "peer leaves" callback only once on group delete.

### DIFF
--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -262,7 +262,7 @@ static void group_av_peer_new(void *object, uint32_t groupnumber, uint32_t frien
     group_peer_set_object(group_av->g_c, groupnumber, friendgroupnumber, peer_av);
 }
 
-static void group_av_peer_delete(void *object, uint32_t groupnumber, uint32_t friendgroupnumber, void *peer_object)
+static void group_av_peer_delete(void *object, uint32_t groupnumber, void *peer_object)
 {
     Group_Peer_AV *peer_av = (Group_Peer_AV *)peer_object;
 

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -551,7 +551,7 @@ static int delpeer(Group_Chats *g_c, uint32_t groupnumber, int peer_index, void 
     }
 
     if (g->peer_on_leave) {
-        g->peer_on_leave(g->object, groupnumber, peer_index, peer_object);
+        g->peer_on_leave(g->object, groupnumber, peer_object);
     }
 
     return 0;
@@ -787,10 +787,8 @@ int del_groupchat(Group_Chats *g_c, uint32_t groupnumber)
         kill_friend_connection(g_c->fr_c, g->close[i].number);
     }
 
-    for (i = 0; i < g->numpeers; ++i) {
-        if (g->peer_on_leave) {
-            g->peer_on_leave(g->object, groupnumber, i, g->group[i].object);
-        }
+    if (g->peer_on_leave) {
+        g->peer_on_leave(g->object, groupnumber, g->group[i].object);
     }
 
     free(g->group);
@@ -1205,8 +1203,7 @@ int callback_groupchat_peer_new(const Group_Chats *g_c, uint32_t groupnumber, vo
  * return 0 on success.
  * return -1 on failure.
  */
-int callback_groupchat_peer_delete(Group_Chats *g_c, uint32_t groupnumber, void (*function)(void *, uint32_t, uint32_t,
-                                   void *))
+int callback_groupchat_peer_delete(Group_Chats *g_c, uint32_t groupnumber, void (*function)(void *, uint32_t, void *))
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -104,7 +104,7 @@ typedef struct {
     void *object;
 
     void (*peer_on_join)(void *, uint32_t, uint32_t);
-    void (*peer_on_leave)(void *, uint32_t, uint32_t, void *);
+    void (*peer_on_leave)(void *, uint32_t, void *);
     void (*group_on_delete)(void *, uint32_t);
 } Group_c;
 
@@ -377,13 +377,12 @@ int callback_groupchat_peer_new(const Group_Chats *g_c, uint32_t groupnumber, vo
 
 /* Set a function to be called when a peer leaves a group chat.
  *
- * Function(void *group object (set with group_set_object), uint32_t groupnumber, uint32_t friendgroupnumber, void *group peer object (set with group_peer_set_object))
+ * Function(void *group object (set with group_set_object), uint32_t groupnumber, void *group peer object (set with group_peer_set_object))
  *
  * return 0 on success.
  * return -1 on failure.
  */
-int callback_groupchat_peer_delete(Group_Chats *g_c, uint32_t groupnumber, void (*function)(void *, uint32_t, uint32_t,
-                                   void *));
+int callback_groupchat_peer_delete(Group_Chats *g_c, uint32_t groupnumber, void (*function)(void *, uint32_t, void *));
 
 /* Set a function to be called when the group chat is deleted.
  *


### PR DESCRIPTION
We used to pass the actual peer numbers of peers leaving, but we no
longer know these in the PGC world, so we don't pass them anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/976)
<!-- Reviewable:end -->
