### PR TITLE
Fix style in DHT.c.

### DIFF
--- a/auto_tests/monolith_test.cc
+++ b/auto_tests/monolith_test.cc
@@ -164,7 +164,7 @@ int main(int argc, char *argv[]) {
 #if defined(__x86_64__) && defined(__LP64__)
   // toxcore/DHT
   CHECK_SIZE(Client_data, 496);
-  CHECK_SIZE(Cryptopacket_Handles, 16);
+  CHECK_SIZE(Cryptopacket_Handler, 16);
   CHECK_SIZE(DHT, 676528);
   CHECK_SIZE(DHT_Friend, 5104);
   CHECK_SIZE(Hardening, 144);


### PR DESCRIPTION
* Removed `ARRAY_SIZE` and use NULL markers for end of array, instead.
  The alternative is + size, but for these arrays, NULL markers made
  sense, since they are arrays of non-null pointers.
* Made `INDEX_OF_PK` a self-contained macro, not dependent upon the
  naming inside its call site. This is a minor change but makes the code
  more local and reviews easier.
* No nested structs.
* Use only named function types ending in `_cb` for callbacks.
* Replaced two macros with functions.
* `++i` instead of `i++`.
* struct member names start with lowercase letters.
* It takes a bit of work to support `/**/` comments in preprocessor
  macros, so I've decided not to support these. If a macro is complex
  enough to need comments inside it, it's too complex. `//` comments are
  allowed at the end of macro definitions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/994)
<!-- Reviewable:end -->
