### PR TITLE
Force storing the result of crypto_memcmp in the test.

### DIFF
--- a/toxcore/crypto_core_test.cc
+++ b/toxcore/crypto_core_test.cc
@@ -29,7 +29,8 @@ enum {
 
 clock_t memcmp_time(void *a, void *b, size_t len) {
   clock_t start = clock();
-  crypto_memcmp(a, b, len);
+  volatile int result = crypto_memcmp(a, b, len);
+  (void)result;
   return clock() - start;
 }
 


### PR DESCRIPTION
So we don't accidentally elide the call given that it's a pure function
and its result isn't used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1061)
<!-- Reviewable:end -->
