### PR TITLE
Allow Bazel to rerun tests marked as flaky

### DIFF
--- a/auto_tests/BUILD.bazel
+++ b/auto_tests/BUILD.bazel
@@ -14,11 +14,21 @@ test_sizes = {
     "conference_peer_nick_test": "medium",
 }
 
+flaky_tests = {
+    "crypto_core_test": True,
+    "lan_discovery_test": True,
+    "tcp_relay_test": True,
+}
+
 [cc_test(
     name = src[:-2],
     size = test_sizes.get(
         src[:-2],
         "small",
+    ),
+    flaky = flaky_tests.get(
+        src[:-2],
+        False,
     ),
     srcs = [src],
     args = ["$(location %s)" % src],


### PR DESCRIPTION
Seems like this one works (from Cirrus CI):
```
//c-toxcore/auto_tests:lan_discovery_test FLAKY, failed in 1 out of 2 in 75.0s
  Stats over 2 runs: max = 75.0s, min = 13.1s, avg = 44.0s, dev = 31.0s
```

Resolves #1354 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1358)
<!-- Reviewable:end -->
