### PR TITLE
Display build log for autotools build on failure.

### DIFF
--- a/.travis/autotools-linux
+++ b/.travis/autotools-linux
@@ -41,7 +41,7 @@ travis_script() {
   cd _build  # pushd
   ../configure $CONFIG_FLAGS || (cat config.log && false)
   make "-j$NPROC" -k CFLAGS="$C_FLAGS" LDFLAGS="$LD_FLAGS"
-  make -j50 -k distcheck DISTCHECK_CONFIGURE_FLAGS="$CONFIG_FLAGS"
+  make -j50 -k distcheck DISTCHECK_CONFIGURE_FLAGS="$CONFIG_FLAGS" || (cat build/test-suite.log && false)
   cd -  # popd
 }
 


### PR DESCRIPTION
We can't see the failure messages now, so something like "aborted", which
probably means assertion failure, is not very useful right now.

E.g. https://travis-ci.org/TokTok/c-toxcore/jobs/476028600#L1220

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1290)
<!-- Reviewable:end -->
