### PR TITLE
Always use the passed logger (from Messenger) in msi_kill.

### DIFF
--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -145,7 +145,7 @@ int msi_kill(MSISession *session, const Logger *log)
     m_callback_msi_packet(session->messenger, nullptr, nullptr);
 
     if (pthread_mutex_trylock(session->mutex) != 0) {
-        LOGGER_ERROR(session->messenger->log, "Failed to acquire lock on msi mutex");
+        LOGGER_ERROR(log, "Failed to acquire lock on msi mutex");
         return -1;
     }
 
@@ -166,7 +166,7 @@ int msi_kill(MSISession *session, const Logger *log)
     pthread_mutex_unlock(session->mutex);
     pthread_mutex_destroy(session->mutex);
 
-    LOGGER_DEBUG(session->messenger->log, "Terminated session: %p", (void *)session);
+    LOGGER_DEBUG(log, "Terminated session: %p", (void *)session);
     free(session);
     return 0;
 }


### PR DESCRIPTION
Narrowing down #1149.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1153)
<!-- Reviewable:end -->
