### PR TITLE
Factor out time keeping code into its own module: mono_time.c.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,8 @@ set(toxcore_PKGCONFIG_REQUIRES ${toxcore_PKGCONFIG_REQUIRES} libsodium)
 set(toxcore_SOURCES ${toxcore_SOURCES}
   toxcore/logger.c
   toxcore/logger.h
+  toxcore/mono_time.c
+  toxcore/mono_time.h
   toxcore/network.c
   toxcore/network.h
   toxcore/state.c
@@ -343,6 +345,7 @@ include(CompileGTest)
 unit_test(toxav ring_buffer)
 unit_test(toxav rtp)
 unit_test(toxcore crypto_core)
+unit_test(toxcore mono_time)
 unit_test(toxcore util)
 
 ################################################################################

--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -18,6 +18,7 @@
 #include "../toxcore/TCP_server.h"
 
 #include "../toxcore/crypto_core.h"
+#include "../toxcore/mono_time.h"
 #include "../toxcore/util.h"
 
 #include "helpers.h"

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <time.h>
 
+#include "../toxcore/mono_time.h"
 #include "../toxcore/onion.h"
 #include "../toxcore/onion_announce.h"
 #include "../toxcore/onion_client.h"

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -176,6 +176,8 @@ static void *call_thread(void *pd)
 
     printf("Closing thread\n");
     pthread_exit(nullptr);
+
+    return nullptr;
 }
 
 static void test_av_three_calls(void)

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -33,6 +33,7 @@
 #include "../toxcore/LAN_discovery.h"
 #include "../toxcore/friend_requests.h"
 #include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
 #include "../toxcore/tox.h"
 #include "../toxcore/util.h"
 

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -38,6 +38,7 @@
 #include "../../../toxcore/LAN_discovery.h"
 #include "../../../toxcore/TCP_server.h"
 #include "../../../toxcore/logger.h"
+#include "../../../toxcore/mono_time.h"
 #include "../../../toxcore/onion_announce.h"
 #include "../../../toxcore/util.h"
 

--- a/other/monolith.h
+++ b/other/monolith.h
@@ -13,6 +13,7 @@
 #include "../toxcore/group.c"
 #include "../toxcore/list.c"
 #include "../toxcore/logger.c"
+#include "../toxcore/mono_time.c"
 #include "../toxcore/network.c"
 #include "../toxcore/net_crypto.c"
 #include "../toxcore/onion.c"

--- a/other/travis/env-freebsd.sh
+++ b/other/travis/env-freebsd.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
 CMAKE=cmake
-# Asan is disabled because it's currently broken in FreeBSD 11.
-# We should try enabling it in the next FreeBSD release and see if it works.
-CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DASAN=OFF"
 NPROC=`nproc`
 CURDIR=/root
 RUN_TESTS=true

--- a/other/travis/env.sh
+++ b/other/travis/env.sh
@@ -8,7 +8,6 @@ export PKG_CONFIG_PATH=$CACHE_DIR/lib/pkgconfig
 export ASTYLE=$CACHE_DIR/astyle/build/gcc/bin/astyle
 export CFLAGS="-O3 -DTRAVIS_ENV=1"
 export CXXFLAGS="-O3 -DTRAVIS_ENV=1"
-export CMAKE_EXTRA_FLAGS="-DERROR_ON_WARNING=ON"
 export MAKE=make
 
 BUILD_DIR=_build

--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -28,14 +28,12 @@ RUN $CMAKE                                      \
   -B$BUILD_DIR                                  \
   -H.                                           \
   -DCMAKE_INSTALL_PREFIX:PATH=$CURDIR/_install  \
-  -DASAN=ON                                     \
   -DDEBUG=ON                                    \
   -DMUST_BUILD_TOXAV=ON                         \
   -DSTRICT_ABI=ON                               \
   -DTEST_TIMEOUT_SECONDS=120                    \
   -DTRACE=ON                                    \
-  -DUSE_IPV6=$USE_IPV6                          \
-  $CMAKE_EXTRA_FLAGS
+  -DUSE_IPV6=$USE_IPV6
 
 export CTEST_OUTPUT_ON_FAILURE=1
 

