### PR TITLE
Fix TSAN failures in tests

### DIFF
--- a/toxav/toxav.api.h
+++ b/toxav/toxav.api.h
@@ -53,8 +53,8 @@ extern "C" {
 
 /** \subsection threading Threading implications
  *
- * Unlike the Core API, this API is fully thread-safe. The library will ensure
- * the proper synchronization of parallel calls.
+ * Only ${toxAV.iterate} is thread-safe, all other functions must run from the
+ * tox thread.
  *
  * A common way to run ToxAV (multiple or single instance) is to have a thread,
  * separate from tox instance thread, running a simple ${toxAV.iterate} loop,

--- a/toxav/toxav.h
+++ b/toxav/toxav.h
@@ -49,8 +49,8 @@ extern "C" {
  */
 /** \subsection threading Threading implications
  *
- * Unlike the Core API, this API is fully thread-safe. The library will ensure
- * the proper synchronization of parallel calls.
+ * Only toxav_iterate is thread-safe, all other functions must run from the
+ * tox thread.
  *
  * A common way to run ToxAV (multiple or single instance) is to have a thread,
  * separate from tox instance thread, running a simple toxav_iterate loop,


### PR DESCRIPTION
It seems that call control actions must be synchronized to `tox_iterate` in order to avoid some race conditions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1343)
<!-- Reviewable:end -->
