### PR TITLE
Improve Windows compatibility of toxav code.

### DIFF
--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -30,7 +30,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #define MSI_MAXMSG_SIZE 256
 

--- a/toxav/video.c
+++ b/toxav/video.c
@@ -72,11 +72,11 @@
 #define VIDEO_BITRATE_INITIAL_VALUE 5000
 #define VIDEO_DECODE_BUFFER_SIZE 5 // this buffer has normally max. 1 entry
 
-static const vpx_codec_iface_t *video_codec_decoder_interface(void)
+static vpx_codec_iface_t *video_codec_decoder_interface(void)
 {
     return vpx_codec_vp8_dx();
 }
-static const vpx_codec_iface_t *video_codec_encoder_interface(void)
+static vpx_codec_iface_t *video_codec_encoder_interface(void)
 {
     return vpx_codec_vp8_cx();
 }


### PR DESCRIPTION
- unistd.h doesn't exist on MSVC.
- `vpx_codec_iface_t` is already `const`, so adding `const` qualifiers is
  redundant and causes warnings on MSVC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1209)
<!-- Reviewable:end -->
