### PR TITLE
WIP: investigating auto_tox_many_tcp_test failure

### DIFF
--- a/auto_tests/tox_many_tcp_test.c
+++ b/auto_tests/tox_many_tcp_test.c
@@ -35,103 +35,14 @@ static void accept_friend_request(Tox *m, const uint8_t *public_key, const uint8
     }
 }
 
-#define NUM_FRIENDS 50
-#define NUM_TOXES_TCP 40
+
+// according to zugz's testing: with NUM_TOXES_TCP=5, consistently passes;
+// often fails with 6; consistently fails with 8 or more.
+#define NUM_TOXES_TCP 8
 #define TCP_RELAY_PORT 33448
 
-START_TEST(test_many_clients_tcp)
-{
-    long long unsigned int cur_time = time(nullptr);
-    Tox *toxes[NUM_TOXES_TCP];
-    uint32_t index[NUM_TOXES_TCP];
-    uint32_t i, j;
-    uint32_t to_comp = 974536;
-
-    for (i = 0; i < NUM_TOXES_TCP; ++i) {
-        struct Tox_Options *opts = tox_options_new(nullptr);
-
-        if (i == 0) {
-            tox_options_set_tcp_port(opts, TCP_RELAY_PORT);
-        } else {
-            tox_options_set_udp_enabled(opts, false);
-        }
-
-        index[i] = i + 1;
-        toxes[i] = tox_new_log(opts, nullptr, &index[i]);
-        ck_assert_msg(toxes[i] != nullptr, "Failed to create tox instances %u", i);
-        tox_callback_friend_request(toxes[i], accept_friend_request);
-        uint8_t dpk[TOX_PUBLIC_KEY_SIZE];
-        tox_self_get_dht_id(toxes[0], dpk);
-        TOX_ERR_BOOTSTRAP error = TOX_ERR_BOOTSTRAP_OK;
-        ck_assert_msg(tox_add_tcp_relay(toxes[i], TOX_LOCALHOST, TCP_RELAY_PORT, dpk, &error), "add relay error, %u, %d", i,
-                      error);
-        uint16_t first_port = tox_self_get_udp_port(toxes[0], nullptr);
-        ck_assert_msg(tox_bootstrap(toxes[i], TOX_LOCALHOST, first_port, dpk, nullptr), "Bootstrap error");
-
-        tox_options_free(opts);
-    }
-
-    struct {
-        uint16_t tox1;
-        uint16_t tox2;
-    } pairs[NUM_FRIENDS];
-
-    uint8_t address[TOX_ADDRESS_SIZE];
-
-    for (i = 0; i < NUM_FRIENDS; ++i) {
-loop_top:
-        pairs[i].tox1 = random_u32() % NUM_TOXES_TCP;
-        pairs[i].tox2 = (pairs[i].tox1 + random_u32() % (NUM_TOXES_TCP - 1) + 1) % NUM_TOXES_TCP;
-
-        for (j = 0; j < i; ++j) {
-            if (pairs[j].tox2 == pairs[i].tox1 && pairs[j].tox1 == pairs[i].tox2) {
-                goto loop_top;
-            }
-        }
-
-        tox_self_get_address(toxes[pairs[i].tox1], address);
-
-        TOX_ERR_FRIEND_ADD test;
-        uint32_t num = tox_friend_add(toxes[pairs[i].tox2], address, (const uint8_t *)"Gentoo", 7, &test);
-
-        if (test == TOX_ERR_FRIEND_ADD_ALREADY_SENT) {
-            goto loop_top;
-        }
-
-        ck_assert_msg(num != UINT32_MAX && test == TOX_ERR_FRIEND_ADD_OK, "Failed to add friend error code: %i", test);
-    }
-
-    while (true) {
-        uint16_t counter = 0;
-
-        for (i = 0; i < NUM_TOXES_TCP; ++i) {
-            for (j = 0; j < tox_self_get_friend_list_size(toxes[i]); ++j) {
-                if (tox_friend_get_connection_status(toxes[i], j, nullptr) == TOX_CONNECTION_TCP) {
-                    ++counter;
-                }
-            }
-        }
-
-        if (counter == NUM_FRIENDS * 2) {
-            break;
-        }
-
-        for (i = 0; i < NUM_TOXES_TCP; ++i) {
-            tox_iterate(toxes[i], &to_comp);
-        }
-
-        c_sleep(50);
-    }
-
-    for (i = 0; i < NUM_TOXES_TCP; ++i) {
-        tox_kill(toxes[i]);
-    }
-
-    printf("test_many_clients_tcp succeeded, took %llu seconds\n", time(nullptr) - cur_time);
-}
-END_TEST
-
-#define NUM_TCP_RELAYS 3
+#define NUM_TCP_RELAYS (NUM_TOXES_TCP - 1)
+#define NUM_FRIENDS ((NUM_TOXES_TCP - NUM_TCP_RELAYS) * NUM_TCP_RELAYS)
 
 START_TEST(test_many_clients_tcp_b)
 {
@@ -147,6 +58,7 @@ START_TEST(test_many_clients_tcp_b)
         if (i < NUM_TCP_RELAYS) {
             tox_options_set_tcp_port(opts, TCP_RELAY_PORT + i);
         } else {
+            // this is crucial for making the test fail!
             tox_options_set_udp_enabled(opts, 0);
         }
 
@@ -155,9 +67,11 @@ START_TEST(test_many_clients_tcp_b)
         ck_assert_msg(toxes[i] != nullptr, "Failed to create tox instances %u", i);
         tox_callback_friend_request(toxes[i], accept_friend_request);
         uint8_t dpk[TOX_PUBLIC_KEY_SIZE];
-        tox_self_get_dht_id(toxes[(i % NUM_TCP_RELAYS)], dpk);
-        ck_assert_msg(tox_add_tcp_relay(toxes[i], TOX_LOCALHOST, TCP_RELAY_PORT + (i % NUM_TCP_RELAYS), dpk, nullptr),
-                      "add relay error");
+        if (i >= NUM_TCP_RELAYS) {
+            tox_self_get_dht_id(toxes[(i % NUM_TCP_RELAYS)], dpk);
+            ck_assert_msg(tox_add_tcp_relay(toxes[i], TOX_LOCALHOST, TCP_RELAY_PORT + (i % NUM_TCP_RELAYS), dpk, nullptr),
+                    "add relay error");
+        }
         tox_self_get_dht_id(toxes[0], dpk);
         uint16_t first_port = tox_self_get_udp_port(toxes[0], nullptr);
         ck_assert_msg(tox_bootstrap(toxes[i], TOX_LOCALHOST, first_port, dpk, nullptr), "Bootstrap error");
@@ -165,63 +79,52 @@ START_TEST(test_many_clients_tcp_b)
         tox_options_free(opts);
     }
 
