### PR TITLE
Use `(void)` for empty parameter lists in C.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -23,7 +23,7 @@
 #define net_family_ipv6 net_family_ipv4
 #endif
 
-static inline IP get_loopback()
+static inline IP get_loopback(void)
 {
     IP ip;
 #if USE_IPV6

--- a/auto_tests/dht_test.c
+++ b/auto_tests/dht_test.c
@@ -19,7 +19,7 @@ static bool enable_broken_tests = false;
 #define USE_IPV6 1
 #endif
 
-static inline IP get_loopback()
+static inline IP get_loopback(void)
 {
     IP ip;
 #if USE_IPV6

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -17,7 +17,7 @@
 #define USE_IPV6 1
 #endif
 
-static inline IP get_loopback()
+static inline IP get_loopback(void)
 {
     IP ip;
 #if USE_IPV6


### PR DESCRIPTION
Because `()` means "some unknown number of parameters".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1150)
<!-- Reviewable:end -->
