### PR TITLE
 Increase NOFILE limit for tox-bootstrapd

### DIFF
--- a/.travis/cmake-freebsd-stage1
+++ b/.travis/cmake-freebsd-stage1
@@ -111,6 +111,7 @@ travis_install() {
     # Install required toxcore dependencies
     RUN PAGER=cat ASSUME_ALWAYS_YES=YES pkg install git \
                                                     opus \
+                                                    libconfig \
                                                     libvpx \
                                                     libsodium \
                                                     gmake \

--- a/.travis/tox-bootstrapd-docker
+++ b/.travis/tox-bootstrapd-docker
@@ -23,7 +23,7 @@ cat docker/Dockerfile
 sudo docker build -t tox-bootstrapd docker/
 sudo useradd --home-dir /var/lib/tox-bootstrapd --create-home --system --shell /sbin/nologin --comment "Account to run Tox's DHT bootstrap daemon" --user-group tox-bootstrapd
 sudo chmod 700 /var/lib/tox-bootstrapd
-sudo docker run -d --name tox-bootstrapd -v /var/lib/tox-bootstrapd/:/var/lib/tox-bootstrapd/ -p 443:443 -p 3389:3389 -p 33445:33445 -p 33445:33445/udp tox-bootstrapd
+sudo docker run -d --name tox-bootstrapd -v /var/lib/tox-bootstrapd/:/var/lib/tox-bootstrapd/ --ulimit nofile=32768:32768 -p 443:443 -p 3389:3389 -p 33445:33445 -p 33445:33445/udp tox-bootstrapd
 
 sudo ls -lbh /var/lib/tox-bootstrapd
 
@@ -56,6 +56,12 @@ sudo docker ps -a
 
 if [ "`sudo docker inspect -f {{.State.Running}} tox-bootstrapd`" != "true" ]; then
   echo "Error: Container is not running"
+  exit 1
+fi
+
+cat /proc/$(pidof tox-bootstrapd)/limits
+if ! cat /proc/$(pidof tox-bootstrapd)/limits | grep -P '^Max open files(\s+)32768(\s+)32768(\s+)files'; then
+  echo "Error: ulimit is not set to the expected value"
   exit 1
 fi
 

--- a/other/bootstrap_daemon/README.md
+++ b/other/bootstrap_daemon/README.md
@@ -219,7 +219,7 @@ sudo docker build -t tox-bootstrapd docker/
 sudo useradd --home-dir /var/lib/tox-bootstrapd --create-home --system --shell /sbin/nologin --comment "Account to run Tox's DHT bootstrap daemon" --user-group tox-bootstrapd
 sudo chmod 700 /var/lib/tox-bootstrapd
 
-sudo docker run -d --name tox-bootstrapd --restart always -v /var/lib/tox-bootstrapd/:/var/lib/tox-bootstrapd/ -p 443:443 -p 3389:3389 -p 33445:33445 -p 33445:33445/udp tox-bootstrapd
+sudo docker run -d --name tox-bootstrapd --restart always -v /var/lib/tox-bootstrapd/:/var/lib/tox-bootstrapd/ --ulimit nofile=32768:32768 -p 443:443 -p 3389:3389 -p 33445:33445 -p 33445:33445/udp tox-bootstrapd
 ```
 
 We create a new user and protect its home directory in order to mount it in the Docker image, so that the kyepair the daemon uses would be stored on the host system, which makes it less likely that you would loose the keypair while playing with or updating the Docker container.

--- a/other/bootstrap_daemon/tox-bootstrapd.service
+++ b/other/bootstrap_daemon/tox-bootstrapd.service
@@ -11,6 +11,9 @@ WorkingDirectory=/var/lib/tox-bootstrapd
 ExecStart=/usr/local/bin/tox-bootstrapd --config /etc/tox-bootstrapd.conf
 User=tox-bootstrapd
 Group=tox-bootstrapd
+# TCP Server needs to be able to have lots of TCP sockets open.
+LimitNOFILE=32768
+# Uncomment to allow binding to ports < 1024, e.g. 443 (HTTPS) for TCP Server
 #CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 [Install]


### PR DESCRIPTION
tox-bootstrapd can use around 600 TCP sockets during TCP server's normal
functioning. Many systems default to having a soft limit of 1024 open file
descriptors, which we are close to reaching, so it was suggested we bump that
limit to a higher number. iphy suggested increasing it to 32768.

Related to the discussion at #1227.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1234)
<!-- Reviewable:end -->
