### PR TITLE
Fix memory leak in error path in group A/V.

### DIFF
--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -262,7 +262,10 @@ static void group_av_peer_new(void *object, uint32_t groupnumber, uint32_t frien
     }
 
     peer_av->buffer = create_queue(GROUP_JBUF_SIZE);
-    group_peer_set_object(group_av->g_c, groupnumber, friendgroupnumber, peer_av);
+
+    if (group_peer_set_object(group_av->g_c, groupnumber, friendgroupnumber, peer_av) == -1) {
+        free(peer_av);
+    }
 }
 
 static void group_av_peer_delete(void *object, uint32_t groupnumber, void *peer_object)


### PR DESCRIPTION
This probably doesn't happen, but it can in theory, so we avoid it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1080)
<!-- Reviewable:end -->
