### PR TITLE
Make afl_toxsave.c a bit more portable; fix memory leak.

### DIFF
--- a/testing/afl_toxsave.c
+++ b/testing/afl_toxsave.c
@@ -1,5 +1,5 @@
-#include <malloc.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "../toxcore/tox.h"
 
@@ -41,6 +41,7 @@ int main(int argc, char **argv)
 
     Tox_Err_New error_new;
     Tox *tox = tox_new(tox_options, &error_new);
+    tox_options_free(tox_options);
 
     if (!tox || error_new != TOX_ERR_NEW_OK) {
         free(buffer);


### PR DESCRIPTION
malloc.h doesn't exist on most platforms, and certainly not in stdc. No
functions from malloc.h are actually used here, and stdlib.h is enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1413)
<!-- Reviewable:end -->
