### PR TITLE
Enable auto tests under STRICT_ABI if static libs are available.

### DIFF
--- a/cmake/StrictAbi.cmake
+++ b/cmake/StrictAbi.cmake
@@ -53,7 +53,7 @@ if(WIN32 OR APPLE)
   set(STRICT_ABI OFF)
 endif()
 
-if(STRICT_ABI)
+if(STRICT_ABI AND NOT ENABLE_STATIC)
   if(AUTOTEST)
     message("AUTOTEST option is incompatible with STRICT_ABI. Disabling AUTOTEST.")
   endif()


### PR DESCRIPTION
STRICT_ABI only breaks linkage if static libraries are not available,
because then we try to link against shared libraries with hidden symbols.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1289)
<!-- Reviewable:end -->
