### PR TITLE
Add LAN_discovery to the list of apidsl-generated files.

### DIFF
--- a/other/astyle/format-source
+++ b/other/astyle/format-source
@@ -35,6 +35,7 @@ apidsl_curl() {
 }
 
 # Check if apidsl generated sources are up to date.
+$APIDSL toxcore/LAN_discovery.api.h > toxcore/LAN_discovery.h &
 $APIDSL toxcore/crypto_core.api.h > toxcore/crypto_core.h &
 $APIDSL toxcore/ping.api.h > toxcore/ping.h &
 $APIDSL toxcore/ping_array.api.h > toxcore/ping_array.h &
@@ -42,7 +43,7 @@ $APIDSL toxcore/tox.api.h > toxcore/tox.h &
 $APIDSL toxav/toxav.api.h > toxav/toxav.h &
 $APIDSL toxencryptsave/toxencryptsave.api.h > toxencryptsave/toxencryptsave.h &
 
-wait; wait; wait; wait; wait; wait
+wait; wait; wait; wait; wait; wait; wait
 
 if grep '<unresolved>' */*.h; then
   echo "error: some apidsl references were unresolved"

--- a/toxcore/LAN_discovery.h
+++ b/toxcore/LAN_discovery.h
@@ -70,4 +70,4 @@ bool ip_is_local(IP ip);
  */
 bool ip_is_lan(IP ip);
 
-#endif
+#endif // C_TOXCORE_TOXCORE_LAN_DISCOVERY_H


### PR DESCRIPTION
So it gets regenerated when the .api.h file changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1206)
<!-- Reviewable:end -->