--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -45,7 +45,7 @@ extern "C" {
 #include "../toxav/ring_buffer.c"
 
 #include "../toxav/toxav.h"
-#include "../toxcore/network.h" /* current_time_monotonic() */
+#include "../toxcore/mono_time.h" /* current_time_monotonic() */
 #include "../toxcore/tox.h"
 #include "../toxcore/util.h"
 

--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -29,6 +29,7 @@
 #include "rtp.h"
 
 #include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
 
 static struct JitterBuffer *jbuf_new(uint32_t capacity);
 static void jbuf_clear(struct JitterBuffer *q);

--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -31,6 +31,7 @@
 #include "ring_buffer.h"
 
 #include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
 #include "../toxcore/util.h"
 
 #define BWC_PACKET_ID 196

--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
 #include "../toxcore/util.h"
 
 #define GROUP_JBUF_SIZE 6

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -32,6 +32,7 @@
 
 #include "../toxcore/Messenger.h"
 #include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
 #include "../toxcore/util.h"
 
 enum {

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -28,6 +28,7 @@
 
 #include "../toxcore/Messenger.h"
 #include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
 #include "../toxcore/util.h"
 
 #include <assert.h>

--- a/toxav/video.c
+++ b/toxav/video.c
@@ -32,6 +32,7 @@
 #include "rtp.h"
 
 #include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
 #include "../toxcore/network.h"
 
 /**

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -59,6 +59,22 @@ cc_library(
 )
 
 cc_library(
+    name = "mono_time",
+    srcs = ["mono_time.c"],
+    hdrs = ["mono_time.h"],
+    deps = [":ccompat"],
+)
+
+cc_test(
+    name = "mono_time_test",
+    srcs = ["mono_time_test.cc"],
+    deps = [
+        ":mono_time",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "network",
     srcs = [
         "network.c",
@@ -77,6 +93,7 @@ cc_library(
         ":ccompat",
         ":crypto_core",
         ":logger",
+        ":mono_time",
     ],
 )
 

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -29,6 +29,7 @@
 
 #include "LAN_discovery.h"
 #include "logger.h"
+#include "mono_time.h"
 #include "network.h"
 #include "ping.h"
 #include "state.h"

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -8,6 +8,8 @@ libtoxcore_la_includedir = $(includedir)/tox
 libtoxcore_la_SOURCES = ../toxcore/ccompat.h \
                         ../toxcore/DHT.h \
                         ../toxcore/DHT.c \
+                        ../toxcore/mono_time.h \
+                        ../toxcore/mono_time.c \
                         ../toxcore/network.h \
                         ../toxcore/network.c \
                         ../toxcore/crypto_core.h \

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -34,6 +34,7 @@
 #include <time.h>
 
 #include "logger.h"
+#include "mono_time.h"
 #include "network.h"
 #include "state.h"
 #include "util.h"
@@ -1764,8 +1765,8 @@ static int handle_filecontrol(Messenger *m, int32_t friendnumber, uint8_t receiv
 
             if (position >= ft->size) {
                 LOGGER_DEBUG(m->log,
-                             "file control (friend %d, file %d): seek position %lld exceeds file size %lld",
-                             friendnumber, filenumber, (unsigned long long)position, (unsigned long long)ft->size);
+                             "file control (friend %d, file %d): seek position %ld exceeds file size %ld",
+                             friendnumber, filenumber, (unsigned long)position, (unsigned long)ft->size);
                 return -1;
             }
 

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "mono_time.h"
 #include "util.h"
 
 struct TCP_Client_Connection {

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "mono_time.h"
 #include "util.h"
 
 

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -39,6 +39,7 @@
 #include <unistd.h>
 #endif
 
+#include "mono_time.h"
 #include "util.h"
 
 typedef struct TCP_Secure_Connection {

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "mono_time.h"
 #include "util.h"
 
 #define PORTS_PER_DISCOVERY 10

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "mono_time.h"
 #include "util.h"
 
 /* return 1 if the groupnumber is not valid.

--- a/toxcore/mono_time.c
+++ b/toxcore/mono_time.c
@@ -1,0 +1,157 @@
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif
+
+#if !defined(OS_WIN32) && (defined(_WIN32) || defined(__WIN32__) || defined(WIN32))
+#define OS_WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+#ifdef __APPLE__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
+#ifndef OS_WIN32
+#include <sys/time.h>
+#endif
+
+#include "mono_time.h"
+
+#include <stdlib.h>
+#include <time.h>
+
+#include "ccompat.h"
+
+/* don't call into system billions of times for no reason */
+struct Mono_Time {
+    uint64_t time;
+    uint64_t base_time;
+};
+
+Mono_Time *mono_time_new(void)
+{
+    Mono_Time *monotime = (Mono_Time *)malloc(sizeof(Mono_Time));
+
+    if (monotime == nullptr) {
+        return nullptr;
+    }
+
+    monotime->time = 0;
+    monotime->base_time = 0;
+
+    return monotime;
+}
+
+void mono_time_free(Mono_Time *monotime)
+{
+    free(monotime);
+}
+
+void mono_time_update(Mono_Time *monotime)
+{
+    if (monotime->base_time == 0) {
+        monotime->base_time = ((uint64_t)time(nullptr) - (current_time_monotonic() / 1000ULL));
+    }
+
+    monotime->time = (current_time_monotonic() / 1000ULL) + monotime->base_time;
+}
+
+uint64_t mono_time_get(const Mono_Time *monotime)
+{
+    return monotime->time;
+}
+
+bool mono_time_is_timeout(const Mono_Time *monotime, uint64_t timestamp, uint64_t timeout)
+{
+    return timestamp + timeout <= mono_time_get(monotime);
+}
+
+
+static Mono_Time global_time;
+
+/* XXX: note that this is not thread-safe; if multiple threads call unix_time_update() concurrently, the return value of
+ * unix_time() may fail to increase monotonically with increasing time */
+void unix_time_update(void)
+{
+    mono_time_update(&global_time);
+}
+uint64_t unix_time(void)
+{
+    return mono_time_get(&global_time);
+}
+int is_timeout(uint64_t timestamp, uint64_t timeout)
+{
+    return mono_time_is_timeout(&global_time, timestamp, timeout);
+}
+
+
+
+/* return current UNIX time in microseconds (us). */
+uint64_t current_time_actual(void)
+{
+    uint64_t time;
+#ifdef OS_WIN32
+    /* This probably works fine */
+    FILETIME ft;
+    GetSystemTimeAsFileTime(&ft);
+    time = ft.dwHighDateTime;
+    time <<= 32;
+    time |= ft.dwLowDateTime;
+    time -= 116444736000000000ULL;
+    return time / 10;
+#else
+    struct timeval a;
+    gettimeofday(&a, nullptr);
+    time = 1000000ULL * a.tv_sec + a.tv_usec;
+    return time;
+#endif
+}
+
+
+#ifdef OS_WIN32
+static uint64_t last_monotime;
+static uint64_t add_monotime;
+#endif
+
+/* return current monotonic time in milliseconds (ms). */
+uint64_t current_time_monotonic(void)
+{
+    uint64_t time;
+#ifdef OS_WIN32
+    uint64_t old_add_monotime = add_monotime;
+    time = (uint64_t)GetTickCount() + add_monotime;
+
+    /* Check if time has decreased because of 32 bit wrap from GetTickCount(), while avoiding false positives from race
+     * conditions when multiple threads call this function at once */
+    if (time + 0x10000 < last_monotime) {
+        uint32_t add = ~0;
+        /* use old_add_monotime rather than simply incrementing add_monotime, to handle the case that many threads
+         * simultaneously detect an overflow */
+        add_monotime = old_add_monotime + add;
+        time += add;
+    }
+
+    last_monotime = time;
+#else
+    struct timespec monotime;
+#if defined(__linux__) && defined(CLOCK_MONOTONIC_RAW)
+    clock_gettime(CLOCK_MONOTONIC_RAW, &monotime);
+#elif defined(__APPLE__)
+    clock_serv_t muhclock;
+    mach_timespec_t machtime;
+
+    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &muhclock);
+    clock_get_time(muhclock, &machtime);
+    mach_port_deallocate(mach_task_self(), muhclock);
+
+    monotime.tv_sec = machtime.tv_sec;
+    monotime.tv_nsec = machtime.tv_nsec;
+#else
+    clock_gettime(CLOCK_MONOTONIC, &monotime);
+#endif
+    time = 1000ULL * monotime.tv_sec + (monotime.tv_nsec / 1000000ULL);
+#endif
+    return time;
+}

--- a/toxcore/mono_time.h
+++ b/toxcore/mono_time.h
@@ -1,0 +1,35 @@
+#ifndef C_TOXCORE_TOXCORE_MONO_TIME_H
+#define C_TOXCORE_TOXCORE_MONO_TIME_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct Mono_Time Mono_Time;
+
+Mono_Time *mono_time_new(void);
+void mono_time_free(Mono_Time *monotime);
+
+void mono_time_update(Mono_Time *monotime);
+uint64_t mono_time_get(const Mono_Time *monotime);
+bool mono_time_is_timeout(const Mono_Time *monotime, uint64_t timestamp, uint64_t timeout);
+
+// TODO(#405): Use per-tox monotime, delete these functions.
+void unix_time_update(void);
+uint64_t unix_time(void);
+int is_timeout(uint64_t timestamp, uint64_t timeout);
+
+/* return current UNIX time in microseconds (us). */
+uint64_t current_time_actual(void);
+
+/* return current monotonic time in milliseconds (ms). */
+uint64_t current_time_monotonic(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // C_TOXCORE_TOXCORE_MONO_TIME_H

--- a/toxcore/mono_time_test.cc
+++ b/toxcore/mono_time_test.cc
@@ -1,0 +1,30 @@
+#include "mono_time.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Util, UnixTimeIncreasesOverTime) {
+  unix_time_update();
+  uint64_t const start = unix_time();
+
+  while (start == unix_time()) {
+    unix_time_update();
+  }
+
+  uint64_t const end = unix_time();
+  EXPECT_GT(end, start);
+}
+
+TEST(Util, IsTimeout) {
+  uint64_t const start = unix_time();
+  EXPECT_FALSE(is_timeout(start, 1));
+
+  while (start == unix_time()) {
+    unix_time_update();
+  }
+
+  EXPECT_TRUE(is_timeout(start, 1));
+}
+
+}  // namespace

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "mono_time.h"
 #include "util.h"
 
 typedef struct Packet_Data {

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -381,9 +381,6 @@ int set_socket_reuseaddr(Socket sock);
  */
 int set_socket_dualstack(Socket sock);
 
-/* return current monotonic time in milliseconds (ms). */
-uint64_t current_time_monotonic(void);
-
 /* Basic network functions: */
 
 /* Function to send packet(data) of length length to ip_port. */

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "mono_time.h"
 #include "util.h"
 
 #define RETURN_1 ONION_RETURN_1

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -31,6 +31,7 @@
 #include <string.h>
 
 #include "LAN_discovery.h"
+#include "mono_time.h"
 #include "util.h"
 
 #define PING_ID_TIMEOUT ONION_ANNOUNCE_TIMEOUT

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -32,6 +32,7 @@
 #include <string.h>
 
 #include "LAN_discovery.h"
+#include "mono_time.h"
 #include "util.h"
 
 /* defines for the array size and

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -33,6 +33,7 @@
 #include <string.h>
 
 #include "DHT.h"
+#include "mono_time.h"
 #include "network.h"
 #include "ping_array.h"
 #include "util.h"

--- a/toxcore/ping_array.c
+++ b/toxcore/ping_array.c
@@ -31,6 +31,7 @@
 #include <string.h>
 
 #include "crypto_core.h"
+#include "mono_time.h"
 #include "util.h"
 
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -518,6 +518,11 @@ static void set_friend_error(int32_t ret, Tox_Err_Friend_Add *error)
         case FAERR_NOMEM:
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_MALLOC);
             break;
+
+        default:
+            /* can't happen */
+            assert(!"impossible: unknown friend-add error");
+            break;
     }
 }
 
