### PR TITLE
Always print output on failure in cmake tests on Travis.

### DIFF
--- a/.travis/cmake-linux
+++ b/.travis/cmake-linux
@@ -92,8 +92,8 @@ travis_script() {
 
   cd _build  # pushd
   make "-j$NPROC" -k install
-  make "-j$NPROC" test ARGS="-j50" || \
-    make "-j$NPROC" test ARGS="-j50 --rerun-failed" CTEST_OUTPUT_ON_FAILURE=1
+  ctest -j50 --output-on-failure || \
+    ctest -j50 --output-on-failure --rerun-failed
   cd -  # popd
 }
 


### PR DESCRIPTION
Not only the second time it fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1107)
<!-- Reviewable:end -->
