### PR TITLE
Improve cmake build for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ set(toxcore_SOURCES ${toxcore_SOURCES}
 include(CheckFunctionExists)
 check_function_exists(explicit_bzero HAVE_EXPLICIT_BZERO)
 check_function_exists(memset_s HAVE_MEMSET_S)
-set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} ${LIBSODIUM_LIBRARIES})
+set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} sodium)
 set(toxcore_PKGCONFIG_REQUIRES ${toxcore_PKGCONFIG_REQUIRES} libsodium)
 
 # LAYER 2: Basic networking
@@ -275,7 +275,7 @@ if(BUILD_TOXAV)
     toxav/toxav_old.c
     toxav/video.c
     toxav/video.h)
-  set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} ${OPUS_LIBRARIES} ${VPX_LIBRARIES})
+  set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} Opus::Opus Vpx::Vpx)
   set(toxcore_PKGCONFIG_REQUIRES ${toxcore_PKGCONFIG_REQUIRES} opus vpx)
 
   set(toxcore_API_HEADERS ${toxcore_API_HEADERS} ${toxcore_SOURCE_DIR}/toxav/toxav.h^toxav)
@@ -304,10 +304,9 @@ set(toxcore_API_HEADERS ${toxcore_API_HEADERS} ${toxcore_SOURCE_DIR}/toxencrypts
 # any potential libvpx linking.
 message("CMAKE_THREAD_LIBS_INIT: ${CMAKE_THREAD_LIBS_INIT}")
 if(CMAKE_THREAD_LIBS_INIT)
-  set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} ${CMAKE_THREAD_LIBS_INIT})
+  set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} Threads::Threads)
   set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 endif()
-
 
 if(NSL_LIBRARIES)
   set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} ${NSL_LIBRARIES})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,10 +18,12 @@ install:
   - mkdir pthreads-win32 && cd pthreads-win32
   - if not exist %APPDATA%\downloads\pthreads.zip curl -L ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip -o %APPDATA%\downloads\pthreads.zip
   - unzip %APPDATA%\downloads\pthreads.zip
+  - copy Pre-built.2\lib\x86\* Pre-built.2\lib\
   - cd ../..
 
+# TODO currently don't have prebuilt libraries for libvpx and libopus so we will just build with BUILD_TOXAV=OFF for now
 before_build:
-  - cmake . -DBOOTSTRAP_DAEMON=OFF -DENABLE_SHARED=OFF -DBUILD_TOXAV=OFF
+  - cmake . -DBOOTSTRAP_DAEMON=OFF -DENABLE_SHARED=OFF -DBUILD_TOXAV=OFF -DCMAKE_PREFIX_PATH="third_party\pthreads-win32\Pre-built.2;third_party\libsodium"
 
 build:
   project: INSTALL.vcxproj

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -5,19 +5,45 @@
 ###############################################################################
 
 include(ModulePackage)
+include(SimpleFindPackage)
+
+if (MSVC)
+  set(THREADS_USE_PTHREADS_WIN32 1)
+endif()
 
 find_package(Threads REQUIRED)
+
+if (MSVC)
+  set_property(TARGET Threads::Threads APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS "HAVE_STRUCT_TIMESPEC")
+endif()
 
 find_library(NSL_LIBRARIES          nsl          )
 find_library(RT_LIBRARIES           rt           )
 find_library(SOCKET_LIBRARIES       socket       )
 
-# For toxcore.
-pkg_use_module(LIBSODIUM            libsodium    )
+# for toxcore
+
+# Try to find both static and shared variants of sodium
+set(sodium_USE_STATIC_LIBS ON)
+find_package(sodium)
+if (NOT sodium_FOUND)
+  set(sodium_USE_STATIC_LIBS OFF)
+  find_package(sodium REQUIRED)
+endif()
 
 # For toxav.
-pkg_use_module(OPUS                 opus         )
-pkg_use_module(VPX                  vpx          )
+simple_find_package(Opus
+  INCLUDE_NAMES opus.h
+  PKGCFG_NAME opus
+  LIB_NAMES opus
+  PATH_SUFFIXES opus
+  )
+
+simple_find_package(Vpx
+  PKGCFG_NAME vpx
+  INCLUDE_NAMES vpx_codec.h
+  PATH_SUFFIXES vpx
+  LIB_NAMES vpx vpxmd)
 
 # For tox-bootstrapd.
 pkg_use_module(LIBCONFIG            libconfig    )
