### PR TITLE
Style fixes in TCP code; remove MIN and PAIR from util.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ if(BUILD_TOXAV)
     toxav/groupav.h
     toxav/msi.c
     toxav/msi.h
+    toxav/pair.h
     toxav/ring_buffer.c
     toxav/ring_buffer.h
     toxav/rtp.c

--- a/auto_tests/file_transfer_test.c
+++ b/auto_tests/file_transfer_test.c
@@ -286,7 +286,7 @@ static void file_transfer_test(void)
             printf("after %u iterations: %.2fMiB done\n", (unsigned int)i + 1, (double)size_recv / 1024 / 1024);
         }
 
-        c_sleep(MIN(tox1_interval, MIN(tox2_interval, tox3_interval)));
+        c_sleep(min_u32(tox1_interval, min_u32(tox2_interval, tox3_interval)));
     }
 
     ck_assert_msg(file_sending_done, "file sending did not complete after %u iterations: sendf_ok:%u file_recv:%u "
@@ -348,7 +348,7 @@ static void file_transfer_test(void)
         uint32_t tox2_interval = tox_iteration_interval(tox2);
         uint32_t tox3_interval = tox_iteration_interval(tox3);
 
-        c_sleep(MIN(tox1_interval, MIN(tox2_interval, tox3_interval)));
+        c_sleep(min_u32(tox1_interval, min_u32(tox2_interval, tox3_interval)));
     }
 
     printf("Starting file 0 transfer test.\n");
@@ -397,7 +397,7 @@ static void file_transfer_test(void)
         uint32_t tox2_interval = tox_iteration_interval(tox2);
         uint32_t tox3_interval = tox_iteration_interval(tox3);
 
-        c_sleep(MIN(tox1_interval, MIN(tox2_interval, tox3_interval)));
+        c_sleep(min_u32(tox1_interval, min_u32(tox2_interval, tox3_interval)));
     }
 
     printf("file_transfer_test succeeded, took %llu seconds\n", time(nullptr) - cur_time);

