### PR TITLE
Use per-instance `Mono_Time` instead of a global `unix_time`

### DIFF
--- a/auto_tests/dht_test.c
+++ b/auto_tests/dht_test.c
@@ -32,39 +32,39 @@ static inline IP get_loopback()
     return ip;
 }
 
-static void mark_bad(IPPTsPng *ipptp)
+static void mark_bad(const Mono_Time *mono_time, IPPTsPng *ipptp)
 {
-    ipptp->timestamp = unix_time() - 2 * BAD_NODE_TIMEOUT;
+    ipptp->timestamp = mono_time_get(mono_time) - 2 * BAD_NODE_TIMEOUT;
     ipptp->hardening.routes_requests_ok = 0;
     ipptp->hardening.send_nodes_ok = 0;
     ipptp->hardening.testing_requests = 0;
 }
 
-static void mark_possible_bad(IPPTsPng *ipptp)
+static void mark_possible_bad(const Mono_Time *mono_time, IPPTsPng *ipptp)
 {
-    ipptp->timestamp = unix_time();
+    ipptp->timestamp = mono_time_get(mono_time);
     ipptp->hardening.routes_requests_ok = 0;
     ipptp->hardening.send_nodes_ok = 0;
     ipptp->hardening.testing_requests = 0;
 }
 
-static void mark_good(IPPTsPng *ipptp)
+static void mark_good(const Mono_Time *mono_time, IPPTsPng *ipptp)
 {
-    ipptp->timestamp = unix_time();
+    ipptp->timestamp = mono_time_get(mono_time);
     ipptp->hardening.routes_requests_ok = (HARDENING_ALL_OK >> 0) & 1;
     ipptp->hardening.send_nodes_ok = (HARDENING_ALL_OK >> 1) & 1;
     ipptp->hardening.testing_requests = (HARDENING_ALL_OK >> 2) & 1;
 }
 
-static void mark_all_good(Client_data *list, uint32_t length, uint8_t ipv6)
+static void mark_all_good(const Mono_Time *mono_time, Client_data *list, uint32_t length, uint8_t ipv6)
 {
     uint32_t i;
 
     for (i = 0; i < length; ++i) {
         if (ipv6) {
-            mark_good(&list[i].assoc6);
+            mark_good(mono_time, &list[i].assoc6);
         } else {
-            mark_good(&list[i].assoc4);
+            mark_good(mono_time, &list[i].assoc4);
         }
     }
 }
