### PR TITLE
Fix bazel build version at 0.22.0 for CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: cirrusci/bazel:latest
+    image: cirrusci/bazel:0.22.0
     cpu: 8
     memory: 12G
   configure_script:


### PR DESCRIPTION
To make this reproducible. With floating versions (always latest), this
can break any time a new bazel version is released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1314)
<!-- Reviewable:end -->
