### PR TITLE
Limit number of group chats to 65536.

### DIFF
--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -138,7 +138,7 @@ typedef struct Group_Chats {
     Friend_Connections *fr_c;
 
     Group_c *chats;
-    uint32_t num_chats;
+    uint16_t num_chats;
 
     g_conference_invite_cb *invite_callback;
     g_conference_message_cb *message_callback;


### PR DESCRIPTION
By changing numchats from uint32_t to uint16_t. This is done in PGC. This
PR is making that change in master to reduce the diff in the PGC branch.

Also:
* Inverted groupnumber_not_valid and renamed to is_groupnumber_valid.
* Renamed realloc_groupchats to realloc_conferences and made it return bool.
* Added setup_conference function that currently just zeroes the
  conference structure but later will initialise more values.
* Made some `i` iterator variables local to the for-loop using
  for-init-decl. This is also done in PGC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1000)
<!-- Reviewable:end -->
