### PR TITLE
Some improvements to tox-bootstrapd's Dockerfile

### DIFF
--- a/.travis/tox-bootstrapd-docker
+++ b/.travis/tox-bootstrapd-docker
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -exu
+
 # Copy source code to other/bootstrap_daemon/docker/c-toxcore
 OLD_PWD=$PWD
 cd /tmp
@@ -13,7 +15,8 @@ cd other/bootstrap_daemon
 
 # Make Docker container use our current source code instead of master branch
 sed -i "s|WORKDIR /tmp/tox|WORKDIR /tmp/tox\nADD /c-toxcore ./c-toxcore/|g" docker/Dockerfile
-sed -i '/git clone/d' docker/Dockerfile
+sed -i 's|git clone|echo \\\#git clone|g' docker/Dockerfile
+sed -i 's|git checkout|echo \\\#git checkout|g' docker/Dockerfile
 
 cat docker/Dockerfile
 

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -4,14 +4,10 @@ WORKDIR /tmp/tox
 
 RUN export BUILD_PACKAGES="\
       build-essential \
-      libtool \
-      autotools-dev \
-      automake \
-      checkinstall \
+      cmake \
       git \
-      yasm \
-      libsodium-dev \
       libconfig-dev \
+      libsodium-dev \
       python3" && \
     export RUNTIME_PACKAGES="\
       libconfig9 \
@@ -22,12 +18,21 @@ RUN export BUILD_PACKAGES="\
     git clone https://github.com/TokTok/c-toxcore && \
     cd c-toxcore && \
     # checkout latest release version
-    git checkout $(git tag --list | grep -P '^v(\d+).(\d+).(\d+)$' | sed "s/v/v /g" | sed "s/\./ /g" | sort -snk4,4 | sort -snk3,3 | sort -snk2,2 | tail -n 1 | sed 's/v /v/g' | sed 's/ /\./g') && \
-    ./autogen.sh && \
-    ./configure --enable-daemon && \
+    git checkout $(git tag --list | grep -P '^v(\d+).(\d+).(\d+)$' | \
+      sed "s/v/v /g" | sed "s/\./ /g" | \
+      sort -snk4,4 | sort -snk3,3 | sort -snk2,2 | tail -n 1 | \
+      sed 's/v /v/g' | sed 's/ /\./g') && \
+    mkdir _build && \
+    cd _build && \
+    cmake .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DENABLE_SHARED=ON \
+      -DENABLE_STATIC=OFF \
+      -DBUILD_TOXAV=OFF \
+      -DBOOTSTRAP_DAEMON=ON && \
     make -j`nproc` && \
     make install -j`nproc` && \
-    ldconfig && \
+    cd .. && \
 # add new user
     useradd --home-dir /var/lib/tox-bootstrapd --create-home \
       --system --shell /sbin/nologin \

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -21,6 +21,8 @@ RUN export BUILD_PACKAGES="\
 # install toxcore and daemon
     git clone https://github.com/TokTok/c-toxcore && \
     cd c-toxcore && \
+    # checkout latest release version
+    git checkout $(git tag --list | grep -P '^v(\d+).(\d+).(\d+)$' | sed "s/v/v /g" | sed "s/\./ /g" | sort -snk4,4 | sort -snk3,3 | sort -snk2,2 | tail -n 1 | sed 's/v /v/g' | sed 's/ /\./g') && \
     ./autogen.sh && \
     ./configure --enable-daemon && \
     make -j`nproc` && \


### PR DESCRIPTION
Users probably shouldn't run toxcore master, running the highest version tag sounds better.

Switched it to use cmake to build toxcore instead of sing autotools while I was at it, since we are supposedly phasing out autotools at some point (maybe?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1211)
<!-- Reviewable:end -->