@@ -183,7 +183,7 @@ static void test_addto_lists_bad(DHT            *dht,
     uint8_t ipv6 = net_family_is_ipv6(ip_port->ip.family) ? 1 : 0;
 
     random_bytes(public_key, sizeof(public_key));
-    mark_all_good(list, length, ipv6);
+    mark_all_good(dht->mono_time, list, length, ipv6);
 
     test1 = random_u32() % (length / 3);
     test2 = random_u32() % (length / 3) + length / 3;
@@ -196,13 +196,13 @@ static void test_addto_lists_bad(DHT            *dht,
 
     // mark nodes as "bad"
     if (ipv6) {
-        mark_bad(&list[test1].assoc6);
-        mark_bad(&list[test2].assoc6);
-        mark_bad(&list[test3].assoc6);
+        mark_bad(dht->mono_time, &list[test1].assoc6);
+        mark_bad(dht->mono_time, &list[test2].assoc6);
+        mark_bad(dht->mono_time, &list[test3].assoc6);
     } else {
-        mark_bad(&list[test1].assoc4);
-        mark_bad(&list[test2].assoc4);
-        mark_bad(&list[test3].assoc4);
+        mark_bad(dht->mono_time, &list[test1].assoc4);
+        mark_bad(dht->mono_time, &list[test2].assoc4);
+        mark_bad(dht->mono_time, &list[test3].assoc4);
     }
 
     ip_port->port += 1;
@@ -227,7 +227,7 @@ static void test_addto_lists_possible_bad(DHT            *dht,
     uint8_t ipv6 = net_family_is_ipv6(ip_port->ip.family) ? 1 : 0;
 
     random_bytes(public_key, sizeof(public_key));
-    mark_all_good(list, length, ipv6);
+    mark_all_good(dht->mono_time, list, length, ipv6);
 
     test1 = random_u32() % (length / 3);
     test2 = random_u32() % (length / 3) + length / 3;
@@ -240,13 +240,13 @@ static void test_addto_lists_possible_bad(DHT            *dht,
 
     // mark nodes as "possibly bad"
     if (ipv6) {
-        mark_possible_bad(&list[test1].assoc6);
-        mark_possible_bad(&list[test2].assoc6);
-        mark_possible_bad(&list[test3].assoc6);
+        mark_possible_bad(dht->mono_time, &list[test1].assoc6);
+        mark_possible_bad(dht->mono_time, &list[test2].assoc6);
+        mark_possible_bad(dht->mono_time, &list[test3].assoc6);
     } else {
-        mark_possible_bad(&list[test1].assoc4);
-        mark_possible_bad(&list[test2].assoc4);
-        mark_possible_bad(&list[test3].assoc4);
+        mark_possible_bad(dht->mono_time, &list[test1].assoc4);
+        mark_possible_bad(dht->mono_time, &list[test2].assoc4);
+        mark_possible_bad(dht->mono_time, &list[test3].assoc4);
     }
 
     ip_port->port += 1;
@@ -288,7 +288,7 @@ static void test_addto_lists_good(DHT            *dht,
     uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t ipv6 = net_family_is_ipv6(ip_port->ip.family) ? 1 : 0;
 
-    mark_all_good(list, length, ipv6);
+    mark_all_good(dht->mono_time, list, length, ipv6);
 
     // check "good" client id replacement
     do {
@@ -319,10 +319,13 @@ static void test_addto_lists(IP ip)
     uint32_t index = 1;
     logger_callback_log(log, (logger_cb *)print_debug_log, nullptr, &index);
 
+    Mono_Time *mono_time = mono_time_new();
+    ck_assert_msg(mono_time != nullptr, "Failed to create Mono_Time");
+
     Networking_Core *net = new_networking(log, ip, TOX_PORT_DEFAULT);
     ck_assert_msg(net != nullptr, "Failed to create Networking_Core");
 
-    DHT *dht = new_dht(log, net, true);
+    DHT *dht = new_dht(log, mono_time, net, true);
     ck_assert_msg(dht != nullptr, "Failed to create DHT");
 
     IP_Port ip_port;
@@ -451,6 +454,7 @@ static void test_list_main(void)
 {
     DHT *dhts[NUM_DHT];
     Logger *logs[NUM_DHT];
+    Mono_Time *mono_times[NUM_DHT];
     uint32_t index[NUM_DHT];
 
     uint8_t cmp_list1[NUM_DHT][MAX_FRIEND_CLIENTS][CRYPTO_PUBLIC_KEY_SIZE + 1];
@@ -466,7 +470,9 @@ static void test_list_main(void)
         index[i] = i + 1;
         logger_callback_log(logs[i], (logger_cb *)print_debug_log, nullptr, &index[i]);
 
-        dhts[i] = new_dht(logs[i], new_networking(logs[i], ip, DHT_DEFAULT_PORT + i), true);
+        mono_times[i] = mono_time_new();
+
+        dhts[i] = new_dht(logs[i], mono_times[i], new_networking(logs[i], ip, DHT_DEFAULT_PORT + i), true);
         ck_assert_msg(dhts[i] != nullptr, "Failed to create dht instances %u", i);
         ck_assert_msg(net_port(dhts[i]->net) != DHT_DEFAULT_PORT + i,
                       "Bound to wrong port: %d", net_port(dhts[i]->net));
@@ -573,6 +579,7 @@ static void test_list_main(void)
         Networking_Core *n = dhts[i]->net;
         kill_dht(dhts[i]);
         kill_networking(n);
+        mono_time_free(mono_times[i]);
         logger_kill(logs[i]);
     }
 }
@@ -598,9 +605,8 @@ static void test_DHT_test(void)
     uint32_t to_comp = 8394782;
     DHT *dhts[NUM_DHT];
     Logger *logs[NUM_DHT];
+    Mono_Time *mono_times[NUM_DHT];
     uint32_t index[NUM_DHT];
-
-    unix_time_update();
 
     uint32_t i, j;
 
@@ -612,7 +618,9 @@ static void test_DHT_test(void)
         index[i] = i + 1;
         logger_callback_log(logs[i], (logger_cb *)print_debug_log, nullptr, &index[i]);
 
-        dhts[i] = new_dht(logs[i], new_networking(logs[i], ip, DHT_DEFAULT_PORT + i), true);
+        mono_times[i] = mono_time_new();
+
+        dhts[i] = new_dht(logs[i], mono_times[i], new_networking(logs[i], ip, DHT_DEFAULT_PORT + i), true);
         ck_assert_msg(dhts[i] != nullptr, "Failed to create dht instances %u", i);
         ck_assert_msg(net_port(dhts[i]->net) != DHT_DEFAULT_PORT + i, "Bound to wrong port");
     }
@@ -663,7 +671,7 @@ loop_top:
         }
 
         for (i = 0; i < NUM_DHT; ++i) {
-            unix_time_update();
+            mono_time_update(mono_times[i]);
             networking_poll(dhts[i]->net, nullptr);
             do_dht(dhts[i]);
         }
@@ -675,6 +683,7 @@ loop_top:
         Networking_Core *n = dhts[i]->net;
         kill_dht(dhts[i]);
         kill_networking(n);
+        mono_time_free(mono_times[i]);
         logger_kill(logs[i]);
     }
 }
@@ -791,8 +800,6 @@ static void test_dht_node_packing(void)
 int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
-
-    unix_time_update();
 
     test_dht_create_packet();
     test_dht_node_packing();

--- a/auto_tests/messenger_test.c
+++ b/auto_tests/messenger_test.c
@@ -341,13 +341,15 @@ int main(void)
     good_id   = hex_string_to_bin(good_id_str);
     bad_id    = hex_string_to_bin(bad_id_str);
 
+    Mono_Time *mono_time = mono_time_new();
+
     /* IPv6 status from global define */
     Messenger_Options options = {0};
     options.ipv6enabled = TOX_ENABLE_IPV6_DEFAULT;
     options.port_range[0] = 41234;
     options.port_range[1] = 44234;
     options.log_callback = (logger_cb *)print_debug_log;
-    m = new_messenger(&options, nullptr);
+    m = new_messenger(mono_time, &options, nullptr);
 
     /* setup a default friend and friendnum */
     if (m_addfriend_norequest(m, friend_id) < 0) {
@@ -375,6 +377,7 @@ int main(void)
     free(bad_id);
 
     kill_messenger(m);
+    mono_time_free(mono_time);
 
     return number_failed;
 }

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -115,12 +115,11 @@ int main(int argc, char *argv[])
     IP ip;
     ip_init(&ip, ipv6enabled);
 
-    unix_time_update();
-
     Logger *logger = logger_new();
-    DHT *dht = new_dht(logger, new_networking(logger, ip, PORT), true);
-    Onion *onion = new_onion(dht);
-    Onion_Announce *onion_a = new_onion_announce(dht);
+    Mono_Time *mono_time = mono_time_new();
+    DHT *dht = new_dht(logger, mono_time, new_networking(logger, ip, PORT), true);
+    Onion *onion = new_onion(mono_time, dht);
+    Onion_Announce *onion_a = new_onion_announce(mono_time, dht);
 
 #ifdef DHT_NODE_EXTRA_PACKETS
     bootstrap_set_callbacks(dht_get_net(dht), DHT_VERSION_NUMBER, DHT_MOTD, sizeof(DHT_MOTD));
@@ -188,7 +187,7 @@ int main(int argc, char *argv[])
     lan_discovery_init(dht);
 
     while (1) {
-        unix_time_update();
+        mono_time_update(mono_time);
 
         if (is_waiting_for_dht_connection && dht_isconnected(dht)) {
             printf("Connected to other bootstrap node successfully.\n");
@@ -197,13 +196,13 @@ int main(int argc, char *argv[])
 
         do_dht(dht);
 
-        if (is_timeout(last_LANdiscovery, is_waiting_for_dht_connection ? 5 : LAN_DISCOVERY_INTERVAL)) {
+        if (mono_time_is_timeout(mono_time, last_LANdiscovery, is_waiting_for_dht_connection ? 5 : LAN_DISCOVERY_INTERVAL)) {
             lan_discovery_send(net_htons(PORT), dht);
-            last_LANdiscovery = unix_time();
+            last_LANdiscovery = mono_time_get(mono_time);
         }
 
 #ifdef TCP_RELAY_ENABLED
-        do_TCP_server(tcp_s);
+        do_TCP_server(tcp_s, mono_time);
 #endif
         networking_poll(dht_get_net(dht), nullptr);
 

--- a/other/astyle/format-source
+++ b/other/astyle/format-source
@@ -36,11 +36,13 @@ apidsl_curl() {
 
 # Check if apidsl generated sources are up to date.
 $APIDSL toxcore/crypto_core.api.h > toxcore/crypto_core.h &
+$APIDSL toxcore/ping.api.h > toxcore/ping.h &
+$APIDSL toxcore/ping_array.api.h > toxcore/ping_array.h &
 $APIDSL toxcore/tox.api.h > toxcore/tox.h &
 $APIDSL toxav/toxav.api.h > toxav/toxav.h &
 $APIDSL toxencryptsave/toxencryptsave.api.h > toxencryptsave/toxencryptsave.h &
 
-wait; wait; wait; wait
+wait; wait; wait; wait; wait; wait
 
 if grep '<unresolved>' */*.h; then
   echo "error: some apidsl references were unresolved"

--- a/testing/DHT_test.c
+++ b/testing/DHT_test.c
@@ -190,11 +190,11 @@ int main(int argc, char *argv[])
     IP ip;
     ip_init(&ip, ipv6enabled);
 
-    DHT *dht = new_dht(nullptr, new_networking(nullptr, ip, PORT), true);
+    Mono_Time *const mono_time = mono_time_new();
+    DHT *dht = new_dht(nullptr, mono_time, new_networking(nullptr, ip, PORT), true);
     printf("OUR ID: ");
-    uint32_t i;
 
-    for (i = 0; i < 32; i++) {
+    for (uint32_t i = 0; i < 32; i++) {
         const uint8_t *const self_public_key = dht_get_self_public_key(dht);
 
         if (self_public_key[i] < 16) {
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
 #endif
 
     while (1) {
-        unix_time_update();
+        mono_time_update(mono_time);
 
         do_dht(dht);
 

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -107,11 +107,16 @@ int main(int argc, char *argv[])
         exit(0);
     }
 
-    unix_time_update();
+    Mono_Time *const mono_time = mono_time_new();
+
+    if (mono_time == nullptr) {
+        fputs("Failed to allocate monotonic timer datastructure\n", stderr);
+        exit(0);
+    }
 
     Messenger_Options options = {0};
     options.ipv6enabled = ipv6enabled;
-    m = new_messenger(&options, nullptr);
+    m = new_messenger(mono_time, &options, nullptr);
 
     if (!m) {
         fputs("Failed to allocate messenger datastructure\n", stderr);
@@ -180,7 +185,7 @@ int main(int argc, char *argv[])
     perror("Initialization");
 
     while (1) {
-        unix_time_update();
+        mono_time_update(mono_time);
 
         uint8_t name[128];
         const char *const filename = "Save.bak";

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -93,6 +93,7 @@ typedef struct Cryptopacket_Handler {
 
 struct DHT {
     const Logger *log;
+    Mono_Time *mono_time;
     Networking_Core *net;
 
     bool hole_punching_enabled;
@@ -243,7 +244,8 @@ static unsigned int bit_by_bit_cmp(const uint8_t *pk1, const uint8_t *pk2)
  * If shared key is already in shared_keys, copy it to shared_key.
  * else generate it into shared_key and copy it to shared_keys
  */
-void get_shared_key(Shared_Keys *shared_keys, uint8_t *shared_key, const uint8_t *secret_key, const uint8_t *public_key)
+void get_shared_key(const Mono_Time *mono_time, Shared_Keys *shared_keys, uint8_t *shared_key,
+                    const uint8_t *secret_key, const uint8_t *public_key)
 {
     uint32_t num = ~0;
     uint32_t curr = 0;
@@ -256,12 +258,12 @@ void get_shared_key(Shared_Keys *shared_keys, uint8_t *shared_key, const uint8_t
             if (id_equal(public_key, key->public_key)) {
                 memcpy(shared_key, key->shared_key, CRYPTO_SHARED_KEY_SIZE);
                 ++key->times_requested;
-                key->time_last_requested = unix_time();
+                key->time_last_requested = mono_time_get(mono_time);
                 return;
             }
 
             if (num != 0) {
-                if (is_timeout(key->time_last_requested, KEYS_TIMEOUT)) {
+                if (mono_time_is_timeout(mono_time, key->time_last_requested, KEYS_TIMEOUT)) {
                     num = 0;
                     curr = index;
                 } else if (num > key->times_requested) {
@@ -283,7 +285,7 @@ void get_shared_key(Shared_Keys *shared_keys, uint8_t *shared_key, const uint8_t
         key->times_requested = 1;
         memcpy(key->public_key, public_key, CRYPTO_PUBLIC_KEY_SIZE);
         memcpy(key->shared_key, shared_key, CRYPTO_SHARED_KEY_SIZE);
-        key->time_last_requested = unix_time();
+        key->time_last_requested = mono_time_get(mono_time);
     }
 }
 
@@ -292,7 +294,7 @@ void get_shared_key(Shared_Keys *shared_keys, uint8_t *shared_key, const uint8_t
  */
 void dht_get_shared_key_recv(DHT *dht, uint8_t *shared_key, const uint8_t *public_key)
 {
-    get_shared_key(&dht->shared_keys_recv, shared_key, dht->self_secret_key, public_key);
+    get_shared_key(dht->mono_time, &dht->shared_keys_recv, shared_key, dht->self_secret_key, public_key);
 }
 
 /* Copy shared_key to encrypt/decrypt DHT packet from public_key into shared_key
@@ -300,7 +302,7 @@ void dht_get_shared_key_recv(DHT *dht, uint8_t *shared_key, const uint8_t *publi
  */
 void dht_get_shared_key_sent(DHT *dht, uint8_t *shared_key, const uint8_t *public_key)
 {
-    get_shared_key(&dht->shared_keys_sent, shared_key, dht->self_secret_key, public_key);
+    get_shared_key(dht->mono_time, &dht->shared_keys_sent, shared_key, dht->self_secret_key, public_key);
 }
 
 #define CRYPTO_SIZE 1 + CRYPTO_PUBLIC_KEY_SIZE * 2 + CRYPTO_NONCE_SIZE
@@ -667,7 +669,8 @@ static uint32_t index_of_client_ip_port(const Client_data *array, uint32_t size,
 
 /* Update ip_port of client if it's needed.
  */
-static void update_client(const Logger *log, int index, Client_data *client, IP_Port ip_port)
+static void update_client(const Logger *log, const Mono_Time *mono_time, int index, Client_data *client,
+                          IP_Port ip_port)
 {
     IPPTsPng *assoc;
     int ip_version;
@@ -697,7 +700,7 @@ static void update_client(const Logger *log, int index, Client_data *client, IP_
     }
 
     assoc->ip_port = ip_port;
-    assoc->timestamp = unix_time();
+    assoc->timestamp = mono_time_get(mono_time);
 }
 
 /* Check if client with public_key is already in list of length length.
@@ -707,15 +710,15 @@ static void update_client(const Logger *log, int index, Client_data *client, IP_
  *
  *  return True(1) or False(0)
  */
-static int client_or_ip_port_in_list(const Logger *log, Client_data *list, uint16_t length, const uint8_t *public_key,
-                                     IP_Port ip_port)
+static int client_or_ip_port_in_list(const Logger *log, const Mono_Time *mono_time, Client_data *list, uint16_t length,
+                                     const uint8_t *public_key, IP_Port ip_port)
 {
-    const uint64_t temp_time = unix_time();
+    const uint64_t temp_time = mono_time_get(mono_time);
     uint32_t index = index_of_client_pk(list, length, public_key);
 
     /* if public_key is in list, find it and maybe overwrite ip_port */
     if (index != UINT32_MAX) {
-        update_client(log, index, &list[index], ip_port);
+        update_client(log, mono_time, index, &list[index], ip_port);
         return 1;
     }
 
@@ -793,7 +796,7 @@ static uint8_t hardening_correct(const Hardening *h)
 /*
  * helper for get_close_nodes(). argument list is a monster :D
  */
-static void get_close_nodes_inner(const uint8_t *public_key, Node_format *nodes_list,
+static void get_close_nodes_inner(const Mono_Time *mono_time, const uint8_t *public_key, Node_format *nodes_list,
                                   Family sa_family, const Client_data *client_list, uint32_t client_list_length,
                                   uint32_t *num_nodes_ptr, uint8_t is_LAN, uint8_t want_good)
 {
@@ -824,7 +827,7 @@ static void get_close_nodes_inner(const uint8_t *public_key, Node_format *nodes_
         }
 
         /* node not in a good condition? */
-        if (is_timeout(ipptp->timestamp, BAD_NODE_TIMEOUT)) {
+        if (mono_time_is_timeout(mono_time, ipptp->timestamp, BAD_NODE_TIMEOUT)) {
             continue;
         }
 
@@ -862,14 +865,14 @@ static int get_somewhat_close_nodes(const DHT *dht, const uint8_t *public_key, N
                                     Family sa_family, uint8_t is_LAN, uint8_t want_good)
 {
     uint32_t num_nodes = 0;
-    get_close_nodes_inner(public_key, nodes_list, sa_family,
+    get_close_nodes_inner(dht->mono_time, public_key, nodes_list, sa_family,
                           dht->close_clientlist, LCLIENT_LIST, &num_nodes, is_LAN, 0);
 
     /* TODO(irungentoo): uncomment this when hardening is added to close friend clients */
 #if 0
 
     for (uint32_t i = 0; i < dht->num_friends; ++i) {
-        get_close_nodes_inner(dht, public_key, nodes_list, sa_family,
+        get_close_nodes_inner(dht->mono_time, public_key, nodes_list, sa_family,
                               dht->friends_list[i].client_list, MAX_FRIEND_CLIENTS,
                               &num_nodes, is_LAN, want_good);
     }
@@ -877,7 +880,7 @@ static int get_somewhat_close_nodes(const DHT *dht, const uint8_t *public_key, N
 #endif
 
     for (uint32_t i = 0; i < dht->num_friends; ++i) {
-        get_close_nodes_inner(public_key, nodes_list, sa_family,
+        get_close_nodes_inner(dht->mono_time, public_key, nodes_list, sa_family,
                               dht->friends_list[i].client_list, MAX_FRIEND_CLIENTS,
                               &num_nodes, is_LAN, 0);
     }
@@ -893,13 +896,14 @@ int get_close_nodes(const DHT *dht, const uint8_t *public_key, Node_format *node
 }
 
 typedef struct DHT_Cmp_data {
+    const Mono_Time *mono_time;
     const uint8_t *base_public_key;
     Client_data entry;
 } DHT_Cmp_data;
 
-static bool assoc_timeout(const IPPTsPng *assoc)
+static bool assoc_timeout(const Mono_Time *mono_time, const IPPTsPng *assoc)
 {
-    return is_timeout(assoc->timestamp, BAD_NODE_TIMEOUT);
+    return mono_time_is_timeout(mono_time, assoc->timestamp, BAD_NODE_TIMEOUT);
 }
 
 static bool incorrect_hardening(const IPPTsPng *assoc)
@@ -916,8 +920,8 @@ static int cmp_dht_entry(const void *a, const void *b)
     const Client_data entry2 = cmp2.entry;
     const uint8_t *cmp_public_key = cmp1.base_public_key;
 
-    bool t1 = assoc_timeout(&entry1.assoc4) && assoc_timeout(&entry1.assoc6);
-    bool t2 = assoc_timeout(&entry2.assoc4) && assoc_timeout(&entry2.assoc6);
+    bool t1 = assoc_timeout(cmp1.mono_time, &entry1.assoc4) && assoc_timeout(cmp1.mono_time, &entry1.assoc6);
+    bool t2 = assoc_timeout(cmp2.mono_time, &entry2.assoc4) && assoc_timeout(cmp2.mono_time, &entry2.assoc6);
 
     if (t1 && t2) {
         return 0;
@@ -960,20 +964,23 @@ static int cmp_dht_entry(const void *a, const void *b)
  * return 0 if node can't be stored.
  * return 1 if it can.
  */
-static unsigned int store_node_ok(const Client_data *client, const uint8_t *public_key, const uint8_t *comp_public_key)
+static unsigned int store_node_ok(const Client_data *client, const Mono_Time *mono_time, const uint8_t *public_key,
+                                  const uint8_t *comp_public_key)
 {
-    return (is_timeout(client->assoc4.timestamp, BAD_NODE_TIMEOUT)
-            && is_timeout(client->assoc6.timestamp, BAD_NODE_TIMEOUT))
+    return (mono_time_is_timeout(mono_time, client->assoc4.timestamp, BAD_NODE_TIMEOUT)
+            && mono_time_is_timeout(mono_time, client->assoc6.timestamp, BAD_NODE_TIMEOUT))
            || id_closest(comp_public_key, client->public_key, public_key) == 2;
 }
 
-static void sort_client_list(Client_data *list, unsigned int length, const uint8_t *comp_public_key)
+static void sort_client_list(Client_data *list, const Mono_Time *mono_time, unsigned int length,
+                             const uint8_t *comp_public_key)
 {
     // Pass comp_public_key to qsort with each Client_data entry, so the
     // comparison function can use it as the base of comparison.
     VLA(DHT_Cmp_data, cmp_list, length);
 
     for (uint32_t i = 0; i < length; ++i) {
+        cmp_list[i].mono_time = mono_time;
         cmp_list[i].base_public_key = comp_public_key;
         cmp_list[i].entry = list[i];
     }
@@ -985,7 +992,7 @@ static void sort_client_list(Client_data *list, unsigned int length, const uint8
     }
 }
 
-static void update_client_with_reset(Client_data *client, const IP_Port *ip_port)
+static void update_client_with_reset(const Mono_Time *mono_time, Client_data *client, const IP_Port *ip_port)
 {
     IPPTsPng *ipptp_write = nullptr;
     IPPTsPng *ipptp_clear = nullptr;
@@ -999,7 +1006,7 @@ static void update_client_with_reset(Client_data *client, const IP_Port *ip_port
     }
 
     ipptp_write->ip_port = *ip_port;
-    ipptp_write->timestamp = unix_time();
+    ipptp_write->timestamp = mono_time_get(mono_time);
 
     ip_reset(&ipptp_write->ret_ip_port.ip);
     ipptp_write->ret_ip_port.port = 0;
@@ -1022,7 +1029,8 @@ static void update_client_with_reset(Client_data *client, const IP_Port *ip_port
  *  than public_key.
  *
  *  returns true when the item was stored, false otherwise */
-static bool replace_all(Client_data    *list,
+static bool replace_all(const Mono_Time *mono_time,
+                        Client_data    *list,
                         uint16_t        length,
                         const uint8_t  *public_key,
                         IP_Port         ip_port,
@@ -1032,17 +1040,17 @@ static bool replace_all(Client_data    *list,
         return false;
     }
 
-    if (!store_node_ok(&list[1], public_key, comp_public_key) &&
-            !store_node_ok(&list[0], public_key, comp_public_key)) {
+    if (!store_node_ok(&list[1], mono_time, public_key, comp_public_key) &&
+            !store_node_ok(&list[0], mono_time, public_key, comp_public_key)) {
         return false;
     }
 
-    sort_client_list(list, length, comp_public_key);
+    sort_client_list(list, mono_time, length, comp_public_key);
 
     Client_data *const client = &list[0];
     id_copy(client->public_key, public_key);
 
-    update_client_with_reset(client, &ip_port);
+    update_client_with_reset(mono_time, client, &ip_port);
     return true;
 }
 
@@ -1066,8 +1074,8 @@ static int add_to_close(DHT *dht, const uint8_t *public_key, IP_Port ip_port, bo
          * index is left as >= LCLIENT_LENGTH */
         Client_data *const client = &dht->close_clientlist[(index * LCLIENT_NODES) + i];
 
-        if (!is_timeout(client->assoc4.timestamp, BAD_NODE_TIMEOUT) ||
-                !is_timeout(client->assoc6.timestamp, BAD_NODE_TIMEOUT)) {
+        if (!mono_time_is_timeout(dht->mono_time, client->assoc4.timestamp, BAD_NODE_TIMEOUT) ||
+                !mono_time_is_timeout(dht->mono_time, client->assoc6.timestamp, BAD_NODE_TIMEOUT)) {
             continue;
         }
 
@@ -1076,7 +1084,7 @@ static int add_to_close(DHT *dht, const uint8_t *public_key, IP_Port ip_port, bo
         }
 
         id_copy(client->public_key, public_key);
-        update_client_with_reset(client, &ip_port);
+        update_client_with_reset(dht->mono_time, client, &ip_port);
         return 0;
     }
 
@@ -1090,8 +1098,8 @@ bool node_addable_to_close_list(DHT *dht, const uint8_t *public_key, IP_Port ip_
     return add_to_close(dht, public_key, ip_port, 1) == 0;
 }
 
-static bool is_pk_in_client_list(const Client_data *list, unsigned int client_list_length, const uint8_t *public_key,
-                                 IP_Port ip_port)
+static bool is_pk_in_client_list(const Client_data *list, unsigned int client_list_length, const Mono_Time *mono_time,
+                                 const uint8_t *public_key, IP_Port ip_port)
 {
     const uint32_t index = index_of_client_pk(list, client_list_length, public_key);
 
@@ -1103,7 +1111,7 @@ static bool is_pk_in_client_list(const Client_data *list, unsigned int client_li
                             ? &list[index].assoc4
                             : &list[index].assoc6;
 
-    return !is_timeout(assoc->timestamp, BAD_NODE_TIMEOUT);
+    return !mono_time_is_timeout(mono_time, assoc->timestamp, BAD_NODE_TIMEOUT);
 }
 
 static bool is_pk_in_close_list(DHT *dht, const uint8_t *public_key, IP_Port ip_port)
@@ -1114,7 +1122,8 @@ static bool is_pk_in_close_list(DHT *dht, const uint8_t *public_key, IP_Port ip_
         index = LCLIENT_LENGTH - 1;
     }
 
-    return is_pk_in_client_list(dht->close_clientlist + index * LCLIENT_NODES, LCLIENT_NODES, public_key, ip_port);
+    return is_pk_in_client_list(dht->close_clientlist + index * LCLIENT_NODES, LCLIENT_NODES, dht->mono_time, public_key,
+                                ip_port);
 }
 
 /* Check if the node obtained with a get_nodes with public_key should be pinged.
@@ -1153,17 +1162,18 @@ static bool ping_node_from_getnodes_ok(DHT *dht, const uint8_t *public_key, IP_P
 
         bool store_ok = false;
 
-        if (store_node_ok(&dht_friend->client_list[1], public_key, dht_friend->public_key)) {
+        if (store_node_ok(&dht_friend->client_list[1], dht->mono_time, public_key, dht_friend->public_key)) {
             store_ok = true;
         }
 
-        if (store_node_ok(&dht_friend->client_list[0], public_key, dht_friend->public_key)) {
+        if (store_node_ok(&dht_friend->client_list[0], dht->mono_time, public_key, dht_friend->public_key)) {
             store_ok = true;
         }
 
         unsigned int *const friend_num = &dht_friend->num_to_bootstrap;
         const uint32_t index = index_of_node_pk(dht_friend->to_bootstrap, *friend_num, public_key);
-        const bool pk_in_list = is_pk_in_client_list(dht_friend->client_list, MAX_FRIEND_CLIENTS, public_key, ip_port);
+        const bool pk_in_list = is_pk_in_client_list(dht_friend->client_list, MAX_FRIEND_CLIENTS, dht->mono_time, public_key,
+                                ip_port);
 
         if (store_ok && index == UINT32_MAX && !pk_in_list) {
             if (*friend_num < MAX_SENT_NODES) {
@@ -1200,8 +1210,8 @@ uint32_t addto_lists(DHT *dht, IP_Port ip_port, const uint8_t *public_key)
     /* NOTE: Current behavior if there are two clients with the same id is
      * to replace the first ip by the second.
      */
-    const bool in_close_list = client_or_ip_port_in_list(dht->log, dht->close_clientlist,
-                               LCLIENT_LIST, public_key, ip_port);
+    const bool in_close_list = client_or_ip_port_in_list(dht->log, dht->mono_time, dht->close_clientlist, LCLIENT_LIST,
+                               public_key, ip_port);
 
     /* add_to_close should be called only if !in_list (don't extract to variable) */
     if (in_close_list || add_to_close(dht, public_key, ip_port, 0)) {
@@ -1211,12 +1221,13 @@ uint32_t addto_lists(DHT *dht, IP_Port ip_port, const uint8_t *public_key)
     DHT_Friend *friend_foundip = nullptr;
 
     for (uint32_t i = 0; i < dht->num_friends; ++i) {
-        const bool in_list = client_or_ip_port_in_list(dht->log, dht->friends_list[i].client_list,
+        const bool in_list = client_or_ip_port_in_list(dht->log, dht->mono_time, dht->friends_list[i].client_list,
                              MAX_FRIEND_CLIENTS, public_key, ip_port);
 
         /* replace_all should be called only if !in_list (don't extract to variable) */
-        if (in_list || replace_all(dht->friends_list[i].client_list, MAX_FRIEND_CLIENTS, public_key,
-                                   ip_port, dht->friends_list[i].public_key)) {
+        if (in_list
+                || replace_all(dht->mono_time, dht->friends_list[i].client_list, MAX_FRIEND_CLIENTS, public_key, ip_port,
+                               dht->friends_list[i].public_key)) {
             DHT_Friend *dht_friend = &dht->friends_list[i];
 
             if (id_equal(public_key, dht_friend->public_key)) {
@@ -1241,9 +1252,10 @@ uint32_t addto_lists(DHT *dht, IP_Port ip_port, const uint8_t *public_key)
     return used;
 }
 
-static bool update_client_data(Client_data *array, size_t size, IP_Port ip_port, const uint8_t *pk)
+static bool update_client_data(const Mono_Time *mono_time, Client_data *array, size_t size, IP_Port ip_port,
+                               const uint8_t *pk)
 {
-    const uint64_t temp_time = unix_time();
+    const uint64_t temp_time = mono_time_get(mono_time);
     const uint32_t index = index_of_client_pk(array, size, pk);
 
     if (index == UINT32_MAX) {
@@ -1278,7 +1290,7 @@ static void returnedip_ports(DHT *dht, IP_Port ip_port, const uint8_t *public_ke
     }
 
     if (id_equal(public_key, dht->self_public_key)) {
-        update_client_data(dht->close_clientlist, LCLIENT_LIST, ip_port, nodepublic_key);
+        update_client_data(dht->mono_time, dht->close_clientlist, LCLIENT_LIST, ip_port, nodepublic_key);
         return;
     }
 
@@ -1286,7 +1298,7 @@ static void returnedip_ports(DHT *dht, IP_Port ip_port, const uint8_t *public_ke
         if (id_equal(public_key, dht->friends_list[i].public_key)) {
             Client_data *const client_list = dht->friends_list[i].client_list;
 
-            if (update_client_data(client_list, MAX_FRIEND_CLIENTS, ip_port, nodepublic_key)) {
+            if (update_client_data(dht->mono_time, client_list, MAX_FRIEND_CLIENTS, ip_port, nodepublic_key)) {
                 return;
             }
         }
@@ -1314,9 +1326,9 @@ static int getnodes(DHT *dht, IP_Port ip_port, const uint8_t *public_key, const 
 
     if (sendback_node != nullptr) {
         memcpy(plain_message + sizeof(receiver), sendback_node, sizeof(Node_format));
-        ping_id = ping_array_add(dht->dht_harden_ping_array, plain_message, sizeof(plain_message));
+        ping_id = ping_array_add(dht->dht_harden_ping_array, dht->mono_time, plain_message, sizeof(plain_message));
     } else {
-        ping_id = ping_array_add(dht->dht_ping_array, plain_message, sizeof(receiver));
+        ping_id = ping_array_add(dht->dht_ping_array, dht->mono_time, plain_message, sizeof(receiver));
     }
 
     if (ping_id == 0) {
@@ -1433,9 +1445,9 @@ static bool sent_getnode_to_node(DHT *dht, const uint8_t *public_key, IP_Port no
 {
     uint8_t data[sizeof(Node_format) * 2];
 
-    if (ping_array_check(dht->dht_ping_array, data, sizeof(data), ping_id) == sizeof(Node_format)) {
+    if (ping_array_check(dht->dht_ping_array, dht->mono_time, data, sizeof(data), ping_id) == sizeof(Node_format)) {
         memset(sendback_node, 0, sizeof(Node_format));
-    } else if (ping_array_check(dht->dht_harden_ping_array, data, sizeof(data), ping_id) == sizeof(data)) {
+    } else if (ping_array_check(dht->dht_harden_ping_array, dht->mono_time, data, sizeof(data), ping_id) == sizeof(data)) {
         memcpy(sendback_node, data + sizeof(Node_format), sizeof(Node_format));
     } else {
         return false;
@@ -1678,7 +1690,7 @@ int dht_getfriendip(const DHT *dht, const uint8_t *public_key, IP_Port *ip_port)
     for (const IPPTsPng * const *it = assocs; *it; ++it) {
         const IPPTsPng *const assoc = *it;
 
-        if (!is_timeout(assoc->timestamp, BAD_NODE_TIMEOUT)) {
+        if (!mono_time_is_timeout(dht->mono_time, assoc->timestamp, BAD_NODE_TIMEOUT)) {
             *ip_port = assoc->ip_port;
             return 1;
         }
@@ -1692,7 +1704,7 @@ static uint8_t do_ping_and_sendnode_requests(DHT *dht, uint64_t *lastgetnode, co
         Client_data *list, uint32_t list_count, uint32_t *bootstrap_times, bool sortable)
 {
     uint8_t not_kill = 0;
-    const uint64_t temp_time = unix_time();
+    const uint64_t temp_time = mono_time_get(dht->mono_time);
 
     uint32_t num_nodes = 0;
     VLA(Client_data *, client_list, list_count * 2);
@@ -1709,17 +1721,17 @@ static uint8_t do_ping_and_sendnode_requests(DHT *dht, uint64_t *lastgetnode, co
         for (uint32_t j = 0; j < sizeof(assocs) / sizeof(assocs[0]); ++j) {
             IPPTsPng *const assoc = assocs[j];
 
-            if (!is_timeout(assoc->timestamp, KILL_NODE_TIMEOUT)) {
+            if (!mono_time_is_timeout(dht->mono_time, assoc->timestamp, KILL_NODE_TIMEOUT)) {
                 sort = 0;
                 ++not_kill;
 
-                if (is_timeout(assoc->last_pinged, PING_INTERVAL)) {
+                if (mono_time_is_timeout(dht->mono_time, assoc->last_pinged, PING_INTERVAL)) {
                     getnodes(dht, assoc->ip_port, client->public_key, public_key, nullptr);
                     assoc->last_pinged = temp_time;
                 }
 
                 /* If node is good. */
-                if (!is_timeout(assoc->timestamp, BAD_NODE_TIMEOUT)) {
+                if (!mono_time_is_timeout(dht->mono_time, assoc->timestamp, BAD_NODE_TIMEOUT)) {
                     client_list[num_nodes] = client;
                     assoc_list[num_nodes] = assoc;
                     ++num_nodes;
@@ -1736,10 +1748,11 @@ static uint8_t do_ping_and_sendnode_requests(DHT *dht, uint64_t *lastgetnode, co
     }
 
     if (sortable && sort_ok) {
-        sort_client_list(list, list_count, public_key);
+        sort_client_list(list, dht->mono_time, list_count, public_key);
     }
 
-    if ((num_nodes != 0) && (is_timeout(*lastgetnode, GET_NODE_INTERVAL) || *bootstrap_times < MAX_BOOTSTRAP_TIMES)) {
+    if ((num_nodes != 0) && (mono_time_is_timeout(dht->mono_time, *lastgetnode, GET_NODE_INTERVAL)
+                             || *bootstrap_times < MAX_BOOTSTRAP_TIMES)) {
         uint32_t rand_node = random_u32() % num_nodes;
 
         if ((num_nodes - 1) != rand_node) {
@@ -1801,7 +1814,7 @@ static void do_Close(DHT *dht)
      *
      * so: reset all nodes to be BAD_NODE_TIMEOUT, but not
      * KILL_NODE_TIMEOUT, so we at least keep trying pings */
-    const uint64_t badonly = unix_time() - BAD_NODE_TIMEOUT;
+    const uint64_t badonly = mono_time_get(dht->mono_time) - BAD_NODE_TIMEOUT;
 
     for (size_t i = 0; i < LCLIENT_LIST; ++i) {
         Client_data *const client = &dht->close_clientlist[i];
@@ -1906,19 +1919,21 @@ static int friend_iplist(const DHT *dht, IP_Port *ip_portlist, uint16_t friend_n
         const Client_data *const client = &dht_friend->client_list[i];
 
         /* If ip is not zero and node is good. */
-        if (ip_isset(&client->assoc4.ret_ip_port.ip) && !is_timeout(client->assoc4.ret_timestamp, BAD_NODE_TIMEOUT)) {
+        if (ip_isset(&client->assoc4.ret_ip_port.ip)
+                && !mono_time_is_timeout(dht->mono_time, client->assoc4.ret_timestamp, BAD_NODE_TIMEOUT)) {
             ipv4s[num_ipv4s] = client->assoc4.ret_ip_port;
             ++num_ipv4s;
         }
 
-        if (ip_isset(&client->assoc6.ret_ip_port.ip) && !is_timeout(client->assoc6.ret_timestamp, BAD_NODE_TIMEOUT)) {
+        if (ip_isset(&client->assoc6.ret_ip_port.ip)
+                && !mono_time_is_timeout(dht->mono_time, client->assoc6.ret_timestamp, BAD_NODE_TIMEOUT)) {
             ipv6s[num_ipv6s] = client->assoc6.ret_ip_port;
             ++num_ipv6s;
         }
 
         if (id_equal(client->public_key, dht_friend->public_key)) {
-            if (!is_timeout(client->assoc6.timestamp, BAD_NODE_TIMEOUT)
-                    || !is_timeout(client->assoc4.timestamp, BAD_NODE_TIMEOUT)) {
+            if (!mono_time_is_timeout(dht->mono_time, client->assoc6.timestamp, BAD_NODE_TIMEOUT)
+                    || !mono_time_is_timeout(dht->mono_time, client->assoc4.timestamp, BAD_NODE_TIMEOUT)) {
                 return 0; /* direct connectivity */
             }
         }
@@ -1997,7 +2012,7 @@ int route_tofriend(const DHT *dht, const uint8_t *friend_id, const uint8_t *pack
             const IPPTsPng *const assoc = *it;
 
             /* If ip is not zero and node is good. */
-            if (ip_isset(&assoc->ret_ip_port.ip) && !is_timeout(assoc->ret_timestamp, BAD_NODE_TIMEOUT)) {
+            if (ip_isset(&assoc->ret_ip_port.ip) && !mono_time_is_timeout(dht->mono_time, assoc->ret_timestamp, BAD_NODE_TIMEOUT)) {
                 const int retval = sendpacket(dht->net, assoc->ip_port, packet, length);
 
                 if ((unsigned int)retval == length) {
@@ -2039,7 +2054,7 @@ static int routeone_tofriend(DHT *dht, const uint8_t *friend_id, const uint8_t *
             const IPPTsPng *const assoc = *it;
 
             /* If ip is not zero and node is good. */
-            if (ip_isset(&assoc->ret_ip_port.ip) && !is_timeout(assoc->ret_timestamp, BAD_NODE_TIMEOUT)) {
+            if (ip_isset(&assoc->ret_ip_port.ip) && !mono_time_is_timeout(dht->mono_time, assoc->ret_timestamp, BAD_NODE_TIMEOUT)) {
                 ip_list[n] = assoc->ip_port;
                 ++n;
             }
@@ -2116,7 +2131,7 @@ static int handle_NATping(void *object, IP_Port source, const uint8_t *source_pu
     if (packet[0] == NAT_PING_REQUEST) {
         /* 1 is reply */
         send_NATping(dht, source_pubkey, ping_id, NAT_PING_RESPONSE);
-        dht_friend->nat.recv_nat_ping_timestamp = unix_time();
+        dht_friend->nat.recv_nat_ping_timestamp = mono_time_get(dht->mono_time);
         return 0;
     }
 
@@ -2243,7 +2258,7 @@ static void punch_holes(DHT *dht, IP ip, uint16_t *port_list, uint16_t numports,
 
 static void do_NAT(DHT *dht)
 {
-    const uint64_t temp_time = unix_time();
+    const uint64_t temp_time = mono_time_get(dht->mono_time);
 
     for (uint32_t i = 0; i < dht->num_friends; ++i) {
         IP_Port ip_list[MAX_FRIEND_CLIENTS];
@@ -2393,7 +2408,7 @@ static uint32_t have_nodes_closelist(DHT *dht, Node_format *nodes, uint16_t num)
         const IPPTsPng *const temp = get_closelist_IPPTsPng(dht, nodes[i].public_key, nodes[i].ip_port.ip.family);
 
         if (temp) {
-            if (!is_timeout(temp->timestamp, BAD_NODE_TIMEOUT)) {
+            if (!mono_time_is_timeout(dht->mono_time, temp->timestamp, BAD_NODE_TIMEOUT)) {
                 ++counter;
             }
         }
@@ -2464,7 +2479,7 @@ static int handle_hardening(void *object, IP_Port source, const uint8_t *source_
                 return 1;
             }
 
-            if (is_timeout(temp->hardening.send_nodes_timestamp, HARDENING_INTERVAL)) {
+            if (mono_time_is_timeout(dht->mono_time, temp->hardening.send_nodes_timestamp, HARDENING_INTERVAL)) {
                 return 1;
             }
 
@@ -2512,7 +2527,8 @@ static Node_format random_node(DHT *dht, Family sa_family)
  *
  * return the number of nodes.
  */
-static uint16_t list_nodes(Client_data *list, size_t length, Node_format *nodes, uint16_t max_num)
+static uint16_t list_nodes(Client_data *list, size_t length, const Mono_Time *mono_time, Node_format *nodes,
+                           uint16_t max_num)
 {
     if (max_num == 0) {
         return 0;
@@ -2523,11 +2539,11 @@ static uint16_t list_nodes(Client_data *list, size_t length, Node_format *nodes,
     for (size_t i = length; i != 0; --i) {
         const IPPTsPng *assoc = nullptr;
 
-        if (!is_timeout(list[i - 1].assoc4.timestamp, BAD_NODE_TIMEOUT)) {
+        if (!mono_time_is_timeout(mono_time, list[i - 1].assoc4.timestamp, BAD_NODE_TIMEOUT)) {
             assoc = &list[i - 1].assoc4;
         }
 
-        if (!is_timeout(list[i - 1].assoc6.timestamp, BAD_NODE_TIMEOUT)) {
+        if (!mono_time_is_timeout(mono_time, list[i - 1].assoc6.timestamp, BAD_NODE_TIMEOUT)) {
             if (assoc == nullptr) {
                 assoc = &list[i - 1].assoc6;
             } else if (random_u08() % 2) {
@@ -2563,8 +2579,8 @@ uint16_t randfriends_nodes(DHT *dht, Node_format *nodes, uint16_t max_num)
     const uint32_t r = random_u32();
 
     for (size_t i = 0; i < DHT_FAKE_FRIEND_NUMBER; ++i) {
-        count += list_nodes(dht->friends_list[(i + r) % DHT_FAKE_FRIEND_NUMBER].client_list, MAX_FRIEND_CLIENTS, nodes + count,
-                            max_num - count);
+        count += list_nodes(dht->friends_list[(i + r) % DHT_FAKE_FRIEND_NUMBER].client_list, MAX_FRIEND_CLIENTS, dht->mono_time,
+                            nodes + count, max_num - count);
 
         if (count >= max_num) {
             break;
@@ -2580,7 +2596,7 @@ uint16_t randfriends_nodes(DHT *dht, Node_format *nodes, uint16_t max_num)
  */
 uint16_t closelist_nodes(DHT *dht, Node_format *nodes, uint16_t max_num)
 {
-    return list_nodes(dht->close_clientlist, LCLIENT_LIST, nodes, max_num);
+    return list_nodes(dht->close_clientlist, LCLIENT_LIST, dht->mono_time, nodes, max_num);
 }
 
 #if DHT_HARDENING
@@ -2599,12 +2615,12 @@ static void do_hardening(DHT *dht)
             sa_family = net_family_ipv6;
         }
 
-        if (is_timeout(cur_iptspng->timestamp, BAD_NODE_TIMEOUT)) {
+        if (mono_time_is_timeout(dht->mono_time, cur_iptspng->timestamp, BAD_NODE_TIMEOUT)) {
             continue;
         }
 
         if (cur_iptspng->hardening.send_nodes_ok == 0) {
-            if (is_timeout(cur_iptspng->hardening.send_nodes_timestamp, HARDENING_INTERVAL)) {
+            if (mono_time_is_timeout(dht->mono_time, cur_iptspng->hardening.send_nodes_timestamp, HARDENING_INTERVAL)) {
                 Node_format rand_node = random_node(dht, sa_family);
 
                 if (!ipport_isset(&rand_node.ip_port)) {
@@ -2622,11 +2638,11 @@ static void do_hardening(DHT *dht)
                 // TODO(irungentoo): The search id should maybe not be ours?
                 if (send_hardening_getnode_req(dht, &rand_node, &to_test, dht->self_public_key) > 0) {
                     memcpy(cur_iptspng->hardening.send_nodes_pingedid, rand_node.public_key, CRYPTO_PUBLIC_KEY_SIZE);
-                    cur_iptspng->hardening.send_nodes_timestamp = unix_time();
+                    cur_iptspng->hardening.send_nodes_timestamp = mono_time_get(dht->mono_time);
                 }
             }
         } else {
-            if (is_timeout(cur_iptspng->hardening.send_nodes_timestamp, HARDEN_TIMEOUT)) {
+            if (mono_time_is_timeout(dht->mono_time, cur_iptspng->hardening.send_nodes_timestamp, HARDEN_TIMEOUT)) {
                 cur_iptspng->hardening.send_nodes_ok = 0;
             }
         }
@@ -2688,7 +2704,7 @@ static int cryptopacket_handle(void *object, IP_Port source, const uint8_t *pack
 
 /*----------------------------------------------------------------------------------*/
 
-DHT *new_dht(const Logger *log, Networking_Core *net, bool holepunching_enabled)
+DHT *new_dht(const Logger *log, Mono_Time *mono_time, Networking_Core *net, bool holepunching_enabled)
 {
     if (net == nullptr) {
         return nullptr;
@@ -2700,12 +2716,13 @@ DHT *new_dht(const Logger *log, Networking_Core *net, bool holepunching_enabled)
         return nullptr;
     }
 
+    dht->mono_time = mono_time;
     dht->log = log;
     dht->net = net;
 
     dht->hole_punching_enabled = holepunching_enabled;
 
-    dht->ping = ping_new(dht);
+    dht->ping = ping_new(mono_time, dht);
 
     if (dht->ping == nullptr) {
         kill_dht(dht);
@@ -2738,7 +2755,7 @@ DHT *new_dht(const Logger *log, Networking_Core *net, bool holepunching_enabled)
 
 void do_dht(DHT *dht)
 {
-    if (dht->last_run == unix_time()) {
+    if (dht->last_run == mono_time_get(dht->mono_time)) {
         return;
     }
 
@@ -2754,7 +2771,7 @@ void do_dht(DHT *dht)
 #if DHT_HARDENING
     do_hardening(dht);
 #endif
-    dht->last_run = unix_time();
+    dht->last_run = mono_time_get(dht->mono_time);
 }
 
 void kill_dht(DHT *dht)
@@ -2961,8 +2978,8 @@ bool dht_isconnected(const DHT *dht)
     for (uint32_t i = 0; i < LCLIENT_LIST; ++i) {
         const Client_data *const client = &dht->close_clientlist[i];
 
-        if (!is_timeout(client->assoc4.timestamp, BAD_NODE_TIMEOUT) ||
-                !is_timeout(client->assoc6.timestamp, BAD_NODE_TIMEOUT)) {
+        if (!mono_time_is_timeout(dht->mono_time, client->assoc4.timestamp, BAD_NODE_TIMEOUT) ||
+                !mono_time_is_timeout(dht->mono_time, client->assoc6.timestamp, BAD_NODE_TIMEOUT)) {
             return true;
         }
     }
@@ -2978,11 +2995,13 @@ bool dht_non_lan_connected(const DHT *dht)
     for (uint32_t i = 0; i < LCLIENT_LIST; ++i) {
         const Client_data *const client = &dht->close_clientlist[i];
 
-        if (!is_timeout(client->assoc4.timestamp, BAD_NODE_TIMEOUT) && ip_is_lan(client->assoc4.ip_port.ip) == -1) {
+        if (!mono_time_is_timeout(dht->mono_time, client->assoc4.timestamp, BAD_NODE_TIMEOUT)
+                && ip_is_lan(client->assoc4.ip_port.ip) == -1) {
             return true;
         }
 
-        if (!is_timeout(client->assoc6.timestamp, BAD_NODE_TIMEOUT) && ip_is_lan(client->assoc6.ip_port.ip) == -1) {
+        if (!mono_time_is_timeout(dht->mono_time, client->assoc6.timestamp, BAD_NODE_TIMEOUT)
+                && ip_is_lan(client->assoc6.ip_port.ip) == -1) {
             return true;
         }
     }

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -26,6 +26,7 @@
 
 #include "crypto_core.h"
 #include "logger.h"
+#include "mono_time.h"
 #include "network.h"
 #include "ping_array.h"
 
@@ -240,8 +241,8 @@ const uint8_t *dht_get_friend_public_key(const DHT *dht, uint32_t friend_num);
  * If shared key is already in shared_keys, copy it to shared_key.
  * else generate it into shared_key and copy it to shared_keys
  */
-void get_shared_key(Shared_Keys *shared_keys, uint8_t *shared_key, const uint8_t *secret_key,
-                    const uint8_t *public_key);
+void get_shared_key(const Mono_Time *mono_time, Shared_Keys *shared_keys, uint8_t *shared_key,
+                    const uint8_t *secret_key, const uint8_t *public_key);
 
 /* Copy shared_key to encrypt/decrypt DHT packet from public_key into shared_key
  * for packets that we receive.
@@ -401,7 +402,7 @@ void dht_save(const DHT *dht, uint8_t *data);
 int dht_load(DHT *dht, const uint8_t *data, uint32_t length);
 
 /* Initialize DHT. */
-DHT *new_dht(const Logger *log, Networking_Core *net, bool holepunching_enabled);
+DHT *new_dht(const Logger *log, Mono_Time *mono_time, Networking_Core *net, bool holepunching_enabled);
 
 void kill_dht(DHT *dht);
 

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1949,7 +1949,7 @@ static int friend_already_added(const uint8_t *real_pk, void *data)
 }
 
 /* Run this at startup. */
-Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
+Messenger *new_messenger(Mono_Time *mono_time, Messenger_Options *options, unsigned int *error)
 {
     if (!options) {
         return nullptr;
@@ -1964,6 +1964,8 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
     if (!m) {
         return nullptr;
     }
+
+    m->mono_time = mono_time;
 
     m->fr = friendreq_new();
 
@@ -2010,7 +2012,7 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
         return nullptr;
     }
 
-    m->dht = new_dht(m->log, m->net, options->hole_punching_enabled);
+    m->dht = new_dht(m->log, m->mono_time, m->net, options->hole_punching_enabled);
 
     if (m->dht == nullptr) {
         kill_networking(m->net);
@@ -2020,7 +2022,7 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
         return nullptr;
     }
 
-    m->net_crypto = new_net_crypto(m->log, m->dht, &options->proxy_info);
+    m->net_crypto = new_net_crypto(m->log, m->mono_time, m->dht, &options->proxy_info);
 
     if (m->net_crypto == nullptr) {
         kill_networking(m->net);
@@ -2031,10 +2033,10 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
         return nullptr;
     }
 
-    m->onion = new_onion(m->dht);
-    m->onion_a = new_onion_announce(m->dht);
-    m->onion_c =  new_onion_client(m->net_crypto);
-    m->fr_c = new_friend_connections(m->onion_c, options->local_discovery_enabled);
+    m->onion = new_onion(m->mono_time, m->dht);
+    m->onion_a = new_onion_announce(m->mono_time, m->dht);
+    m->onion_c =  new_onion_client(m->mono_time, m->net_crypto);
+    m->fr_c = new_friend_connections(m->mono_time, m->onion_c, options->local_discovery_enabled);
 
     if (!(m->onion && m->onion_a && m->onion_c)) {
         kill_friend_connections(m->fr_c);
@@ -2468,7 +2470,7 @@ static int m_handle_packet(void *object, int i, const uint8_t *temp, uint16_t le
 static void do_friends(Messenger *m, void *userdata)
 {
     uint32_t i;
-    uint64_t temp_time = unix_time();
+    uint64_t temp_time = mono_time_get(m->mono_time);
 
     for (i = 0; i < m->numfriends; ++i) {
         if (m->friendlist[i].status == FRIEND_ADDED) {
@@ -2609,7 +2611,7 @@ void do_messenger(Messenger *m, void *userdata)
     }
 
     if (m->tcp_server) {
-        do_TCP_server(m->tcp_server);
+        do_TCP_server(m->tcp_server, m->mono_time);
     }
 
     do_net_crypto(m->net_crypto, userdata);
@@ -2618,8 +2620,8 @@ void do_messenger(Messenger *m, void *userdata)
     do_friends(m, userdata);
     connection_status_callback(m, userdata);
 
-    if (unix_time() > m->lastdump + DUMPING_CLIENTS_FRIENDS_EVERY_N_SECONDS) {
-        m->lastdump = unix_time();
+    if (mono_time_get(m->mono_time) > m->lastdump + DUMPING_CLIENTS_FRIENDS_EVERY_N_SECONDS) {
+        m->lastdump = mono_time_get(m->mono_time);
         uint32_t client, last_pinged;
 
         for (client = 0; client < LCLIENT_LIST; ++client) {

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -233,6 +233,7 @@ typedef struct Friend {
 
 struct Messenger {
     Logger *log;
+    Mono_Time *mono_time;
 
     Networking_Core *net;
     Net_Crypto *net_crypto;
@@ -738,7 +739,7 @@ typedef enum Messenger_Error {
  *
  *  if error is not NULL it will be set to one of the values in the enum above.
  */
-Messenger *new_messenger(Messenger_Options *options, unsigned int *error);
+Messenger *new_messenger(Mono_Time *mono_time, Messenger_Options *options, unsigned int *error);
 
 /* Run this before closing shop
  * Free all datastructures.

--- a/toxcore/TCP_client.h
+++ b/toxcore/TCP_client.h
@@ -64,12 +64,12 @@ void tcp_con_set_custom_uint(TCP_Client_Connection *con, uint32_t value);
 
 /* Create new TCP connection to ip_port/public_key
  */
-TCP_Client_Connection *new_TCP_connection(IP_Port ip_port, const uint8_t *public_key, const uint8_t *self_public_key,
-        const uint8_t *self_secret_key, TCP_Proxy_Info *proxy_info);
+TCP_Client_Connection *new_TCP_connection(const Mono_Time *mono_time, IP_Port ip_port, const uint8_t *public_key,
+        const uint8_t *self_public_key, const uint8_t *self_secret_key, TCP_Proxy_Info *proxy_info);
 
 /* Run the TCP connection
  */
-void do_TCP_connection(TCP_Client_Connection *tcp_connection, void *userdata);
+void do_TCP_connection(Mono_Time *mono_time, TCP_Client_Connection *tcp_connection, void *userdata);
 
 /* Kill the TCP connection
  */

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -219,7 +219,7 @@ uint32_t tcp_copy_connected_relays(TCP_Connections *tcp_c, Node_format *tcp_rela
  *
  * Returns NULL on failure.
  */
-TCP_Connections *new_tcp_connections(const uint8_t *secret_key, TCP_Proxy_Info *proxy_info);
+TCP_Connections *new_tcp_connections(Mono_Time *mono_time, const uint8_t *secret_key, TCP_Proxy_Info *proxy_info);
 
 void do_tcp_connections(TCP_Connections *tcp_c, void *userdata);
 void kill_tcp_connections(TCP_Connections *tcp_c);

--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -87,7 +87,7 @@ TCP_Server *new_TCP_server(uint8_t ipv6_enabled, uint16_t num_sockets, const uin
 
 /* Run the TCP_server
  */
-void do_TCP_server(TCP_Server *tcp_server);
+void do_TCP_server(TCP_Server *tcp_server, Mono_Time *mono_time);
 
 /* Kill the TCP server
  */

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -158,7 +158,8 @@ typedef int fr_request_cb(void *object, const uint8_t *source_pubkey, const uint
 void set_friend_request_callback(Friend_Connections *fr_c, fr_request_cb *fr_request_callback, void *object);
 
 /* Create new friend_connections instance. */
-Friend_Connections *new_friend_connections(Onion_Client *onion_c, bool local_discovery_enabled);
+Friend_Connections *new_friend_connections(const Mono_Time *mono_time, Onion_Client *onion_c,
+        bool local_discovery_enabled);
 
 /* main friend_connections loop. */
 void do_friend_connections(Friend_Connections *fr_c, void *userdata);

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -172,6 +172,8 @@ typedef struct Group_Lossy_Handler {
 } Group_Lossy_Handler;
 
 typedef struct Group_Chats {
+    const Mono_Time *mono_time;
+
     Messenger *m;
     Friend_Connections *fr_c;
 
@@ -433,7 +435,7 @@ int callback_groupchat_peer_delete(Group_Chats *g_c, uint32_t groupnumber, peer_
 int callback_groupchat_delete(Group_Chats *g_c, uint32_t groupnumber, group_on_delete_cb *function);
 
 /* Create new groupchat instance. */
-Group_Chats *new_groupchats(Messenger *m);
+Group_Chats *new_groupchats(Mono_Time *mono_time, Messenger *m);
 
 /* main groupchats loop. */
 void do_groupchats(Group_Chats *g_c, void *userdata);

--- a/toxcore/mono_time.c
+++ b/toxcore/mono_time.c
@@ -41,6 +41,8 @@ Mono_Time *mono_time_new(void)
     monotime->time = 0;
     monotime->base_time = 0;
 
+    mono_time_update(monotime);
+
     return monotime;
 }
 
@@ -66,27 +68,6 @@ uint64_t mono_time_get(const Mono_Time *monotime)
 bool mono_time_is_timeout(const Mono_Time *monotime, uint64_t timestamp, uint64_t timeout)
 {
     return timestamp + timeout <= mono_time_get(monotime);
-}
-
-
-//!TOKSTYLE-
-// No global mutable state in Tokstyle.
-static Mono_Time global_time;
-//!TOKSTYLE+
-
-/* XXX: note that this is not thread-safe; if multiple threads call unix_time_update() concurrently, the return value of
- * unix_time() may fail to increase monotonically with increasing time */
-void unix_time_update(void)
-{
-    mono_time_update(&global_time);
-}
-uint64_t unix_time(void)
-{
-    return mono_time_get(&global_time);
-}
-int is_timeout(uint64_t timestamp, uint64_t timeout)
-{
-    return mono_time_is_timeout(&global_time, timestamp, timeout);
 }
 
 

--- a/toxcore/mono_time.h
+++ b/toxcore/mono_time.h
@@ -8,7 +8,39 @@
 extern "C" {
 #endif
 
+#ifndef MONO_TIME_DEFINED
+#define MONO_TIME_DEFINED
+/**
+ * The timer portion of the toxcore event loop.
+ *
+ * We update the time exactly once per tox_iterate call. Programs built on lower
+ * level APIs such as the DHT bootstrap node must update the time manually in
+ * each iteration.
+ *
+ * Time is kept per Tox instance, not globally, even though "time" as a concept
+ * is global. This is because by definition `mono_time` represents the time at
+ * the start of an iteration, and also by definition the time when all network
+ * events for the current iteration occurred. This affects mainly two situations:
+ *
+ * 1. Two timers started in the same iteration: e.g. two timers set to expire in
+ *    10 seconds will both expire at the same time, i.e. about 10 seconds later.
+ *    If the time were global, `mono_time` would be a random number that is
+ *    either the time at the start of an iteration, or 1 second later (since the
+ *    timer resolution is 1 second). This can happen when one update happens at
+ *    e.g. 10:00:00.995 and a few milliseconds later a concurrently running
+ *    instance updates the time at 10:00:01.005, making one timer expire a
+ *    second after the other.
+ * 2. One timer based on an event: if we want to encode a behaviour of a timer
+ *    expiring e.g. 10 seconds after a network event occurred, we simply start a
+ *    timer in the event handler. If a concurrent instance updates the time
+ *    underneath us, it may instead expire 9 seconds after the event.
+ *
+ * Both these situations cause incorrect behaviour randomly. In practice,
+ * toxcore is somewhat robust against strange timer behaviour, but the
+ * implementation should at least theoretically match the specification.
+ */
 typedef struct Mono_Time Mono_Time;
+#endif /* MONO_TIME_DEFINED */
 
 Mono_Time *mono_time_new(void);
 void mono_time_free(Mono_Time *monotime);
@@ -16,11 +48,6 @@ void mono_time_free(Mono_Time *monotime);
 void mono_time_update(Mono_Time *monotime);
 uint64_t mono_time_get(const Mono_Time *monotime);
 bool mono_time_is_timeout(const Mono_Time *monotime, uint64_t timestamp, uint64_t timeout);
-
-// TODO(#405): Use per-tox monotime, delete these functions.
-void unix_time_update(void);
-uint64_t unix_time(void);
-int is_timeout(uint64_t timestamp, uint64_t timeout);
 
 /* return current monotonic time in milliseconds (ms). */
 uint64_t current_time_monotonic(void);

--- a/toxcore/mono_time_test.cc
+++ b/toxcore/mono_time_test.cc
@@ -5,26 +5,34 @@
 namespace {
 
 TEST(Util, UnixTimeIncreasesOverTime) {
-  unix_time_update();
-  uint64_t const start = unix_time();
+  Mono_Time *mono_time = mono_time_new();
 
-  while (start == unix_time()) {
-    unix_time_update();
+  mono_time_update(mono_time);
+  uint64_t const start = mono_time_get(mono_time);
+
+  while (start == mono_time_get(mono_time)) {
+    mono_time_update(mono_time);
   }
 
-  uint64_t const end = unix_time();
+  uint64_t const end = mono_time_get(mono_time);
   EXPECT_GT(end, start);
+
+  mono_time_free(mono_time);
 }
 
 TEST(Util, IsTimeout) {
-  uint64_t const start = unix_time();
-  EXPECT_FALSE(is_timeout(start, 1));
+  Mono_Time *mono_time = mono_time_new();
 
-  while (start == unix_time()) {
-    unix_time_update();
+  uint64_t const start = mono_time_get(mono_time);
+  EXPECT_FALSE(mono_time_is_timeout(mono_time, start, 1));
+
+  while (start == mono_time_get(mono_time)) {
+    mono_time_update(mono_time);
   }
 
-  EXPECT_TRUE(is_timeout(start, 1));
+  EXPECT_TRUE(mono_time_is_timeout(mono_time, start, 1));
+
+  mono_time_free(mono_time);
 }
 
 }  // namespace

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -343,7 +343,7 @@ void load_secret_key(Net_Crypto *c, const uint8_t *sk);
 /* Create new instance of Net_Crypto.
  *  Sets all the global connection variables to their default values.
  */
-Net_Crypto *new_net_crypto(const Logger *log, DHT *dht, TCP_Proxy_Info *proxy_info);
+Net_Crypto *new_net_crypto(const Logger *log, Mono_Time *mono_time, DHT *dht, TCP_Proxy_Info *proxy_info);
 
 /* return the optimal interval in ms for running do_net_crypto.
  */

--- a/toxcore/onion.h
+++ b/toxcore/onion.h
@@ -25,11 +25,13 @@
 #define ONION_H
 
 #include "DHT.h"
+#include "mono_time.h"
 
 typedef int onion_recv_1_cb(void *object, IP_Port dest, const uint8_t *data, uint16_t length);
 
 typedef struct Onion {
-    DHT     *dht;
+    Mono_Time *mono_time;
+    DHT *dht;
     Networking_Core *net;
     uint8_t secret_symmetric_key[CRYPTO_SYMMETRIC_KEY_SIZE];
     uint64_t timestamp;
@@ -158,7 +160,7 @@ int onion_send_1(const Onion *onion, const uint8_t *plain, uint16_t len, IP_Port
  */
 void set_callback_handle_recv_1(Onion *onion, onion_recv_1_cb *function, void *object);
 
-Onion *new_onion(DHT *dht);
+Onion *new_onion(Mono_Time *mono_time, DHT *dht);
 
 void kill_onion(Onion *onion);
 

--- a/toxcore/onion_announce.h
+++ b/toxcore/onion_announce.h
@@ -120,7 +120,7 @@ int send_data_request(Networking_Core *net, const Onion_Path *path, IP_Port dest
                       const uint8_t *encrypt_public_key, const uint8_t *nonce, const uint8_t *data, uint16_t length);
 
 
-Onion_Announce *new_onion_announce(DHT *dht);
+Onion_Announce *new_onion_announce(Mono_Time *mono_time, DHT *dht);
 
 void kill_onion_announce(Onion_Announce *onion_a);
 

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -188,7 +188,7 @@ void oniondata_registerhandler(Onion_Client *onion_c, uint8_t byte, oniondata_ha
 
 void do_onion_client(Onion_Client *onion_c);
 
-Onion_Client *new_onion_client(Net_Crypto *c);
+Onion_Client *new_onion_client(Mono_Time *mono_time, Net_Crypto *c);
 
 void kill_onion_client(Onion_Client *onion_c);
 

--- a/toxcore/ping.api.h
+++ b/toxcore/ping.api.h
@@ -35,12 +35,13 @@
 
 class iP_Port { struct this; }
 class dHT { struct this; }
+class mono_Time { struct this; }
 
 class ping {
 
 struct this;
 
-static this new(dHT::this *dht);
+static this new(const mono_Time::this *mono_time, dHT::this *dht);
 void kill();
 
 /** Add nodes to the to_ping list.

--- a/toxcore/ping.h
+++ b/toxcore/ping.h
@@ -41,12 +41,17 @@ typedef struct IP_Port IP_Port;
 typedef struct DHT DHT;
 #endif /* DHT_DEFINED */
 
+#ifndef MONO_TIME_DEFINED
+#define MONO_TIME_DEFINED
+typedef struct Mono_Time Mono_Time;
+#endif /* MONO_TIME_DEFINED */
+
 #ifndef PING_DEFINED
 #define PING_DEFINED
 typedef struct Ping Ping;
 #endif /* PING_DEFINED */
 
-Ping *ping_new(DHT *dht);
+Ping *ping_new(const struct Mono_Time *mono_time, DHT *dht);
 
 void ping_kill(Ping *ping);
 

--- a/toxcore/ping_array.api.h
+++ b/toxcore/ping_array.api.h
@@ -28,6 +28,8 @@
 #include "network.h"
 %}
 
+class mono_Time { struct this; }
+
 class ping_Array {
 
 struct this;
@@ -53,7 +55,7 @@ void kill();
  * return ping_id on success.
  * return 0 on failure.
  */
-uint64_t add(const uint8_t *data, uint32_t length);
+uint64_t add(const mono_Time::this *mono_time, const uint8_t *data, uint32_t length);
 
 /**
  * Check if ping_id is valid and not timed out.
@@ -63,7 +65,7 @@ uint64_t add(const uint8_t *data, uint32_t length);
  * return length of data copied on success.
  * return -1 on failure.
  */
-int32_t check(uint8_t[length] data, uint64_t ping_id);
+int32_t check(const mono_Time::this *mono_time, uint8_t[length] data, uint64_t ping_id);
 
 }
 

--- a/toxcore/ping_array.h
+++ b/toxcore/ping_array.h
@@ -26,6 +26,11 @@
 
 #include "network.h"
 
+#ifndef MONO_TIME_DEFINED
+#define MONO_TIME_DEFINED
+typedef struct Mono_Time Mono_Time;
+#endif /* MONO_TIME_DEFINED */
+
 #ifndef PING_ARRAY_DEFINED
 #define PING_ARRAY_DEFINED
 typedef struct Ping_Array Ping_Array;
@@ -52,7 +57,8 @@ void ping_array_kill(struct Ping_Array *_array);
  * return ping_id on success.
  * return 0 on failure.
  */
-uint64_t ping_array_add(struct Ping_Array *_array, const uint8_t *data, uint32_t length);
+uint64_t ping_array_add(struct Ping_Array *_array, const struct Mono_Time *mono_time, const uint8_t *data,
+                        uint32_t length);
 
 /**
  * Check if ping_id is valid and not timed out.
@@ -62,6 +68,7 @@ uint64_t ping_array_add(struct Ping_Array *_array, const uint8_t *data, uint32_t
  * return length of data copied on success.
  * return -1 on failure.
  */
-int32_t ping_array_check(struct Ping_Array *_array, uint8_t *data, size_t length, uint64_t ping_id);
+int32_t ping_array_check(struct Ping_Array *_array, const struct Mono_Time *mono_time, uint8_t *data, size_t length,
+                         uint64_t ping_id);
 
 #endif


### PR DESCRIPTION
This avoids some global state.

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1038)
<!-- Reviewable:end -->
