### PR TITLE
Fix misaligned 4-byte access in trace logging.

### DIFF
--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -405,16 +405,23 @@ bool set_socket_dualstack(Socket sock)
 
 static uint32_t data_0(uint16_t buflen, const uint8_t *buffer)
 {
-    // TODO(iphydf): Do this differently. Right now this is most likely a
-    // misaligned memory access in reality, and definitely undefined behaviour
-    // in terms of C standard.
-    const uint8_t *const start = buffer + 1;
-    return buflen > 4 ? net_ntohl(*(const uint32_t *)start) : 0;
+    uint32_t data = 0;
+
+    if (buflen > 4) {
+        net_unpack_u32(buffer + 1, &data);
+    }
+
+    return data;
 }
 static uint32_t data_1(uint16_t buflen, const uint8_t *buffer)
 {
-    const uint8_t *const start = buffer + 5;
-    return buflen > 7 ? net_ntohl(*(const uint32_t *)start) : 0;
+    uint32_t data = 0;
+
+    if (buflen > 7) {
+        net_unpack_u32(buffer + 5, &data);
+    }
+
+    return data;
 }
 
 static void loglogdata(const Logger *log, const char *message, const uint8_t *buffer,


### PR DESCRIPTION
This code is undefined behaviour as is, and breaks on various platforms
requiring strict alignment (many microcontrollers).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1293)
<!-- Reviewable:end -->
