### PR TITLE
Fix tox-bootstrapd's README and update Dockerfile

### DIFF
--- a/other/bootstrap_daemon/README.md
+++ b/other/bootstrap_daemon/README.md
@@ -45,9 +45,11 @@ Copy `tox-bootstrapd.service` to `/etc/systemd/system/`:
 sudo cp tox-bootstrapd.service /etc/systemd/system/
 ```
 
-You must uncomment the next line in tox-bootstrapd.service, if you want to use port number < 1024 
+You must uncomment the next line in tox-bootstrapd.service, if you want to use port number < 1024:
 
-    #CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+```
+#CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+```
 
 and, possibly, install `libcap2-bin` or `libcap2` package, depending of your distribution.
 
@@ -78,14 +80,17 @@ Then update your toxcore git repository, rebuild the toxcore and the daemon and 
 
 Check if `tox-bootstrapd.service` in toxcore git repository was modified since the last time you copied it, as you might need to update it too.
 
+Reload `tox-bootstrapd.service` if you have updated modified it:
+
+```sh
+sudo systemctl daemon-reload
+```
+
 After all of this is done, simply start the daemon back again:
 
 ```sh
 sudo systemctl start tox-bootstrapd.service
 ```
-
-Note that `tox-bootstrapd.service` file might
-
 
 ### Troubleshooting
 

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 WORKDIR /tmp/tox
 
@@ -11,7 +11,7 @@ RUN export BUILD_PACKAGES="\
       python3" && \
     export RUNTIME_PACKAGES="\
       libconfig9 \
-      libsodium18" && \
+      libsodium23" && \
 # get all deps
     apt-get update && apt-get install -y $BUILD_PACKAGES $RUNTIME_PACKAGES && \
 # install toxcore and daemon


### PR DESCRIPTION
The README had an abrupt line:

```
Note that `tox-bootstrapd.service` file might
```

I believe  I wanted to say that the the unit file might need to be reloaded, which I have added above.

Also updated the Dockerfile to use Debian Buster - tested it to make sure it works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1349)
<!-- Reviewable:end -->
