### PR TITLE
Reduce the number of times `unix_time_update` is called.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -39,6 +39,7 @@ static inline IP get_loopback()
 static void do_TCP_server_delay(TCP_Server *tcp_s, int delay)
 {
     c_sleep(delay);
+    unix_time_update();
     do_TCP_server(tcp_s);
     c_sleep(delay);
 }
@@ -141,6 +142,7 @@ START_TEST(test_basic)
         i += msg_length;
 
         c_sleep(50);
+        unix_time_update();
         do_TCP_server(tcp_s);
     }
 
@@ -477,6 +479,7 @@ START_TEST(test_client)
     const uint8_t LOOP_SIZE = 3;
 
     for (uint8_t i = 0; i < LOOP_SIZE; i++) {
+        unix_time_update();
         do_TCP_connection(conn, nullptr); // Run the connection loop.
 
         // The status of the connection should continue to be TCP_CLIENT_CONFIRMED after multiple subsequent do_TCP_connection() calls.
@@ -584,6 +587,7 @@ START_TEST(test_client_invalid)
     TCP_Client_Connection *conn = new_TCP_connection(ip_port_tcp_s, self_public_key, f_public_key, f_secret_key, nullptr);
 
     // Run the client's main loop but not the server.
+    unix_time_update();
     do_TCP_connection(conn, nullptr);
     c_sleep(50);
 
@@ -592,11 +596,13 @@ START_TEST(test_client_invalid)
                   TCP_CLIENT_CONNECTING, tcp_con_status(conn));
     // After 5s...
     c_sleep(5000);
+    unix_time_update();
     do_TCP_connection(conn, nullptr);
     ck_assert_msg(tcp_con_status(conn) == TCP_CLIENT_CONNECTING, "Wrong status. Expected: %d, is: %d.",
                   TCP_CLIENT_CONNECTING, tcp_con_status(conn));
     // 11s... (Should wait for 10 before giving up.)
     c_sleep(6000);
+    unix_time_update();
     do_TCP_connection(conn, nullptr);
     ck_assert_msg(tcp_con_status(conn) == TCP_CLIENT_DISCONNECTED, "Wrong status. Expected: %d, is: %d.",
                   TCP_CLIENT_DISCONNECTED, tcp_con_status(conn));

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -31,6 +31,8 @@ static inline IP get_loopback()
 }
 static void do_onion(Onion *onion)
 {
+    unix_time_update();
+
     networking_poll(onion->net, nullptr);
     do_dht(onion->dht);
 }
@@ -327,6 +329,8 @@ static Onions *new_onions(uint16_t port, uint32_t *index)
         return nullptr;
     }
 
+    unix_time_update();
+
     logger_callback_log(on->log, (logger_cb *)print_debug_log, nullptr, index);
 
     Networking_Core *net = new_networking(on->log, ip, port);
