### PR TITLE
Include `CTest` in CMakeLists.txt to get valgrind support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ message("SOVERSION: ${SOVERSION}")
 ################################################################################
 
 include(ApiDsl)
+include(CTest)
 include(ModulePackage)
 include(StrictAbi)
 include(GNUInstallDirs)


### PR DESCRIPTION
We can now run `ctest --output-on-failure -D ExperimentalMemCheck -j 50`
to run valgrind on all tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1229)
<!-- Reviewable:end -->
