### PR TITLE
Disable bazel remote cache on CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,11 +8,12 @@ cirrus-ci_task:
     - echo "build --jobs=50 --curses=no --verbose_failures" | tee ~/.bazelrc
     - echo "build --config=linux" | tee -a ~/.bazelrc
     - echo "build --config=clang" | tee -a ~/.bazelrc
-    - echo "build --config=remote" | tee -a ~/.bazelrc
+#    - echo "build --config=remote" | tee -a ~/.bazelrc
     - cd .. && mv cirrus-ci-build c-toxcore
     - git clone --branch=upgrade-bazel --depth=1 https://github.com/iphydf/toktok-stack cirrus-ci-build
     - mv c-toxcore cirrus-ci-build
     - cd -
     - bazel version
   test_all_script:
-    - bazel test --copt=-DUSE_IPV6=0 -c opt -k //c-toxcore/...
+    - RUN_TEST="bazel test --copt=-DUSE_IPV6=0 -c opt -k //c-toxcore/..."
+    - $RUN_TEST || $RUN_TEST


### PR DESCRIPTION
code.tox.chat is down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1400)
<!-- Reviewable:end -->
