### PR TITLE
Set `_POSIX_C_SOURCE` to 200112L. We need it for C99 compat.

### DIFF
--- a/testing/misc_tools.c
+++ b/testing/misc_tools.c
@@ -27,7 +27,7 @@
 
 #ifndef _POSIX_C_SOURCE
 // For nanosleep().
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #endif
 
 #include "misc_tools.h"


### PR DESCRIPTION
It is invalid to compile an XPG3, XPG4, XPG4v2, or XPG5 application
using c99.  The same is true for POSIX.1-1990, POSIX.2-1992, POSIX.1b,
and POSIX.1c applications. Likewise, it is invalid to compile an XPG6
or a POSIX.1-2001 application with anything other than a c99 or later
compiler.  Therefore, Solaris libc forces an error in both cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1094)
<!-- Reviewable:end -->
