### PR TITLE
Make a separate `struct Tox` containing the Messenger.

### DIFF
--- a/other/analysis/gen-file.sh
+++ b/other/analysis/gen-file.sh
@@ -40,9 +40,6 @@ echo "#include <cstdio>" >> amalgamation.cc
 echo "#include <memory>" >> amalgamation.cc
 echo "#include <random>" >> amalgamation.cc
 
-echo "#define TOX_DEFINED" >> amalgamation.cc
-echo "typedef struct Messenger Tox;" >> amalgamation.cc
-
 put auto_tests/check_compat.h
 
 FIND_QUERY="find . '-(' -name '*.cc' -or -name '*.c' '-)'"

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -123,12 +123,15 @@ ToxAV *toxav_new(Tox *tox, TOXAV_ERR_NEW *error)
 {
     TOXAV_ERR_NEW rc = TOXAV_ERR_NEW_OK;
     ToxAV *av = nullptr;
-    Messenger *m = (Messenger *)tox;
 
     if (tox == nullptr) {
         rc = TOXAV_ERR_NEW_NULL;
         goto END;
     }
+
+    // TODO(iphydf): Don't rely on toxcore internals.
+    Messenger *m;
+    m = *(Messenger **)tox;
 
     if (m->msi_packet) {
         rc = TOXAV_ERR_NEW_MULTIPLE;

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1985,7 +1985,7 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
         return nullptr;
     }
 
-    logger_callback_log(m->log, options->log_callback, m, options->log_user_data);
+    logger_callback_log(m->log, options->log_callback, options->log_context, options->log_user_data);
 
     unsigned int net_err = 0;
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -61,6 +61,7 @@ typedef struct Messenger_Options {
     bool local_discovery_enabled;
 
     logger_cb *log_callback;
+    void *log_context;
     void *log_user_data;
 } Messenger_Options;
 


### PR DESCRIPTION
This allows Tox to contain additional data on top of Messenger, making
Messenger not necessarily the most top-level object. E.g. groups are
built on Messenger and currently awkwardly void-pointered into it to
pretend there is no cyclic dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1030)
<!-- Reviewable:end -->
