### PR TITLE
Fix coding style in rtp module.

### DIFF
--- a/toxav/rtp.h
+++ b/toxav/rtp.h
@@ -45,16 +45,16 @@ extern "C" {
 /**
  * Payload type identifier. Also used as rtp callback prefix.
  */
-enum {
+typedef enum RTP_Type {
     RTP_TYPE_AUDIO = 192,
     RTP_TYPE_VIDEO = 193,
-};
+} RTP_Type;
 
 /**
  * A bit mask (up to 64 bits) specifying features of the current frame affecting
  * the behaviour of the decoder.
  */
-enum RTPFlags {
+typedef enum RTPFlags {
     /**
      * Support frames larger than 64KiB. The full 32 bit length and offset are
      * set in \ref RTPHeader::data_length_full and \ref RTPHeader::offset_full.
@@ -64,7 +64,7 @@ enum RTPFlags {
      * Whether the packet is part of a key frame.
      */
     RTP_KEY_FRAME = 1 << 1,
-};
+} RTPFlags;
 
 
 struct RTPHeader {
@@ -159,6 +159,8 @@ struct RTPWorkBufferList {
 
 #define DISMISS_FIRST_LOST_VIDEO_PACKET_COUNT 10
 
+typedef int rtp_m_cb(void *cs, struct RTPMessage *msg);
+
 /**
  * RTP control session.
  */
@@ -175,7 +177,7 @@ typedef struct RTPSession {
     uint32_t friend_number;
     BWController *bwc;
     void *cs;
-    int (*mcb)(void *, struct RTPMessage *msg);
+    rtp_m_cb *mcb;
 } RTPSession;
 
 
@@ -198,8 +200,7 @@ size_t rtp_header_pack(uint8_t *rdata, const struct RTPHeader *header);
 size_t rtp_header_unpack(const uint8_t *data, struct RTPHeader *header);
 
 RTPSession *rtp_new(int payload_type, Messenger *m, uint32_t friendnumber,
-                    BWController *bwc, void *cs,
-                    int (*mcb)(void *, struct RTPMessage *));
+                    BWController *bwc, void *cs, rtp_m_cb *mcb);
 void rtp_kill(RTPSession *session);
 int rtp_allow_receiving(RTPSession *session);
 int rtp_stop_receiving(RTPSession *session);


### PR DESCRIPTION
* Named callback types only.
* No anonymous enums or structs.
* `++i` instead of `i++`.
* Don't use enums to specify integer constants. Enums should be
  enumerations. All values of an enum type should be listed[1].

[1] I don't know what to do about bit masks yet, but given that enums by
C standard can only go up to 32767 portably and 2^31 in reality, they are
probably not useful for 64 bit bit masks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1083)
<!-- Reviewable:end -->
