### PR TITLE
Add deprecation notice to some UPPER_CASE enums.

### DIFF
--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -342,6 +342,9 @@ const MAX_HOSTNAME_LENGTH         = 255;
 
 /**
  * Represents the possible statuses a client can have.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 enum class USER_STATUS {
   /**
@@ -364,6 +367,9 @@ enum class USER_STATUS {
 /**
  * Represents message types for ${tox.friend.send.message} and conference
  * messages.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 enum class MESSAGE_TYPE {
   /**
@@ -387,6 +393,9 @@ enum class MESSAGE_TYPE {
 
 /**
  * Type of proxy used to connect to TCP relays.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 enum class PROXY_TYPE {
   /**
@@ -405,6 +414,9 @@ enum class PROXY_TYPE {
 
 /**
  * Type of savedata to create the Tox instance from.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 enum class SAVEDATA_TYPE {
   /**
@@ -424,6 +436,9 @@ enum class SAVEDATA_TYPE {
 
 /**
  * Severity level of log messages.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 enum class LOG_LEVEL {
   /**
@@ -813,6 +828,9 @@ bool add_tcp_relay(string host, uint16_t port, const uint8_t[PUBLIC_KEY_SIZE] pu
 
 /**
  * Protocols that can be used to connect to the network or friends.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 enum class CONNECTION {
   /**
@@ -2104,6 +2122,9 @@ namespace conference {
 
   /**
    * Conference types for the ${event invite} event.
+   *
+   * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+   *   Camel_Snake_Case versions, instead.
    */
   enum class TYPE {
     /**

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -374,6 +374,9 @@ uint32_t tox_max_hostname_length(void);
 
 /**
  * Represents the possible statuses a client can have.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 typedef enum TOX_USER_STATUS {
 
@@ -400,6 +403,9 @@ typedef enum TOX_USER_STATUS {
 /**
  * Represents message types for tox_friend_send_message and conference
  * messages.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 typedef enum TOX_MESSAGE_TYPE {
 
@@ -428,6 +434,9 @@ typedef enum TOX_MESSAGE_TYPE {
 
 /**
  * Type of proxy used to connect to TCP relays.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 typedef enum TOX_PROXY_TYPE {
 
@@ -451,6 +460,9 @@ typedef enum TOX_PROXY_TYPE {
 
 /**
  * Type of savedata to create the Tox instance from.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 typedef enum TOX_SAVEDATA_TYPE {
 
@@ -474,6 +486,9 @@ typedef enum TOX_SAVEDATA_TYPE {
 
 /**
  * Severity level of log messages.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 typedef enum TOX_LOG_LEVEL {
 
@@ -972,6 +987,9 @@ bool tox_add_tcp_relay(Tox *tox, const char *host, uint16_t port, const uint8_t 
 
 /**
  * Protocols that can be used to connect to the network or friends.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 typedef enum TOX_CONNECTION {
 
@@ -2379,6 +2397,9 @@ void tox_callback_file_recv_chunk(Tox *tox, tox_file_recv_chunk_cb *callback);
 
 /**
  * Conference types for the conference_invite event.
+ *
+ * @deprecated All UPPER_CASE enum type names are deprecated. Use the
+ *   Camel_Snake_Case versions, instead.
  */
 typedef enum TOX_CONFERENCE_TYPE {
 


### PR DESCRIPTION
The enumerators won't change, but the type name will change in 0.3.0.
Reasoning:
- Type names in toxcore start with an uppercase letter and either have at
  least one lowercase letter in them, or are less than 4 characters long.
- Constants consist of 4 or more uppercase letters or underscores.

By these rules, "DHT" is a type name, but "TOX_USER_STATUS" is a
constant. We provide Tox_User_Status as an alternative for now, and will
switch to that in 0.3.0, removing the UPPER_CASE versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1036)
<!-- Reviewable:end -->
