### PR TITLE
Call `abort` instead of `exit` on test failure.

### DIFF
--- a/auto_tests/check_compat.h
+++ b/auto_tests/check_compat.h
@@ -44,7 +44,7 @@ static inline int srunner_ntests_failed(SRunner *r)
 #define ck_assert(ok) do {                                              \
   if (!(ok)) {                                                          \
     fprintf(stderr, "%s:%d: failed `%s'\n", __FILE__, __LINE__, #ok);   \
-    exit(EXIT_FAILURE);                                                 \
+    abort();                                                            \
   }                                                                     \
 } while (0)
 
@@ -53,7 +53,7 @@ static inline int srunner_ntests_failed(SRunner *r)
     fprintf(stderr, "%s:%d: failed `%s': ", __FILE__, __LINE__, #ok);   \
     fprintf(stderr, __VA_ARGS__);                                       \
     fprintf(stderr, "\n");                                              \
-    exit(EXIT_FAILURE);                                                 \
+    abort();                                                            \
   }                                                                     \
 } while (0)
 
@@ -61,7 +61,7 @@ static inline int srunner_ntests_failed(SRunner *r)
   fprintf(stderr, "%s:%d: ", __FILE__, __LINE__);                       \
   fprintf(stderr, __VA_ARGS__);                                         \
   fprintf(stderr, "\n");                                                \
-  exit(EXIT_FAILURE);                                                   \
+  abort();                                                              \
 } while (0)
 
 #endif // CHECK_COMPAT_H


### PR DESCRIPTION
This raises a signal, so we can more easily catch it with gdb.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1129)
<!-- Reviewable:end -->
