### PR TITLE
Remove a function-like macro and replace it with a function.

### DIFF
--- a/toxcore/state.c
+++ b/toxcore/state.c
@@ -79,6 +79,11 @@ uint16_t lendian_to_host16(uint16_t lendian)
 #endif
 }
 
+uint16_t host_tolendian16(uint16_t host)
+{
+    return lendian_to_host16(host);
+}
+
 void host_to_lendian32(uint8_t *dest,  uint32_t num)
 {
 #ifdef WORDS_BIGENDIAN

--- a/toxcore/state.h
+++ b/toxcore/state.h
@@ -39,7 +39,7 @@ uint8_t *state_write_section_header(uint8_t *data, uint16_t cookie_type, uint32_
 // Utilities for state data serialisation.
 
 uint16_t lendian_to_host16(uint16_t lendian);
-#define host_tolendian16(x) lendian_to_host16(x)
+uint16_t host_tolendian16(uint16_t host);
 
 void host_to_lendian32(uint8_t *dest, uint32_t num);
 void lendian_to_host32(uint32_t *dest, const uint8_t *lendian);


### PR DESCRIPTION
No use making this a macro. LTO will inline this anyway, if we care about
performance. Generally, we avoid function-like macros that can be functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1208)
<!-- Reviewable:end -->
