### PR TITLE
Make tox-bootstrapd free memory on SIGINT and SIGTERM

### DIFF
--- a/other/analysis/run-clang
+++ b/other/analysis/run-clang
@@ -14,6 +14,7 @@ clang++ -o /dev/null amalgamation.cc		\
 	-Wno-cast-align				\
 	-Wno-conversion				\
 	-Wno-covered-switch-default		\
+	-Wno-disabled-macro-expansion		\
 	-Wno-documentation-deprecated-sync	\
 	-Wno-missing-field-initializers		\
 	-Wno-old-style-cast			\


### PR DESCRIPTION
Useful for using memory analyzing tools.

Closes #1220

```bash
sed -i 's/DMIN_LOGGER_LEVEL/DMIN_LOGGER_LEVEL_IGNORE/' CMakeLists.txt
mkdir _build
cd _build
cmake -DBOOTSTRAP_DAEMON=ON \
      -DBUILD_TOXAV=OFF \
      -DENABLE_STATIC=ON \
      -DENABLE_SHARED=OFF \
      -DCMAKE_BUILD_TYPE=Debug \
      ..
make
cp ../other/bootstrap_daemon/tox-bootstrapd.conf .
sed -i "s|/var/lib/tox-bootstrapd|${PWD}|" tox-bootstrapd.conf
sed -i "s|/var/run/tox-bootstrapd|${PWD}|" tox-bootstrapd.conf
sed -i '/^bootstrap_nodes = /,$d' tox-bootstrapd.conf
python3 ../other/bootstrap_daemon/docker/get-nodes.py >> tox-bootstrapd.conf
valgrind --leak-check=full --show-leak-kinds=all \
         ./tox-bootstrapd --foreground --config tox-bootstrapd.conf
```
```
==13673== Memcheck, a memory error detector
==13673== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==13673== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==13673== Command: ./tox-bootstrapd --foreground --config tox-bootstrapd.conf
==13673== 
^C==13673== 
==13673== HEAP SUMMARY:
==13673==     in use at exit: 0 bytes in 0 blocks
==13673==   total heap usage: 2,801 allocs, 2,801 frees, 9,422,380 bytes allocated
==13673== 
==13673== All heap blocks were freed -- no leaks are possible
==13673== 
==13673== For counts of detected and suppressed errors, rerun with: -v
==13673== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1221)
<!-- Reviewable:end -->