@@ -29,49 +55,3 @@ pkg_use_module(MSGPACK              msgpack      )
 pkg_use_module(OPENCV               opencv       )
 pkg_use_module(PORTAUDIO            portaudio-2.0)
 pkg_use_module(SNDFILE              sndfile      )
-
-###############################################################################
-#
-# :: For MSVC Windows builds.
-#
-# These require specific installation paths of dependencies:
-# - libsodium in third-party/libsodium/Win32/Release/v140/dynamic
-# - pthreads in third-party/pthreads-win32/Pre-built.2
-#
-###############################################################################
-
-if(MSVC)
-  # libsodium
-  # ---------
-  find_library(LIBSODIUM_LIBRARIES
-    NAMES sodium libsodium
-    PATHS
-      "third_party/libsodium/Win32/Release/v140/dynamic"
-      "third_party/libsodium/x64/Release/v140/dynamic"
-  )
-  if(LIBSODIUM_LIBRARIES)
-    include_directories("third_party/libsodium/include")
-    set(LIBSODIUM_FOUND TRUE)
-    message("libsodium: ${LIBSODIUM_LIBRARIES}")
-  else()
-    message(FATAL_ERROR "libsodium libraries not found")
-  endif()
-
-  # pthreads
-  # --------
-  if(CMAKE_USE_WIN32_THREADS_INIT)
-    find_library(CMAKE_THREAD_LIBS_INIT
-      NAMES pthreadVC2
-      PATHS
-        "third_party/pthreads-win32/Pre-built.2/lib/x86"
-        "third_party/pthreads-win32/Pre-built.2/lib/x64"
-    )
-    if(CMAKE_THREAD_LIBS_INIT)
-      include_directories("third_party/pthreads-win32/Pre-built.2/include")
-      add_definitions(-DHAVE_STRUCT_TIMESPEC)
-      message("libpthreads: ${CMAKE_THREAD_LIBS_INIT}")
-    else()
-      message(FATAL_ERROR "libpthreads libraries not found")
-    endif()
-  endif()
-endif()

