### PR TITLE
Check that LOGGER macros are only called with string literals.

### DIFF
--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -871,8 +871,13 @@ Networking_Core *new_networking_ex(const Logger *log, IP ip, uint16_t port_from,
 
         int neterror = net_error();
         const char *strerror = net_new_strerror(neterror);
-        LOGGER_DEBUG(log, res < 0 ? "Failed to activate local multicast membership. (%d, %s)" :
-                     "Local multicast group FF02::1 joined successfully. (%d, %s)", neterror, strerror);
+
+        if (res < 0) {
+            LOGGER_DEBUG(log, "Failed to activate local multicast membership. (%d, %s)", neterror, strerror);
+        } else {
+            LOGGER_DEBUG(log, "Local multicast group FF02::1 joined successfully. (%d, %s)", neterror, strerror);
+        }
+
         net_kill_strerror(strerror);
     }
 


### PR DESCRIPTION
Avoid any dynamic format strings, even ones like `cond ? "str1" : "str2"`.

See https://github.com/TokTok/hs-tokstyle/pull/45 for the corresponding validator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1397)
<!-- Reviewable:end -->
