### PR TITLE
fix missing group title length check

### DIFF
--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -3294,6 +3294,11 @@ static State_Load_Status load_conferences(Group_Chats *g_c, const uint8_t *data,
         }
 
         g->title_len = *data;
+
+        if (g->title_len > MAX_NAME_LENGTH) {
+            return STATE_LOAD_STATUS_ERROR;
+        }
+
         ++data;
 
         if (length < (uint32_t)(data - init_data) + g->title_len) {

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -3328,6 +3328,11 @@ static State_Load_Status load_conferences(Group_Chats *g_c, const uint8_t *data,
             data += sizeof(uint64_t);
 
             peer->nick_len = *data;
+
+            if (peer->nick_len > MAX_NAME_LENGTH) {
+                return STATE_LOAD_STATUS_ERROR;
+            }
+
             ++data;
 
             if (length < (uint32_t)(data - init_data) + peer->nick_len) {


### PR DESCRIPTION
This fixes a buffer overflow when a malformed *.tox save file is
loaded.

Again found with AFL and #1331

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1334)
<!-- Reviewable:end -->