@@ -385,6 +389,8 @@ static Onions *new_onions(uint16_t port, uint32_t *index)
 
 static void do_onions(Onions *on)
 {
+    unix_time_update();
+
     networking_poll(on->onion->net, nullptr);
     do_dht(on->onion->dht);
     do_onion_client(on->onion_c);

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -115,6 +115,8 @@ int main(int argc, char *argv[])
     IP ip;
     ip_init(&ip, ipv6enabled);
 
+    unix_time_update();
+
     Logger *logger = logger_new();
     DHT *dht = new_dht(logger, new_networking(logger, ip, PORT), true);
     Onion *onion = new_onion(dht);
@@ -186,6 +188,8 @@ int main(int argc, char *argv[])
     lan_discovery_init(dht);
 
     while (1) {
+        unix_time_update();
+
         if (is_waiting_for_dht_connection && dht_isconnected(dht)) {
             printf("Connected to other bootstrap node successfully.\n");
             is_waiting_for_dht_connection = 0;

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -230,6 +230,8 @@ int main(int argc, char *argv[])
     IP ip;
     ip_init(&ip, enable_ipv6);
 
+    unix_time_update();
+
     Logger *logger = logger_new();
 
     Networking_Core *net = new_networking(logger, ip, port);
@@ -336,6 +338,8 @@ int main(int argc, char *argv[])
     }
 
     while (1) {
+        unix_time_update();
+
         do_dht(dht);
 
         if (enable_lan_discovery && is_timeout(last_LANdiscovery, LAN_DISCOVERY_INTERVAL)) {

--- a/testing/DHT_test.c
+++ b/testing/DHT_test.c
@@ -42,6 +42,7 @@
 
 #include "../toxcore/DHT.h"
 #include "../toxcore/friend_requests.h"
+#include "../toxcore/mono_time.h"
 #include "misc_tools.h"
 
 #define PORT 33445
@@ -237,6 +238,8 @@ int main(int argc, char *argv[])
 #endif
 
     while (1) {
+        unix_time_update();
+
         do_dht(dht);
 
 #if 0 /* TODO(slvr): */

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -47,6 +47,7 @@
 #endif
 
 #include "../toxcore/Messenger.h"
+#include "../toxcore/mono_time.h"
 #include "misc_tools.h"
 
 static void print_message(Messenger *m, uint32_t friendnumber, unsigned int type, const uint8_t *string, size_t length,
@@ -105,6 +106,8 @@ int main(int argc, char *argv[])
         printf("       %s [--ipv4|--ipv6] Save.bak (to read Save.bak as state file)\n", argv[0]);
         exit(0);
     }
+
+    unix_time_update();
 
     Messenger_Options options = {0};
     options.ipv6enabled = ipv6enabled;
@@ -177,6 +180,8 @@ int main(int argc, char *argv[])
     perror("Initialization");
 
     while (1) {
+        unix_time_update();
+
         uint8_t name[128];
         const char *const filename = "Save.bak";
         getname(m, num, name);

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2690,9 +2690,6 @@ static int cryptopacket_handle(void *object, IP_Port source, const uint8_t *pack
 
 DHT *new_dht(const Logger *log, Networking_Core *net, bool holepunching_enabled)
 {
-    /* init time */
-    unix_time_update();
-
     if (net == nullptr) {
         return nullptr;
     }
@@ -2741,8 +2738,6 @@ DHT *new_dht(const Logger *log, Networking_Core *net, bool holepunching_enabled)
 
 void do_dht(DHT *dht)
 {
-    unix_time_update();
-
     if (dht->last_run == unix_time()) {
         return;
     }
@@ -2963,8 +2958,6 @@ int dht_load(DHT *dht, const uint8_t *data, uint32_t length)
  */
 bool dht_isconnected(const DHT *dht)
 {
-    unix_time_update();
-
     for (uint32_t i = 0; i < LCLIENT_LIST; ++i) {
         const Client_data *const client = &dht->close_clientlist[i];
 
@@ -2982,8 +2975,6 @@ bool dht_isconnected(const DHT *dht)
  */
 bool dht_non_lan_connected(const DHT *dht)
 {
-    unix_time_update();
-
     for (uint32_t i = 0; i < LCLIENT_LIST; ++i) {
         const Client_data *const client = &dht->close_clientlist[i];
 

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2603,8 +2603,6 @@ void do_messenger(Messenger *m, void *userdata)
         }
     }
 
-    unix_time_update();
-
     if (!m->options.udp_disabled) {
         networking_poll(m->net, userdata);
         do_dht(m->dht);

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -985,8 +985,6 @@ static int do_confirmed_TCP(TCP_Client_Connection *conn, void *userdata)
  */
 void do_TCP_connection(TCP_Client_Connection *tcp_connection, void *userdata)
 {
-    unix_time_update();
-
     if (tcp_connection->status == TCP_CLIENT_DISCONNECTED) {
         return;
     }

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -1424,8 +1424,6 @@ static void do_TCP_epoll(TCP_Server *tcp_server)
 
 void do_TCP_server(TCP_Server *tcp_server)
 {
-    unix_time_update();
-
 #ifdef TCP_SERVER_USE_EPOLL
     do_TCP_epoll(tcp_server);
 

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2925,8 +2925,6 @@ void load_secret_key(Net_Crypto *c, const uint8_t *sk)
  */
 Net_Crypto *new_net_crypto(const Logger *log, DHT *dht, TCP_Proxy_Info *proxy_info)
 {
-    unix_time_update();
-
     if (dht == nullptr) {
         return nullptr;
     }
@@ -3016,7 +3014,6 @@ uint32_t crypto_run_interval(const Net_Crypto *c)
 /* Main loop. */
 void do_net_crypto(Net_Crypto *c, void *userdata)
 {
-    unix_time_update();
     kill_timedout(c, userdata);
     do_tcp(c, userdata);
     send_crypto_packets(c);

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -641,8 +641,6 @@ void networking_poll(Networking_Core *net, void *userdata)
         return;
     }
 
-    unix_time_update();
-
     IP_Port ip_port;
     uint8_t data[MAX_UDP_PACKET_SIZE];
     uint32_t length;

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -38,6 +38,7 @@
 #include "Messenger.h"
 #include "group.h"
 #include "logger.h"
+#include "mono_time.h"
 
 #include "../toxencryptsave/defines.h"
 
@@ -334,6 +335,8 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
         SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);
         return nullptr;
     }
+
+    unix_time_update();
 
     Messenger_Options m_options = {0};
 
@@ -653,6 +656,8 @@ uint32_t tox_iteration_interval(const Tox *tox)
 
 void tox_iterate(Tox *tox, void *user_data)
 {
+    unix_time_update();
+
     Messenger *m = tox->m;
     struct Tox_Userdata tox_data = { tox, user_data };
     do_messenger(m, &tox_data);


### PR DESCRIPTION
Reduced by, e.g.:
* `file_transfer_test`: 33% of the `clock_gettime` calls.
* `tox_many_test`: 53% of the `clock_gettime` calls.

Other tests will see similar improvements. Real world applications will
be closer to 40-50% improvement, since tox_many_test has 100 nodes, while
file_transfer_test has 2 nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1057)
<!-- Reviewable:end -->
