### PR TITLE
Use do-while instead of while in tests.

### DIFF
--- a/auto_tests/bootstrap_test.c
+++ b/auto_tests/bootstrap_test.c
@@ -24,13 +24,13 @@ int main(void)
 
     printf("Waiting for connection");
 
-    while (tox_self_get_connection_status(tox_udp) == TOX_CONNECTION_NONE) {
+    do {
         printf(".");
         fflush(stdout);
 
         tox_iterate(tox_udp, nullptr);
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (tox_self_get_connection_status(tox_udp) == TOX_CONNECTION_NONE);
 
     const TOX_CONNECTION status = tox_self_get_connection_status(tox_udp);
     ck_assert_msg(status == TOX_CONNECTION_UDP,

--- a/auto_tests/conference_double_invite_test.c
+++ b/auto_tests/conference_double_invite_test.c
@@ -63,12 +63,12 @@ static void conference_double_invite_test(Tox **toxes, State *state)
 
     fprintf(stderr, "Waiting for invitation to arrive\n");
 
-    while (!state[0].joined || !state[1].joined) {
+    do {
         tox_iterate(toxes[0], &state[0]);
         tox_iterate(toxes[1], &state[1]);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (!state[0].joined || !state[1].joined);
 
     fprintf(stderr, "Invitations accepted\n");
 

--- a/auto_tests/conference_peer_nick_test.c
+++ b/auto_tests/conference_peer_nick_test.c
@@ -107,26 +107,25 @@ static void conference_peer_nick_test(Tox **toxes, State *state)
 
     fprintf(stderr, "Waiting for invitation to arrive and peers to be in the group\n");
 
-    while (!state[0].joined || !state[1].joined || !state[0].friend_in_group || !state[1].friend_in_group) {
+    do {
         tox_iterate(toxes[0], &state[0]);
         tox_iterate(toxes[1], &state[1]);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (!state[0].joined || !state[1].joined || !state[0].friend_in_group || !state[1].friend_in_group);
 
     fprintf(stderr, "Running tox0, but not tox1, waiting for tox1 to drop out\n");
 
-    while (state[0].friend_in_group) {
+    do {
         tox_iterate(toxes[0], &state[0]);
 
         // Rebuild peer list after every iteration.
         rebuild_peer_list(toxes[0]);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (state[0].friend_in_group);
 
     fprintf(stderr, "Invitations accepted\n");
-
 }
 
 int main(void)

--- a/auto_tests/conference_simple_test.c
+++ b/auto_tests/conference_simple_test.c
@@ -165,26 +165,26 @@ int main(void)
     // Wait for self connection.
     fprintf(stderr, "Waiting for toxes to come online\n");
 
-    while (!state1.self_online || !state2.self_online || !state3.self_online) {
+    do {
         tox_iterate(tox1, &state1);
         tox_iterate(tox2, &state2);
         tox_iterate(tox3, &state3);
 
         c_sleep(100);
-    }
+    } while (!state1.self_online || !state2.self_online || !state3.self_online);
 
     fprintf(stderr, "Toxes are online\n");
 
     // Wait for friend connection.
     fprintf(stderr, "Waiting for friends to connect\n");
 
-    while (!state1.friend_online || !state2.friend_online || !state3.friend_online) {
+    do {
         tox_iterate(tox1, &state1);
         tox_iterate(tox2, &state2);
         tox_iterate(tox3, &state3);
 
         c_sleep(100);
-    }
+    } while (!state1.friend_online || !state2.friend_online || !state3.friend_online);
 
     fprintf(stderr, "Friends are connected\n");
 
@@ -208,25 +208,25 @@ int main(void)
 
     fprintf(stderr, "Waiting for invitation to arrive\n");
 
-    while (!state1.joined || !state2.joined || !state3.joined) {
+    do {
         tox_iterate(tox1, &state1);
         tox_iterate(tox2, &state2);
         tox_iterate(tox3, &state3);
 
         c_sleep(100);
-    }
+    } while (!state1.joined || !state2.joined || !state3.joined);
 
     fprintf(stderr, "Invitations accepted\n");
 
     fprintf(stderr, "Waiting for peers to come online\n");
 
-    while (state1.peers == 0 || state2.peers == 0 || state3.peers == 0) {
+    do {
         tox_iterate(tox1, &state1);
         tox_iterate(tox2, &state2);
         tox_iterate(tox3, &state3);
 
         c_sleep(100);
-    }
+    } while (state1.peers == 0 || state2.peers == 0 || state3.peers == 0);
 
     fprintf(stderr, "All peers are online\n");
 
@@ -244,13 +244,13 @@ int main(void)
 
     fprintf(stderr, "Waiting for messages to arrive\n");
 
-    while (!state2.received || !state3.received) {
+    do {
         tox_iterate(tox1, &state1);
         tox_iterate(tox2, &state2);
         tox_iterate(tox3, &state3);
 
         c_sleep(100);
-    }
+    } while (!state2.received || !state3.received);
 
     fprintf(stderr, "Messages received. Test complete.\n");
 

--- a/auto_tests/conference_test.c
+++ b/auto_tests/conference_test.c
@@ -216,7 +216,7 @@ static void test_many_group(void)
     printf("waiting for everyone to come online\n");
     unsigned online_count = 0;
 
-    while (online_count != NUM_GROUP_TOX) {
+    do {
         online_count = 0;
 
         for (uint16_t i = 0; i < NUM_GROUP_TOX; ++i) {
@@ -228,7 +228,7 @@ static void test_many_group(void)
         fflush(stdout);
 
         c_sleep(1000);
-    }
+    } while (online_count != NUM_GROUP_TOX);
 
     printf("friends connected, took %d seconds\n", (int)(time(nullptr) - cur_time));
 
@@ -243,7 +243,7 @@ static void test_many_group(void)
     printf("waiting for invitations to be made\n");
     uint16_t invited_count = 0;
 
-    while (invited_count != NUM_GROUP_TOX - 1) {
+    do {
         invited_count = 0;
 
         for (uint16_t i = 0; i < NUM_GROUP_TOX; ++i) {
@@ -252,13 +252,13 @@ static void test_many_group(void)
         }
 
         c_sleep(50);
-    }
+    } while (invited_count != NUM_GROUP_TOX - 1);
 
     cur_time = time(nullptr);
     printf("waiting for all toxes to be in the group\n");
     uint16_t fully_connected_count = 0;
 
-    while (fully_connected_count != NUM_GROUP_TOX) {
+    do {
         fully_connected_count = 0;
         printf("current peer counts: [");
 
@@ -284,7 +284,7 @@ static void test_many_group(void)
         fflush(stdout);
 
         c_sleep(200);
-    }
+    } while (fully_connected_count != NUM_GROUP_TOX);
 
     for (uint16_t i = 0; i < NUM_GROUP_TOX; ++i) {
         uint32_t peer_count = tox_conference_peer_count(toxes[i], 0, nullptr);

--- a/auto_tests/dht_test.c
+++ b/auto_tests/dht_test.c
@@ -655,7 +655,7 @@ loop_top:
         dht_bootstrap(dhts[(i - 1) % NUM_DHT], ip_port, dhts[i]->self_public_key);
     }
 
-    while (1) {
+    while (true) {
         uint16_t counter = 0;
 
         for (i = 0; i < NUM_DHT_FRIENDS; ++i) {

--- a/auto_tests/file_transfer_test.c
+++ b/auto_tests/file_transfer_test.c
@@ -184,11 +184,7 @@ static void file_transfer_test(void)
 
     printf("Waiting for toxes to come online\n");
 
-    while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
-            tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE ||
-            tox_self_get_connection_status(tox3) == TOX_CONNECTION_NONE ||
-            tox_friend_get_connection_status(tox2, 0, nullptr) == TOX_CONNECTION_NONE ||
-            tox_friend_get_connection_status(tox3, 0, nullptr) == TOX_CONNECTION_NONE) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
         tox_iterate(tox3, nullptr);
@@ -200,7 +196,11 @@ static void file_transfer_test(void)
                tox_friend_get_connection_status(tox2, 0, nullptr),
                tox_friend_get_connection_status(tox3, 0, nullptr));
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
+             tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE ||
+             tox_self_get_connection_status(tox3) == TOX_CONNECTION_NONE ||
+             tox_friend_get_connection_status(tox2, 0, nullptr) == TOX_CONNECTION_NONE ||
+             tox_friend_get_connection_status(tox3, 0, nullptr) == TOX_CONNECTION_NONE);
 
     printf("Starting file transfer test: 100MiB file.\n");
 
@@ -292,7 +292,7 @@ static void file_transfer_test(void)
     max_sending = 100 * 1024;
     m_send_reached = 0;
 
-    while (!file_sending_done) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
         tox_iterate(tox3, nullptr);
@@ -302,7 +302,7 @@ static void file_transfer_test(void)
         uint32_t tox3_interval = tox_iteration_interval(tox3);
 
         c_sleep(min_u32(tox1_interval, min_u32(tox2_interval, tox3_interval)));
-    }
+    } while (!file_sending_done);
 
     ck_assert_msg(sendf_ok && file_recv && m_send_reached && totalf_size == file_size && size_recv == max_sending
                   && sending_pos == size_recv && file_accepted == 1,
@@ -336,7 +336,7 @@ static void file_transfer_test(void)
     ck_assert_msg(tox_file_get_file_id(tox2, 0, fnum, file_cmp_id, &gfierr), "tox_file_get_file_id failed");
     ck_assert_msg(gfierr == TOX_ERR_FILE_GET_OK, "wrong error");
 
-    while (!file_sending_done) {
+    do {
         uint32_t tox1_interval = tox_iteration_interval(tox1);
         uint32_t tox2_interval = tox_iteration_interval(tox2);
         uint32_t tox3_interval = tox_iteration_interval(tox3);
@@ -346,7 +346,7 @@ static void file_transfer_test(void)
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
         tox_iterate(tox3, nullptr);
-    }
+    } while (!file_sending_done);
 
     ck_assert_msg(sendf_ok && file_recv && totalf_size == file_size && size_recv == file_size
                   && sending_pos == size_recv && file_accepted == 1,

--- a/auto_tests/friend_request_test.c
+++ b/auto_tests/friend_request_test.c
@@ -43,13 +43,13 @@ static void test_friend_request(void)
 
     tox_bootstrap(tox2, "localhost", dht_port, dht_key, nullptr);
 
-    while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
-            tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
+             tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE);
 
     printf("Toxes are online, took %lu seconds.\n", (unsigned long)(time(nullptr) - cur_time));
     const time_t con_time = time(nullptr);
@@ -63,13 +63,13 @@ static void test_friend_request(void)
     const uint32_t test = tox_friend_add(tox1, address, (const uint8_t *)FR_MESSAGE, sizeof(FR_MESSAGE), nullptr);
     ck_assert_msg(test == 0, "failed to add friend error code: %u", test);
 
-    while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
-            tox_friend_get_connection_status(tox2, 0, nullptr) != TOX_CONNECTION_UDP) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
+             tox_friend_get_connection_status(tox2, 0, nullptr) != TOX_CONNECTION_UDP);
 
     printf("Tox clients connected took %lu seconds.\n", (unsigned long)(time(nullptr) - con_time));
     printf("friend_request_test succeeded, took %lu seconds.\n", (unsigned long)(time(nullptr) - cur_time));

--- a/auto_tests/lan_discovery_test.c
+++ b/auto_tests/lan_discovery_test.c
@@ -16,15 +16,15 @@ int main(void)
 
     printf("Waiting for LAN discovery. This loop will attempt to run until successful.");
 
-    while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
-            tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE) {
+    do {
         printf(".");
         fflush(stdout);
 
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
         c_sleep(1000);
-    }
+    } while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
+             tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE);
 
     printf(" %d <-> %d\n",
            tox_self_get_connection_status(tox1),

--- a/auto_tests/lossless_packet_test.c
+++ b/auto_tests/lossless_packet_test.c
@@ -50,12 +50,12 @@ static void test_lossless_packet(Tox **toxes, State *state)
     ret = tox_friend_send_lossless_packet(toxes[0], 0, packet, TOX_MAX_CUSTOM_PACKET_SIZE, nullptr);
     ck_assert_msg(ret == true, "tox_friend_send_lossless_packet fail %i", ret);
 
-    while (!state[1].custom_packet_received) {
+    do {
         tox_iterate(toxes[0], nullptr);
         tox_iterate(toxes[1], &state[1]);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (!state[1].custom_packet_received);
 }
 
 int main(void)

--- a/auto_tests/lossy_packet_test.c
+++ b/auto_tests/lossy_packet_test.c
@@ -46,11 +46,11 @@ static void test_lossy_packet(Tox **toxes, State *state)
     ret = tox_friend_send_lossy_packet(toxes[0], 0, packet, TOX_MAX_CUSTOM_PACKET_SIZE, nullptr);
     ck_assert_msg(ret == true, "tox_friend_send_lossy_packet fail %i", ret);
 
-    while (!state[1].custom_packet_received) {
+    do {
         tox_iterate(toxes[0], nullptr);
         tox_iterate(toxes[1], &state[1]);
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (!state[1].custom_packet_received);
 }
 
 int main(void)

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -192,18 +192,18 @@ static void test_basic(void)
 
     handled_test_1 = 0;
 
-    while (handled_test_1 == 0) {
+    do {
         do_onion(onion1);
         do_onion(onion2);
-    }
+    } while (handled_test_1 == 0);
 
     networking_registerhandler(onion1->net, NET_PACKET_ANNOUNCE_RESPONSE, &handle_test_2, onion1);
     handled_test_2 = 0;
 
-    while (handled_test_2 == 0) {
+    do {
         do_onion(onion1);
         do_onion(onion2);
-    }
+    } while (handled_test_2 == 0);
 
     Onion_Announce *onion1_a = new_onion_announce(mono_time1, onion1->dht);
     Onion_Announce *onion2_a = new_onion_announce(mono_time2, onion2->dht);
@@ -223,11 +223,11 @@ static void test_basic(void)
     ck_assert_msg(ret == 0, "Failed to create/send onion announce_request packet.");
     handled_test_3 = 0;
 
-    while (handled_test_3 == 0) {
+    do {
         do_onion(onion1);
         do_onion(onion2);
         c_sleep(50);
-    }
+    } while (handled_test_3 == 0);
 
     random_bytes(sb_data, sizeof(sb_data));
     memcpy(&s, sb_data, sizeof(uint64_t));
@@ -241,13 +241,13 @@ static void test_basic(void)
                           dht_get_self_public_key(onion1->dht),
                           dht_get_self_public_key(onion1->dht), s);
 
-    while (memcmp(onion_announce_entry_public_key(onion2_a, ONION_ANNOUNCE_MAX_ENTRIES - 2),
-                  dht_get_self_public_key(onion1->dht),
-                  CRYPTO_PUBLIC_KEY_SIZE) != 0) {
+    do {
         do_onion(onion1);
         do_onion(onion2);
         c_sleep(50);
-    }
+    } while (memcmp(onion_announce_entry_public_key(onion2_a, ONION_ANNOUNCE_MAX_ENTRIES - 2),
+                    dht_get_self_public_key(onion1->dht),
+                    CRYPTO_PUBLIC_KEY_SIZE) != 0);
 
     c_sleep(1000);
     Logger *log3 = logger_new();
@@ -266,11 +266,11 @@ static void test_basic(void)
     ck_assert_msg(ret == 0, "Failed to create/send onion data_request packet.");
     handled_test_4 = 0;
 
-    while (handled_test_4 == 0) {
+    do {
         do_onion(onion1);
         do_onion(onion2);
         c_sleep(50);
-    }
+    } while (handled_test_4 == 0);
 
     kill_onion_announce(onion2_a);
     kill_onion_announce(onion1_a);
@@ -513,7 +513,7 @@ static void test_announce(void)
 
     uint32_t connected = 0;
 
-    while (connected != NUM_ONIONS) {
+    do {
         connected = 0;
 
         for (i = 0; i < NUM_ONIONS; ++i) {
@@ -522,7 +522,7 @@ static void test_announce(void)
         }
 
         c_sleep(50);
-    }
+    } while (connected != NUM_ONIONS);
 
     printf("connected\n");
 
@@ -548,23 +548,23 @@ static void test_announce(void)
 
     IP_Port ip_port;
 
-    while (!first || !last) {
+    do {
         for (i = 0; i < NUM_ONIONS; ++i) {
             do_onions(onions[i]);
         }
 
         c_sleep(50);
-    }
+    } while (!first || !last);
 
     printf("Waiting for ips\n");
 
-    while (!first_ip || !last_ip) {
+    do {
         for (i = 0; i < NUM_ONIONS; ++i) {
             do_onions(onions[i]);
         }
 
         c_sleep(50);
-    }
+    } while (!first_ip || !last_ip);
 
     onion_getfriendip(onions[NUM_LAST]->onion_c, frnum, &ip_port);
     ck_assert_msg(ip_port.port == net_port(onions[NUM_FIRST]->onion->net), "Port in returned ip not correct.");

--- a/auto_tests/run_auto_test.h
+++ b/auto_tests/run_auto_test.h
@@ -72,19 +72,19 @@ static void run_auto_test(uint32_t tox_count, void test(Tox **toxes, State *stat
         tox_bootstrap(toxes[i], "localhost", dht_port, dht_key, nullptr);
     }
 
-    while (!all_connected(tox_count, toxes)) {
+    do {
         iterate_all(tox_count, toxes, state);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (!all_connected(tox_count, toxes));
 
     printf("toxes are online\n");
 
-    while (!all_friends_connected(tox_count, toxes)) {
+    do {
         iterate_all(tox_count, toxes, state);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (!all_friends_connected(tox_count, toxes));
 
     printf("tox clients connected\n");
 

--- a/auto_tests/save_load_test.c
+++ b/auto_tests/save_load_test.c
@@ -63,7 +63,7 @@ static void test_few_clients(void)
 
     uint8_t off = 1;
 
-    while (1) {
+    while (true) {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
         tox_iterate(tox3, nullptr);
@@ -103,7 +103,7 @@ static void test_few_clients(void)
     cur_time = time(nullptr);
     off = 1;
 
-    while (1) {
+    while (true) {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
         tox_iterate(tox3, nullptr);

--- a/auto_tests/send_message_test.c
+++ b/auto_tests/send_message_test.c
@@ -50,12 +50,12 @@ static void send_message_test(Tox **toxes, State *state)
     tox_friend_send_message(toxes[0], 0, TOX_MESSAGE_TYPE_NORMAL, msgs, TOX_MAX_MESSAGE_LENGTH, &errm);
     ck_assert_msg(errm == TOX_ERR_FRIEND_SEND_MESSAGE_OK, "TOX_MAX_MESSAGE_LENGTH is too big? error=%d", errm);
 
-    while (!state[1].message_received) {
+    do {
         tox_iterate(toxes[0], &state[0]);
         tox_iterate(toxes[1], &state[1]);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (!state[1].message_received);
 }
 
 int main(void)

--- a/auto_tests/set_name_test.c
+++ b/auto_tests/set_name_test.c
@@ -49,22 +49,22 @@ static void test_set_name(void)
 
     tox_bootstrap(tox2, "localhost", dht_port, dht_key, nullptr);
 
-    while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
-            tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
+             tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE);
 
     printf("toxes are online, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
     const time_t con_time = time(nullptr);
 
-    while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
-            tox_friend_get_connection_status(tox2, 0, nullptr) != TOX_CONNECTION_UDP) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
+             tox_friend_get_connection_status(tox2, 0, nullptr) != TOX_CONNECTION_UDP);
 
     printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
 
@@ -75,11 +75,11 @@ static void test_set_name(void)
 
     bool nickname_updated = false;
 
-    while (!nickname_updated) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, &nickname_updated);
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (!nickname_updated);
 
     ck_assert_msg(tox_friend_get_name_size(tox2, 0, nullptr) == sizeof(NICKNAME), "Name length not correct");
     uint8_t temp_name[sizeof(NICKNAME)];

--- a/auto_tests/set_status_message_test.c
+++ b/auto_tests/set_status_message_test.c
@@ -51,24 +51,24 @@ static void test_set_status_message(void)
 
     tox_bootstrap(tox2, "localhost", dht_port, dht_key, nullptr);
 
-    while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
-            tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
+             tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE);
 
     printf("toxes are online, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
     const time_t con_time = time(nullptr);
 
-    while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
-            tox_friend_get_connection_status(tox2, 0, nullptr) != TOX_CONNECTION_UDP) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
 
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
+             tox_friend_get_connection_status(tox2, 0, nullptr) != TOX_CONNECTION_UDP);
 
     printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
 
@@ -80,11 +80,11 @@ static void test_set_status_message(void)
 
     bool status_updated = false;
 
-    while (!status_updated) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, &status_updated);
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (!status_updated);
 
     ck_assert_msg(tox_friend_get_status_message_size(tox2, 0, nullptr) == sizeof(STATUS_MESSAGE),
                   "status message length not correct");

--- a/auto_tests/tcp_relay_test.c
+++ b/auto_tests/tcp_relay_test.c
@@ -28,13 +28,13 @@ int main(void)
 
     printf("Waiting for connection");
 
-    while (tox_self_get_connection_status(tox_tcp) == TOX_CONNECTION_NONE) {
+    do {
         printf(".");
         fflush(stdout);
 
         tox_iterate(tox_tcp, nullptr);
         c_sleep(ITERATION_INTERVAL);
-    }
+    } while (tox_self_get_connection_status(tox_tcp) == TOX_CONNECTION_NONE);
 
     const TOX_CONNECTION status = tox_self_get_connection_status(tox_tcp);
     ck_assert_msg(status == TOX_CONNECTION_TCP,

--- a/auto_tests/tox_many_tcp_test.c
+++ b/auto_tests/tox_many_tcp_test.c
@@ -101,7 +101,7 @@ loop_top:
         ck_assert_msg(num != UINT32_MAX && test == TOX_ERR_FRIEND_ADD_OK, "Failed to add friend error code: %i", test);
     }
 
-    while (1) {
+    while (true) {
         uint16_t counter = 0;
 
         for (i = 0; i < NUM_TOXES_TCP; ++i) {
@@ -197,7 +197,7 @@ loop_top:
 
     uint16_t last_count = 0;
 
-    while (1) {
+    while (true) {
         uint16_t counter = 0;
 
         for (i = 0; i < NUM_TOXES_TCP; ++i) {

--- a/auto_tests/tox_many_test.c
+++ b/auto_tests/tox_many_test.c
@@ -92,7 +92,7 @@ loop_top:
 
     uint16_t last_count = 0;
 
-    while (1) {
+    while (true) {
         uint16_t counter = 0;
 
         for (uint32_t i = 0; i < TCP_TEST_NUM_TOXES; ++i) {

--- a/auto_tests/toxav_basic_test.c
+++ b/auto_tests/toxav_basic_test.c
@@ -121,9 +121,9 @@ static void regular_call_flow(
         ck_assert(0);
     }
 
-    time_t start_time = time(nullptr);
+    const time_t start_time = time(nullptr);
 
-    while (BobCC->state != TOXAV_FRIEND_CALL_STATE_FINISHED) {
+    do {
         if (BobCC->incoming) {
             TOXAV_ERR_ANSWER answer_err;
             toxav_answer(BobAV, 0, a_br, v_br, &answer_err);
@@ -148,7 +148,7 @@ static void regular_call_flow(
         }
 
         iterate_tox(bootstrap, Alice, Bob);
-    }
+    } while (BobCC->state != TOXAV_FRIEND_CALL_STATE_FINISHED);
 
     printf("Success!\n");
 }
@@ -195,7 +195,7 @@ static void test_av_flows(void)
 
     uint8_t off = 1;
 
-    while (1) {
+    while (true) {
         iterate_tox(bootstrap, Alice, Bob);
 
         if (tox_self_get_connection_status(bootstrap) &&
@@ -270,9 +270,9 @@ static void test_av_flows(void)
             }
         }
 
-        while (!BobCC.incoming) {
+        do {
             iterate_tox(bootstrap, Alice, Bob);
-        }
+        } while (!BobCC.incoming);
 
         /* Reject */
         {
@@ -285,9 +285,9 @@ static void test_av_flows(void)
             }
         }
 
-        while (AliceCC.state != TOXAV_FRIEND_CALL_STATE_FINISHED) {
+        do {
             iterate_tox(bootstrap, Alice, Bob);
-        }
+        } while (AliceCC.state != TOXAV_FRIEND_CALL_STATE_FINISHED);
 
         printf("Success!\n");
     }
@@ -308,9 +308,9 @@ static void test_av_flows(void)
             }
         }
 
-        while (!BobCC.incoming) {
+        do {
             iterate_tox(bootstrap, Alice, Bob);
-        }
+        } while (!BobCC.incoming);
 
         /* Cancel */
         {
@@ -324,9 +324,9 @@ static void test_av_flows(void)
         }
 
         /* Alice will not receive end state */
-        while (BobCC.state != TOXAV_FRIEND_CALL_STATE_FINISHED) {
+        do {
             iterate_tox(bootstrap, Alice, Bob);
-        }
+        } while (BobCC.state != TOXAV_FRIEND_CALL_STATE_FINISHED);
 
         printf("Success!\n");
     }
@@ -348,9 +348,9 @@ static void test_av_flows(void)
             }
         }
 
-        while (!BobCC.incoming) {
+        do {
             iterate_tox(bootstrap, Alice, Bob);
-        }
+        } while (!BobCC.incoming);
 
         /* At first try all stuff while in invalid state */
         ck_assert(!toxav_call_control(AliceAV, 0, TOXAV_CALL_CONTROL_PAUSE, nullptr));
@@ -438,9 +438,9 @@ static void test_av_flows(void)
             }
         }
 
-        while (!BobCC.incoming) {
+        do {
             iterate_tox(bootstrap, Alice, Bob);
-        }
+        } while (!BobCC.incoming);
 
         {
             TOXAV_ERR_ANSWER rc;
@@ -506,9 +506,9 @@ static void test_av_flows(void)
             }
         }
 
-        while (!BobCC.incoming) {
+        do {
             iterate_tox(bootstrap, Alice, Bob);
-        }
+        } while (!BobCC.incoming);
 
         {
             TOXAV_ERR_ANSWER rc;

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -116,9 +116,9 @@ static void *call_thread(void *pd)
         }
     }
 
-    while (!BobCC->incoming) {
+    do {
         c_sleep(10);
-    }
+    } while (!BobCC->incoming);
 
     { /* Answer */
         TOXAV_ERR_ANSWER rc;
@@ -139,7 +139,7 @@ static void *call_thread(void *pd)
 
     time_t start_time = time(nullptr);
 
-    while (time(nullptr) - start_time < 4) {
+    do {
         toxav_iterate(AliceAV);
         toxav_iterate(BobAV);
 
@@ -150,7 +150,7 @@ static void *call_thread(void *pd)
         toxav_video_send_frame(BobAV, 0, 800, 600, video_y, video_u, video_v, nullptr);
 
         c_sleep(10);
-    }
+    } while (time(nullptr) - start_time < 4);
 
     { /* Hangup */
         TOXAV_ERR_CALL_CONTROL rc;
@@ -228,7 +228,7 @@ static void test_av_three_calls(void)
 
     uint8_t off = 1;
 
-    while (1) {
+    while (true) {
         tox_iterate(bootstrap, nullptr);
         tox_iterate(Alice, nullptr);
         tox_iterate(Bobs[0], nullptr);
@@ -290,14 +290,14 @@ static void test_av_three_calls(void)
 
     time_t start_time = time(nullptr);
 
-    while (time(nullptr) - start_time < 5) {
+    do {
         tox_iterate(bootstrap, nullptr);
         tox_iterate(Alice, nullptr);
         tox_iterate(Bobs[0], nullptr);
         tox_iterate(Bobs[1], nullptr);
         tox_iterate(Bobs[2], nullptr);
         c_sleep(20);
-    }
+    } while (time(nullptr) - start_time < 5);
 
     ck_assert(pthread_join(tids[0], &retval) == 0);
     ck_assert(retval == nullptr);

--- a/auto_tests/typing_test.c
+++ b/auto_tests/typing_test.c
@@ -45,24 +45,24 @@ static void test_typing(void)
 
     tox_bootstrap(tox2, "localhost", dht_port, dht_key, nullptr);
 
-    while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
-            tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
 
         c_sleep(200);
-    }
+    } while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
+             tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE);
 
     printf("toxes are online, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
     const time_t con_time = time(nullptr);
 
-    while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
-            tox_friend_get_connection_status(tox2, 0, nullptr) != TOX_CONNECTION_UDP) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, nullptr);
 
         c_sleep(200);
-    }
+    } while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
+             tox_friend_get_connection_status(tox2, 0, nullptr) != TOX_CONNECTION_UDP);
 
     printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
 
@@ -71,20 +71,20 @@ static void test_typing(void)
 
     bool is_typing = false;
 
-    while (!is_typing) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, &is_typing);
         c_sleep(200);
-    }
+    } while (!is_typing);
 
     ck_assert_msg(tox_friend_get_typing(tox2, 0, nullptr) == 1, "Typing failure");
     tox_self_set_typing(tox1, 0, false, nullptr);
 
-    while (is_typing) {
+    do {
         tox_iterate(tox1, nullptr);
         tox_iterate(tox2, &is_typing);
         c_sleep(200);
-    }
+    } while (is_typing);
 
     TOX_ERR_FRIEND_QUERY err_t;
     ck_assert_msg(tox_friend_get_typing(tox2, 0, &err_t) == 0, "Typing failure");


### PR DESCRIPTION
This forces all the loop bodies to be executed at least once, which is
harmless since it just means one more tox event loop iteration. This
reduces the jitter we see in coverage measurements, which is partially
caused by loops sometimes being entered and sometimes not (because their
condition happens to randomly already be true).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1119)
<!-- Reviewable:end -->
