### PR TITLE
Fix pthread_mutex_destroy getting too many arguments

### DIFF
--- a/toxcore/mono_time.c
+++ b/toxcore/mono_time.c
@@ -139,7 +139,7 @@ Mono_Time *mono_time_new(void)
 void mono_time_free(Mono_Time *mono_time)
 {
 #ifdef OS_WIN32
-    pthread_mutex_destroy(&mono_time->last_clock_lock, nullptr);
+    pthread_mutex_destroy(&mono_time->last_clock_lock);
 #endif
     pthread_rwlock_destroy(mono_time->time_update_lock);
     free(mono_time->time_update_lock);


### PR DESCRIPTION
I got an angry email from one of my Travis builds about Toxcore not building on Windows anymore.

https://ci.appveyor.com/project/iphydf/c-toxcore/builds/27267869?fullLog=true#L847
https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutex_destroy.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1347)
<!-- Reviewable:end -->
