### PR TITLE
Remove LOGGER_ERROR for harmless send failure.

### DIFF
--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -1174,7 +1174,7 @@ static int64_t send_lossless_packet(Net_Crypto *c, int crypt_connection_id, cons
         }
     } else {
         conn->maximum_speed_reached = 1;
-        LOGGER_ERROR(c->log, "send_data_packet failed");
+        LOGGER_DEBUG(c->log, "send_data_packet failed");
     }
 
     return packet_num;


### PR DESCRIPTION
Change LOGGER_ERROR to LOGGER_DEBUG for failed packet send in 
send_lossless_packet(), since the packet is added to the send queue anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1003)
<!-- Reviewable:end -->
