### PR TITLE
Consistently use 'mono_time' rather than 'monotime'

### DIFF
--- a/toxcore/mono_time.c
+++ b/toxcore/mono_time.c
@@ -32,40 +32,39 @@ struct Mono_Time {
 
 Mono_Time *mono_time_new(void)
 {
-    Mono_Time *monotime = (Mono_Time *)malloc(sizeof(Mono_Time));
+    Mono_Time *mono_time = (Mono_Time *)malloc(sizeof(Mono_Time));
 
-    if (monotime == nullptr) {
+    if (mono_time == nullptr) {
         return nullptr;
     }
 
-    monotime->time = 0;
-    monotime->base_time = (uint64_t)time(nullptr) - (current_time_monotonic(monotime) / 1000ULL);
+    mono_time->time = 0;
+    mono_time->base_time = (uint64_t)time(nullptr) - (current_time_monotonic(mono_time) / 1000ULL);
 
-    mono_time_update(monotime);
+    mono_time_update(mono_time);
 
-    return monotime;
+    return mono_time;
 }
 
-void mono_time_free(Mono_Time *monotime)
+void mono_time_free(Mono_Time *mono_time)
 {
-    free(monotime);
+    free(mono_time);
 }
 
-void mono_time_update(Mono_Time *monotime)
+void mono_time_update(Mono_Time *mono_time)
 {
-    monotime->time = (current_time_monotonic(monotime) / 1000ULL) + monotime->base_time;
+    mono_time->time = (current_time_monotonic(mono_time) / 1000ULL) + mono_time->base_time;
 }
 
-uint64_t mono_time_get(const Mono_Time *monotime)
+uint64_t mono_time_get(const Mono_Time *mono_time)
 {
-    return monotime->time;
+    return mono_time->time;
 }
 
-bool mono_time_is_timeout(const Mono_Time *monotime, uint64_t timestamp, uint64_t timeout)
+bool mono_time_is_timeout(const Mono_Time *mono_time, uint64_t timestamp, uint64_t timeout)
 {
-    return timestamp + timeout <= mono_time_get(monotime);
+    return timestamp + timeout <= mono_time_get(mono_time);
 }
-
 
 //!TOKSTYLE-
 // No global mutable state in Tokstyle.
@@ -76,7 +75,7 @@ static uint64_t add_clock_mono;
 //!TOKSTYLE+
 
 /* return current monotonic time in milliseconds (ms). */
-uint64_t current_time_monotonic(const Mono_Time *monotime)
+uint64_t current_time_monotonic(const Mono_Time *mono_time)
 {
     uint64_t time;
 #ifdef OS_WIN32

--- a/toxcore/mono_time.h
+++ b/toxcore/mono_time.h
@@ -43,14 +43,14 @@ typedef struct Mono_Time Mono_Time;
 #endif /* MONO_TIME_DEFINED */
 
 Mono_Time *mono_time_new(void);
-void mono_time_free(Mono_Time *monotime);
+void mono_time_free(Mono_Time *mono_time);
 
-void mono_time_update(Mono_Time *monotime);
-uint64_t mono_time_get(const Mono_Time *monotime);
-bool mono_time_is_timeout(const Mono_Time *monotime, uint64_t timestamp, uint64_t timeout);
+void mono_time_update(Mono_Time *mono_time);
+uint64_t mono_time_get(const Mono_Time *mono_time);
+bool mono_time_is_timeout(const Mono_Time *mono_time, uint64_t timestamp, uint64_t timeout);
 
 /* return current monotonic time in milliseconds (ms). */
-uint64_t current_time_monotonic(const Mono_Time *monotime);
+uint64_t current_time_monotonic(const Mono_Time *mono_time);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1109)
<!-- Reviewable:end -->
