### PR TITLE
Standardise on having a comma at the end of enums.

### DIFF
--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -274,7 +274,7 @@ void toxav_iterate(ToxAV *av)
     av->dmsst += current_time_monotonic(av->m->mono_time) - start;
 
     if (++av->dmssc == 3) {
-        av->dmssa = av->dmsst / 3 + 5 /* NOTE Magic Offset for precision */;
+        av->dmssa = av->dmsst / 3 + 5; /* NOTE Magic Offset 5 for precision */
         av->dmssc = 0;
         av->dmsst = 0;
     }

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -33,7 +33,7 @@
 
 typedef enum Message_Type {
     MESSAGE_NORMAL,
-    MESSAGE_ACTION
+    MESSAGE_ACTION,
 } Message_Type;
 
 typedef struct Messenger Messenger;
@@ -98,7 +98,7 @@ typedef enum Friend_Add_Error {
     FAERR_ALREADYSENT = -4,
     FAERR_BADCHECKSUM = -6,
     FAERR_SETNEWNOSPAM = -7,
-    FAERR_NOMEM = -8
+    FAERR_NOMEM = -8,
 } Friend_Add_Error;
 
 
@@ -109,7 +109,7 @@ typedef enum Connection_Status {
     CONNECTION_NONE,
     CONNECTION_TCP,
     CONNECTION_UDP,
-    CONNECTION_UNKNOWN
+    CONNECTION_UNKNOWN,
 } Connection_Status;
 
 /* USERSTATUS -
@@ -120,7 +120,7 @@ typedef enum Userstatus {
     USERSTATUS_NONE,
     USERSTATUS_AWAY,
     USERSTATUS_BUSY,
-    USERSTATUS_INVALID
+    USERSTATUS_INVALID,
 } Userstatus;
 
 #define FILE_ID_LENGTH 32
@@ -140,26 +140,26 @@ typedef enum Filestatus {
     FILESTATUS_NOT_ACCEPTED,
     FILESTATUS_TRANSFERRING,
     // FILESTATUS_BROKEN,
-    FILESTATUS_FINISHED
+    FILESTATUS_FINISHED,
 } Filestatus;
 
 typedef enum File_Pause {
     FILE_PAUSE_NOT,
     FILE_PAUSE_US,
     FILE_PAUSE_OTHER,
-    FILE_PAUSE_BOTH
+    FILE_PAUSE_BOTH,
 } File_Pause;
 
 typedef enum Filecontrol {
     FILECONTROL_ACCEPT,
     FILECONTROL_PAUSE,
     FILECONTROL_KILL,
-    FILECONTROL_SEEK
+    FILECONTROL_SEEK,
 } Filecontrol;
 
 typedef enum Filekind {
     FILEKIND_DATA,
-    FILEKIND_AVATAR
+    FILEKIND_AVATAR,
 } Filekind;
 
 
@@ -722,7 +722,7 @@ typedef enum Messenger_Error {
     MESSENGER_ERROR_NONE,
     MESSENGER_ERROR_PORT,
     MESSENGER_ERROR_TCP_SERVER,
-    MESSENGER_ERROR_OTHER
+    MESSENGER_ERROR_OTHER,
 } Messenger_Error;
 
 /* Run this at startup.

--- a/toxcore/TCP_client.h
+++ b/toxcore/TCP_client.h
@@ -17,7 +17,7 @@
 typedef enum TCP_Proxy_Type {
     TCP_PROXY_NONE,
     TCP_PROXY_HTTP,
-    TCP_PROXY_SOCKS5
+    TCP_PROXY_SOCKS5,
 } TCP_Proxy_Type;
 
 typedef struct TCP_Proxy_Info {

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -43,7 +43,7 @@
 typedef enum Friendconn_Status {
     FRIENDCONN_STATUS_NONE,
     FRIENDCONN_STATUS_CONNECTING,
-    FRIENDCONN_STATUS_CONNECTED
+    FRIENDCONN_STATUS_CONNECTED,
 } Friendconn_Status;
 
 typedef struct Friend_Connections Friend_Connections;

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -265,7 +265,7 @@ static uint64_t calculate_comp_value(const uint8_t *pk1, const uint8_t *pk2)
 typedef enum Groupchat_Closest {
     GROUPCHAT_CLOSEST_NONE,
     GROUPCHAT_CLOSEST_ADDED,
-    GROUPCHAT_CLOSEST_REMOVED
+    GROUPCHAT_CLOSEST_REMOVED,
 } Groupchat_Closest;
 
 static int add_to_closest(Group_Chats *g_c, uint32_t groupnumber, const uint8_t *real_pk, const uint8_t *temp_pk)

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -14,12 +14,12 @@
 typedef enum Groupchat_Status {
     GROUPCHAT_STATUS_NONE,
     GROUPCHAT_STATUS_VALID,
-    GROUPCHAT_STATUS_CONNECTED
+    GROUPCHAT_STATUS_CONNECTED,
 } Groupchat_Status;
 
 typedef enum Groupchat_Type {
     GROUPCHAT_TYPE_TEXT,
-    GROUPCHAT_TYPE_AV
+    GROUPCHAT_TYPE_AV,
 } Groupchat_Type;
 
 #define MAX_LOSSY_COUNT 256
@@ -63,7 +63,7 @@ typedef struct Group_Peer {
 typedef enum Groupchat_Close_Type {
     GROUPCHAT_CLOSE_NONE,
     GROUPCHAT_CLOSE_CONNECTION,
-    GROUPCHAT_CLOSE_ONLINE
+    GROUPCHAT_CLOSE_ONLINE,
 } Groupchat_Close_Type;
 
 /* Connection is to one of the closest DESIRED_CLOSE_CONNECTIONS peers */

--- a/toxcore/logger.h
+++ b/toxcore/logger.h
@@ -23,7 +23,7 @@ typedef enum Logger_Level {
     LOGGER_LEVEL_DEBUG,
     LOGGER_LEVEL_INFO,
     LOGGER_LEVEL_WARNING,
-    LOGGER_LEVEL_ERROR
+    LOGGER_LEVEL_ERROR,
 } Logger_Level;
 
 typedef struct Logger Logger;

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -2070,7 +2070,8 @@ Tox_Conference_Type tox_conference_get_type(const Tox *tox, uint32_t conference_
     return (Tox_Conference_Type)ret;
 }
 
-bool tox_conference_get_id(const Tox *tox, uint32_t conference_number, uint8_t *id /* TOX_CONFERENCE_ID_SIZE bytes */)
+/* id is TOX_CONFERENCE_ID_SIZE bytes */
+bool tox_conference_get_id(const Tox *tox, uint32_t conference_number, uint8_t *id)
 {
     lock(tox);
     bool ret = conference_get_id(tox->m->conferences_object, conference_number, id);
@@ -2079,7 +2080,8 @@ bool tox_conference_get_id(const Tox *tox, uint32_t conference_number, uint8_t *
 }
 
 // TODO(iphydf): Delete in 0.3.0.
-bool tox_conference_get_uid(const Tox *tox, uint32_t conference_number, uint8_t *uid /* TOX_CONFERENCE_ID_SIZE bytes */)
+/* uid is TOX_CONFERENCE_ID_SIZE bytes */
+bool tox_conference_get_uid(const Tox *tox, uint32_t conference_number, uint8_t *uid)
 {
     return tox_conference_get_id(tox, conference_number, uid);
 }


### PR DESCRIPTION
Most of our enums already have one. Some didn't. Tokstyle is going to
require commas at the end of enumerator lists in enum definitions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1389)
<!-- Reviewable:end -->
