### PR TITLE
Avoid casting back and forth between void-ptr.

### DIFF
--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -131,7 +131,9 @@ ToxAV *toxav_new(Tox *tox, Toxav_Err_New *error)
 
     // TODO(iphydf): Don't rely on toxcore internals.
     Messenger *m;
+    //!TOKSTYLE-
     m = *(Messenger **)tox;
+    //!TOKSTYLE+
 
     if (m->msi_packet) {
         rc = TOXAV_ERR_NEW_MULTIPLE;

--- a/toxav/toxav_old.c
+++ b/toxav/toxav_old.c
@@ -24,7 +24,9 @@
 int toxav_add_av_groupchat(Tox *tox, audio_data_cb *audio_callback, void *userdata)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    //!TOKSTYLE-
     Messenger *m = *(Messenger **)tox;
+    //!TOKSTYLE+
     return add_av_groupchat(m->log, tox, m->conferences_object, audio_callback, userdata);
 }
 
@@ -42,7 +44,9 @@ int toxav_join_av_groupchat(Tox *tox, uint32_t friendnumber, const uint8_t *data
                             audio_data_cb *audio_callback, void *userdata)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    //!TOKSTYLE-
     Messenger *m = *(Messenger **)tox;
+    //!TOKSTYLE+
     return join_av_groupchat(m->log, tox, m->conferences_object, friendnumber, data, length, audio_callback, userdata);
 }
 
@@ -63,7 +67,9 @@ int toxav_group_send_audio(Tox *tox, uint32_t groupnumber, const int16_t *pcm, u
                            uint32_t sample_rate)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    //!TOKSTYLE-
     Messenger *m = *(Messenger **)tox;
+    //!TOKSTYLE+
     return group_send_audio(m->conferences_object, groupnumber, pcm, samples, channels, sample_rate);
 }
 
@@ -88,7 +94,9 @@ int toxav_group_send_audio(Tox *tox, uint32_t groupnumber, const int16_t *pcm, u
 int toxav_groupchat_enable_av(Tox *tox, uint32_t groupnumber, audio_data_cb *audio_callback, void *userdata)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    //!TOKSTYLE-
     Messenger *m = *(Messenger **)tox;
+    //!TOKSTYLE+
     return groupchat_enable_av(m->log, tox, m->conferences_object, groupnumber, audio_callback, userdata);
 }
 
@@ -100,7 +108,9 @@ int toxav_groupchat_enable_av(Tox *tox, uint32_t groupnumber, audio_data_cb *aud
 int toxav_groupchat_disable_av(Tox *tox, uint32_t groupnumber)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    //!TOKSTYLE-
     Messenger *m = *(Messenger **)tox;
+    //!TOKSTYLE+
     return groupchat_disable_av(m->conferences_object, groupnumber);
 }
 
@@ -109,6 +119,8 @@ int toxav_groupchat_disable_av(Tox *tox, uint32_t groupnumber)
 bool toxav_groupchat_av_enabled(Tox *tox, uint32_t groupnumber)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    //!TOKSTYLE-
     Messenger *m = *(Messenger **)tox;
+    //!TOKSTYLE+
     return groupchat_av_enabled(m->conferences_object, groupnumber);
 }


### PR DESCRIPTION
In windows network code, we implement inet_pton and inet_ntop, which take
void pointers. We can do slightly better because we already know the type
when we call these functions, so we can avoid casting between void
pointer and the addr struct types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1390)
<!-- Reviewable:end -->
