### PR TITLE
Include necessary opencv2 header on OSX.

### DIFF
--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -63,6 +63,9 @@ extern "C" {
 #include <opencv/cv.h>
 #include <opencv/cvwimage.h>
 #include <opencv/highgui.h>
+#ifdef __APPLE__
+#include <opencv2/videoio/videoio_c.h>
+#endif
 
 #include <assert.h>
 #include <sched.h>


### PR DESCRIPTION
opencv2 is deprecated and homebrew ships with opencv3 now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1141)
<!-- Reviewable:end -->
