### PR TITLE
Make function defns match their decls regarding storage class.

### DIFF
--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -355,7 +355,8 @@ static struct RTPMessage *jbuf_read(struct JitterBuffer *q, int32_t *success)
     *success = 0;
     return nullptr;
 }
-OpusEncoder *create_audio_encoder(const Logger *log, int32_t bit_rate, int32_t sampling_rate, int32_t channel_count)
+static OpusEncoder *create_audio_encoder(const Logger *log, int32_t bit_rate, int32_t sampling_rate,
+        int32_t channel_count)
 {
     int status = OPUS_OK;
     /*
@@ -448,8 +449,8 @@ FAILURE:
     return nullptr;
 }
 
-bool reconfigure_audio_encoder(const Logger *log, OpusEncoder **e, int32_t new_br, int32_t new_sr, uint8_t new_ch,
-                               int32_t *old_br, int32_t *old_sr, int32_t *old_ch)
+static bool reconfigure_audio_encoder(const Logger *log, OpusEncoder **e, int32_t new_br, int32_t new_sr,
+                                      uint8_t new_ch, int32_t *old_br, int32_t *old_sr, int32_t *old_ch)
 {
     /* Values are checked in toxav.c */
     if (*old_sr != new_sr || *old_ch != new_ch) {
@@ -480,7 +481,7 @@ bool reconfigure_audio_encoder(const Logger *log, OpusEncoder **e, int32_t new_b
     return true;
 }
 
-bool reconfigure_audio_decoder(ACSession *ac, int32_t sampling_rate, int8_t channels)
+static bool reconfigure_audio_decoder(ACSession *ac, int32_t sampling_rate, int8_t channels)
 {
     if (sampling_rate != ac->ld_sample_rate || channels != ac->ld_channel_count) {
         if (current_time_monotonic(ac->mono_time) - ac->ldrts < 500) {

--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -120,7 +120,7 @@ void bwc_add_recv(BWController *bwc, uint32_t recv_bytes)
     send_update(bwc);
 }
 
-void send_update(BWController *bwc)
+static void send_update(BWController *bwc)
 {
     if (bwc->packet_loss_counted_cycles > BWC_AVG_LOSS_OVER_CYCLES_COUNT &&
             current_time_monotonic(bwc->m->mono_time) - bwc->cycle.last_sent_timestamp > BWC_SEND_INTERVAL_MS) {
@@ -180,7 +180,7 @@ static int on_update(BWController *bwc, const struct BWCMessage *msg)
     return 0;
 }
 
-int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length, void *object)
+static int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length, void *object)
 {
     if (length - 1 != sizeof(struct BWCMessage)) {
         return -1;

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -309,13 +309,13 @@ int msi_change_capabilities(MSICall *call, uint8_t capabilities)
 /**
  * Private functions
  */
-void msg_init(MSIMessage *dest, MSIRequest request)
+static void msg_init(MSIMessage *dest, MSIRequest request)
 {
     memset(dest, 0, sizeof(*dest));
     dest->request.exists = true;
     dest->request.value = request;
 }
-int msg_parse_in(const Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t length)
+static int msg_parse_in(const Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t length)
 {
     /* Parse raw data received from socket into MSIMessage struct */
 
@@ -394,7 +394,8 @@ int msg_parse_in(const Logger *log, MSIMessage *dest, const uint8_t *data, uint1
 
     return 0;
 }
-uint8_t *msg_parse_header_out(MSIHeaderID id, uint8_t *dest, const void *value, uint8_t value_len, uint16_t *length)
+static uint8_t *msg_parse_header_out(MSIHeaderID id, uint8_t *dest, const void *value, uint8_t value_len,
+                                     uint16_t *length)
 {
     /* Parse a single header for sending */
     assert(dest);
@@ -412,7 +413,7 @@ uint8_t *msg_parse_header_out(MSIHeaderID id, uint8_t *dest, const void *value, 
 
     return dest + value_len; /* Set to next position ready to be written */
 }
-int send_message(Messenger *m, uint32_t friend_number, const MSIMessage *msg)
+static int send_message(Messenger *m, uint32_t friend_number, const MSIMessage *msg)
 {
     /* Parse and send message */
     assert(m);
@@ -457,7 +458,7 @@ int send_message(Messenger *m, uint32_t friend_number, const MSIMessage *msg)
 
     return -1;
 }
-int send_error(Messenger *m, uint32_t friend_number, MSIError error)
+static int send_error(Messenger *m, uint32_t friend_number, MSIError error)
 {
     /* Send error message */
     assert(m);
@@ -473,7 +474,7 @@ int send_error(Messenger *m, uint32_t friend_number, MSIError error)
     send_message(m, friend_number, &msg);
     return 0;
 }
-int invoke_callback(MSICall *call, MSICallbackID cb)
+static int invoke_callback(MSICall *call, MSICallbackID cb)
 {
     assert(call);
 
@@ -510,7 +511,7 @@ static MSICall *get_call(MSISession *session, uint32_t friend_number)
 
     return session->calls[friend_number];
 }
-MSICall *new_call(MSISession *session, uint32_t friend_number)
+static MSICall *new_call(MSISession *session, uint32_t friend_number)
 {
     assert(session);
 
@@ -563,7 +564,7 @@ MSICall *new_call(MSISession *session, uint32_t friend_number)
     session->calls[friend_number] = rc;
     return rc;
 }
-void kill_call(MSICall *call)
+static void kill_call(MSICall *call)
 {
     /* Assume that session mutex is locked */
     if (call == nullptr) {
@@ -604,7 +605,7 @@ CLEAR_CONTAINER:
     free(call);
     session->calls = nullptr;
 }
-void on_peer_status(Messenger *m, uint32_t friend_number, uint8_t status, void *data)
+static void on_peer_status(Messenger *m, uint32_t friend_number, uint8_t status, void *data)
 {
     MSISession *session = (MSISession *)data;
 
@@ -630,7 +631,7 @@ void on_peer_status(Messenger *m, uint32_t friend_number, uint8_t status, void *
             break;
     }
 }
-void handle_init(MSICall *call, const MSIMessage *msg)
+static void handle_init(MSICall *call, const MSIMessage *msg)
 {
     assert(call);
     LOGGER_DEBUG(call->session->messenger->log,
@@ -691,7 +692,7 @@ FAILURE:
     send_error(call->session->messenger, call->friend_number, call->error);
     kill_call(call);
 }
-void handle_push(MSICall *call, const MSIMessage *msg)
+static void handle_push(MSICall *call, const MSIMessage *msg)
 {
     assert(call);
 
@@ -746,7 +747,7 @@ FAILURE:
     send_error(call->session->messenger, call->friend_number, call->error);
     kill_call(call);
 }
-void handle_pop(MSICall *call, const MSIMessage *msg)
+static void handle_pop(MSICall *call, const MSIMessage *msg)
 {
     assert(call);
 
@@ -791,7 +792,7 @@ void handle_pop(MSICall *call, const MSIMessage *msg)
 
     kill_call(call);
 }
-void handle_msi_packet(Messenger *m, uint32_t friend_number, const uint8_t *data, uint16_t length, void *object)
+static void handle_msi_packet(Messenger *m, uint32_t friend_number, const uint8_t *data, uint16_t length, void *object)
 {
     LOGGER_DEBUG(m->log, "Got msi message");
 

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -956,7 +956,7 @@ void toxav_callback_video_receive_frame(ToxAV *av, toxav_video_receive_frame_cb 
  * :: Internal
  *
  ******************************************************************************/
-void callback_bwc(BWController *bwc, uint32_t friend_number, float loss, void *user_data)
+static void callback_bwc(BWController *bwc, uint32_t friend_number, float loss, void *user_data)
 {
     /* Callback which is called when the internal measure mechanism reported packet loss.
      * We report suggested lowered bitrate to an app. If app is sending both audio and video,
@@ -1001,7 +1001,7 @@ void callback_bwc(BWController *bwc, uint32_t friend_number, float loss, void *u
 
     pthread_mutex_unlock(call->av->mutex);
 }
-int callback_invite(void *toxav_inst, MSICall *call)
+static int callback_invite(void *toxav_inst, MSICall *call)
 {
     ToxAV *toxav = (ToxAV *)toxav_inst;
     pthread_mutex_lock(toxav->mutex);
@@ -1029,7 +1029,7 @@ int callback_invite(void *toxav_inst, MSICall *call)
     pthread_mutex_unlock(toxav->mutex);
     return 0;
 }
-int callback_start(void *toxav_inst, MSICall *call)
+static int callback_start(void *toxav_inst, MSICall *call)
 {
     ToxAV *toxav = (ToxAV *)toxav_inst;
     pthread_mutex_lock(toxav->mutex);
@@ -1057,7 +1057,7 @@ int callback_start(void *toxav_inst, MSICall *call)
     pthread_mutex_unlock(toxav->mutex);
     return 0;
 }
-int callback_end(void *toxav_inst, MSICall *call)
+static int callback_end(void *toxav_inst, MSICall *call)
 {
     ToxAV *toxav = (ToxAV *)toxav_inst;
     pthread_mutex_lock(toxav->mutex);
@@ -1072,7 +1072,7 @@ int callback_end(void *toxav_inst, MSICall *call)
     pthread_mutex_unlock(toxav->mutex);
     return 0;
 }
-int callback_error(void *toxav_inst, MSICall *call)
+static int callback_error(void *toxav_inst, MSICall *call)
 {
     ToxAV *toxav = (ToxAV *)toxav_inst;
     pthread_mutex_lock(toxav->mutex);
@@ -1087,7 +1087,7 @@ int callback_error(void *toxav_inst, MSICall *call)
     pthread_mutex_unlock(toxav->mutex);
     return 0;
 }
-int callback_capabilites(void *toxav_inst, MSICall *call)
+static int callback_capabilites(void *toxav_inst, MSICall *call)
 {
     ToxAV *toxav = (ToxAV *)toxav_inst;
     pthread_mutex_lock(toxav->mutex);
@@ -1109,14 +1109,14 @@ int callback_capabilites(void *toxav_inst, MSICall *call)
     pthread_mutex_unlock(toxav->mutex);
     return 0;
 }
-bool audio_bit_rate_invalid(uint32_t bit_rate)
+static bool audio_bit_rate_invalid(uint32_t bit_rate)
 {
     /* Opus RFC 6716 section-2.1.1 dictates the following:
      * Opus supports all bit rates from 6 kbit/s to 510 kbit/s.
      */
     return bit_rate < 6 || bit_rate > 510;
 }
-bool video_bit_rate_invalid(uint32_t bit_rate)
+static bool video_bit_rate_invalid(uint32_t bit_rate)
 {
     /* https://www.webmproject.org/docs/webm-sdk/structvpx__codec__enc__cfg.html shows the following:
      * unsigned int rc_target_bitrate
@@ -1127,7 +1127,7 @@ bool video_bit_rate_invalid(uint32_t bit_rate)
      */
     return bit_rate > UINT_MAX;
 }
-bool invoke_call_state_callback(ToxAV *av, uint32_t friend_number, uint32_t state)
+static bool invoke_call_state_callback(ToxAV *av, uint32_t friend_number, uint32_t state)
 {
     if (av->scb) {
         av->scb(av, friend_number, state, av->scb_user_data);
@@ -1138,7 +1138,7 @@ bool invoke_call_state_callback(ToxAV *av, uint32_t friend_number, uint32_t stat
     return true;
 }
 
-ToxAVCall *call_new(ToxAV *av, uint32_t friend_number, Toxav_Err_Call *error)
+static ToxAVCall *call_new(ToxAV *av, uint32_t friend_number, Toxav_Err_Call *error)
 {
     /* Assumes mutex locked */
     Toxav_Err_Call rc = TOXAV_ERR_CALL_OK;
@@ -1228,7 +1228,7 @@ RETURN:
     return call;
 }
 
-ToxAVCall *call_get(ToxAV *av, uint32_t friend_number)
+static ToxAVCall *call_get(ToxAV *av, uint32_t friend_number)
 {
     /* Assumes mutex locked */
     if (av->calls == nullptr || av->calls_tail < friend_number) {
@@ -1238,7 +1238,7 @@ ToxAVCall *call_get(ToxAV *av, uint32_t friend_number)
     return av->calls[friend_number];
 }
 
-ToxAVCall *call_remove(ToxAVCall *call)
+static ToxAVCall *call_remove(ToxAVCall *call)
 {
     if (call == nullptr) {
         return nullptr;
@@ -1288,7 +1288,7 @@ CLEAR:
     return nullptr;
 }
 
-bool call_prepare_transmission(ToxAVCall *call)
+static bool call_prepare_transmission(ToxAVCall *call)
 {
     /* Assumes mutex locked */
 
@@ -1371,7 +1371,7 @@ FAILURE_2:
     return false;
 }
 
-void call_kill_transmission(ToxAVCall *call)
+static void call_kill_transmission(ToxAVCall *call)
 {
     if (call == nullptr || call->active == 0) {
         return;


### PR DESCRIPTION
We want functions declared as `static` to also be defined as `static`.

See https://github.com/TokTok/hs-tokstyle/pull/44 for the corresponding tokstyle check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1396)
<!-- Reviewable:end -->
