### PR TITLE
Prune long long warnings.

### DIFF
--- a/auto_tests/file_saving_test.c
+++ b/auto_tests/file_saving_test.c
@@ -85,7 +85,7 @@ static void load_data_decrypted(void)
     uint8_t *cipher = (uint8_t *)malloc(size);
     uint8_t *clear = (uint8_t *)malloc(size - TOX_PASS_ENCRYPTION_EXTRA_LENGTH);
     size_t read_value = fread(cipher, sizeof(*cipher), size, f);
-    printf("Read read_vavue = %u of %ld\n", (unsigned)read_value, size);
+    printf("Read read_vavue = %u of %lu\n", (unsigned)read_value, (unsigned long)size);
 
     TOX_ERR_DECRYPTION derr;
 

--- a/auto_tests/friend_request_test.c
+++ b/auto_tests/friend_request_test.c
@@ -51,7 +51,7 @@ static void test_friend_request(void)
         c_sleep(ITERATION_INTERVAL);
     }
 
-    printf("Toxes are online, took %ld seconds.\n", time(nullptr) - cur_time);
+    printf("Toxes are online, took %lu seconds.\n", (unsigned long)(time(nullptr) - cur_time));
     const time_t con_time = time(nullptr);
 
     printf("Tox1 adds tox2 as friend, tox2 accepts.\n");
@@ -71,8 +71,8 @@ static void test_friend_request(void)
         c_sleep(ITERATION_INTERVAL);
     }
 
-    printf("Tox clients connected took %ld seconds.\n", time(nullptr) - con_time);
-    printf("friend_request_test succeeded, took %ld seconds.\n", time(nullptr) - cur_time);
+    printf("Tox clients connected took %lu seconds.\n", (unsigned long)(time(nullptr) - con_time));
+    printf("friend_request_test succeeded, took %lu seconds.\n", (unsigned long)(time(nullptr) - cur_time));
 
     tox_kill(tox1);
     tox_kill(tox2);

