### PR TITLE
Make the tsan build fail instead of swallowing its errors.

### DIFF
--- a/.circleci/cmake-asan
+++ b/.circleci/cmake-asan
@@ -24,5 +24,9 @@ cd _build
 
 ninja install -j$(nproc)
 
+export ASAN_OPTIONS="detect_invalid_pointer_pairs=1"
+export ASAN_OPTIONS="$ASAN_OPTIONS,detect_stack_use_after_return=1"
+export ASAN_OPTIONS="$ASAN_OPTIONS,strict_init_order=1"
+export ASAN_OPTIONS="$ASAN_OPTIONS,strict_string_checks=1"
 ctest -j50 --output-on-failure ||
 ctest -j50 --output-on-failure --rerun-failed

--- a/.circleci/cmake-tsan
+++ b/.circleci/cmake-tsan
@@ -24,6 +24,7 @@ cd _build
 
 ninja install -j$(nproc)
 
+export TSAN_OPTIONS="halt_on_error=1"
+export TSAN_OPTIONS="$TSAN_OPTIONS,second_deadlock_stack=1"
 ctest -j50 --output-on-failure ||
-ctest -j50 --output-on-failure --rerun-failed ||
-true  # TODO(iphydf): remove this line once the data races are fixed.
+ctest -j50 --output-on-failure --rerun-failed


### PR DESCRIPTION
We'll make it non-required, but we want to know about these failures so
we are incentivised to fix them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1133)
<!-- Reviewable:end -->
