### PR TITLE
Add Cirrus CI configuration.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,24 @@
+---
+cirrus-ci_task:
+  container:
+    image: cirrusci/bazel:latest
+    cpu: 8
+    memory: 12G
+  configure_script:
+    - sudo apt update
+    - sudo apt install -y
+        autopoint
+        libasound2-dev
+        libcv-dev
+        libhighgui-dev
+        libopenal-dev
+    - echo "build --jobs=50 --curses=no --verbose_failures" | sudo tee /etc/bazel.bazelrc
+    - echo "build --config=linux" | sudo tee -a /etc/bazel.bazelrc
+    - echo "build --config=gcc" | sudo tee -a /etc/bazel.bazelrc
+    - echo "build --config=remote" | sudo tee -a /etc/bazel.bazelrc
+    - cd .. && mv cirrus-ci-build c-toxcore
+    - git clone --depth=1 https://github.com/TokTok/toktok-stack cirrus-ci-build
+    - mv c-toxcore cirrus-ci-build
+    - cd -
+  test_all_script:
+    - bazel test -c opt -k //c-toxcore/...

--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -20,6 +20,7 @@ cc_library(
 
 cc_test(
     name = "ring_buffer_test",
+    size = "small",
     srcs = ["ring_buffer_test.cc"],
     deps = [
         ":ring_buffer",
@@ -56,6 +57,7 @@ cc_library(
 
 cc_test(
     name = "rtp_test",
+    size = "small",
     srcs = ["rtp_test.cc"],
     deps = [
         ":rtp",

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -30,6 +30,7 @@ cc_library(
 
 cc_test(
     name = "crypto_core_test",
+    size = "small",
     srcs = ["crypto_core_test.cc"],
     deps = [
         ":crypto_core",
@@ -67,6 +68,7 @@ cc_library(
 
 cc_test(
     name = "mono_time_test",
+    size = "small",
     srcs = ["mono_time_test.cc"],
     deps = [
         ":mono_time",
@@ -99,6 +101,7 @@ cc_library(
 
 cc_test(
     name = "util_test",
+    size = "small",
     srcs = ["util_test.cc"],
     deps = [
         ":network",
@@ -115,6 +118,7 @@ cc_library(
 
 cc_test(
     name = "ping_array_test",
+    size = "small",
     srcs = ["ping_array_test.cc"],
     deps = [
         ":ping_array",


### PR DESCRIPTION
This CI can run Bazel tests, because it supports IPv6. This is nice,
because now we can run IPv6 tests on every PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1198)
<!-- Reviewable:end -->
