### PR TITLE
fix concurrency issues in mono_time

### DIFF
--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -63,7 +63,10 @@ cc_library(
     name = "mono_time",
     srcs = ["mono_time.c"],
     hdrs = ["mono_time.h"],
-    deps = [":ccompat"],
+    deps = [
+        ":ccompat",
+        "@pthread",
+    ],
 )
 
 cc_test(


### PR DESCRIPTION
Since mono_time is accessed from the main thread as well as the toxav
thread it is needed to properly lock time updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1345)
<!-- Reviewable:end -->