--- a/cmake/FindThreads.cmake
+++ b/cmake/FindThreads.cmake
@@ -1,0 +1,255 @@
+# Updated FindThreads.cmake that supports pthread-win32
+# Downloaded from http://www.vtk.org/Bug/bug_view_advanced_page.php?bug_id=6399
+
+# - This module determines the thread library of the system.
+#
+# The following variables are set
+#  CMAKE_THREAD_LIBS_INIT     - the thread library
+#  CMAKE_USE_SPROC_INIT       - are we using sproc?
+#  CMAKE_USE_WIN32_THREADS_INIT - using WIN32 threads?
+#  CMAKE_USE_PTHREADS_INIT    - are we using pthreads
+#  CMAKE_HP_PTHREADS_INIT     - are we using hp pthreads
+#
+# If use of pthreads-win32 is desired, the following variables
+# can be set.
+#
+#  THREADS_USE_PTHREADS_WIN32 -
+#    Setting this to true searches for the pthreads-win32
+#    port (since CMake 2.8.0)
+#
+#  THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME
+#      C  = no exceptions (default)
+#         (NOTE: This is the default scheme on most POSIX thread
+#          implementations and what you should probably be using)
+#      CE = C++ Exception Handling
+#      SE = Structure Exception Handling (MSVC only)
+#      (NOTE: Changing this option from the default may affect
+#       the portability of your application.  See pthreads-win32
+#       documentation for more details.)
+#
+#======================================================
+# Example usage where threading library
+# is provided by the system:
+#
+#   find_package(Threads REQUIRED)
+#   add_executable(foo foo.cc)
+#   target_link_libraries(foo ${CMAKE_THREAD_LIBS_INIT})
+#
+# Example usage if pthreads-win32 is desired on Windows
+# or a system provided thread library:
+#
+#   set(THREADS_USE_PTHREADS_WIN32 true)
+#   find_package(Threads REQUIRED)
+#   include_directories(${THREADS_PTHREADS_INCLUDE_DIR})
+#
+#   add_executable(foo foo.cc)
+#   target_link_libraries(foo ${CMAKE_THREAD_LIBS_INIT})
+#
+
+INCLUDE (CheckIncludeFiles)
+INCLUDE (CheckLibraryExists)
+SET(Threads_FOUND FALSE)
+
+IF(WIN32 AND NOT CYGWIN AND THREADS_USE_PTHREADS_WIN32)
+  SET(_Threads_ptwin32 true)
+ENDIF()
+
+# Do we have sproc?
+IF(CMAKE_SYSTEM MATCHES IRIX)
+  CHECK_INCLUDE_FILES("sys/types.h;sys/prctl.h"  CMAKE_HAVE_SPROC_H)
+ENDIF()
+
+IF(CMAKE_HAVE_SPROC_H)
+  # We have sproc
+  SET(CMAKE_USE_SPROC_INIT 1)
+
+ELSEIF(_Threads_ptwin32)
+
+  IF(NOT DEFINED THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME)
+    # Assign the default scheme
+    SET(THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME "C")
+  ELSE()
+    # Validate the scheme specified by the user
+    IF(NOT THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "C" AND
+       NOT THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "CE" AND
+       NOT THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "SE")
+         MESSAGE(FATAL_ERROR "See documentation for FindPthreads.cmake, only C, CE, and SE modes are allowed")
+    ENDIF()
+    IF(NOT MSVC AND THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "SE")
+      MESSAGE(FATAL_ERROR "Structured Exception Handling is only allowed for MSVC")
+    ENDIF(NOT MSVC AND THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "SE")
+  ENDIF()
+
+  FIND_PATH(THREADS_PTHREADS_INCLUDE_DIR pthread.h)
+  
+  # Determine the library filename
+  IF(MSVC)
+    SET(_Threads_pthreads_libname
+        pthreadV${THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME}2)
+  ELSEIF(MINGW)
+    SET(_Threads_pthreads_libname
+        pthreadG${THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME}2)
+  ELSE()
+    MESSAGE(FATAL_ERROR "This should never happen")
+  ENDIF()
+
+  # Use the include path to help find the library if possible
+  SET(_Threads_lib_paths "")
+  IF(THREADS_PTHREADS_INCLUDE_DIR)
+     GET_FILENAME_COMPONENT(_Threads_root_dir
+                            ${THREADS_PTHREADS_INCLUDE_DIR} PATH)
+     SET(_Threads_lib_paths ${_Threads_root_dir}/lib)
+  ENDIF()
+  FIND_LIBRARY(THREADS_PTHREADS_WIN32_LIBRARY
+               NAMES ${_Threads_pthreads_libname}
+               PATHS ${_Threads_lib_paths}
+               DOC "The Portable Threads Library for Win32"
+               NO_SYSTEM_PATH
+               )
+
+  IF(THREADS_PTHREADS_INCLUDE_DIR AND THREADS_PTHREADS_WIN32_LIBRARY)
+    MARK_AS_ADVANCED(THREADS_PTHREADS_INCLUDE_DIR)
+    SET(CMAKE_THREAD_LIBS_INIT ${THREADS_PTHREADS_WIN32_LIBRARY})
+    SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+    SET(Threads_FOUND TRUE)
+  ENDIF()
+
+  MARK_AS_ADVANCED(THREADS_PTHREADS_WIN32_LIBRARY)
+
+ELSE()
+  # Do we have pthreads?
+  CHECK_INCLUDE_FILES("pthread.h" CMAKE_HAVE_PTHREAD_H)
+  IF(CMAKE_HAVE_PTHREAD_H)
+
+    #
+    # We have pthread.h
+    # Let's check for the library now.
+    #
+    SET(CMAKE_HAVE_THREADS_LIBRARY)
+    IF(NOT THREADS_HAVE_PTHREAD_ARG)
+
+      # Do we have -lpthreads
+      CHECK_LIBRARY_EXISTS(pthreads pthread_create "" CMAKE_HAVE_PTHREADS_CREATE)
+      IF(CMAKE_HAVE_PTHREADS_CREATE)
+        SET(CMAKE_THREAD_LIBS_INIT "-lpthreads")
+        SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+        SET(Threads_FOUND TRUE)
+      ENDIF()
+
+      # Ok, how about -lpthread
+      CHECK_LIBRARY_EXISTS(pthread pthread_create "" CMAKE_HAVE_PTHREAD_CREATE)
+      IF(CMAKE_HAVE_PTHREAD_CREATE)
+        SET(CMAKE_THREAD_LIBS_INIT "-lpthread")
+        SET(Threads_FOUND TRUE)
+        SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+      ENDIF()
+
+      IF(CMAKE_SYSTEM MATCHES "SunOS.*")
+        # On sun also check for -lthread
+        CHECK_LIBRARY_EXISTS(thread thr_create "" CMAKE_HAVE_THR_CREATE)
+        IF(CMAKE_HAVE_THR_CREATE)
+          SET(CMAKE_THREAD_LIBS_INIT "-lthread")
+          SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+          SET(Threads_FOUND TRUE)
+        ENDIF()
+      ENDIF(CMAKE_SYSTEM MATCHES "SunOS.*")
+
+    ENDIF(NOT THREADS_HAVE_PTHREAD_ARG)
+
+    IF(NOT CMAKE_HAVE_THREADS_LIBRARY)
+      # If we did not found -lpthread, -lpthread, or -lthread, look for -pthread
+      IF("THREADS_HAVE_PTHREAD_ARG" MATCHES "^THREADS_HAVE_PTHREAD_ARG")
+        MESSAGE(STATUS "Check if compiler accepts -pthread")
+        TRY_RUN(THREADS_PTHREAD_ARG THREADS_HAVE_PTHREAD_ARG
+          ${CMAKE_BINARY_DIR}
+          ${CMAKE_ROOT}/Modules/CheckForPthreads.c
+          CMAKE_FLAGS -DLINK_LIBRARIES:STRING=-pthread
+          COMPILE_OUTPUT_VARIABLE OUTPUT)
+
+        IF(THREADS_HAVE_PTHREAD_ARG)
+          IF(THREADS_PTHREAD_ARG MATCHES "^2$")
+            SET(Threads_FOUND TRUE)
+            MESSAGE(STATUS "Check if compiler accepts -pthread - yes")
+          ELSE()
+            MESSAGE(STATUS "Check if compiler accepts -pthread - no")
+            FILE(APPEND 
+              ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log 
+              "Determining if compiler accepts -pthread returned ${THREADS_PTHREAD_ARG} instead of 2. The compiler had the following output:\n${OUTPUT}\n\n")
+          ENDIF()
+        ELSE()
+          MESSAGE(STATUS "Check if compiler accepts -pthread - no")
+          FILE(APPEND 
+            ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log 
+            "Determining if compiler accepts -pthread failed with the following output:\n${OUTPUT}\n\n")
+        ENDIF()
+
+      ENDIF("THREADS_HAVE_PTHREAD_ARG" MATCHES "^THREADS_HAVE_PTHREAD_ARG")
+
+      IF(THREADS_HAVE_PTHREAD_ARG)
+        SET(Threads_FOUND TRUE)
+        SET(CMAKE_THREAD_LIBS_INIT "-pthread")
+      ENDIF()
+
+    ENDIF(NOT CMAKE_HAVE_THREADS_LIBRARY)
+  ENDIF(CMAKE_HAVE_PTHREAD_H)
+ENDIF()
+
+IF(CMAKE_THREAD_LIBS_INIT)
+  SET(CMAKE_USE_PTHREADS_INIT 1)
+  SET(Threads_FOUND TRUE)
+ENDIF()
+
+IF(CMAKE_SYSTEM MATCHES "Windows"
+   AND NOT THREADS_USE_PTHREADS_WIN32)
+  SET(CMAKE_USE_WIN32_THREADS_INIT 1)
+  SET(Threads_FOUND TRUE)
+ENDIF()
+
+IF(CMAKE_USE_PTHREADS_INIT)
+  IF(CMAKE_SYSTEM MATCHES "HP-UX-*")
+    # Use libcma if it exists and can be used.  It provides more
+    # symbols than the plain pthread library.  CMA threads
+    # have actually been deprecated:
+    #   http://docs.hp.com/en/B3920-90091/ch12s03.html#d0e11395
+    #   http://docs.hp.com/en/947/d8.html
+    # but we need to maintain compatibility here.
+    # The CMAKE_HP_PTHREADS setting actually indicates whether CMA threads
+    # are available.
+    CHECK_LIBRARY_EXISTS(cma pthread_attr_create "" CMAKE_HAVE_HP_CMA)
+    IF(CMAKE_HAVE_HP_CMA)
+      SET(CMAKE_THREAD_LIBS_INIT "-lcma")
+      SET(CMAKE_HP_PTHREADS_INIT 1)
+      SET(Threads_FOUND TRUE)
+    ENDIF(CMAKE_HAVE_HP_CMA)
+    SET(CMAKE_USE_PTHREADS_INIT 1)
+  ENDIF()
+
+  IF(CMAKE_SYSTEM MATCHES "OSF1-V*")
+    SET(CMAKE_USE_PTHREADS_INIT 0)
+    SET(CMAKE_THREAD_LIBS_INIT )
+  ENDIF()
+
+  IF(CMAKE_SYSTEM MATCHES "CYGWIN_NT*")
+    SET(CMAKE_USE_PTHREADS_INIT 1)
+    SET(Threads_FOUND TRUE)
+    SET(CMAKE_THREAD_LIBS_INIT )
+    SET(CMAKE_USE_WIN32_THREADS_INIT 0)
+  ENDIF()
+ENDIF(CMAKE_USE_PTHREADS_INIT)
+
+INCLUDE(FindPackageHandleStandardArgs)
+IF(_Threads_ptwin32)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Threads DEFAULT_MSG
+    THREADS_PTHREADS_WIN32_LIBRARY THREADS_PTHREADS_INCLUDE_DIR)
+ELSE()
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Threads DEFAULT_MSG Threads_FOUND)
+ENDIF()
+
+if(THREADS_FOUND AND NOT TARGET Threads::Threads)
+  add_library(Threads::Threads INTERFACE IMPORTED)
+
+  if(CMAKE_THREAD_LIBS_INIT)
+    set_property(TARGET Threads::Threads PROPERTY INTERFACE_LINK_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}")
+    set_property(TARGET Threads::Threads PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${THREADS_PTHREADS_INCLUDE_DIR}")
+  endif()
+endif()

--- a/cmake/Findsodium.cmake
+++ b/cmake/Findsodium.cmake
@@ -1,0 +1,288 @@
+# Written in 2016 by Henrik Steffen Gaßmann <henrik@gassmann.onl>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+# Tries to find the local libsodium installation.
+#
+# On Windows the sodium_DIR environment variable is used as a default
+# hint which can be overridden by setting the corresponding cmake variable.
+#
+# Once done the following variables will be defined:
+#
+#   sodium_FOUND
+#   sodium_INCLUDE_DIR
+#   sodium_LIBRARY_DEBUG
+#   sodium_LIBRARY_RELEASE
+#
+#
+# Furthermore an imported "sodium" target is created.
+#
+
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU"
+    OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    set(_GCC_COMPATIBLE 1)
+endif()
+
+# static library option
+if (NOT DEFINED sodium_USE_STATIC_LIBS)
+    option(sodium_USE_STATIC_LIBS "enable to statically link against sodium" OFF)
+endif()
+if(NOT (sodium_USE_STATIC_LIBS EQUAL sodium_USE_STATIC_LIBS_LAST))
+    unset(sodium_LIBRARY CACHE)
+    unset(sodium_LIBRARY_DEBUG CACHE)
+    unset(sodium_LIBRARY_RELEASE CACHE)
+    unset(sodium_DLL_DEBUG CACHE)
+    unset(sodium_DLL_RELEASE CACHE)
+    set(sodium_USE_STATIC_LIBS_LAST ${sodium_USE_STATIC_LIBS} CACHE INTERNAL "internal change tracking variable")
+endif()
+
+
+########################################################################
+# UNIX
+if (UNIX)
+    # import pkg-config
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(sodium_PKG QUIET libsodium)
+    endif()
+
+    if(sodium_USE_STATIC_LIBS)
+        foreach(_libname ${sodium_PKG_STATIC_LIBRARIES})
+            if (NOT _libname MATCHES "^lib.*\\.a$") # ignore strings already ending with .a
+                list(INSERT sodium_PKG_STATIC_LIBRARIES 0 "lib${_libname}.a")
+            endif()
+        endforeach()
+        list(REMOVE_DUPLICATES sodium_PKG_STATIC_LIBRARIES)
+
+        # if pkgconfig for libsodium doesn't provide
+        # static lib info, then override PKG_STATIC here..
+        if (sodium_PKG_STATIC_LIBRARIES STREQUAL "")
+            set(sodium_PKG_STATIC_LIBRARIES libsodium.a)
+        endif()
+
+        set(XPREFIX sodium_PKG_STATIC)
+    else()
+        if (sodium_PKG_LIBRARIES STREQUAL "")
+            set(sodium_PKG_LIBRARIES sodium)
+        endif()
+
+        set(XPREFIX sodium_PKG)
+    endif()
+
+    find_path(sodium_INCLUDE_DIR sodium.h
+        HINTS ${${XPREFIX}_INCLUDE_DIRS}
+    )
+    find_library(sodium_LIBRARY_DEBUG NAMES ${${XPREFIX}_LIBRARIES}
+        HINTS ${${XPREFIX}_LIBRARY_DIRS}
+    )
+    find_library(sodium_LIBRARY_RELEASE NAMES ${${XPREFIX}_LIBRARIES}
+        HINTS ${${XPREFIX}_LIBRARY_DIRS}
+    )
+
+
+########################################################################
+# Windows
+elseif (WIN32)
+    set(sodium_DIR "$ENV{sodium_DIR}" CACHE FILEPATH "sodium install directory")
+    mark_as_advanced(sodium_DIR)
+
+    find_path(sodium_INCLUDE_DIR sodium.h
+        HINTS ${sodium_DIR}
+        PATH_SUFFIXES include
+    )
+
+    if (MSVC)
+        # detect target architecture
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/arch.c" [=[
+            #if defined _M_IX86
+            #error ARCH_VALUE x86_32
+            #elif defined _M_X64
+            #error ARCH_VALUE x86_64
+            #endif
+            #error ARCH_VALUE unknown
+        ]=])
+        try_compile(_UNUSED_VAR "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/arch.c"
+            OUTPUT_VARIABLE _COMPILATION_LOG
+        )
+        string(REGEX REPLACE ".*ARCH_VALUE ([a-zA-Z0-9_]+).*" "\\1" _TARGET_ARCH "${_COMPILATION_LOG}")
+
+        # construct library path
+        if (_TARGET_ARCH STREQUAL "x86_32")
+            string(APPEND _PLATFORM_PATH "Win32")
+        elseif(_TARGET_ARCH STREQUAL "x86_64")
+            string(APPEND _PLATFORM_PATH "x64")
+        else()
+            message(FATAL_ERROR "the ${_TARGET_ARCH} architecture is not supported by Findsodium.cmake.")
+        endif()
+        string(APPEND _PLATFORM_PATH "/$$CONFIG$$")
+
+        if (MSVC_VERSION LESS 1900)
+            math(EXPR _VS_VERSION "${MSVC_VERSION} / 10 - 60")
+        else()
+            math(EXPR _VS_VERSION "${MSVC_VERSION} / 10 - 50")
+        endif()
+        string(APPEND _PLATFORM_PATH "/v${_VS_VERSION}")
+
+        if (sodium_USE_STATIC_LIBS)
+            string(APPEND _PLATFORM_PATH "/static")
+        else()
+            string(APPEND _PLATFORM_PATH "/dynamic")
+        endif()
+
+        string(REPLACE "$$CONFIG$$" "Debug" _DEBUG_PATH_SUFFIX "${_PLATFORM_PATH}")
+        string(REPLACE "$$CONFIG$$" "Release" _RELEASE_PATH_SUFFIX "${_PLATFORM_PATH}")
+
+        find_library(sodium_LIBRARY_DEBUG libsodium.lib
+            HINTS ${sodium_DIR}
+            PATH_SUFFIXES ${_DEBUG_PATH_SUFFIX}
+        )
+        find_library(sodium_LIBRARY_RELEASE libsodium.lib
+            HINTS ${sodium_DIR}
+            PATH_SUFFIXES ${_RELEASE_PATH_SUFFIX}
+        )
+        if (NOT sodium_USE_STATIC_LIBS)
+            set(CMAKE_FIND_LIBRARY_SUFFIXES_BCK ${CMAKE_FIND_LIBRARY_SUFFIXES})
+            set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+            find_library(sodium_DLL_DEBUG libsodium
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES ${_DEBUG_PATH_SUFFIX}
+            )
+            find_library(sodium_DLL_RELEASE libsodium
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES ${_RELEASE_PATH_SUFFIX}
+            )
+            set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BCK})
+        endif()
+
+    elseif(_GCC_COMPATIBLE)
+        if (sodium_USE_STATIC_LIBS)
+            find_library(sodium_LIBRARY_DEBUG libsodium.a
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES lib
+            )
+            find_library(sodium_LIBRARY_RELEASE libsodium.a
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES lib
+            )
+        else()
+            find_library(sodium_LIBRARY_DEBUG libsodium.dll.a
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES lib
+            )
+            find_library(sodium_LIBRARY_RELEASE libsodium.dll.a
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES lib
+            )
+
+            file(GLOB _DLL
+                LIST_DIRECTORIES false
+                RELATIVE "${sodium_DIR}/bin"
+                "${sodium_DIR}/bin/libsodium*.dll"
+            )
+            find_library(sodium_DLL_DEBUG ${_DLL} libsodium
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES bin
+            )
+            find_library(sodium_DLL_RELEASE ${_DLL} libsodium
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES bin
+            )
+        endif()
+    else()
+        message(FATAL_ERROR "this platform is not supported by FindSodium.cmake")
+    endif()
+
+
+########################################################################
+# unsupported
+else()
+    message(FATAL_ERROR "this platform is not supported by FindSodium.cmake")
+endif()
+
+
+########################################################################
+# common stuff
+
+# extract sodium version
+if (sodium_INCLUDE_DIR)
+    set(_VERSION_HEADER "${_INCLUDE_DIR}/sodium/version.h")
+    if (EXISTS _VERSION_HEADER)
+        file(READ "${_VERSION_HEADER}" _VERSION_HEADER_CONTENT)
+        string(REGEX REPLACE ".*#[ \t]*define[ \t]*SODIUM_VERSION_STRING[ \t]*\"([^\n]*)\".*" "\\1"
+            sodium_VERSION "${_VERSION_HEADER_CONTENT}")
+        set(sodium_VERSION "${sodium_VERSION}" PARENT_SCOPE)
+    endif()
+endif()
+
+# communicate results
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(sodium
+    REQUIRED_VARS
+        sodium_LIBRARY_RELEASE
+        sodium_LIBRARY_DEBUG
+        sodium_INCLUDE_DIR
+    VERSION_VAR
+        sodium_VERSION
+)
+
+# mark file paths as advanced
+mark_as_advanced(sodium_INCLUDE_DIR)
+mark_as_advanced(sodium_LIBRARY_DEBUG)
+mark_as_advanced(sodium_LIBRARY_RELEASE)
+if (WIN32)
+    mark_as_advanced(sodium_DLL_DEBUG)
+    mark_as_advanced(sodium_DLL_RELEASE)
+endif()
+
+# create imported target
+if(sodium_USE_STATIC_LIBS)
+    set(_LIB_TYPE STATIC)
+else()
+    set(_LIB_TYPE SHARED)
+endif()
+add_library(sodium ${_LIB_TYPE} IMPORTED)
+
+set_target_properties(sodium PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${sodium_INCLUDE_DIR}"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)
+
+if (sodium_USE_STATIC_LIBS)
+    set_target_properties(sodium PROPERTIES
+        INTERFACE_COMPILE_DEFINITIONS "SODIUM_STATIC"
+        IMPORTED_LOCATION "${sodium_LIBRARY_RELEASE}"
+        IMPORTED_LOCATION_DEBUG "${sodium_LIBRARY_DEBUG}"
+    )
+else()
+    if (UNIX)
+        set_target_properties(sodium PROPERTIES
+            IMPORTED_LOCATION "${sodium_LIBRARY_RELEASE}"
+            IMPORTED_LOCATION_DEBUG "${sodium_LIBRARY_DEBUG}"
+        )
+    elseif (WIN32)
+        set_target_properties(sodium PROPERTIES
+            IMPORTED_IMPLIB "${sodium_LIBRARY_RELEASE}"
+            IMPORTED_IMPLIB_DEBUG "${sodium_LIBRARY_DEBUG}"
+        )
+        if (NOT (sodium_DLL_DEBUG MATCHES ".*-NOTFOUND"))
+            set_target_properties(sodium PROPERTIES
+                IMPORTED_LOCATION_DEBUG "${sodium_DLL_DEBUG}"
+            )
+        endif()
+        if (NOT (sodium_DLL_RELEASE MATCHES ".*-NOTFOUND"))
+            set_target_properties(sodium PROPERTIES
+                IMPORTED_LOCATION_RELWITHDEBINFO "${sodium_DLL_RELEASE}"
+                IMPORTED_LOCATION_MINSIZEREL "${sodium_DLL_RELEASE}"
+                IMPORTED_LOCATION_RELEASE "${sodium_DLL_RELEASE}"
+            )
+        endif()
+    endif()
+endif()

--- a/cmake/ModulePackage.cmake
+++ b/cmake/ModulePackage.cmake
@@ -47,17 +47,23 @@ function(install_module lib)
       VERSION ${SOVERSION}
       SOVERSION ${SOVERSION_MAJOR}
     )
