### PR TITLE
Use run_auto_test fixture in typing_test.c

### DIFF
--- a/auto_tests/typing_test.c
+++ b/auto_tests/typing_test.c
@@ -15,91 +15,50 @@
 #include "../toxcore/util.h"
 #include "check_compat.h"
 
+typedef struct State {
+    uint32_t index;
+    uint64_t clock;
+    bool friend_is_typing;
+} State;
+
+#include "run_auto_test.h"
+
 static void typing_callback(Tox *m, uint32_t friendnumber, bool typing, void *userdata)
 {
-    bool *is_typing = (bool *)userdata;
-    *is_typing = typing;
+    State *state = (State *)userdata;
+    state->friend_is_typing = typing;
 }
 
-static void test_typing(void)
+static void test_typing(Tox **toxes, State *state)
 {
-    printf("initialising 2 toxes\n");
-    uint32_t index[] = { 1, 2 };
-    const time_t cur_time = time(nullptr);
-    Tox *const tox1 = tox_new_log(nullptr, nullptr, &index[0]);
-    Tox *const tox2 = tox_new_log(nullptr, nullptr, &index[1]);
+    time_t cur_time = time(nullptr);
 
-    ck_assert_msg(tox1 && tox2, "failed to create 2 tox instances");
-
-    printf("tox1 adds tox2 as friend, tox2 adds tox1\n");
-    uint8_t public_key[TOX_PUBLIC_KEY_SIZE];
-    tox_self_get_public_key(tox2, public_key);
-    tox_friend_add_norequest(tox1, public_key, nullptr);
-    tox_self_get_public_key(tox1, public_key);
-    tox_friend_add_norequest(tox2, public_key, nullptr);
-
-    printf("bootstrapping tox2 off tox1\n");
-    uint8_t dht_key[TOX_PUBLIC_KEY_SIZE];
-    tox_self_get_dht_id(tox1, dht_key);
-    const uint16_t dht_port = tox_self_get_udp_port(tox1, nullptr);
-
-    tox_bootstrap(tox2, "localhost", dht_port, dht_key, nullptr);
+    tox_callback_friend_typing(toxes[1], &typing_callback);
+    tox_self_set_typing(toxes[0], 0, true, nullptr);
 
     do {
-        tox_iterate(tox1, nullptr);
-        tox_iterate(tox2, nullptr);
+        iterate_all_wait(2, toxes, state, 200);
+    } while (!state[1].friend_is_typing);
 
-        c_sleep(200);
-    } while (tox_self_get_connection_status(tox1) == TOX_CONNECTION_NONE ||
-             tox_self_get_connection_status(tox2) == TOX_CONNECTION_NONE);
-
-    printf("toxes are online, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
-    const time_t con_time = time(nullptr);
+    ck_assert_msg(tox_friend_get_typing(toxes[1], 0, nullptr) == 1,
+                  "tox_friend_get_typing should have returned true, but it didn't");
+    tox_self_set_typing(toxes[0], 0, false, nullptr);
 
     do {
-        tox_iterate(tox1, nullptr);
-        tox_iterate(tox2, nullptr);
-
-        c_sleep(200);
-    } while (tox_friend_get_connection_status(tox1, 0, nullptr) != TOX_CONNECTION_UDP ||
-             tox_friend_get_connection_status(tox2, 0, nullptr) != TOX_CONNECTION_UDP);
-
-    printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
-
-    tox_callback_friend_typing(tox2, &typing_callback);
-    tox_self_set_typing(tox1, 0, true, nullptr);
-
-    bool is_typing = false;
-
-    do {
-        tox_iterate(tox1, nullptr);
-        tox_iterate(tox2, &is_typing);
-        c_sleep(200);
-    } while (!is_typing);
-
-    ck_assert_msg(tox_friend_get_typing(tox2, 0, nullptr) == 1, "Typing failure");
-    tox_self_set_typing(tox1, 0, false, nullptr);
-
-    do {
-        tox_iterate(tox1, nullptr);
-        tox_iterate(tox2, &is_typing);
-        c_sleep(200);
-    } while (is_typing);
+        iterate_all_wait(2, toxes, state, 200);
+    } while (state[1].friend_is_typing);
 
     TOX_ERR_FRIEND_QUERY err_t;
-    ck_assert_msg(tox_friend_get_typing(tox2, 0, &err_t) == 0, "Typing failure");
-    ck_assert_msg(err_t == TOX_ERR_FRIEND_QUERY_OK, "Typing failure");
+    ck_assert_msg(tox_friend_get_typing(toxes[1], 0, &err_t) == 0,
+                  "tox_friend_get_typing should have returned false, but it didn't");
+    ck_assert_msg(err_t == TOX_ERR_FRIEND_QUERY_OK, "tox_friend_get_typing call did not return correct error");
 
     printf("test_typing succeeded, took %lu seconds\n", (unsigned long)(time(nullptr) - cur_time));
-
-    tox_kill(tox1);
-    tox_kill(tox2);
 }
 
 int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
-
-    test_typing();
+    run_auto_test(2, test_typing, false);
     return 0;
 }


### PR DESCRIPTION
Implements the run_auto_test fixture in typing_test.c to save lines of code because we need to think of the starving african programmers.

Also improves a few error messages to help developers discern where the assert failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1157)
<!-- Reviewable:end -->