--- a/auto_tests/save_load_test.c
+++ b/auto_tests/save_load_test.c
@@ -71,7 +71,7 @@ static void test_few_clients(void)
         if (tox_self_get_connection_status(tox1) && tox_self_get_connection_status(tox2)
                 && tox_self_get_connection_status(tox3)) {
             if (off) {
-                printf("Toxes are online, took %ld seconds\n", time(nullptr) - cur_time);
+                printf("Toxes are online, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
                 con_time = time(nullptr);
                 off = 0;
             }
@@ -86,7 +86,7 @@ static void test_few_clients(void)
     }
 
     ck_assert_msg(connected_t1, "Tox1 isn't connected. %u", connected_t1);
-    printf("tox clients connected took %ld seconds\n", time(nullptr) - con_time);
+    printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
 
     const size_t save_size1 = tox_get_savedata_size(tox2);
     ck_assert_msg(save_size1 != 0, "save is invalid size %u", (unsigned)save_size1);
@@ -111,7 +111,7 @@ static void test_few_clients(void)
         if (tox_self_get_connection_status(tox1) && tox_self_get_connection_status(tox2)
                 && tox_self_get_connection_status(tox3)) {
             if (off) {
-                printf("Toxes are online again after reloading, took %ld seconds\n", time(nullptr) - cur_time);
+                printf("Toxes are online again after reloading, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
                 con_time = time(nullptr);
                 off = 0;
             }
@@ -125,9 +125,9 @@ static void test_few_clients(void)
         c_sleep(ITERATION_INTERVAL);
     }
 
-    printf("tox clients connected took %ld seconds\n", time(nullptr) - con_time);
+    printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
 
-    printf("test_few_clients succeeded, took %ld seconds\n", time(nullptr) - cur_time);
+    printf("test_few_clients succeeded, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
 
     tox_options_free(options);
     tox_kill(tox1);

--- a/auto_tests/set_name_test.c
+++ b/auto_tests/set_name_test.c
@@ -56,7 +56,7 @@ static void test_set_name(void)
         c_sleep(ITERATION_INTERVAL);
     }
 
-    printf("toxes are online, took %ld seconds\n", time(nullptr) - cur_time);
+    printf("toxes are online, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
     const time_t con_time = time(nullptr);
 
     while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
@@ -66,7 +66,7 @@ static void test_set_name(void)
         c_sleep(ITERATION_INTERVAL);
     }
 
-    printf("tox clients connected took %ld seconds\n", time(nullptr) - con_time);
+    printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
 
     tox_callback_friend_name(tox2, nickchange_callback);
     TOX_ERR_SET_INFO err_n;
@@ -86,7 +86,7 @@ static void test_set_name(void)
     tox_friend_get_name(tox2, 0, temp_name, nullptr);
     ck_assert_msg(memcmp(temp_name, NICKNAME, sizeof(NICKNAME)) == 0, "Name not correct");
 
-    printf("test_set_name succeeded, took %ld seconds\n", time(nullptr) - cur_time);
+    printf("test_set_name succeeded, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
 
     tox_kill(tox1);
     tox_kill(tox2);

--- a/auto_tests/set_status_message_test.c
+++ b/auto_tests/set_status_message_test.c
@@ -59,7 +59,7 @@ static void test_set_status_message(void)
         c_sleep(ITERATION_INTERVAL);
     }
 
-    printf("toxes are online, took %ld seconds\n", time(nullptr) - cur_time);
+    printf("toxes are online, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
     const time_t con_time = time(nullptr);
 
     while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
@@ -70,7 +70,7 @@ static void test_set_status_message(void)
         c_sleep(ITERATION_INTERVAL);
     }
 
-    printf("tox clients connected took %ld seconds\n", time(nullptr) - con_time);
+    printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
 
     TOX_ERR_SET_INFO err_n;
     tox_callback_friend_status_message(tox2, status_callback);
@@ -93,7 +93,7 @@ static void test_set_status_message(void)
     ck_assert_msg(memcmp(cmp_status, STATUS_MESSAGE, sizeof(STATUS_MESSAGE)) == 0,
                   "status message not correct");
 
-    printf("test_set_status_message succeeded, took %ld seconds\n", time(nullptr) - cur_time);
+    printf("test_set_status_message succeeded, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
 
     tox_kill(tox1);
     tox_kill(tox2);

--- a/auto_tests/tox_many_test.c
+++ b/auto_tests/tox_many_test.c
@@ -123,7 +123,7 @@ loop_top:
         tox_kill(toxes[i]);
     }
 
-    printf("test_many_clients succeeded, took %ld seconds\n", time(nullptr) - cur_time);
+    printf("test_many_clients succeeded, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
 }
 
 int main(void)

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -240,7 +240,7 @@ static void test_av_three_calls(void)
                 tox_self_get_connection_status(Bobs[0]) &&
                 tox_self_get_connection_status(Bobs[1]) &&
                 tox_self_get_connection_status(Bobs[2]) && off) {
-            printf("Toxes are online, took %ld seconds\n", time(nullptr) - cur_time);
+            printf("Toxes are online, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
             off = 0;
         }
 
@@ -262,7 +262,7 @@ static void test_av_three_calls(void)
     BobsAV[2] = setup_av_instance(Bobs[2], BobsCC + 2);
 
     printf("Created 4 instances of ToxAV\n");
-    printf("All set after %ld seconds!\n", time(nullptr) - cur_time);
+    printf("All set after %lu seconds!\n", (unsigned long)(time(nullptr) - cur_time));
 
     thread_data tds[3];
     tds[0].AliceAV = AliceAV;

--- a/auto_tests/typing_test.c
+++ b/auto_tests/typing_test.c
@@ -53,7 +53,7 @@ static void test_typing(void)
         c_sleep(200);
     }
 
-    printf("toxes are online, took %ld seconds\n", time(nullptr) - cur_time);
+    printf("toxes are online, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
     const time_t con_time = time(nullptr);
 
     while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
@@ -64,7 +64,7 @@ static void test_typing(void)
         c_sleep(200);
     }
 
-    printf("tox clients connected took %ld seconds\n", time(nullptr) - con_time);
+    printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
 
     tox_callback_friend_typing(tox2, &typing_callback);
     tox_self_set_typing(tox1, 0, true, nullptr);
@@ -90,7 +90,7 @@ static void test_typing(void)
     ck_assert_msg(tox_friend_get_typing(tox2, 0, &err_t) == 0, "Typing failure");
     ck_assert_msg(err_t == TOX_ERR_FRIEND_QUERY_OK, "Typing failure");
 
-    printf("test_typing succeeded, took %ld seconds\n", time(nullptr) - cur_time);
+    printf("test_typing succeeded, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
 
     tox_kill(tox1);
     tox_kill(tox2);


### PR DESCRIPTION
I hope this doesn't happen only at OpenBSD :P

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1055)
<!-- Reviewable:end -->