-    struct {
-        uint16_t tox1;
-        uint16_t tox2;
-    } pairs[NUM_FRIENDS];
-
     uint8_t address[TOX_ADDRESS_SIZE];
 
-    for (i = 0; i < NUM_FRIENDS; ++i) {
-loop_top:
-        pairs[i].tox1 = random_u32() % NUM_TOXES_TCP;
-        pairs[i].tox2 = (pairs[i].tox1 + random_u32() % (NUM_TOXES_TCP - 1) + 1) % NUM_TOXES_TCP;
+    for (i = NUM_TCP_RELAYS; i < NUM_TOXES_TCP; ++i) {
+        for (j = 0; j < NUM_TCP_RELAYS; ++j) {
 
-        for (j = 0; j < i; ++j) {
-            if (pairs[j].tox2 == pairs[i].tox1 && pairs[j].tox1 == pairs[i].tox2) {
-                goto loop_top;
-            }
+            tox_self_get_address(toxes[i], address);
+
+            TOX_ERR_FRIEND_ADD test;
+            uint32_t num = tox_friend_add(toxes[j], address, (const uint8_t *)"Gentoo", 7, &test);
+
+            ck_assert_msg(test == TOX_ERR_FRIEND_ADD_OK, "Tox %u failed to add tox %u" , i, j);
+
+            ck_assert_msg(num != UINT32_MAX && test == TOX_ERR_FRIEND_ADD_OK, "Failed to add friend error code: %i", test);
         }
-
-        tox_self_get_address(toxes[pairs[i].tox1], address);
-
-        TOX_ERR_FRIEND_ADD test;
-        uint32_t num = tox_friend_add(toxes[pairs[i].tox2], address, (const uint8_t *)"Gentoo", 7, &test);
-
-        if (test == TOX_ERR_FRIEND_ADD_ALREADY_SENT) {
-            goto loop_top;
-        }
-
-        ck_assert_msg(num != UINT32_MAX && test == TOX_ERR_FRIEND_ADD_OK, "Failed to add friend error code: %i", test);
     }
+
+    printf("friends added\n");
 
     uint16_t last_count = 0;
 
     while (true) {
-        uint16_t counter = 0;
-
-        for (i = 0; i < NUM_TOXES_TCP; ++i) {
-            for (j = 0; j < tox_self_get_friend_list_size(toxes[i]); ++j) {
-                if (tox_friend_get_connection_status(toxes[i], j, nullptr) == TOX_CONNECTION_TCP) {
-                    ++counter;
-                }
-            }
-        }
-
-        if (counter != last_count) {
-            printf("many_clients_tcp_b got to %u\n", counter);
-            last_count = counter;
-        }
-
-        if (counter == NUM_FRIENDS * 2) {
-            break;
-        }
-
         for (i = 0; i < NUM_TOXES_TCP; ++i) {
             tox_iterate(toxes[i], &to_comp);
         }
 
         c_sleep(30);
+
+        uint16_t failcount = 0;
+        uint16_t count = 0;
+
+        for (i = 0; i < NUM_TOXES_TCP; ++i) {
+            for (j = 0; j < tox_self_get_friend_list_size(toxes[i]); ++j) {
+                count++;
+                if (tox_friend_get_connection_status(toxes[i], j, nullptr) == TOX_CONNECTION_NONE) {
+                    failcount++;
+                }
+            }
+        }
+
+        if (failcount != last_count) {
+            printf("%d:%d\n", failcount, count);
+            last_count = failcount;
+        }
+        if (failcount == 0 && count == NUM_FRIENDS * 2) {
+            break;
+        }
     }
 
     for (i = 0; i < NUM_TOXES_TCP; ++i) {
@@ -237,10 +140,6 @@ static Suite *tox_suite(void)
 {
     Suite *s = suite_create("Tox many tcp");
 
-    /* Each tox connects to a single tox TCP    */
-    DEFTESTCASE(many_clients_tcp);
-
-    /* Try to make a connection to each "older sibling" tox instance via TCP */
     DEFTESTCASE(many_clients_tcp_b);
 
     return s;


### PR DESCRIPTION
Currently just a minimised version of the test which consistently fails (i.e. 
times out).

This version of the test has 7 TCP-servers who have UDP enabled, and one 
further tox with UDP disabled who connects via one of the TCP servers, while 
the TCP servers bootstrap off the first but don't connect via TCP. The TCP 
servers send friend requests to the other peer, and not all of the friend 
requests get through.

It's important that the friend requests are made this way round - the other 
way works fine.

I don't currently see what the problem could be.

I tried applying this test to old toxcores to test if it's a regression - the 
earliest I got it to compile against was 0a61d110 (4 Jan 2017), and it failed 
there too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1148)
<!-- Reviewable:end -->
