### PR TITLE
Mark file-local function definitions as `static`.

### DIFF
--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -57,8 +57,8 @@ struct BWCMessage {
     uint32_t recv;
 };
 
-int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length, void *object);
-void send_update(BWController *bwc);
+static int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length, void *object);
+static void send_update(BWController *bwc);
 
 BWController *bwc_new(Messenger *m, uint32_t friendnumber, m_cb *mcb, void *mcb_user_data)
 {

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -61,20 +61,21 @@ typedef struct MSIMessage {
 } MSIMessage;
 
 
-void msg_init(MSIMessage *dest, MSIRequest request);
-int msg_parse_in(const Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t length);
-uint8_t *msg_parse_header_out(MSIHeaderID id, uint8_t *dest, const void *value, uint8_t value_len, uint16_t *length);
+static void msg_init(MSIMessage *dest, MSIRequest request);
+static int msg_parse_in(const Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t length);
+static uint8_t *msg_parse_header_out(MSIHeaderID id, uint8_t *dest, const void *value, uint8_t value_len,
+                                     uint16_t *length);
 static int send_message(Messenger *m, uint32_t friend_number, const MSIMessage *msg);
-int send_error(Messenger *m, uint32_t friend_number, MSIError error);
+static int send_error(Messenger *m, uint32_t friend_number, MSIError error);
 static int invoke_callback(MSICall *call, MSICallbackID cb);
 static MSICall *get_call(MSISession *session, uint32_t friend_number);
-MSICall *new_call(MSISession *session, uint32_t friend_number);
-void kill_call(MSICall *call);
-void on_peer_status(Messenger *m, uint32_t friend_number, uint8_t status, void *data);
-void handle_init(MSICall *call, const MSIMessage *msg);
-void handle_push(MSICall *call, const MSIMessage *msg);
-void handle_pop(MSICall *call, const MSIMessage *msg);
-void handle_msi_packet(Messenger *m, uint32_t friend_number, const uint8_t *data, uint16_t length, void *object);
+static MSICall *new_call(MSISession *session, uint32_t friend_number);
+static void kill_call(MSICall *call);
+static void on_peer_status(Messenger *m, uint32_t friend_number, uint8_t status, void *data);
+static void handle_init(MSICall *call, const MSIMessage *msg);
+static void handle_push(MSICall *call, const MSIMessage *msg);
+static void handle_pop(MSICall *call, const MSIMessage *msg);
+static void handle_msi_packet(Messenger *m, uint32_t friend_number, const uint8_t *data, uint16_t length, void *object);
 
 
 /**

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -102,22 +102,22 @@ struct ToxAV {
     uint32_t interval; /** Calculated interval */
 };
 
-void callback_bwc(BWController *bwc, uint32_t friend_number, float loss, void *user_data);
+static void callback_bwc(BWController *bwc, uint32_t friend_number, float loss, void *user_data);
 
-int callback_invite(void *toxav_inst, MSICall *call);
-int callback_start(void *toxav_inst, MSICall *call);
-int callback_end(void *toxav_inst, MSICall *call);
-int callback_error(void *toxav_inst, MSICall *call);
-int callback_capabilites(void *toxav_inst, MSICall *call);
+static int callback_invite(void *toxav_inst, MSICall *call);
+static int callback_start(void *toxav_inst, MSICall *call);
+static int callback_end(void *toxav_inst, MSICall *call);
+static int callback_error(void *toxav_inst, MSICall *call);
+static int callback_capabilites(void *toxav_inst, MSICall *call);
 
-bool audio_bit_rate_invalid(uint32_t bit_rate);
-bool video_bit_rate_invalid(uint32_t bit_rate);
-bool invoke_call_state_callback(ToxAV *av, uint32_t friend_number, uint32_t state);
-ToxAVCall *call_new(ToxAV *av, uint32_t friend_number, Toxav_Err_Call *error);
-ToxAVCall *call_get(ToxAV *av, uint32_t friend_number);
-ToxAVCall *call_remove(ToxAVCall *call);
-bool call_prepare_transmission(ToxAVCall *call);
-void call_kill_transmission(ToxAVCall *call);
+static bool audio_bit_rate_invalid(uint32_t bit_rate);
+static bool video_bit_rate_invalid(uint32_t bit_rate);
+static bool invoke_call_state_callback(ToxAV *av, uint32_t friend_number, uint32_t state);
+static ToxAVCall *call_new(ToxAV *av, uint32_t friend_number, Toxav_Err_Call *error);
+static ToxAVCall *call_get(ToxAV *av, uint32_t friend_number);
+static ToxAVCall *call_remove(ToxAVCall *call);
+static bool call_prepare_transmission(ToxAVCall *call);
+static void call_kill_transmission(ToxAVCall *call);
 
 ToxAV *toxav_new(Tox *tox, Toxav_Err_New *error)
 {


### PR DESCRIPTION
https://github.com/TokTok/hs-tokstyle/pull/43 implements a validation for
this. We should avoid locally declaring functions from another
translation unit, and instead use header files to export/import them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1395)
<!-- Reviewable:end -->