@@ -826,7 +831,9 @@ static void set_message_error(int ret, Tox_Err_Friend_Send_Message *error)
             break;
 
         case -5:
+        default:
             /* can't happen */
+            assert(!"impossible: unknown send-message error");
             break;
     }
 }

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -34,73 +34,10 @@
 #include "util.h"
 
 #include "crypto_core.h" /* for CRYPTO_PUBLIC_KEY_SIZE */
-#include "network.h" /* for current_time_monotonic */
 
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-
-
-/* don't call into system billions of times for no reason */
-struct Unix_Time {
-    uint64_t time;
-    uint64_t base_time;
-};
-
-Unix_Time *unix_time_new(void)
-{
-    Unix_Time *unixtime = (Unix_Time *)malloc(sizeof(Unix_Time));
-
-    if (unixtime == nullptr) {
-        return nullptr;
-    }
-
-    unixtime->time = 0;
-    unixtime->base_time = 0;
-
-    return unixtime;
-}
-
-void unix_time_free(Unix_Time *unixtime)
-{
-    free(unixtime);
-}
-
-void unix_time_update_r(Unix_Time *unixtime)
-{
-    if (unixtime->base_time == 0) {
-        unixtime->base_time = ((uint64_t)time(nullptr) - (current_time_monotonic() / 1000ULL));
-    }
-
-    unixtime->time = (current_time_monotonic() / 1000ULL) + unixtime->base_time;
-}
-
-uint64_t unix_time_get(const Unix_Time *unixtime)
-{
-    return unixtime->time;
-}
-
-int unix_time_is_timeout(const Unix_Time *unixtime, uint64_t timestamp, uint64_t timeout)
-{
-    return timestamp + timeout <= unix_time_get(unixtime);
-}
-
-static Unix_Time global_time;
-
-/* XXX: note that this is not thread-safe; if multiple threads call unix_time_update() concurrently, the return value of
- * unix_time() may fail to increase monotonically with increasing time */
-void unix_time_update(void)
-{
-    unix_time_update_r(&global_time);
-}
-uint64_t unix_time(void)
-{
-    return unix_time_get(&global_time);
-}
-int is_timeout(uint64_t timestamp, uint64_t timeout)
-{
-    return unix_time_is_timeout(&global_time, timestamp, timeout);
-}
 
 
 /* id functions */

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -36,33 +36,70 @@
 #include "crypto_core.h" /* for CRYPTO_PUBLIC_KEY_SIZE */
 #include "network.h" /* for current_time_monotonic */
 
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
 
 /* don't call into system billions of times for no reason */
