### PR TITLE
Add global friend_connection status callback, for use with conference rejoining

### DIFF
--- a/auto_tests/conference_test.c
+++ b/auto_tests/conference_test.c
@@ -207,6 +207,8 @@ static void run_conference_tests(Tox **toxes, State *state)
 
     for (uint16_t i = 0; i < NUM_GROUP_TOX; ++i) {
         tox_callback_conference_message(toxes[i], &handle_conference_message);
+
+        iterate_all_wait(NUM_GROUP_TOX, toxes, state, ITERATION_INTERVAL);
     }
 
     TOX_ERR_CONFERENCE_SEND_MESSAGE err;

--- a/auto_tests/conference_test.c
+++ b/auto_tests/conference_test.c
@@ -129,6 +129,22 @@ static bool all_connected_to_group(uint32_t tox_count, Tox **toxes)
     return true;
 }
 
+static bool names_propagated(uint32_t tox_count, Tox **toxes, State *state)
+{
+    for (uint16_t i = 0; i < tox_count; ++i) {
+        for (uint16_t j = 0; j < tox_count; ++j) {
+            const size_t len = tox_conference_peer_get_name_size(toxes[i], 0, j, nullptr);
+
+            if (len != NAMELEN) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+
 /* returns a random index at which a list of booleans is false
  * (some such index is required to exist)
  * */
@@ -145,9 +161,9 @@ static uint32_t random_false_index(bool *list, const uint32_t length)
 
 static void run_conference_tests(Tox **toxes, State *state)
 {
-    /* disabling name propagation check for now, as it occasionally fails due
-     * to disconnections too short to trigger freezing */
-    const bool check_name_propagation = false;
+    /* disabling name change propagation check for now, as it occasionally
+     * fails due to disconnections too short to trigger freezing */
+    const bool check_name_change_propagation = false;
 
     printf("letting random toxes timeout\n");
     bool disconnected[NUM_GROUP_TOX] = {0};
@@ -171,7 +187,7 @@ static void run_conference_tests(Tox **toxes, State *state)
         c_sleep(20);
     } while (!toxes_are_disconnected_from_group(NUM_GROUP_TOX, toxes, NUM_DISCONNECT, disconnected));
 
-    if (check_name_propagation) {
+    if (check_name_change_propagation) {
         printf("changing names\n");
 
         for (uint16_t i = 0; i < NUM_GROUP_TOX; ++i) {
@@ -208,13 +224,9 @@ static void run_conference_tests(Tox **toxes, State *state)
 
     ck_assert_msg(num_recv == NUM_GROUP_TOX, "failed to recv group messages");
 
-    for (uint16_t i = 0; i < NUM_GROUP_TOX; ++i) {
-        for (uint16_t j = 0; j < NUM_GROUP_TOX; ++j) {
-            const size_t len = tox_conference_peer_get_name_size(toxes[i], 0, j, nullptr);
-            ck_assert_msg(len == NAMELEN, "name of #%u according to #%u has incorrect length %u", state[j].index, state[i].index,
-                          (unsigned int)len);
-
-            if (check_name_propagation) {
+    if (check_name_change_propagation) {
+        for (uint16_t i = 0; i < NUM_GROUP_TOX; ++i) {
+            for (uint16_t j = 0; j < NUM_GROUP_TOX; ++j) {
                 uint8_t name[NAMELEN];
                 tox_conference_peer_get_name(toxes[i], 0, j, name, nullptr);
                 /* Note the toxes will have been reordered */
@@ -320,6 +332,12 @@ static void test_many_group(Tox **toxes, State *state)
         tox_conference_get_title(toxes[i], 0, title, nullptr);
         ck_assert_msg(memcmp("Gentoo", title, ret) == 0, "Wrong title");
     }
+
+    printf("waiting for names to propagate\n");
+
+    do {
+        iterate_all_wait(NUM_GROUP_TOX, toxes, state, ITERATION_INTERVAL);
+    } while (!names_propagated(NUM_GROUP_TOX, toxes, state));
 
     printf("group connected, took %d seconds\n", (int)((state[0].clock - pregroup_clock) / 1000));
 

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -85,6 +85,9 @@ struct Friend_Connections {
     fr_request_cb *fr_request_callback;
     void *fr_request_object;
 
+    global_status_cb *global_status_callback;
+    void *global_status_callback_object;
+
     uint64_t last_lan_discovery;
     uint16_t next_lan_port;
 
@@ -403,6 +406,10 @@ static int handle_status(void *object, int number, uint8_t status, void *userdat
     if (status_changed) {
         unsigned int i;
 
+        if (fr_c->global_status_callback) {
+            fr_c->global_status_callback(fr_c->global_status_callback_object, number, status, userdata);
+        }
+
         for (i = 0; i < MAX_FRIEND_CONNECTION_CALLBACKS; ++i) {
             if (friend_con->callbacks[i].status_callback) {
                 friend_con->callbacks[i].status_callback(
@@ -714,6 +721,13 @@ int friend_connection_callbacks(Friend_Connections *fr_c, int friendcon_id, unsi
     friend_con->callbacks[index].callback_id = number;
 
     return 0;
+}
+
+/* Set global status callback for friend connections. */
+void set_global_status_callback(Friend_Connections *fr_c, global_status_cb *global_status_callback, void *object)
+{
+    fr_c->global_status_callback = global_status_callback;
+    fr_c->global_status_callback_object = object;
 }
 
 /* return the crypt_connection_id for the connection.

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -101,9 +101,14 @@ void set_dht_temp_pk(Friend_Connections *fr_c, int friendcon_id, const uint8_t *
  */
 int friend_add_tcp_relay(Friend_Connections *fr_c, int friendcon_id, IP_Port ip_port, const uint8_t *public_key);
 
+typedef int global_status_cb(void *object, int id, uint8_t status, void *userdata);
+
 typedef int fc_status_cb(void *object, int id, uint8_t status, void *userdata);
 typedef int fc_data_cb(void *object, int id, const uint8_t *data, uint16_t length, void *userdata);
 typedef int fc_lossy_data_cb(void *object, int id, const uint8_t *data, uint16_t length, void *userdata);
+
+/* Set global status callback for friend connections. */
+void set_global_status_callback(Friend_Connections *fr_c, global_status_cb *global_status_callback, void *object);
 
 /* Set the callbacks for the friend connection.
  * index is the index (0 to (MAX_FRIEND_CONNECTION_CALLBACKS - 1)) we want the callback to set in the array.

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -878,13 +878,23 @@ static void rejoin_frozen_friend(Group_Chats *g_c, int friendcon_id)
     }
 }
 
+static int g_handle_any_status(void *object, int friendcon_id, uint8_t status, void *userdata)
+{
+    Group_Chats *g_c = (Group_Chats *)object;
+
+    if (status) {
+        rejoin_frozen_friend(g_c, friendcon_id);
+    }
+
+    return 0;
+}
+
 static int g_handle_status(void *object, int friendcon_id, uint8_t status, void *userdata)
 {
     Group_Chats *g_c = (Group_Chats *)object;
 
     if (status) { /* Went online */
         set_conns_status_groups(g_c, friendcon_id, GROUPCHAT_CLOSE_ONLINE, userdata);
-        rejoin_frozen_friend(g_c, friendcon_id);
     } else { /* Went offline */
         set_conns_status_groups(g_c, friendcon_id, GROUPCHAT_CLOSE_CONNECTION, userdata);
         // TODO(irungentoo): remove timedout connections?
@@ -2892,6 +2902,8 @@ Group_Chats *new_groupchats(Mono_Time *mono_time, Messenger *m)
     temp->fr_c = m->fr_c;
     m->conferences_object = temp;
     m_callback_conference_invite(m, &handle_friend_invite_packet);
+
+    set_global_status_callback(m->fr_c, &g_handle_any_status, temp);
 
     return temp;
 }


### PR DESCRIPTION
This lets any friend connection, whether from messenger or from conferences, 
to be used for rejoining a conference. This is how it was meant to work all 
along.

I've also included a couple of tweaks to the conference test in this pr to 
make it more robust. Hopefully, and as far as my (limited) testing can 
determine, the conference test should reliably pass with this pr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1189)
<!-- Reviewable:end -->
