### PR TITLE
Link -lsocket and -lnsl for socket functions on Solaris.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,9 +309,20 @@ if(CMAKE_THREAD_LIBS_INIT)
   set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
+
+if(NSL_LIBRARIES)
+  set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} ${NSL_LIBRARIES})
+  set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} -lnsl)
+endif()
+
 if(RT_LIBRARIES)
   set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} ${RT_LIBRARIES})
   set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} -lrt)
+endif()
+
+if(SOCKET_LIBRARIES)
+  set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} ${SOCKET_LIBRARIES})
+  set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} -lsocket)
 endif()
 
 if(WIN32)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -8,7 +8,9 @@ include(ModulePackage)
 
 find_package(Threads REQUIRED)
 
+find_library(NSL_LIBRARIES          nsl          )
 find_library(RT_LIBRARIES           rt           )
+find_library(SOCKET_LIBRARIES       socket       )
 
 # For toxcore.
 pkg_use_module(LIBSODIUM            libsodium    )

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -29,6 +29,12 @@
 #define _DARWIN_C_SOURCE
 #endif
 
+// For Solaris.
+#ifdef __sun
+#define __EXTENSIONS__ 1
+#endif
+
+// For Linux (and some BSDs).
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 700
 #endif
@@ -84,6 +90,11 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#ifdef __sun
+#include <stropts.h>
+#include <sys/filio.h>
+#endif
 
 #define TOX_EWOULDBLOCK EWOULDBLOCK
 


### PR DESCRIPTION
Also, added some #defines to make symbols visible that are in BSD but not
in UNIX. Solaris needs these, since it's fairly strict with its symbol
visibility in system headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1013)
<!-- Reviewable:end -->
