### PR TITLE
Install the `DHT_bootstrap` binary on `make install`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,7 @@ if(DHT_BOOTSTRAP)
     other/DHT_bootstrap.c
     other/bootstrap_node_packets.c)
   target_link_modules(DHT_bootstrap toxcore misc_tools)
+  install(TARGETS DHT_bootstrap RUNTIME DESTINATION bin)
 endif()
 
 option(BOOTSTRAP_DAEMON "Enable building of tox-bootstrapd" ON)


### PR DESCRIPTION
We didn't install it before, only `tox-bootstrapd`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1092)
<!-- Reviewable:end -->
