### PR TITLE
Remove the use of `CLOCK_MONOTONIC_RAW`.

### DIFF
--- a/toxcore/mono_time.c
+++ b/toxcore/mono_time.c
@@ -120,9 +120,7 @@ static uint64_t current_time_monotonic_default(void *user_data)
     last_clock_mono = time;
 #else
     struct timespec clock_mono;
-#if defined(__linux__) && defined(CLOCK_MONOTONIC_RAW)
-    clock_gettime(CLOCK_MONOTONIC_RAW, &clock_mono);
-#elif defined(__APPLE__)
+#if defined(__APPLE__)
     clock_serv_t muhclock;
     mach_timespec_t machtime;
 


### PR DESCRIPTION
The raw clock isn't subject to NTP adjustments. It may run less
accurately than the regular monotonic clock. I see no reason why raw
would be better for tox than the normal one.

This avoids one piece of OS-specific ifdef'd code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1136)
<!-- Reviewable:end -->
