### PR TITLE
Allow unauthenticated wine packages in the Windows build.

### DIFF
--- a/other/docker/windows/get_packages.sh
+++ b/other/docker/windows/get_packages.sh
@@ -48,7 +48,7 @@ if [ "${SUPPORT_TEST}" = "true" ]; then
 
     dpkg --add-architecture i386
     apt-get update
-    apt-get install -y \
+    apt-get install -y --allow-unauthenticated \
         wine-devel \
         wine-devel-amd64 \
         wine-devel-dbg \


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1281)
<!-- Reviewable:end -->
