### PR TITLE
Fix first loop iteration in dht_test

### DIFF
--- a/auto_tests/dht_test.c
+++ b/auto_tests/dht_test.c
@@ -645,7 +645,7 @@ loop_top:
         IP_Port ip_port;
         ip_port.ip = get_loopback();
         ip_port.port = net_htons(DHT_DEFAULT_PORT + i);
-        dht_bootstrap(dhts[(i - 1) % NUM_DHT], ip_port, dhts[i]->self_public_key);
+        dht_bootstrap(dhts[i], ip_port, dhts[(i + 1) % NUM_DHT]->self_public_key);
     }
 
     while (1) {


### PR DESCRIPTION
Despite the code worked, first loop result could be unexpected
for a developer.
When i == 0:
(i - 1) % NUM_DHT == -1 % 100 == 4294967295 % 100 == 95.
So on the first iteration we'd take 95th element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1091)
<!-- Reviewable:end -->
