### PR TITLE
Avoid forward declaration of rtp structs.

### DIFF
--- a/toxav/audio.h
+++ b/toxav/audio.h
@@ -24,6 +24,7 @@
 
 #include "../toxcore/logger.h"
 #include "../toxcore/util.h"
+#include "rtp.h"
 
 #include <opus.h>
 #include <pthread.h>
@@ -47,8 +48,6 @@
 // These are per frame and per channel.
 #define AUDIO_MAX_BUFFER_SIZE_PCM16 ((AUDIO_MAX_SAMPLE_RATE * AUDIO_MAX_FRAME_DURATION_MS) / 1000)
 #define AUDIO_MAX_BUFFER_SIZE_BYTES (AUDIO_MAX_BUFFER_SIZE_PCM16 * 2)
-
-struct RTPMessage;
 
 typedef struct ACSession_s {
     const Logger *log;

--- a/toxav/video.h
+++ b/toxav/video.h
@@ -24,6 +24,8 @@
 
 #include "../toxcore/logger.h"
 #include "../toxcore/util.h"
+#include "ring_buffer.h"
+#include "rtp.h"
 
 #include <vpx/vpx_decoder.h>
 #include <vpx/vpx_encoder.h>
@@ -34,9 +36,6 @@
 
 
 #include <pthread.h>
-
-struct RTPMessage;
-struct RingBuffer;
 
 typedef struct VCSession_s {
     /* encoding */


### PR DESCRIPTION
Forward declarations are problematic, as they easily allow introducing
cyclic dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1072)
<!-- Reviewable:end -->
