### PR TITLE
Correct the max hostname length constant.

### DIFF
--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -318,12 +318,12 @@ const MAX_FILENAME_LENGTH         = 255;
 /**
  * Maximum length of a hostname, e.g. proxy or bootstrap node names.
  *
- * This length includes the NUL byte. Hostnames are NUL-terminated C strings, so
- * they are 255 characters plus one NUL byte.
+ * This length does not include the NUL byte. Hostnames are NUL-terminated C
+ * strings, so they are 255 characters plus one NUL byte.
  *
  * @deprecated The macro will be removed in 0.3.0. Use the function instead.
  */
-const MAX_HOSTNAME_LENGTH         = 256;
+const MAX_HOSTNAME_LENGTH         = 255;
 
 
 /*******************************************************************************

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -345,12 +345,12 @@ uint32_t tox_max_filename_length(void);
 /**
  * Maximum length of a hostname, e.g. proxy or bootstrap node names.
  *
- * This length includes the NUL byte. Hostnames are NUL-terminated C strings, so
- * they are 255 characters plus one NUL byte.
+ * This length does not include the NUL byte. Hostnames are NUL-terminated C
+ * strings, so they are 255 characters plus one NUL byte.
  *
  * @deprecated The macro will be removed in 0.3.0. Use the function instead.
  */
-#define TOX_MAX_HOSTNAME_LENGTH        256
+#define TOX_MAX_HOSTNAME_LENGTH        255
 
 uint32_t tox_max_hostname_length(void);
 


### PR DESCRIPTION
256 bytes including NUL byte is confusing and makes for really annoying
bindings to other languages that don't account for NUL bytes in their
string length. We pass C strings, not byte arrays, for hostnames, so 255
makes more sense here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1012)
<!-- Reviewable:end -->
