### PR TITLE
Use new WineHQ Debian package repository key

### DIFF
--- a/other/docker/windows/get_packages.sh
+++ b/other/docker/windows/get_packages.sh
@@ -43,12 +43,17 @@ if [ "${SUPPORT_TEST}" = "true" ]; then
 
     # Add Wine package repository to use the latest Wine
     echo "deb https://dl.winehq.org/wine-builds/debian/ stretch main" >> /etc/apt/sources.list
-    curl -o Release.key https://dl.winehq.org/wine-builds/Release.key
+    curl -o Release.key https://dl.winehq.org/wine-builds/winehq.key
+    # Verify against a known good key fingerprint. --dry-run makes it so we don't actually import the key.
+    if ! gpg --batch --dry-run --import --import-options import-show --fingerprint Release.key | grep 'D43F 6401 4536 9C51 D786  DDEA 76F1 A20F F987 672F'; then
+        echo "Error: WineHQ's Debian package repository key fingerprint didn't match the expected one. Exiting."
+        exit 1
+    fi
     apt-key add Release.key
 
     dpkg --add-architecture i386
     apt-get update
-    apt-get install -y --allow-unauthenticated \
+    apt-get install -y \
         wine-devel \
         wine-devel-amd64 \
         wine-devel-dbg \


### PR DESCRIPTION
Please don't use [unauthenticated packages in user scripts](https://github.com/TokTok/c-toxcore/pull/1281). It wouldn't be as bad if unauthenticated packages were used only in the CI as we don't provide any build artifacts there, but that script is also meant to be used by people to produce toxcore dlls through the cross-compilation, it's in [the INSTALL.md instructions](https://github.com/TokTok/c-toxcore/blob/0f8f82a3cf639233c69c893c102a82b6e11ae98e/INSTALL.md#cross-compiling-from-linux), it's not just for CI.

Anyway, the issue was that WineHQ has changed their package signing key:

```
W: GPG error: https://dl.winehq.org/wine-builds/debian stretch InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 76F1A20FF987672F
W: The repository 'https://dl.winehq.org/wine-builds/debian stretch InRelease' is not signed.
...
WARNING: The following packages cannot be authenticated!
  wine-devel-amd64 wine-devel-i386:i386 wine-devel wine-devel-dbg winehq-devel
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
The command '/bin/sh -c sh ./get_packages.sh' returned a non-zero code: 100
```
[(Full log)](https://travis-ci.org/TokTok/c-toxcore/jobs/474712777)

You can see the notice about the key being changed on WineHQ website:

>[The WineHQ repository key was changed on 2018-12-19. If you downloaded and added the key before that time, you will need to download and add the new key and run sudo apt update to accept the repository changes.](https://web.archive.org/web/20190104020220/https://wiki.winehq.org/Debian)

That's my primary source about the key change ^.

I have also faced this key change issue on my own system in December and given how no noise was raised over it for what is now several weeks, it does indeed appear like they simply have changed the key rather than that they got compromised. It would help if they have confirmed the key change on one more resource other than the website, but I couldn't find it being mentioned anywhere else.

I have also added a key fingerprint check in the script, because I figured that if the the package repository is compromised they might as well update the public key to match the signatures of compromised packages and we wouldn't know any better that the key has changed since we download the key every time we use the repository. (We have noticed the change only because they didn't overwrite the old `Release.key` key with the new one, they instead put it under the new `winehq.key` filename). Without that fingerprint check we might as well not bother using the key and use `--allow-unauthenticated`, so this check is important to have.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1284)
<!-- Reviewable:end -->
