### PR TITLE
Use `--config` to tell bazel about the environment.

### DIFF
--- a/.travis/bazel-linux
+++ b/.travis/bazel-linux
@@ -10,7 +10,8 @@ travis_install() {
   chmod +x bazel-0.15.0-installer-linux-x86_64.sh
   ./bazel-0.15.0-installer-linux-x86_64.sh --user
   echo 'build --jobs=4 --curses=no --verbose_failures' >> $HOME/.bazelrc
-  echo "import %workspace%/tools/bazelrc/linux-$CC" >> $HOME/.bazelrc
+  echo 'build --config=linux' >> $HOME/.bazelrc
+  echo "build --config=$CC" >> $HOME/.bazelrc
 }
 
 travis_script() {


### PR DESCRIPTION
Instead of importing a well-known file. This gives toktok-stack more
freedom in where and how it wants to define its interface, as long as it
provides the configurations requested ("linux" and "clang").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1088)
<!-- Reviewable:end -->
