### PR TITLE
Run all tests (and compilation) in parallel with autotools.

### DIFF
--- a/.travis/autotools-linux
+++ b/.travis/autotools-linux
@@ -41,7 +41,7 @@ travis_script() {
   cd _build  # pushd
   ../configure $CONFIG_FLAGS || (cat config.log && false)
   make "-j$NPROC" -k CFLAGS="$C_FLAGS" LDFLAGS="$LD_FLAGS"
-  make "-j$NPROC" -k distcheck DISTCHECK_CONFIGURE_FLAGS="$CONFIG_FLAGS"
+  make -j50 -k distcheck DISTCHECK_CONFIGURE_FLAGS="$CONFIG_FLAGS"
   cd -  # popd
 }
 


### PR DESCRIPTION
With distcheck, it's all or nothing, so we build with -j50 and run tests
with -j50.