### PR TITLE
Run UBSAN (undefined behaviour sanitizer) on Circle CI.

### DIFF
--- a/.circleci/cmake-asan
+++ b/.circleci/cmake-asan
@@ -7,7 +7,7 @@ CACHEDIR="$HOME/cache"
 . ".travis/flags-$CC.sh"
 add_flag -Werror
 add_flag -fdiagnostics-color=always
-add_flag -fsanitize=address
+add_flag -fsanitize=address,undefined
 cmake -B_build -H. -GNinja			\
   -DCMAKE_C_FLAGS="$C_FLAGS"			\
   -DCMAKE_CXX_FLAGS="$CXX_FLAGS"		\


### PR DESCRIPTION
This runs in the same build as asan, so "asan" now stands for both asan
and ubsan.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1196)
<!-- Reviewable:end -->