--- a/auto_tests/monolith_test.cc
+++ b/auto_tests/monolith_test.cc
@@ -161,6 +161,9 @@ void check_size(char const *type) {
  * switch on the PRINT_SIZE above and copy the number into this function.
  */
 int main(int argc, char *argv[]) {
+  static_assert(sizeof(uint64_t) >= sizeof(size_t),
+                "Assumption violated: size_t is more than 64 bits wide");
+
 #if defined(__x86_64__) && defined(__LP64__)
   // toxcore/DHT
   CHECK_SIZE(Client_data, 496);

--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -144,8 +144,8 @@ START_TEST(test_ip_equal)
     ip2.ip.v6.uint32[2] = net_htonl(0xFFFF);
     ip2.ip.v6.uint32[3] = net_htonl(0x7F000001);
 
-    ck_assert_msg(IPV6_IPV4_IN_V6(ip2.ip.v6) != 0,
-                  "IPV6_IPV4_IN_V6(::ffff:127.0.0.1): expected != 0, got 0.");
+    ck_assert_msg(ipv6_ipv4_in_v6(ip2.ip.v6) != 0,
+                  "ipv6_ipv4_in_v6(::ffff:127.0.0.1): expected != 0, got 0.");
 
     res = ip_equal(&ip1, &ip2);
     ck_assert_msg(res != 0, "ip_equal( {TOX_AF_INET, 127.0.0.1}, {TOX_AF_INET6, ::ffff:127.0.0.1} ): "

--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -55,10 +55,16 @@ cc_test(
 )
 
 cc_library(
+    name = "pair",
+    hdrs = ["pair.h"],
+)
+
+cc_library(
     name = "audio",
     srcs = ["audio.c"],
     hdrs = ["audio.h"],
     deps = [
+        ":pair",
         ":public",
         ":rtp",
         "//c-toxcore/toxcore:network",
@@ -78,6 +84,7 @@ cc_library(
     ],
     deps = [
         ":audio",
+        ":pair",
         ":public",
         "//c-toxcore/toxcore:network",
         "@libvpx",

--- a/toxav/Makefile.inc
+++ b/toxav/Makefile.inc
@@ -16,6 +16,7 @@ libtoxav_la_SOURCES = ../toxav/rtp.h \
                     ../toxav/video.c \
                     ../toxav/bwcontroller.h \
                     ../toxav/bwcontroller.c \
+                    ../toxav/pair.h \
                     ../toxav/ring_buffer.h \
                     ../toxav/ring_buffer.c \
                     ../toxav/toxav.h \

--- a/toxav/audio.h
+++ b/toxav/audio.h
@@ -24,6 +24,7 @@
 
 #include "../toxcore/logger.h"
 #include "../toxcore/util.h"
+#include "pair.h"
 
 #include <opus.h>
 #include <pthread.h>

--- a/toxav/pair.h
+++ b/toxav/pair.h
@@ -1,0 +1,6 @@
+#ifndef C_TOXCORE_TOXAV_PAIR_H
+#define C_TOXCORE_TOXAV_PAIR_H
+
+#define PAIR(TYPE1__, TYPE2__) struct { TYPE1__ first; TYPE2__ second; }
+
+#endif // C_TOXCORE_TOXAV_PAIR_H

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -242,6 +242,10 @@ void toxav_iterate(ToxAV *av)
             ac_iterate(i->audio.second);
             vc_iterate(i->video.second);
 
+            // TODO(iphydf): Find out what MIN-semantics are desired here and
+            // use a min_* function from util.h.
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
             if (i->msi_call->self_capabilities & msi_CapRAudio &&
                     i->msi_call->peer_capabilities & msi_CapSAudio) {
                 rc = MIN(i->audio.second->lp_frame_duration, rc);

--- a/toxav/video.h
+++ b/toxav/video.h
@@ -24,6 +24,7 @@
 
 #include "../toxcore/logger.h"
 #include "../toxcore/util.h"
+#include "pair.h"
 
 #include <vpx/vpx_decoder.h>
 #include <vpx/vpx_encoder.h>

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -1192,7 +1192,7 @@ uint32_t addto_lists(DHT *dht, IP_Port ip_port, const uint8_t *public_key)
     uint32_t used = 0;
 
     /* convert IPv4-in-IPv6 to IPv4 */
-    if (net_family_is_ipv6(ip_port.ip.family) && IPV6_IPV4_IN_V6(ip_port.ip.ip.v6)) {
+    if (net_family_is_ipv6(ip_port.ip.family) && ipv6_ipv4_in_v6(ip_port.ip.ip.v6)) {
         ip_port.ip.family = net_family_ipv4;
         ip_port.ip.ip.v4.uint32 = ip_port.ip.ip.v6.uint32[3];
     }
@@ -1272,7 +1272,7 @@ static bool update_client_data(Client_data *array, size_t size, IP_Port ip_port,
 static void returnedip_ports(DHT *dht, IP_Port ip_port, const uint8_t *public_key, const uint8_t *nodepublic_key)
 {
     /* convert IPv4-in-IPv6 to IPv4 */
-    if (net_family_is_ipv6(ip_port.ip.family) && IPV6_IPV4_IN_V6(ip_port.ip.ip.v6)) {
+    if (net_family_is_ipv6(ip_port.ip.family) && ipv6_ipv4_in_v6(ip_port.ip.ip.v6)) {
         ip_port.ip.family = net_family_ipv4;
         ip_port.ip.ip.v4.uint32 = ip_port.ip.ip.v6.uint32[3];
     }

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -717,7 +717,9 @@ int m_copy_statusmessage(const Messenger *m, int32_t friendnumber, uint8_t *buf,
         return -1;
     }
 
-    int msglen = MIN(maxlen, m->friendlist[friendnumber].statusmessage_length);
+    // TODO(iphydf): This should be uint16_t and min_u16. If maxlen exceeds
+    // uint16_t's range, it won't affect the result.
+    uint32_t msglen = min_u32(maxlen, m->friendlist[friendnumber].statusmessage_length);
 
     memcpy(buf, m->friendlist[friendnumber].statusmessage, msglen);
     memset(buf + msglen, 0, maxlen - msglen);
@@ -2855,9 +2857,10 @@ static uint32_t friends_list_save(const Messenger *m, uint8_t *data)
             memcpy(temp.real_pk, m->friendlist[i].real_pk, CRYPTO_PUBLIC_KEY_SIZE);
 
             if (temp.status < 3) {
+                // TODO(iphydf): Use uint16_t and min_u16 here.
                 const size_t friendrequest_length =
-                    MIN(m->friendlist[i].info_size,
-                        MIN(SAVED_FRIEND_REQUEST_SIZE, MAX_FRIEND_REQUEST_DATA_SIZE));
+                    min_u32(m->friendlist[i].info_size,
+                            min_u32(SAVED_FRIEND_REQUEST_SIZE, MAX_FRIEND_REQUEST_DATA_SIZE));
                 memcpy(temp.info, m->friendlist[i].info, friendrequest_length);
 
                 temp.info_size = net_htons(m->friendlist[i].info_size);

--- a/toxcore/TCP_client.h
+++ b/toxcore/TCP_client.h
@@ -29,18 +29,18 @@
 
 #define TCP_CONNECTION_TIMEOUT 10
 
-typedef enum {
+typedef enum TCP_Proxy_Type {
     TCP_PROXY_NONE,
     TCP_PROXY_HTTP,
     TCP_PROXY_SOCKS5
-} TCP_PROXY_TYPE;
+} TCP_Proxy_Type;
 
-typedef struct {
+typedef struct TCP_Proxy_Info {
     IP_Port ip_port;
     uint8_t proxy_type; // a value from TCP_PROXY_TYPE
 } TCP_Proxy_Info;
 
-typedef enum {
+typedef enum TCP_Client_Status {
     TCP_CLIENT_NO_STATUS,
     TCP_CLIENT_PROXY_HTTP_CONNECTING,
     TCP_CLIENT_PROXY_SOCKS5_CONNECTING,
@@ -49,12 +49,13 @@ typedef enum {
     TCP_CLIENT_UNCONFIRMED,
     TCP_CLIENT_CONFIRMED,
     TCP_CLIENT_DISCONNECTED,
-} TCP_CLIENT_STATUS;
+} TCP_Client_Status;
+
 typedef struct TCP_Client_Connection TCP_Client_Connection;
 
 const uint8_t *tcp_con_public_key(const TCP_Client_Connection *con);
 IP_Port tcp_con_ip_port(const TCP_Client_Connection *con);
-TCP_CLIENT_STATUS tcp_con_status(const TCP_Client_Connection *con);
+TCP_Client_Status tcp_con_status(const TCP_Client_Connection *con);
 
 void *tcp_con_custom_object(const TCP_Client_Connection *con);
 uint32_t tcp_con_custom_uint(const TCP_Client_Connection *con);
@@ -68,29 +69,31 @@ TCP_Client_Connection *new_TCP_connection(IP_Port ip_port, const uint8_t *public
 
 /* Run the TCP connection
  */
-void do_TCP_connection(TCP_Client_Connection *TCP_connection, void *userdata);
+void do_TCP_connection(TCP_Client_Connection *tcp_connection, void *userdata);
 
 /* Kill the TCP connection
  */
-void kill_TCP_connection(TCP_Client_Connection *TCP_connection);
+void kill_TCP_connection(TCP_Client_Connection *tcp_connection);
+
+typedef int tcp_onion_response_cb(void *object, const uint8_t *data, uint16_t length, void *userdata);
 
 /* return 1 on success.
  * return 0 if could not send packet.
  * return -1 on failure (connection must be killed).
  */
 int send_onion_request(TCP_Client_Connection *con, const uint8_t *data, uint16_t length);
-void onion_response_handler(TCP_Client_Connection *con, int (*onion_callback)(void *object, const uint8_t *data,
-                            uint16_t length, void *userdata), void *object);
+void onion_response_handler(TCP_Client_Connection *con, tcp_onion_response_cb *onion_callback, void *object);
+
+typedef int tcp_routing_response_cb(void *object, uint8_t connection_id, const uint8_t *public_key);
+typedef int tcp_routing_status_cb(void *object, uint32_t number, uint8_t connection_id, uint8_t status);
 
 /* return 1 on success.
  * return 0 if could not send packet.
  * return -1 on failure (connection must be killed).
  */
 int send_routing_request(TCP_Client_Connection *con, uint8_t *public_key);
-void routing_response_handler(TCP_Client_Connection *con, int (*response_callback)(void *object, uint8_t connection_id,
-                              const uint8_t *public_key), void *object);
-void routing_status_handler(TCP_Client_Connection *con, int (*status_callback)(void *object, uint32_t number,
-                            uint8_t connection_id, uint8_t status), void *object);
+void routing_response_handler(TCP_Client_Connection *con, tcp_routing_response_cb *response_callback, void *object);
+void routing_status_handler(TCP_Client_Connection *con, tcp_routing_status_cb *status_callback, void *object);
 
 /* return 1 on success.
  * return 0 if could not send packet.
@@ -107,21 +110,25 @@ int send_disconnect_request(TCP_Client_Connection *con, uint8_t con_id);
  */
 int set_tcp_connection_number(TCP_Client_Connection *con, uint8_t con_id, uint32_t number);
 
+typedef int tcp_routing_data_cb(void *object, uint32_t number, uint8_t connection_id, const uint8_t *data,
+                                uint16_t length, void *userdata);
+
 /* return 1 on success.
  * return 0 if could not send packet.
  * return -1 on failure.
  */
 int send_data(TCP_Client_Connection *con, uint8_t con_id, const uint8_t *data, uint16_t length);
-void routing_data_handler(TCP_Client_Connection *con, int (*data_callback)(void *object, uint32_t number,
-                          uint8_t connection_id, const uint8_t *data, uint16_t length, void *userdata), void *object);
+void routing_data_handler(TCP_Client_Connection *con, tcp_routing_data_cb *data_callback, void *object);
+
+typedef int tcp_oob_data_cb(void *object, const uint8_t *public_key, const uint8_t *data, uint16_t length,
+                            void *userdata);
 
 /* return 1 on success.
  * return 0 if could not send packet.
  * return -1 on failure.
  */
 int send_oob_packet(TCP_Client_Connection *con, const uint8_t *public_key, const uint8_t *data, uint16_t length);
-void oob_data_handler(TCP_Client_Connection *con, int (*oob_data_callback)(void *object, const uint8_t *public_key,
-                      const uint8_t *data, uint16_t length, void *userdata), void *object);
+void oob_data_handler(TCP_Client_Connection *con, tcp_oob_data_cb *oob_data_callback, void *object);
 
 
 #endif

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -47,14 +47,13 @@ struct TCP_Connections {
     TCP_con *tcp_connections;
     uint32_t tcp_connections_length; /* Length of tcp_connections array. */
 
-    int (*tcp_data_callback)(void *object, int id, const uint8_t *data, uint16_t length, void *userdata);
+    tcp_data_cb *tcp_data_callback;
     void *tcp_data_callback_object;
 
-    int (*tcp_oob_callback)(void *object, const uint8_t *public_key, unsigned int tcp_connections_number,
-                            const uint8_t *data, uint16_t length, void *userdata);
+    tcp_oob_cb *tcp_oob_callback;
     void *tcp_oob_callback_object;
 
-    int (*tcp_onion_callback)(void *object, const uint8_t *data, uint16_t length, void *userdata);
+    tcp_onion_cb *tcp_onion_callback;
     void *tcp_onion_callback_object;
 
     TCP_Proxy_Info proxy_info;
@@ -75,28 +74,44 @@ const uint8_t *tcp_connections_public_key(const TCP_Connections *tcp_c)
  *  return -1 if realloc fails.
  *  return 0 if it succeeds.
  */
-#define MAKE_REALLOC(T)                                         \
-static int realloc_##T(T **array, size_t num)                   \
-{                                                               \
-    if (!num) {                                                 \
-        free(*array);                                           \
-        *array = nullptr;                                       \
-        return 0;                                               \
-    }                                                           \
-                                                                \
-    T *temp_pointer = (T *)realloc(*array, num * sizeof(T));    \
-                                                                \
-    if (!temp_pointer) {                                        \
-        return -1;                                              \
-    }                                                           \
-                                                                \
-    *array = temp_pointer;                                      \
-                                                                \
-    return 0;                                                   \
+static int realloc_TCP_Connection_to(TCP_Connection_to **array, size_t num)
+{
+    if (!num) {
+        free(*array);
+        *array = nullptr;
+        return 0;
+    }
+
+    TCP_Connection_to *temp_pointer =
+        (TCP_Connection_to *)realloc(*array, num * sizeof(TCP_Connection_to));
+
+    if (!temp_pointer) {
+        return -1;
+    }
+
+    *array = temp_pointer;
+
+    return 0;
 }
 
-MAKE_REALLOC(TCP_Connection_to)
-MAKE_REALLOC(TCP_con)
+static int realloc_TCP_con(TCP_con **array, size_t num)
+{
+    if (!num) {
+        free(*array);
+        *array = nullptr;
+        return 0;
+    }
+
+    TCP_con *temp_pointer = (TCP_con *)realloc(*array, num * sizeof(TCP_con));
+
+    if (!temp_pointer) {
+        return -1;
+    }
+
+    *array = temp_pointer;
+
+    return 0;
+}
 
 
 /* return 1 if the connections_number is not valid.
@@ -421,8 +436,7 @@ int tcp_send_oob_packet(TCP_Connections *tcp_c, unsigned int tcp_connections_num
 
 /* Set the callback for TCP data packets.
  */
-void set_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_data_callback)(void *object, int id,
-                                        const uint8_t *data, uint16_t length, void *userdata), void *object)
+void set_packet_tcp_connection_callback(TCP_Connections *tcp_c, tcp_data_cb *tcp_data_callback, void *object)
 {
     tcp_c->tcp_data_callback = tcp_data_callback;
     tcp_c->tcp_data_callback_object = object;
@@ -430,9 +444,7 @@ void set_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_data_c
 
 /* Set the callback for TCP onion packets.
  */
-void set_oob_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_oob_callback)(void *object,
-        const uint8_t *public_key, unsigned int tcp_connections_number, const uint8_t *data, uint16_t length, void *userdata),
-        void *object)
+void set_oob_packet_tcp_connection_callback(TCP_Connections *tcp_c, tcp_oob_cb *tcp_oob_callback, void *object)
 {
     tcp_c->tcp_oob_callback = tcp_oob_callback;
     tcp_c->tcp_oob_callback_object = object;
@@ -440,8 +452,7 @@ void set_oob_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_oo
 
 /* Set the callback for TCP oob data packets.
  */
-void set_onion_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_onion_callback)(void *object,
-        const uint8_t *data, uint16_t length, void *userdata), void *object)
+void set_onion_packet_tcp_connection_callback(TCP_Connections *tcp_c, tcp_onion_cb *tcp_onion_callback, void *object)
 {
     tcp_c->tcp_onion_callback = tcp_onion_callback;
     tcp_c->tcp_onion_callback_object = object;
@@ -915,10 +926,10 @@ static int send_tcp_relay_routing_request(TCP_Connections *tcp_c, int tcp_connec
 
 static int tcp_response_callback(void *object, uint8_t connection_id, const uint8_t *public_key)
 {
-    TCP_Client_Connection *TCP_client_con = (TCP_Client_Connection *)object;
-    TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(TCP_client_con);
+    TCP_Client_Connection *tcp_client_con = (TCP_Client_Connection *)object;
+    TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(tcp_client_con);
 
-    unsigned int tcp_connections_number = tcp_con_custom_uint(TCP_client_con);
+    unsigned int tcp_connections_number = tcp_con_custom_uint(tcp_client_con);
     TCP_con *tcp_con = get_tcp_connection(tcp_c, tcp_connections_number);
 
     if (!tcp_con) {
@@ -948,10 +959,10 @@ static int tcp_response_callback(void *object, uint8_t connection_id, const uint
 
 static int tcp_status_callback(void *object, uint32_t number, uint8_t connection_id, uint8_t status)
 {
-    TCP_Client_Connection *TCP_client_con = (TCP_Client_Connection *)object;
-    TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(TCP_client_con);
+    TCP_Client_Connection *tcp_client_con = (TCP_Client_Connection *)object;
+    TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(tcp_client_con);
 
-    unsigned int tcp_connections_number = tcp_con_custom_uint(TCP_client_con);
+    unsigned int tcp_connections_number = tcp_con_custom_uint(tcp_client_con);
     TCP_con *tcp_con = get_tcp_connection(tcp_c, tcp_connections_number);
     TCP_Connection_to *con_to = get_connection(tcp_c, number);
 
@@ -991,10 +1002,10 @@ static int tcp_conn_data_callback(void *object, uint32_t number, uint8_t connect
         return -1;
     }
 
-    TCP_Client_Connection *TCP_client_con = (TCP_Client_Connection *)object;
-    TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(TCP_client_con);
+    TCP_Client_Connection *tcp_client_con = (TCP_Client_Connection *)object;
+    TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(tcp_client_con);
 
-    unsigned int tcp_connections_number = tcp_con_custom_uint(TCP_client_con);
+    unsigned int tcp_connections_number = tcp_con_custom_uint(tcp_client_con);
     TCP_con *tcp_con = get_tcp_connection(tcp_c, tcp_connections_number);
 
     if (!tcp_con) {
@@ -1021,10 +1032,10 @@ static int tcp_conn_oob_callback(void *object, const uint8_t *public_key, const 
         return -1;
     }
 
-    TCP_Client_Connection *TCP_client_con = (TCP_Client_Connection *)object;
-    TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(TCP_client_con);
+    TCP_Client_Connection *tcp_client_con = (TCP_Client_Connection *)object;
+    TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(tcp_client_con);
 
-    unsigned int tcp_connections_number = tcp_con_custom_uint(TCP_client_con);
+    unsigned int tcp_connections_number = tcp_con_custom_uint(tcp_client_con);
     TCP_con *tcp_con = get_tcp_connection(tcp_c, tcp_connections_number);
 
     if (!tcp_con) {

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -51,20 +51,22 @@
 /* Number of TCP connections used for onion purposes. */
 #define NUM_ONION_TCP_CONNECTIONS RECOMMENDED_FRIEND_TCP_CONNECTIONS
 
-typedef struct {
+typedef struct TCP_Conn_to {
+    uint32_t tcp_connection;
+    unsigned int status;
+    unsigned int connection_id;
+} TCP_Conn_to;
+
+typedef struct TCP_Connection_to {
     uint8_t status;
     uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE]; /* The dht public key of the peer */
 
-    struct {
-        uint32_t tcp_connection;
-        unsigned int status;
-        unsigned int connection_id;
-    } connections[MAX_FRIEND_TCP_CONNECTIONS];
+    TCP_Conn_to connections[MAX_FRIEND_TCP_CONNECTIONS];
 
     int id; /* id used in callbacks. */
 } TCP_Connection_to;
 
-typedef struct {
+typedef struct TCP_con {
     uint8_t status;
     TCP_Client_Connection *connection;
     uint64_t connected_time;
@@ -124,21 +126,24 @@ int set_tcp_onion_status(TCP_Connections *tcp_c, bool status);
 int tcp_send_oob_packet(TCP_Connections *tcp_c, unsigned int tcp_connections_number, const uint8_t *public_key,
                         const uint8_t *packet, uint16_t length);
 
+typedef int tcp_data_cb(void *object, int id, const uint8_t *data, uint16_t length, void *userdata);
+
 /* Set the callback for TCP data packets.
  */
-void set_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_data_callback)(void *object, int id,
-                                        const uint8_t *data, uint16_t length, void *userdata), void *object);
+void set_packet_tcp_connection_callback(TCP_Connections *tcp_c, tcp_data_cb *tcp_data_callback, void *object);
+
+typedef int tcp_onion_cb(void *object, const uint8_t *data, uint16_t length, void *userdata);
 
 /* Set the callback for TCP onion packets.
  */
-void set_onion_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_onion_callback)(void *object,
-        const uint8_t *data, uint16_t length, void *userdata), void *object);
+void set_onion_packet_tcp_connection_callback(TCP_Connections *tcp_c, tcp_onion_cb *tcp_onion_callback, void *object);
+
+typedef int tcp_oob_cb(void *object, const uint8_t *public_key, unsigned int tcp_connections_number,
+                       const uint8_t *data, uint16_t length, void *userdata);
 
 /* Set the callback for TCP oob data packets.
  */
-void set_oob_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_oob_callback)(void *object,
-        const uint8_t *public_key, unsigned int tcp_connections_number, const uint8_t *data, uint16_t length, void *userdata),
-        void *object);
+void set_oob_packet_tcp_connection_callback(TCP_Connections *tcp_c, tcp_oob_cb *tcp_oob_callback, void *object);
 
 /* Create a new TCP connection to public_key.
  *

--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -28,10 +28,6 @@
 #include "list.h"
 #include "onion.h"
 
-#ifdef TCP_SERVER_USE_EPOLL
-#include <sys/epoll.h>
-#endif
-
 #define MAX_INCOMING_CONNECTIONS 256
 
 #define TCP_MAX_BACKLOG MAX_INCOMING_CONNECTIONS
@@ -63,25 +59,19 @@
 #define TCP_PING_FREQUENCY 30
 #define TCP_PING_TIMEOUT 10
 
-#ifdef TCP_SERVER_USE_EPOLL
-#define TCP_SOCKET_LISTENING 0
-#define TCP_SOCKET_INCOMING 1
-#define TCP_SOCKET_UNCONFIRMED 2
-#define TCP_SOCKET_CONFIRMED 3
-#endif
-
-enum {
+typedef enum TCP_Status {
     TCP_STATUS_NO_STATUS,
     TCP_STATUS_CONNECTED,
     TCP_STATUS_UNCONFIRMED,
     TCP_STATUS_CONFIRMED,
-};
+} TCP_Status;
 
 typedef struct TCP_Priority_List TCP_Priority_List;
 
 struct TCP_Priority_List {
     TCP_Priority_List *next;
-    uint16_t size, sent;
+    uint16_t size;
+    uint16_t sent;
     uint8_t data[];
 };
 
@@ -97,11 +87,11 @@ TCP_Server *new_TCP_server(uint8_t ipv6_enabled, uint16_t num_sockets, const uin
 
 /* Run the TCP_server
  */
-void do_TCP_server(TCP_Server *TCP_server);
+void do_TCP_server(TCP_Server *tcp_server);
 
 /* Kill the TCP server
  */
-void kill_TCP_server(TCP_Server *TCP_server);
+void kill_TCP_server(TCP_Server *tcp_server);
 
 /* Read the next two bytes in TCP stream then convert them to
  * length (host byte order).

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -47,42 +47,43 @@
 #endif
 
 #if CRYPTO_PUBLIC_KEY_SIZE != crypto_box_PUBLICKEYBYTES
-#error CRYPTO_PUBLIC_KEY_SIZE should be equal to crypto_box_PUBLICKEYBYTES
+#error "CRYPTO_PUBLIC_KEY_SIZE should be equal to crypto_box_PUBLICKEYBYTES"
 #endif
 
 #if CRYPTO_SECRET_KEY_SIZE != crypto_box_SECRETKEYBYTES
-#error CRYPTO_SECRET_KEY_SIZE should be equal to crypto_box_SECRETKEYBYTES
+#error "CRYPTO_SECRET_KEY_SIZE should be equal to crypto_box_SECRETKEYBYTES"
 #endif
 
 #if CRYPTO_SHARED_KEY_SIZE != crypto_box_BEFORENMBYTES
-#error CRYPTO_SHARED_KEY_SIZE should be equal to crypto_box_BEFORENMBYTES
+#error "CRYPTO_SHARED_KEY_SIZE should be equal to crypto_box_BEFORENMBYTES"
 #endif
 
 #if CRYPTO_SYMMETRIC_KEY_SIZE != crypto_box_BEFORENMBYTES
-#error CRYPTO_SYMMETRIC_KEY_SIZE should be equal to crypto_box_BEFORENMBYTES
+#error "CRYPTO_SYMMETRIC_KEY_SIZE should be equal to crypto_box_BEFORENMBYTES"
 #endif
 
 #if CRYPTO_MAC_SIZE != crypto_box_MACBYTES
-#error CRYPTO_MAC_SIZE should be equal to crypto_box_MACBYTES
+#error "CRYPTO_MAC_SIZE should be equal to crypto_box_MACBYTES"
 #endif
 
 #if CRYPTO_NONCE_SIZE != crypto_box_NONCEBYTES
-#error CRYPTO_NONCE_SIZE should be equal to crypto_box_NONCEBYTES
+#error "CRYPTO_NONCE_SIZE should be equal to crypto_box_NONCEBYTES"
 #endif
 
 #if CRYPTO_SHA256_SIZE != crypto_hash_sha256_BYTES
-#error CRYPTO_SHA256_SIZE should be equal to crypto_hash_sha256_BYTES
+#error "CRYPTO_SHA256_SIZE should be equal to crypto_hash_sha256_BYTES"
 #endif
 
 #if CRYPTO_SHA512_SIZE != crypto_hash_sha512_BYTES
-#error CRYPTO_SHA512_SIZE should be equal to crypto_hash_sha512_BYTES
+#error "CRYPTO_SHA512_SIZE should be equal to crypto_hash_sha512_BYTES"
+#endif
+
+#if CRYPTO_PUBLIC_KEY_SIZE != 32
+#error "CRYPTO_PUBLIC_KEY_SIZE is required to be 32 bytes for public_key_cmp to work,"
 #endif
 
 int32_t public_key_cmp(const uint8_t *pk1, const uint8_t *pk2)
 {
-#if CRYPTO_PUBLIC_KEY_SIZE != 32
-#error CRYPTO_PUBLIC_KEY_SIZE is required to be 32 bytes for public_key_cmp to work,
-#endif
     return crypto_verify_32(pk1, pk2);
 }
 
@@ -186,7 +187,7 @@ int32_t encrypt_data(const uint8_t *public_key, const uint8_t *secret_key, const
     uint8_t k[crypto_box_BEFORENMBYTES];
     encrypt_precompute(public_key, secret_key, k);
     int ret = encrypt_data_symmetric(k, nonce, plain, length, encrypted);
-    crypto_memzero(k, sizeof k);
+    crypto_memzero(k, sizeof(k));
     return ret;
 }
 
@@ -200,7 +201,7 @@ int32_t decrypt_data(const uint8_t *public_key, const uint8_t *secret_key, const
     uint8_t k[crypto_box_BEFORENMBYTES];
     encrypt_precompute(public_key, secret_key, k);
     int ret = decrypt_data_symmetric(k, nonce, encrypted, length, plain);
-    crypto_memzero(k, sizeof k);
+    crypto_memzero(k, sizeof(k));
     return ret;
 }
 
@@ -258,7 +259,7 @@ void increment_nonce_number(uint8_t *nonce, uint32_t host_order_num)
 
     for (; i != 0; --i) {
         carry += (uint_fast16_t) nonce[i - 1] + (uint_fast16_t) num_as_nonce[i - 1];
-        nonce[i - 1] = (unsigned char) carry;
+        nonce[i - 1] = (uint8_t)carry;
         carry >>= 8;
     }
 }

--- a/toxcore/logger.c
+++ b/toxcore/logger.c
@@ -128,7 +128,7 @@ void logger_write(const Logger *log, Logger_Level level, const char *file, int l
     char msg[1024];
     va_list args;
     va_start(args, format);
-    vsnprintf(msg, sizeof msg, format, args);
+    vsnprintf(msg, sizeof(msg), format, args);
     va_end(args);
 
     log->callback(log->context, level, file, line, func, msg, log->userdata);

--- a/toxcore/mono_time.c
+++ b/toxcore/mono_time.c
@@ -69,7 +69,10 @@ bool mono_time_is_timeout(const Mono_Time *monotime, uint64_t timestamp, uint64_
 }
 
 
+//!TOKSTYLE-
+// No global mutable state in Tokstyle.
 static Mono_Time global_time;
+//!TOKSTYLE+
 
 /* XXX: note that this is not thread-safe; if multiple threads call unix_time_update() concurrently, the return value of
  * unix_time() may fail to increase monotonically with increasing time */
@@ -110,10 +113,13 @@ uint64_t current_time_actual(void)
 }
 
 
+//!TOKSTYLE-
+// No global mutable state in Tokstyle.
 #ifdef OS_WIN32
 static uint64_t last_monotime;
 static uint64_t add_monotime;
 #endif
+//!TOKSTYLE+
 
 /* return current monotonic time in milliseconds (ms). */
 uint64_t current_time_monotonic(void)

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -98,7 +98,7 @@ size_t net_socket_data_recv_buffer(Socket sock);
 
 #define MAX_UDP_PACKET_SIZE 2048
 
-typedef enum NET_PACKET_TYPE {
+typedef enum Net_Packet_Type {
     NET_PACKET_PING_REQUEST         = 0x00, /* Ping request packet ID. */
     NET_PACKET_PING_RESPONSE        = 0x01, /* Ping response packet ID. */
     NET_PACKET_GET_NODES            = 0x02, /* Get nodes request packet ID. */
@@ -127,7 +127,7 @@ typedef enum NET_PACKET_TYPE {
     BOOTSTRAP_INFO_PACKET_ID        = 0xf0, /* Only used for bootstrap nodes */
 
     NET_PACKET_MAX                  = 0xff, /* This type must remain within a single uint8. */
-} NET_PACKET_TYPE;
+} Net_Packet_Type;
 
 
 #define TOX_PORTRANGE_FROM 33445
@@ -160,7 +160,7 @@ typedef union IP4 {
 } IP4;
 
 IP4 get_ip4_loopback(void);
-extern const IP4 IP4_BROADCAST;
+extern const IP4 ip4_broadcast;
 
 typedef union IP6 {
     uint8_t uint8[16];
@@ -170,15 +170,17 @@ typedef union IP6 {
 } IP6;
 
 IP6 get_ip6_loopback(void);
-extern const IP6 IP6_BROADCAST;
+extern const IP6 ip6_broadcast;
+
+typedef union IP_Union {
+    IP4 v4;
+    IP6 v6;
+} IP_Union;
 
 #define IP_DEFINED
 typedef struct IP {
     Family family;
-    union {
-        IP4 v4;
-        IP6 v6;
-    } ip;
+    IP_Union ip;
 } IP;
 
 #define IP_PORT_DEFINED
@@ -203,7 +205,7 @@ size_t net_unpack_u32(const uint8_t *bytes, uint32_t *v);
 size_t net_unpack_u64(const uint8_t *bytes, uint64_t *v);
 
 /* Does the IP6 struct a contain an IPv4 address in an IPv6 one? */
-#define IPV6_IPV4_IN_V6(a) ((a.uint64[0] == 0) && (a.uint32[2] == net_htonl (0xffff)))
+bool ipv6_ipv4_in_v6(IP6 a);
 
 #define SIZE_IP4 4
 #define SIZE_IP6 16
@@ -334,8 +336,7 @@ int addr_resolve_or_parse_ip(const char *address, IP *to, IP *extra);
  * Packet data is put into data.
  * Packet length is put into length.
  */
-typedef int (*packet_handler_callback)(void *object, IP_Port ip_port, const uint8_t *data, uint16_t len,
-                                       void *userdata);
+typedef int packet_handler_cb(void *object, IP_Port ip_port, const uint8_t *data, uint16_t len, void *userdata);
 
 typedef struct Networking_Core Networking_Core;
 
@@ -387,7 +388,7 @@ int set_socket_dualstack(Socket sock);
 int sendpacket(Networking_Core *net, IP_Port ip_port, const uint8_t *data, uint16_t length);
 
 /* Function to call when packet beginning with byte is received. */
-void networking_registerhandler(Networking_Core *net, uint8_t byte, packet_handler_callback cb, void *object);
+void networking_registerhandler(Networking_Core *net, uint8_t byte, packet_handler_cb *cb, void *object);
 
 /* Call this several times a second. */
 void networking_poll(Networking_Core *net, void *userdata);

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -66,6 +66,11 @@ void host_to_net(uint8_t *num, uint16_t numbytes)
 #endif
 }
 
+void net_to_host(uint8_t *num, uint16_t numbytes)
+{
+    host_to_net(num, numbytes);
+}
+
 int create_recursive_mutex(pthread_mutex_t *mutex)
 {
     pthread_mutexattr_t attr;
@@ -93,6 +98,11 @@ int create_recursive_mutex(pthread_mutex_t *mutex)
 int32_t max_s32(int32_t a, int32_t b)
 {
     return a > b ? a : b;
+}
+
+uint32_t min_u32(uint32_t a, uint32_t b)
+{
+    return a < b ? a : b;
 }
 
 uint64_t min_u64(uint64_t a, uint64_t b)

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -36,20 +36,18 @@
 extern "C" {
 #endif
 
-#define MIN(a,b) (((a)<(b))?(a):(b))
-#define PAIR(TYPE1__, TYPE2__) struct { TYPE1__ first; TYPE2__ second; }
-
 /* id functions */
 bool id_equal(const uint8_t *dest, const uint8_t *src);
 uint32_t id_copy(uint8_t *dest, const uint8_t *src); /* return value is CLIENT_ID_SIZE */
 
 void host_to_net(uint8_t *num, uint16_t numbytes);
-#define net_to_host(x, y) host_to_net(x, y)
+void net_to_host(uint8_t *num, uint16_t numbytes);
 
 /* Returns -1 if failed or 0 if success */
 int create_recursive_mutex(pthread_mutex_t *mutex);
 
 int32_t max_s32(int32_t a, int32_t b);
+uint32_t min_u32(uint32_t a, uint32_t b);
 uint64_t min_u64(uint64_t a, uint64_t b);
 
 #ifdef __cplusplus


### PR DESCRIPTION
* Moved PAIR to toxav, where it's used (but really this should die).
* Replace most MIN calls with typed `min_*` calls. Didn't replace the
  ones where the desired semantics are unclear. Moved the MIN macro to
  the one place where it's still used.
* Avoid assignments in `while` loops. Instead, factored out the loop body
  into a separate `bool`-returning function.
* Use named types for callbacks (`_cb` types).
* Avoid assignments in `if` conditions.
* Removed `MAKE_REALLOC` and expanded its two calls. We can't have
  templates in C, and this fake templating is ugly and hard to analyse
  and debug (it expands on a single line).
* Moved epoll system include to the .c file, out of the .h file.
* Avoid assignments in expressions (`a = b = c;`).
* Avoid multiple declarators per struct member declaration.
* Fix naming inconsistencies.
* Replace `net_to_host` macro with function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/997)
<!-- Reviewable:end -->
