### PR TITLE
Fix groupav.c style and avoid casts in toxav_old.c.

### DIFF
--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -33,13 +33,13 @@
 #define GROUP_JBUF_SIZE 6
 #define GROUP_JBUF_DEAD_SECONDS 4
 
-typedef struct {
+typedef struct Group_Audio_Packet {
     uint16_t sequnum;
     uint16_t length;
     uint8_t data[];
 } Group_Audio_Packet;
 
-typedef struct {
+typedef struct Group_JitterBuffer {
     Group_Audio_Packet **queue;
     uint32_t size;
     uint32_t capacity;
@@ -56,13 +56,15 @@ static Group_JitterBuffer *create_queue(unsigned int capacity)
         size *= 2;
     }
 
-    Group_JitterBuffer *q;
+    Group_JitterBuffer *q = (Group_JitterBuffer *)calloc(sizeof(Group_JitterBuffer), 1);
 
-    if (!(q = (Group_JitterBuffer *)calloc(sizeof(Group_JitterBuffer), 1))) {
+    if (!q) {
         return nullptr;
     }
 
-    if (!(q->queue = (Group_Audio_Packet **)calloc(sizeof(Group_Audio_Packet *), size))) {
+    q->queue = (Group_Audio_Packet **)calloc(sizeof(Group_Audio_Packet *), size);
+
+    if (!q->queue) {
         free(q);
         return nullptr;
     }
@@ -159,21 +161,22 @@ static Group_Audio_Packet *dequeue(Group_JitterBuffer *q, int *success)
     return nullptr;
 }
 
-typedef struct {
+typedef struct Group_AV {
     const Logger *log;
     Group_Chats *g_c;
     OpusEncoder *audio_encoder;
 
-    unsigned int audio_channels, audio_sample_rate, audio_bitrate;
+    unsigned int audio_channels;
+    unsigned int audio_sample_rate;
+    unsigned int audio_bitrate;
 
     uint16_t audio_sequnum;
 
-    void (*audio_data)(Messenger *m, uint32_t groupnumber, uint32_t peernumber, const int16_t *pcm, uint32_t samples,
-                       uint8_t channels, unsigned int sample_rate, void *userdata);
+    audio_data_cb *audio_data;
     void *userdata;
 } Group_AV;
 
-typedef struct {
+typedef struct Group_Peer_AV {
     Group_JitterBuffer *buffer;
 
     OpusDecoder *audio_decoder;
@@ -228,8 +231,7 @@ static int recreate_encoder(Group_AV *group_av)
     return 0;
 }
 
-static Group_AV *new_group_av(const Logger *log, Group_Chats *g_c, void (*audio_callback)(Messenger *, uint32_t,
-                              uint32_t, const int16_t *, unsigned int, uint8_t, uint32_t, void *), void *userdata)
+static Group_AV *new_group_av(const Logger *log, Group_Chats *g_c, audio_data_cb *audio_callback, void *userdata)
 {
     if (!g_c) {
         return nullptr;
@@ -417,7 +419,7 @@ static int handle_group_audio_packet(void *object, uint32_t groupnumber, uint32_
     }
 
     while (decode_audio_packet((Group_AV *)object, peer_av, groupnumber, friendgroupnumber) == 0) {
-        ;
+        continue;
     }
 
     return 0;
@@ -429,8 +431,7 @@ static int handle_group_audio_packet(void *object, uint32_t groupnumber, uint32_
  * return -1 on failure.
  */
 static int groupchat_enable_av(const Logger *log, Group_Chats *g_c, uint32_t groupnumber,
-                               void (*audio_callback)(Messenger *,
-                                       uint32_t, uint32_t, const int16_t *, unsigned int, uint8_t, uint32_t, void *), void *userdata)
+                               audio_data_cb *audio_callback, void *userdata)
 {
     Group_AV *group_av = new_group_av(log, g_c, audio_callback, userdata);
 
@@ -455,8 +456,7 @@ static int groupchat_enable_av(const Logger *log, Group_Chats *g_c, uint32_t gro
  * return group number on success.
  * return -1 on failure.
  */
-int add_av_groupchat(const Logger *log, Group_Chats *g_c, void (*audio_callback)(Messenger *, uint32_t, uint32_t,
-                     const int16_t *, unsigned int, uint8_t, uint32_t, void *), void *userdata)
+int add_av_groupchat(const Logger *log, Group_Chats *g_c, audio_data_cb *audio_callback, void *userdata)
 {
     int groupnumber = add_groupchat(g_c, GROUPCHAT_TYPE_AV);
 
@@ -478,8 +478,7 @@ int add_av_groupchat(const Logger *log, Group_Chats *g_c, void (*audio_callback)
  * returns -1 on failure.
  */
 int join_av_groupchat(const Logger *log, Group_Chats *g_c, uint32_t friendnumber, const uint8_t *data, uint16_t length,
-                      void (*audio_callback)(Messenger *, uint32_t, uint32_t, const int16_t *, unsigned int, uint8_t, uint32_t, void *),
-                      void *userdata)
+                      audio_data_cb *audio_callback, void *userdata)
 {
     int groupnumber = join_groupchat(g_c, friendnumber, GROUPCHAT_TYPE_AV, data, length);
 
@@ -516,7 +515,8 @@ static int send_audio_packet(Group_Chats *g_c, uint32_t groupnumber, uint8_t *pa
 
     uint8_t data[MAX_CRYPTO_DATA_SIZE];
     uint8_t *ptr = data;
-    *ptr++ = GROUP_AUDIO_PACKET_ID;
+    *ptr = GROUP_AUDIO_PACKET_ID;
+    ++ptr;
 
     ptr += net_pack_u16(ptr, group_av->audio_sequnum);
     memcpy(ptr, packet, length);

--- a/toxav/groupav.h
+++ b/toxav/groupav.h
@@ -27,13 +27,15 @@
 
 #define GROUP_AUDIO_PACKET_ID 192
 
+typedef void audio_data_cb(void *tox, uint32_t groupnumber, uint32_t peernumber, const int16_t *pcm,
+                           uint32_t samples, uint8_t channels, uint32_t sample_rate, void *userdata);
+
 /* Create a new toxav group.
  *
  * return group number on success.
  * return -1 on failure.
  */
-int add_av_groupchat(const Logger *log, Group_Chats *g_c, void (*audio_callback)(Messenger *, uint32_t, uint32_t,
-                     const int16_t *, unsigned int, uint8_t, uint32_t, void *), void *userdata);
+int add_av_groupchat(const Logger *log, Group_Chats *g_c, audio_data_cb *audio_callback, void *userdata);
 
 /* Join a AV group (you need to have been invited first.)
  *
@@ -41,8 +43,7 @@ int add_av_groupchat(const Logger *log, Group_Chats *g_c, void (*audio_callback)
  * returns -1 on failure.
  */
 int join_av_groupchat(const Logger *log, Group_Chats *g_c, uint32_t friendnumber, const uint8_t *data, uint16_t length,
-                      void (*audio_callback)(Messenger *, uint32_t, uint32_t, const int16_t *, unsigned int, uint8_t, uint32_t, void *),
-                      void *userdata);
+                      audio_data_cb *audio_callback, void *userdata);
 
 
 /* Send audio to the group chat.

--- a/toxav/toxav_old.c
+++ b/toxav/toxav_old.c
@@ -35,13 +35,10 @@
  *
  * Note that total size of pcm in bytes is equal to (samples * channels * sizeof(int16_t)).
  */
-int toxav_add_av_groupchat(Tox *tox, void (*audio_callback)(void *, uint32_t, uint32_t, const int16_t *, unsigned int,
-                           uint8_t, uint32_t, void *), void *userdata)
+int toxav_add_av_groupchat(Tox *tox, audio_data_cb *audio_callback, void *userdata)
 {
     Messenger *m = (Messenger *)tox;
-    return add_av_groupchat(m->log, m->conferences_object,
-                            (void (*)(Messenger *, uint32_t, uint32_t, const int16_t *, unsigned int, uint8_t, uint32_t, void *))audio_callback,
-                            userdata);
+    return add_av_groupchat(m->log, m->conferences_object, audio_callback, userdata);
 }
 
 /* Join a AV group (you need to have been invited first.)
@@ -55,14 +52,10 @@ int toxav_add_av_groupchat(Tox *tox, void (*audio_callback)(void *, uint32_t, ui
  * Note that total size of pcm in bytes is equal to (samples * channels * sizeof(int16_t)).
  */
 int toxav_join_av_groupchat(Tox *tox, uint32_t friendnumber, const uint8_t *data, uint16_t length,
-                            void (*audio_callback)
-                            (void *, uint32_t, uint32_t, const int16_t *, unsigned int, uint8_t, uint32_t, void *),
-                            void *userdata)
+                            audio_data_cb *audio_callback, void *userdata)
 {
     Messenger *m = (Messenger *)tox;
-    return join_av_groupchat(m->log, m->conferences_object, friendnumber, data, length,
-                             (void (*)(Messenger *, uint32_t, uint32_t, const int16_t *, unsigned int, uint8_t, uint32_t, void *))audio_callback,
-                             userdata);
+    return join_av_groupchat(m->log, m->conferences_object, friendnumber, data, length, audio_callback, userdata);
 }
 
 /* Send audio to the group chat.


### PR DESCRIPTION
* No anonymous structs.
* No assignment expressions.
* Only one declarator per struct member declaration.
* Named callback types only, no inline types.
* No `;` empty statements.
* `++i` instead of `i++`.

Avoiding a cast in toxav_old.c avoids some potential (and real) bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1082)
<!-- Reviewable:end -->
