### PR TITLE
Fix file transfer speed by using correct RTT

### DIFF
--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -994,7 +994,7 @@ static int handle_request_packet(Mono_Time *mono_time, const Logger *log, Packet
     uint32_t requested = 0;
 
     const uint64_t temp_time = current_time_monotonic(mono_time);
-    uint64_t l_sent_time = ~0;
+    uint64_t l_sent_time = 0;
 
     for (uint32_t i = send_array->buffer_start; i != send_array->buffer_end; ++i) {
         if (length == 0) {
@@ -1552,16 +1552,8 @@ static int handle_data_packet_core(Net_Crypto *c, int crypt_connection_id, const
     }
 
     if (real_data[0] == PACKET_ID_REQUEST) {
-        uint64_t rtt_time;
-
-        if (udp) {
-            rtt_time = conn->rtt_time;
-        } else {
-            rtt_time = DEFAULT_TCP_PING_CONNECTION;
-        }
-
         int requested = handle_request_packet(c->mono_time, c->log, &conn->send_array, real_data, real_length, &rtt_calc_time,
-                                              rtt_time);
+                                              conn->rtt_time);
 
         if (requested == -1) {
             return -1;
@@ -1615,10 +1607,7 @@ static int handle_data_packet_core(Net_Crypto *c, int crypt_connection_id, const
 
     if (rtt_calc_time != 0) {
         uint64_t rtt_time = current_time_monotonic(c->mono_time) - rtt_calc_time;
-
-        if (rtt_time < conn->rtt_time) {
-            conn->rtt_time = rtt_time;
-        }
+        conn->rtt_time = rtt_time;
     }
 
     return 0;


### PR DESCRIPTION
* Don't only update connection RTT with shorter times - update with any
new RTT
* Don't use only default value for TCP, use connection RTT
* Make lastest sent packet correctly measured


This is a purely sender-side fix. Sending from qTox with this change through a slow VPN, then to a TCP relay, then through Tor to Antox on my phone I get about 200KiB/s consistently for a 100MB file. Before the change, I got speeds of about 4KiB/s on the same setup.