### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/testing/misc_tools.c
+++ b/testing/misc_tools.c
@@ -72,11 +72,11 @@ uint8_t *hex_string_to_bin(const char *hex_string)
     // valid. the more proper implementation would be to check if strlen(hex_string)
     // is odd and return error code if it is. we assume strlen is even. if it's not
     // then the last byte just won't be written in 'ret'.
-    size_t i, len = strlen(hex_string) / 2;
+    size_t len = strlen(hex_string) / 2;
     uint8_t *ret = (uint8_t *)malloc(len);
     const char *pos = hex_string;
 
-    for (i = 0; i < len; ++i, pos += 2) {
+    for (size_t i = 0; i < len; ++i, pos += 2) {
         unsigned int val;
         sscanf(pos, "%02x", &val);
         ret[i] = val;

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2193,7 +2193,7 @@ static uint16_t nat_getports(uint16_t *portlist, IP_Port *ip_portlist, uint16_t 
     return num;
 }
 
-static void punch_holes(DHT *dht, IP ip, uint16_t *port_list, uint16_t numports, uint16_t friend_num)
+static void punch_holes(DHT *dht, IP ip, const uint16_t *port_list, uint16_t numports, uint16_t friend_num)
 {
     if (!dht->hole_punching_enabled) {
         return;
@@ -2914,33 +2914,25 @@ int dht_connect_after_load(DHT *dht)
 
 static State_Load_Status dht_load_state_callback(void *outer, const uint8_t *data, uint32_t length, uint16_t type)
 {
-    DHT *dht = (DHT *)outer;
+    DHT *dht = (DHT *) outer;
 
-    switch (type) {
-        case DHT_STATE_TYPE_NODES: {
-            if (length == 0) {
-                break;
-            }
+    if (type != DHT_STATE_TYPE_NODES) {
+        LOGGER_ERROR(dht->log, "Load state (DHT): contains unrecognized part (len %u, type %u)\n", length, type);
+        return STATE_LOAD_STATUS_CONTINUE;
+    }
 
-            free(dht->loaded_nodes_list);
-            // Copy to loaded_clients_list
-            dht->loaded_nodes_list = (Node_format *)calloc(MAX_SAVED_DHT_NODES, sizeof(Node_format));
+    if (length != 0) {
+        free(dht->loaded_nodes_list);
+        // Copy to loaded_clients_list
+        dht->loaded_nodes_list = (Node_format *) calloc(MAX_SAVED_DHT_NODES, sizeof(Node_format));
 
-            const int num = unpack_nodes(dht->loaded_nodes_list, MAX_SAVED_DHT_NODES, nullptr, data, length, 0);
+        const int num = unpack_nodes(dht->loaded_nodes_list, MAX_SAVED_DHT_NODES, nullptr, data, length, 0);
 
-            if (num > 0) {
-                dht->loaded_num_nodes = num;
-            } else {
-                dht->loaded_num_nodes = 0;
-            }
-
-            break;
+        if (num > 0) {
+            dht->loaded_num_nodes = num;
+        } else {
+            dht->loaded_num_nodes = 0;
         }
-
-        default:
-            LOGGER_ERROR(dht->log, "Load state (DHT): contains unrecognized part (len %u, type %u)\n",
-                         length, type);
-            break;
     }
 
     return STATE_LOAD_STATUS_CONTINUE;

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1210,30 +1210,19 @@ static int send_file_control_packet(const Messenger *m, int32_t friendnumber, ui
     return write_cryptpacket_id(m, friendnumber, PACKET_ID_FILE_CONTROL, packet, SIZEOF_VLA(packet), 0);
 }
 
-/* Send a file control request.
- *
- *  return 0 on success
- *  return -1 if friend not valid.
- *  return -2 if friend not online.
- *  return -3 if file number invalid.
- *  return -4 if file control is bad.
- *  return -5 if file already paused.
- *  return -6 if resume file failed because it was only paused by the other.
- *  return -7 if resume file failed because it wasn't paused.
- *  return -8 if packet failed to send.
- */
-int file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, unsigned int control)
+// Send a file control request.
+Filecontrol_Error file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, unsigned int control)
 {
     if (friend_not_valid(m, friendnumber)) {
-        return -1;
+        return FILECONTROL_ERROR_FRIEND_NOT_VALID;
     }
 
     if (m->friendlist[friendnumber].status != FRIEND_ONLINE) {
-        return -2;
+        return FILECONTROL_ERROR_FRIEND_NOT_ONLINE;
     }
 
     uint32_t temp_filenum;
-    uint8_t send_receive, file_number;
+    uint8_t send_receive;
 
     if (filenumber >= (1 << 16)) {
         send_receive = 1;
@@ -1244,10 +1233,10 @@ int file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, 
     }
 
     if (temp_filenum >= MAX_CONCURRENT_FILE_PIPES) {
-        return -3;
+        return FILECONTROL_ERROR_FILE_NUMBER_INVALID;
     }
 
-    file_number = temp_filenum;
+    uint8_t file_number = temp_filenum;
 
     struct File_Transfers *ft;
 
@@ -1258,33 +1247,33 @@ int file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, 
     }
 
     if (ft->status == FILESTATUS_NONE) {
-        return -3;
+        return FILECONTROL_ERROR_FILE_NUMBER_INVALID;
     }
 
     if (control > FILECONTROL_KILL) {
-        return -4;
+        return FILECONTROL_ERROR_FILE_CONTROL_BAD;
     }
 
     if (control == FILECONTROL_PAUSE && ((ft->paused & FILE_PAUSE_US) || ft->status != FILESTATUS_TRANSFERRING)) {
-        return -5;
+        return FILECONTROL_ERROR_FILE_ALREADY_PAUSED;
     }
 
     if (control == FILECONTROL_ACCEPT) {
         if (ft->status == FILESTATUS_TRANSFERRING) {
             if (!(ft->paused & FILE_PAUSE_US)) {
                 if (ft->paused & FILE_PAUSE_OTHER) {
-                    return -6;
+                    return FILECONTROL_ERROR_RESUME_FAILED_PAUSED_BY_OTHER;
                 }
 
-                return -7;
+                return FILECONTROL_ERROR_RESUME_FAILED_NOT_PAUSED;
             }
         } else {
             if (ft->status != FILESTATUS_NOT_ACCEPTED) {
-                return -7;
+                return FILECONTROL_ERROR_RESUME_FAILED_NOT_PAUSED;
             }
 
             if (!send_receive) {
-                return -6;
+                return FILECONTROL_ERROR_RESUME_FAILED_PAUSED_BY_OTHER;
             }
         }
     }
@@ -1306,10 +1295,10 @@ int file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, 
             }
         }
     } else {
-        return -8;
+        return FILECONTROL_ERROR_PACKET_FAILED_TO_SEND;
     }
 
-    return 0;
+    return FILECONTROL_ERROR_NONE;
 }
 
 /* Send a seek file control request.

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -177,6 +177,17 @@ typedef enum Filekind {
     FILEKIND_AVATAR
 } Filekind;
 
+typedef enum Filecontrol_Error {
+    FILECONTROL_ERROR_NONE,
+    FILECONTROL_ERROR_FRIEND_NOT_VALID,
+    FILECONTROL_ERROR_FRIEND_NOT_ONLINE,
+    FILECONTROL_ERROR_FILE_NUMBER_INVALID,
+    FILECONTROL_ERROR_FILE_CONTROL_BAD,
+    FILECONTROL_ERROR_FILE_ALREADY_PAUSED,
+    FILECONTROL_ERROR_RESUME_FAILED_PAUSED_BY_OTHER,
+    FILECONTROL_ERROR_RESUME_FAILED_NOT_PAUSED,
+    FILECONTROL_ERROR_PACKET_FAILED_TO_SEND,
+} Filecontrol_Error;
 
 typedef void m_self_connection_status_cb(Messenger *m, unsigned int connection_status, void *user_data);
 typedef void m_friend_status_cb(Messenger *m, uint32_t friend_number, unsigned int status, void *user_data);
@@ -650,7 +661,7 @@ long int new_filesender(const Messenger *m, int32_t friendnumber, uint32_t file_
  *  return -7 if resume file failed because it wasn't paused.
  *  return -8 if packet failed to send.
  */
-int file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, unsigned int control);
+Filecontrol_Error file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, unsigned int control);
 
 /* Send a seek file control request.
  *

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -710,9 +710,9 @@ static int rm_tcp_connection_from_conn(TCP_Connection_to *con_to, unsigned int t
  */
 static unsigned int online_tcp_connection_from_conn(TCP_Connection_to *con_to)
 {
-    unsigned int i, count = 0;
+    unsigned int count = 0;
 
-    for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+    for (unsigned int i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
         if (con_to->connections[i].tcp_connection) {
             if (con_to->connections[i].status == TCP_CONNECTIONS_STATUS_ONLINE) {
                 ++count;
@@ -1104,9 +1104,9 @@ static int tcp_relay_on_online(TCP_Connections *tcp_c, int tcp_connections_numbe
         return -1;
     }
 
-    unsigned int i, sent = 0;
+    unsigned int sent = 0;
 
-    for (i = 0; i < tcp_c->connections_length; ++i) {
+    for (unsigned int i = 0; i < tcp_c->connections_length; ++i) {
         TCP_Connection_to *con_to = get_connection(tcp_c, i);
 
         if (con_to) {

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -286,7 +286,7 @@ IP6 get_ip6_loopback(void)
 }
 
 #ifndef OS_WIN32
-#define INVALID_SOCKET -1
+#define INVALID_SOCKET (-1)
 #endif
 
 const Socket net_invalid_socket = { (int)INVALID_SOCKET };

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1262,50 +1262,46 @@ bool tox_hash(uint8_t *hash, const uint8_t *data, size_t length)
 bool tox_file_control(Tox *tox, uint32_t friend_number, uint32_t file_number, Tox_File_Control control,
                       Tox_Err_File_Control *error)
 {
-    Messenger *m = tox->m;
-    const int ret = file_control(m, friend_number, file_number, control);
-
-    if (ret == 0) {
-        SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_OK);
-        return 1;
-    }
+    const Filecontrol_Error ret = file_control(tox->m, friend_number, file_number, control);
 
     switch (ret) {
-        case -1:
+        case FILECONTROL_ERROR_NONE:
+            SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_OK);
+            return true;
+
+        case FILECONTROL_ERROR_FRIEND_NOT_VALID:
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_FRIEND_NOT_FOUND);
-            return 0;
+            return false;
 
-        case -2:
+        case FILECONTROL_ERROR_FRIEND_NOT_ONLINE:
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_FRIEND_NOT_CONNECTED);
-            return 0;
+            return false;
 
-        case -3:
+        case FILECONTROL_ERROR_FILE_NUMBER_INVALID:
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_NOT_FOUND);
-            return 0;
+            return false;
 
-        case -4:
-            /* can't happen */
-            return 0;
+        case FILECONTROL_ERROR_FILE_CONTROL_BAD:
+            return false; // Can't happen.
 
-        case -5:
+        case FILECONTROL_ERROR_FILE_ALREADY_PAUSED:
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_ALREADY_PAUSED);
-            return 0;
+            return false;
 
-        case -6:
+        case FILECONTROL_ERROR_RESUME_FAILED_PAUSED_BY_OTHER:
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_DENIED);
-            return 0;
+            return false;
 
-        case -7:
+        case FILECONTROL_ERROR_RESUME_FAILED_NOT_PAUSED:
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_NOT_PAUSED);
-            return 0;
+            return false;
 
-        case -8:
+        case FILECONTROL_ERROR_PACKET_FAILED_TO_SEND:
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_SENDQ);
-            return 0;
+            return false;
     }
 
-    /* can't happen */
-    return 0;
+    return false; // Can't happen.
 }
 
 bool tox_file_seek(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position,


### PR DESCRIPTION
This only fixes a very small subset of the warnings, but fixing all of them at once would make reviews and conflicts a nuisance.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1350)
<!-- Reviewable:end -->