-static uint64_t unix_time_value;
-static uint64_t unix_base_time_value;
+struct Unix_Time {
+    uint64_t time;
+    uint64_t base_time;
+};
+
+Unix_Time *unix_time_new(void)
+{
+    Unix_Time *unixtime = (Unix_Time *)malloc(sizeof(Unix_Time));
+
+    if (unixtime == nullptr) {
+        return nullptr;
+    }
+
+    unixtime->time = 0;
+    unixtime->base_time = 0;
+
+    return unixtime;
+}
+
+void unix_time_free(Unix_Time *unixtime)
+{
+    free(unixtime);
+}
+
+void unix_time_update_r(Unix_Time *unixtime)
+{
+    if (unixtime->base_time == 0) {
+        unixtime->base_time = ((uint64_t)time(nullptr) - (current_time_monotonic() / 1000ULL));
+    }
+
+    unixtime->time = (current_time_monotonic() / 1000ULL) + unixtime->base_time;
+}
+
+uint64_t unix_time_get(const Unix_Time *unixtime)
+{
+    return unixtime->time;
+}
+
+int unix_time_is_timeout(const Unix_Time *unixtime, uint64_t timestamp, uint64_t timeout)
+{
+    return timestamp + timeout <= unix_time_get(unixtime);
+}
+
+static Unix_Time global_time;
 
 /* XXX: note that this is not thread-safe; if multiple threads call unix_time_update() concurrently, the return value of
  * unix_time() may fail to increase monotonically with increasing time */
 void unix_time_update(void)
 {
-    if (unix_base_time_value == 0) {
-        unix_base_time_value = ((uint64_t)time(nullptr) - (current_time_monotonic() / 1000ULL));
-    }
-
-    unix_time_value = (current_time_monotonic() / 1000ULL) + unix_base_time_value;
+    unix_time_update_r(&global_time);
 }
