### PR TITLE
Add API for bump-allocator with trivial implementation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,13 @@ set(toxcore_PKGCONFIG_LIBS)
 # Requires: in pkg-config file.
 set(toxcore_PKGCONFIG_REQUIRES)
 
+# LAYER 0: Memory allocator
+# --------------------
+apidsl(toxcore/mem.api.h)
+set(toxcore_SOURCES ${toxcore_SOURCES}
+  toxcore/mem.c
+  toxcore/mem.h)
+
 # LAYER 1: Crypto core
 # --------------------
 apidsl(toxcore/crypto_core.api.h)

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -13,6 +13,12 @@ cc_library(
 )
 
 cc_library(
+    name = "mem",
+    srcs = ["mem.c"],
+    hdrs = ["mem.h"],
+)
+
+cc_library(
     name = "crypto_core",
     srcs = [
         "crypto_core.c",
@@ -24,6 +30,7 @@ cc_library(
     visibility = ["//c-toxcore:__subpackages__"],
     deps = [
         ":ccompat",
+        ":mem",
         "@libsodium",
     ],
 )

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -8,6 +8,8 @@ libtoxcore_la_includedir = $(includedir)/tox
 libtoxcore_la_SOURCES = ../toxcore/ccompat.h \
                         ../toxcore/DHT.h \
                         ../toxcore/DHT.c \
+                        ../toxcore/mem.h \
+                        ../toxcore/mem.c \
                         ../toxcore/mono_time.h \
                         ../toxcore/mono_time.c \
                         ../toxcore/network.h \

--- a/toxcore/mem.api.h
+++ b/toxcore/mem.api.h
@@ -1,0 +1,58 @@
+%{
+/*
+ * Copyright © 2019 The TokTok team.
+ *
+ * This file is part of Tox, the free peer to peer instant messenger.
+ *
+ * Tox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef C_TOXCORE_TOXCORE_MEM_H
+#define C_TOXCORE_TOXCORE_MEM_H
+
+#include <stddef.h>
+#include <stdint.h>
+%}
+
+static namespace mem {
+
+/**
+ * Bump-allocate an array of elements.
+ *
+ * The bump-allocator strictly requires that the `$bfree` calls are run in
+ * reverse order of allocation (`$bcalloc`). Failure to do so will result in
+ * undefined behaviour (e.g. an assertion failure). Generally, this means the
+ * calls to `$bcalloc` and `$bfree` should be in the same lexical scope.
+ *
+ * @param nmemb Number of elements in the allocated array.
+ * @param size <sizeof_t<`a>> The size of one element.
+ * @return <`a> A dynamically allocated `T[nmemb]`, cast to `void *`.
+ */
+void *bcalloc(uint32_t nmemb, uint32_t size);
+
+/**
+ * Free the most recent allocation from the bump allocator.
+ *
+ * The memory is not cleared on deallocation.
+ *
+ * @param ptr <`a> The pointer last returned by `$bcalloc`.
+ * @param nmemb Number of elements in the allocated array.
+ * @param size <sizeof_t<`a>> The size of one element.
+ */
+void bfree(void *ptr, uint32_t nmemb, uint32_t size);
+
+}  // namespace mem
+
+%{
+#endif  // C_TOXCORE_TOXCORE_MEM_H
+%}

--- a/toxcore/mem.c
+++ b/toxcore/mem.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2019 The TokTok team.
+ *
+ * This file is part of Tox, the free peer to peer instant messenger.
+ *
+ * Tox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "mem.h"
+
+#include <stdlib.h>
+
+void *mem_bcalloc(uint32_t nmemb, uint32_t size)
+{
+    return calloc(nmemb, size);
+}
+
+void mem_bfree(void *ptr, uint32_t nmemb, uint32_t size)
+{
+    free(ptr);
+}

--- a/toxcore/mem.h
+++ b/toxcore/mem.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2019 The TokTok team.
+ *
+ * This file is part of Tox, the free peer to peer instant messenger.
+ *
+ * Tox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef C_TOXCORE_TOXCORE_MEM_H
+#define C_TOXCORE_TOXCORE_MEM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Bump-allocate an array of elements.
+ *
+ * The bump-allocator strictly requires that the `mem_bfree` calls are run in
+ * reverse order of allocation (`mem_bcalloc`). Failure to do so will result in
+ * undefined behaviour (e.g. an assertion failure). Generally, this means the
+ * calls to `mem_bcalloc` and `mem_bfree` should be in the same lexical scope.
+ *
+ * @param nmemb Number of elements in the allocated array.
+ * @param size `sizeof(T)`, the size of one element.
+ * @return A dynamically allocated `T[nmemb]`, cast to `void *`.
+ */
+void *mem_bcalloc(uint32_t nmemb, uint32_t size);
+
+/**
+ * Free the most recent allocation from the bump allocator.
+ *
+ * The memory is not cleared on deallocation.
+ *
+ * @param ptr The pointer last returned by `mem_bcalloc`.
+ */
+void mem_bfree(void *ptr);
+
+#endif  // C_TOXCORE_TOXCORE_MEM_H

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -34,10 +34,9 @@
 #include "util.h"
 
 #include "crypto_core.h" /* for CRYPTO_PUBLIC_KEY_SIZE */
+#include "mem.h"
 
-#include <stdlib.h>
 #include <string.h>
-#include <time.h>
 
 
 /* id functions */
@@ -55,14 +54,14 @@ uint32_t id_copy(uint8_t *dest, const uint8_t *src)
 void host_to_net(uint8_t *num, uint16_t numbytes)
 {
 #ifndef WORDS_BIGENDIAN
-    uint32_t i;
-    VLA(uint8_t, buff, numbytes);
+    uint8_t *buff = (uint8_t *)mem_bcalloc(numbytes, sizeof(uint8_t));
 
-    for (i = 0; i < numbytes; ++i) {
+    for (uint16_t i = 0; i < numbytes; ++i) {
         buff[i] = num[numbytes - i - 1];
     }
 
     memcpy(num, buff, numbytes);
+    mem_bfree(buff, numbytes, sizeof(uint8_t));
 #endif
 }
 


### PR DESCRIPTION
The implementation is not actually a bump allocator at this time, but
implements the API correctly. In the future, we can use this to implement
more efficient local allocations to replace the use of VLAs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1294)
<!-- Reviewable:end -->
