### PR TITLE
add undef guard in tox_many_tcp_test

### DIFF
--- a/auto_tests/tox_many_tcp_test.c
+++ b/auto_tests/tox_many_tcp_test.c
@@ -39,6 +39,10 @@ static void accept_friend_request(Tox *m, const uint8_t *public_key, const uint8
 
 #define NUM_FRIENDS 50
 #define NUM_TOXES_TCP 40
+
+#ifdef TCP_RELAY_PORT
+#undef TCP_RELAY_PORT
+#endif
 #define TCP_RELAY_PORT 33448
 
 START_TEST(test_many_clients_tcp)


### PR DESCRIPTION
This fixes an redefinition error when creating amalgamation.cc during
static analysis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1320)
<!-- Reviewable:end -->