-
 uint64_t unix_time(void)
 {
-    return unix_time_value;
+    return unix_time_get(&global_time);
 }
-
 int is_timeout(uint64_t timestamp, uint64_t timeout)
 {
-    return timestamp + timeout <= unix_time();
+    return unix_time_is_timeout(&global_time, timestamp, timeout);
 }
 
 

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -39,10 +39,20 @@ extern "C" {
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define PAIR(TYPE1__, TYPE2__) struct { TYPE1__ first; TYPE2__ second; }
 
+typedef struct Unix_Time Unix_Time;
+
+Unix_Time *unix_time_new(void);
+void unix_time_free(Unix_Time *unixtime);
+
+// TODO(#405): Use per-tox unixtime, remove unix_time_update, and rename
+// unix_time_update_r to unix_time_update.
+void unix_time_update_r(Unix_Time *unixtime);
+uint64_t unix_time_get(const Unix_Time *unixtime);
+int unix_time_is_timeout(const Unix_Time *unixtime, uint64_t timestamp, uint64_t timeout);
+
 void unix_time_update(void);
 uint64_t unix_time(void);
 int is_timeout(uint64_t timestamp, uint64_t timeout);
-
 
 /* id functions */
 bool id_equal(const uint8_t *dest, const uint8_t *src);

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -39,21 +39,6 @@ extern "C" {
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define PAIR(TYPE1__, TYPE2__) struct { TYPE1__ first; TYPE2__ second; }
 
-typedef struct Unix_Time Unix_Time;
-
-Unix_Time *unix_time_new(void);
-void unix_time_free(Unix_Time *unixtime);
-
-// TODO(#405): Use per-tox unixtime, remove unix_time_update, and rename
-// unix_time_update_r to unix_time_update.
-void unix_time_update_r(Unix_Time *unixtime);
-uint64_t unix_time_get(const Unix_Time *unixtime);
-int unix_time_is_timeout(const Unix_Time *unixtime, uint64_t timestamp, uint64_t timeout);
-
-void unix_time_update(void);
-uint64_t unix_time(void);
-int is_timeout(uint64_t timestamp, uint64_t timeout);
-
 /* id functions */
 bool id_equal(const uint8_t *dest, const uint8_t *src);
 uint32_t id_copy(uint8_t *dest, const uint8_t *src); /* return value is CLIENT_ID_SIZE */

--- a/toxcore/util_test.cc
+++ b/toxcore/util_test.cc
@@ -4,28 +4,7 @@
 
 #include <gtest/gtest.h>
 
-TEST(Util, UnixTimeIncreasesOverTime) {
-  unix_time_update();
-  uint64_t const start = unix_time();
-
-  while (start == unix_time()) {
-    unix_time_update();
-  }
-
-  uint64_t const end = unix_time();
-  EXPECT_GT(end, start);
-}
-
-TEST(Util, IsTimeout) {
-  uint64_t const start = unix_time();
-  EXPECT_FALSE(is_timeout(start, 1));
-
-  while (start == unix_time()) {
-    unix_time_update();
-  }
-
-  EXPECT_TRUE(is_timeout(start, 1));
-}
+namespace {
 
 TEST(Util, TwoRandomIdsAreNotEqual) {
   uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE];
@@ -49,3 +28,5 @@ TEST(Util, IdCopyMakesKeysEqual) {
 
   EXPECT_TRUE(id_equal(pk1, pk2));
 }
+
+}  // namespace


### PR DESCRIPTION
It turns out, `unix_time` is also monotonic, and is used as such, so I've
renamed the new functions to `mono_time_*`.

2018-07-08:
```
00:01 <@irungentoo> the idea used to be that the unix_time() function
  could go backward in time but I think I might have started using it like
  if it could not after I changed it so that it would never go back in time
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/981)
<!-- Reviewable:end -->
