### PR TITLE
Use named types for onion callbacks.

### DIFF
--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -655,7 +655,7 @@ static int handle_recv_1(void *object, IP_Port source, const uint8_t *packet, ui
     return 0;
 }
 
-void set_callback_handle_recv_1(Onion *onion, int (*function)(void *, IP_Port, const uint8_t *, uint16_t), void *object)
+void set_callback_handle_recv_1(Onion *onion, onion_recv_1_cb *function, void *object)
 {
     onion->recv_1_function = function;
     onion->callback_object = object;

--- a/toxcore/onion.h
+++ b/toxcore/onion.h
@@ -150,12 +150,13 @@ int send_onion_response(Networking_Core *net, IP_Port dest, const uint8_t *data,
  */
 int onion_send_1(const Onion *onion, const uint8_t *plain, uint16_t len, IP_Port source, const uint8_t *nonce);
 
+typedef int onion_recv_1_cb(void *, IP_Port, const uint8_t *, uint16_t);
+
 /* Set the callback to be called when the dest ip_port doesn't have TOX_AF_INET6 or TOX_AF_INET as the family.
  *
  * Format: function(void *object, IP_Port dest, uint8_t *data, uint16_t length)
  */
-void set_callback_handle_recv_1(Onion *onion, int (*function)(void *, IP_Port, const uint8_t *, uint16_t),
-                                void *object);
+void set_callback_handle_recv_1(Onion *onion, onion_recv_1_cb *function, void *object);
 
 Onion *new_onion(DHT *dht);
 

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -40,7 +40,7 @@
 #define DATA_REQUEST_MIN_SIZE ONION_DATA_REQUEST_MIN_SIZE
 #define DATA_REQUEST_MIN_SIZE_RECV (DATA_REQUEST_MIN_SIZE + ONION_RETURN_3)
 
-typedef struct {
+typedef struct Onion_Announce_Entry {
     uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE];
     IP_Port ret_ip_port;
     uint8_t ret[ONION_RETURN_3];
@@ -264,7 +264,7 @@ static int in_entries(const Onion_Announce *onion_a, const uint8_t *public_key)
     return -1;
 }
 
-typedef struct {
+typedef struct Cmp_data {
     const uint8_t *base_public_key;
     Onion_Announce_Entry entry;
 } Cmp_data;
@@ -312,14 +312,14 @@ static void sort_onion_announce_list(Onion_Announce_Entry *list, unsigned int le
     // comparison function can use it as the base of comparison.
     VLA(Cmp_data, cmp_list, length);
 
-    for (uint32_t i = 0; i < length; i++) {
+    for (uint32_t i = 0; i < length; ++i) {
         cmp_list[i].base_public_key = comp_public_key;
         cmp_list[i].entry = list[i];
     }
 
     qsort(cmp_list, length, sizeof(Cmp_data), cmp_entry);
 
-    for (uint32_t i = 0; i < length; i++) {
+    for (uint32_t i = 0; i < length; ++i) {
         list[i] = cmp_list[i].entry;
     }
 }

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -124,6 +124,8 @@ int onion_set_friend_online(Onion_Client *onion_c, int friend_num, uint8_t is_on
  */
 int onion_getfriendip(const Onion_Client *onion_c, int friend_num, IP_Port *ip_port);
 
+typedef int recv_tcp_relay_cb(void *object, uint32_t number, IP_Port ip_port, const uint8_t *public_key);
+
 /* Set the function for this friend that will be callbacked with object and number
  * when that friends gives us one of the TCP relays he is connected to.
  *
@@ -132,9 +134,10 @@ int onion_getfriendip(const Onion_Client *onion_c, int friend_num, IP_Port *ip_p
  * return -1 on failure.
  * return 0 on success.
  */
-int recv_tcp_relay_handler(Onion_Client *onion_c, int friend_num, int (*tcp_relay_node_callback)(void *object,
-                           uint32_t number, IP_Port ip_port, const uint8_t *public_key), void *object, uint32_t number);
+int recv_tcp_relay_handler(Onion_Client *onion_c, int friend_num,
+                           recv_tcp_relay_cb *tcp_relay_node_callback, void *object, uint32_t number);
 
+typedef void onion_dht_pk_cb(void *data, int32_t number, const uint8_t *dht_public_key, void *userdata);
 
 /* Set the function for this friend that will be callbacked with object and number
  * when that friend gives us his DHT temporary public key.
@@ -144,8 +147,8 @@ int recv_tcp_relay_handler(Onion_Client *onion_c, int friend_num, int (*tcp_rela
  * return -1 on failure.
  * return 0 on success.
  */
-int onion_dht_pk_callback(Onion_Client *onion_c, int friend_num, void (*function)(void *data, int32_t number,
-                          const uint8_t *dht_public_key, void *userdata), void *object, uint32_t number);
+int onion_dht_pk_callback(Onion_Client *onion_c, int friend_num, onion_dht_pk_cb *function, void *object,
+                          uint32_t number);
 
 /* Set a friends DHT public key.
  * timestamp is the time (current_time_monotonic()) at which the key was last confirmed belonging to
@@ -177,11 +180,11 @@ unsigned int onion_getfriend_DHT_pubkey(const Onion_Client *onion_c, int friend_
  */
 int send_onion_data(Onion_Client *onion_c, int friend_num, const uint8_t *data, uint16_t length);
 
-typedef int (*oniondata_handler_callback)(void *object, const uint8_t *source_pubkey, const uint8_t *data,
-        uint16_t len, void *userdata);
+typedef int oniondata_handler_cb(void *object, const uint8_t *source_pubkey, const uint8_t *data,
+                                 uint16_t len, void *userdata);
 
 /* Function to call when onion data packet with contents beginning with byte is received. */
-void oniondata_registerhandler(Onion_Client *onion_c, uint8_t byte, oniondata_handler_callback cb, void *object);
+void oniondata_registerhandler(Onion_Client *onion_c, uint8_t byte, oniondata_handler_cb *cb, void *object);
 
 void do_onion_client(Onion_Client *onion_c);
 


### PR DESCRIPTION
This is now a style rule: you can only use typedef'd function types.

Previous rules now applied in `onion_*.c`:
* `struct`s must have a name (typedef of unnamed struct is not allowed).
* `++i` for increment-stmt, not `i++`, e.g. in loops.
* Only a single declarator per struct member declaration.
* Type_Names vs. variable_names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/987)
<!-- Reviewable:end -->