-    install(TARGETS ${lib}_shared
+    install(TARGETS ${lib}_shared EXPORT ${lib}Targets
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
   if(ENABLE_STATIC)
-    install(TARGETS ${lib}_static
+    install(TARGETS ${lib}_static EXPORT ${lib}Targets
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
+
+  install(EXPORT ${lib}Targets
+    FILE ${lib}Targets.cmake
+    NAMESPACE ${lib}::
+    DESTINATION lib/cmake/${lib}
+  )
 
   string(REPLACE ";" " " ${lib}_PKGCONFIG_LIBS "${${lib}_PKGCONFIG_LIBS}")
   string(REPLACE ";" " " ${lib}_PKGCONFIG_REQUIRES "${${lib}_PKGCONFIG_REQUIRES}")

--- a/cmake/SimpleFindPackage.cmake
+++ b/cmake/SimpleFindPackage.cmake
@@ -1,0 +1,37 @@
+macro(simple_find_package pkg)
+  set(oneValueArgs PKGCFG_NAME)
+  set(multiValueArgs PATH_SUFFIXES INCLUDE_NAMES LIB_NAMES)
+  cmake_parse_arguments(arg "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_${pkg} QUIET ${arg_PKGCFG_NAME})
+
+  find_path(${pkg}_INCLUDE_DIR
+    NAMES ${arg_INCLUDE_NAMES}
+    HINTS ${PC_${pkg}_INCLUDE_DIRS}
+    PATH_SUFFIXES ${arg_PATH_SUFFIXES})
+
+  find_library(${pkg}_LIBRARY
+    NAMES ${arg_LIB_NAMES}
+    HINTS ${PC_${pkg}_LIBRARY_DIRS})
+
+  mark_as_advanced(${pkg}_LIBRARY ${pkg}_INCLUDE_DIR)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(${pkg} 
+    FOUND_VAR ${pkg}_FOUND
+    REQUIRED_VARS
+      ${pkg}_LIBRARY
+      ${pkg}_INCLUDE_DIR)
+
+  if (${pkg}_FOUND)
+    set(${pkg}_INCLUDE_DIRS ${${pkg}_INCLUDE_DIR})
+    set(${pkg}_LIBRARIES ${${pkg}_LIBRARY})
+  endif()
+
+  if (${pkg}_FOUND AND NOT TARGET ${pkg}::${pkg})
+    add_library(${pkg}::${pkg} UNKNOWN IMPORTED)
+    set_target_properties(${pkg}::${pkg} PROPERTIES
+      IMPORTED_LOCATION "${${pkg}_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${${pkg}_INCLUDE_DIR}")
+  endif()
+endmacro()

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -30,7 +30,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #define MSI_MAXMSG_SIZE 256
 


### PR DESCRIPTION
Current cmake files don't handle MSVC builds very well. They don't support toxav and only support libs being in a specific location. I've adjusted them to build on MSVC for me a lot better.

1. Setup a root prefix semi like linux would (include/ lib/ bin/). Copy pthread libs to lib and headers to include.
2. Download latest libsodium and extract it
3. build libvpx and libopus, installing them to the same directory we put pthreads in
3. `cmake .. -DCMAKE_INSTALL_PREFIX="<dir with pthreads/opus/vpx>" -DCMAKE_PREFIX_PATH="<path to libsodium extracted binaries>" -G"Visual Studio 15 2017 Win64"
4. cmake --build . --target install --config Release

After this I was able to build/link qtox and have an audio/video call with a friend on linux using the toxlib I built.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1191)
<!-- Reviewable:end -->
