### PR TITLE
Remove unused `m_callback_log` function.

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -842,11 +842,6 @@ static void set_friend_typing(const Messenger *m, int32_t friendnumber, uint8_t 
     m->friendlist[friendnumber].is_typing = is_typing;
 }
 
-void m_callback_log(Messenger *m, logger_cb *function, void *context, void *userdata)
-{
-    logger_callback_log(m->log, function, context, userdata);
-}
-
 /* Set the function that will be executed when a friend request is received. */
 void m_callback_friendrequest(Messenger *m, m_friend_request_cb *function)
 {

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -481,10 +481,6 @@ int m_set_usertyping(Messenger *m, int32_t friendnumber, uint8_t is_typing);
  */
 int m_get_istyping(const Messenger *m, int32_t friendnumber);
 
-/* Set the logger callback.
- */
-void m_callback_log(Messenger *m, logger_cb *function, void *context, void *userdata);
-
 /* Set the function that will be executed when a friend request is received.
  *  Function format is function(uint8_t * public_key, uint8_t * data, size_t length)
  */


### PR DESCRIPTION
The logger callback can only be set once at the beginning, because it
requires user data coming from `Tox_Options`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1047)
<!-- Reviewable:end -->
