### PR TITLE
Set C++11/C99 flag manually in older cmake on not-msvc.

### DIFF
--- a/.travis/flags.sh
+++ b/.travis/flags.sh
@@ -28,6 +28,8 @@ add_flag -O3 -march=native
 
 # Warn on non-ISO C.
 add_c_flag -pedantic
+add_c_flag -std=c99
+add_cxx_flag -std=c++11
 
 add_flag -g3
 add_flag -ftrapv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,12 @@ enable_testing()
 
 set(CMAKE_MACOSX_RPATH ON)
 
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.1.0")
+if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
+  if(NOT MSVC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  endif()
+else()
   # Set standard version for compiler.
   set(CMAKE_C_STANDARD 99)
   set(CMAKE_CXX_STANDARD 11)

--- a/toxcore/ccompat.h
+++ b/toxcore/ccompat.h
@@ -38,7 +38,7 @@
 
 #endif
 
-#ifndef __cplusplus
+#if !defined(__cplusplus) || __cplusplus < 201103L
 #define nullptr NULL
 #endif
 


### PR DESCRIPTION
These flags are needed so the code actually compiles, so can't only be
set on Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1006)
<!-- Reviewable:end -->
