### PR TITLE
Fix the `PORT_ALLOC` failure of `save_compatibility_test`.

### DIFF
--- a/auto_tests/save_compatibility_test.c
+++ b/auto_tests/save_compatibility_test.c
@@ -78,8 +78,9 @@ static void test_save_compatibility(const char *save_path)
     options.savedata_length = size;
     options.savedata_type = TOX_SAVEDATA_TYPE_TOX_SAVE;
 
+    size_t index = 0;
     Tox_Err_New err;
-    Tox *tox = tox_new(&options, &err);
+    Tox *tox = tox_new_log(&options, &err, &index);
     ck_assert_msg(tox, "failed to create tox, error number: %d", err);
 
     free(save_data);


### PR DESCRIPTION
`tox_new_log` has a much larger range of ports it can select from.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1124)
<!-- Reviewable:end -->
