### PR TITLE
Add new semi-private API functions to set per-packet-id custom handlers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ apidsl(toxcore/tox.api.h)
 set(toxcore_SOURCES ${toxcore_SOURCES}
   toxcore/tox_api.c
   toxcore/tox.c
+  toxcore/tox_private.h
   toxcore/tox.h)
 set(toxcore_API_HEADERS ${toxcore_API_HEADERS} ${toxcore_SOURCE_DIR}/toxcore/tox.h^tox)
 

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -272,6 +272,7 @@ cc_library(
     srcs = [
         "tox.c",
         "tox.h",
+        "tox_private.h",
         "tox_api.c",
     ],
     visibility = ["//c-toxcore:__subpackages__"],

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -32,6 +32,7 @@ libtoxcore_la_SOURCES = ../toxcore/ccompat.h \
                         ../toxcore/state.h \
                         ../toxcore/state.c \
                         ../toxcore/tox.h \
+                        ../toxcore/tox_private.h \
                         ../toxcore/tox.c \
                         ../toxcore/tox_api.c \
                         ../toxcore/util.h \

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1889,7 +1889,8 @@ int send_custom_lossless_packet(const Messenger *m, int32_t friendnumber, const 
         return -2;
     }
 
-    if (data[0] < PACKET_ID_RANGE_LOSSLESS_CUSTOM_START || data[0] > PACKET_ID_RANGE_LOSSLESS_CUSTOM_END) {
+    if ((data[0] < PACKET_ID_RANGE_LOSSLESS_CUSTOM_START || data[0] > PACKET_ID_RANGE_LOSSLESS_CUSTOM_END)
+            && data[0] != PACKET_ID_MSI) {
         return -3;
     }
 

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -2670,7 +2670,7 @@ namespace friend {
     FRIEND_NOT_CONNECTED,
     /**
      * The first byte of data was not in the specified range for the packet type.
-     * This range is 200-254 for lossy, and 160-191 for lossless packets.
+     * This range is 192-254 for lossy, and 69, 160-191 for lossless packets.
      */
     INVALID,
     /**
@@ -2692,7 +2692,7 @@ namespace friend {
     /**
      * Send a custom lossy packet to a friend.
      *
-     * The first byte of data must be in the range 200-254. Maximum length of a
+     * The first byte of data must be in the range 192-254. Maximum length of a
      * custom packet is $MAX_CUSTOM_PACKET_SIZE.
      *
      * Lossy packets behave like UDP packets, meaning they might never reach the
@@ -2716,7 +2716,7 @@ namespace friend {
     /**
      * Send a custom lossless packet to a friend.
      *
-     * The first byte of data must be in the range 160-191. Maximum length of a
+     * The first byte of data must be in the range 69, 160-191. Maximum length of a
      * custom packet is $MAX_CUSTOM_PACKET_SIZE.
      *
      * Lossless packet behaviour is comparable to TCP (reliability, arrive in order)

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -17,6 +17,7 @@
 #endif
 
 #include "tox.h"
+#include "tox_private.h"
 
 #include <assert.h>
 #include <stdlib.h>
@@ -89,8 +90,10 @@ struct Tox {
     tox_conference_title_cb *conference_title_callback;
     tox_conference_peer_name_cb *conference_peer_name_callback;
     tox_conference_peer_list_changed_cb *conference_peer_list_changed_callback;
-    tox_friend_lossy_packet_cb *friend_lossy_packet_callback;
-    tox_friend_lossless_packet_cb *friend_lossless_packet_callback;
+    tox_friend_lossy_packet_cb *friend_lossy_packet_callback_per_pktid[UINT8_MAX + 1];
+    tox_friend_lossless_packet_cb *friend_lossless_packet_callback_per_pktid[UINT8_MAX + 1];
+
+    void *toxav_object; // workaround to store a ToxAV object (setter and getter functions are available)
 };
 
 static void lock(const Tox *tox)
@@ -309,20 +312,28 @@ static void tox_conference_peer_list_changed_handler(Messenger *m, uint32_t conf
 static void tox_friend_lossy_packet_handler(Messenger *m, uint32_t friend_number, uint8_t packet_id,
         const uint8_t *data, size_t length, void *user_data)
 {
+    assert(data != nullptr);
+    assert(length > 0);
+
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
-    if (tox_data->tox->friend_lossy_packet_callback != nullptr) {
-        tox_data->tox->friend_lossy_packet_callback(tox_data->tox, friend_number, data, length, tox_data->user_data);
+    if (tox_data->tox->friend_lossy_packet_callback_per_pktid[packet_id] != nullptr) {
+        tox_data->tox->friend_lossy_packet_callback_per_pktid[packet_id](tox_data->tox, friend_number, data, length,
+                tox_data->user_data);
     }
 }
 
 static void tox_friend_lossless_packet_handler(Messenger *m, uint32_t friend_number, uint8_t packet_id,
         const uint8_t *data, size_t length, void *user_data)
 {
+    assert(data != nullptr);
+    assert(length > 0);
+
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
-    if (tox_data->tox->friend_lossless_packet_callback != nullptr) {
-        tox_data->tox->friend_lossless_packet_callback(tox_data->tox, friend_number, data, length, tox_data->user_data);
+    if (tox_data->tox->friend_lossless_packet_callback_per_pktid[packet_id] != nullptr) {
+        tox_data->tox->friend_lossless_packet_callback_per_pktid[packet_id](tox_data->tox, friend_number, data, length,
+                tox_data->user_data);
     }
 }
 
@@ -2171,9 +2182,7 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
         return 0;
     }
 
-    // TODO(oxij): this feels ugly, this is needed only because m_send_custom_lossy_packet in Messenger.c
-    // sends both AV and custom packets despite its name and this API hides those AV packets
-    if (data[0] <= PACKET_ID_RANGE_LOSSY_AV_END) {
+    if (data[0] < PACKET_ID_RANGE_LOSSY_START || data[0] > PACKET_ID_RANGE_LOSSY_END) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_INVALID);
         return 0;
     }
@@ -2193,7 +2202,17 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
 
 void tox_callback_friend_lossy_packet(Tox *tox, tox_friend_lossy_packet_cb *callback)
 {
-    tox->friend_lossy_packet_callback = callback;
+    /* start at PACKET_ID_RANGE_LOSSY_CUSTOM_START so ToxAV Packets are excluded */
+    for (uint8_t i = PACKET_ID_RANGE_LOSSY_CUSTOM_START; i <= PACKET_ID_RANGE_LOSSY_END; ++i) {
+        tox->friend_lossy_packet_callback_per_pktid[i] = callback;
+    }
+}
+
+void tox_callback_friend_lossy_packet_per_pktid(Tox *tox, tox_friend_lossy_packet_cb *callback, uint8_t pktid)
+{
+    if (pktid >= PACKET_ID_RANGE_LOSSY_START && pktid <= PACKET_ID_RANGE_LOSSY_END) {
+        tox->friend_lossy_packet_callback_per_pktid[pktid] = callback;
+    }
 }
 
 bool tox_friend_send_lossless_packet(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
@@ -2224,7 +2243,17 @@ bool tox_friend_send_lossless_packet(Tox *tox, uint32_t friend_number, const uin
 
 void tox_callback_friend_lossless_packet(Tox *tox, tox_friend_lossless_packet_cb *callback)
 {
-    tox->friend_lossless_packet_callback = callback;
+    for (uint8_t i = PACKET_ID_RANGE_LOSSLESS_CUSTOM_START; i <= PACKET_ID_RANGE_LOSSLESS_CUSTOM_END; ++i) {
+        tox->friend_lossless_packet_callback_per_pktid[i] = callback;
+    }
+}
+
+void tox_callback_friend_lossless_packet_per_pktid(Tox *tox, tox_friend_lossless_packet_cb *callback, uint8_t pktid)
+{
+    if ((pktid >= PACKET_ID_RANGE_LOSSLESS_CUSTOM_START && pktid <= PACKET_ID_RANGE_LOSSLESS_CUSTOM_END)
+            || pktid == PACKET_ID_MSI) {
+        tox->friend_lossless_packet_callback_per_pktid[pktid] = callback;
+    }
 }
 
 void tox_self_get_dht_id(const Tox *tox, uint8_t *dht_id)
@@ -2234,6 +2263,21 @@ void tox_self_get_dht_id(const Tox *tox, uint8_t *dht_id)
         memcpy(dht_id, dht_get_self_public_key(tox->m->dht), CRYPTO_PUBLIC_KEY_SIZE);
         unlock(tox);
     }
+}
+
+void tox_set_av_object(Tox *tox, void *object)
+{
+    lock(tox);
+    tox->toxav_object = object;
+    unlock(tox);
+}
+
+void *tox_get_av_object(const Tox *tox)
+{
+    lock(tox);
+    void *object = tox->toxav_object;
+    unlock(tox);
+    return object;
 }
 
 uint16_t tox_self_get_udp_port(const Tox *tox, Tox_Err_Get_Port *error)

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -3067,7 +3067,7 @@ typedef enum TOX_ERR_FRIEND_CUSTOM_PACKET {
 
     /**
      * The first byte of data was not in the specified range for the packet type.
-     * This range is 200-254 for lossy, and 160-191 for lossless packets.
+     * This range is 192-254 for lossy, and 69, 160-191 for lossless packets.
      */
     TOX_ERR_FRIEND_CUSTOM_PACKET_INVALID,
 
@@ -3092,7 +3092,7 @@ typedef enum TOX_ERR_FRIEND_CUSTOM_PACKET {
 /**
  * Send a custom lossy packet to a friend.
  *
- * The first byte of data must be in the range 200-254. Maximum length of a
+ * The first byte of data must be in the range 192-254. Maximum length of a
  * custom packet is TOX_MAX_CUSTOM_PACKET_SIZE.
  *
  * Lossy packets behave like UDP packets, meaning they might never reach the
@@ -3115,7 +3115,7 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
 /**
  * Send a custom lossless packet to a friend.
  *
- * The first byte of data must be in the range 160-191. Maximum length of a
+ * The first byte of data must be in the range 69, 160-191. Maximum length of a
  * custom packet is TOX_MAX_CUSTOM_PACKET_SIZE.
  *
  * Lossless packet behaviour is comparable to TCP (reliability, arrive in order)

--- a/toxcore/tox_private.h
+++ b/toxcore/tox_private.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2016-2020 The TokTok team.
+ * Copyright © 2013 Tox project.
+ */
+
+#ifndef C_TOXCORE_TOXCORE_TOX_PRIVATE_H
+#define C_TOXCORE_TOXCORE_TOX_PRIVATE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Set the callback for the `friend_lossy_packet` event for a specific packet ID.
+ * Pass NULL to unset.
+ *
+ * allowed packet ID range:
+ * from `PACKET_ID_RANGE_LOSSY_START` to `PACKET_ID_RANGE_LOSSY_END` (both inclusive)
+ */
+void tox_callback_friend_lossy_packet_per_pktid(Tox *tox, tox_friend_lossy_packet_cb *callback, uint8_t pktid);
+
+/**
+ * Set the callback for the `friend_lossless_packet` event for a specific packet ID.
+ * Pass NULL to unset.
+ *
+ * allowed packet ID range:
+ * from `PACKET_ID_RANGE_LOSSLESS_CUSTOM_START` to `PACKET_ID_RANGE_LOSSLESS_CUSTOM_END` (both inclusive)
+ * and
+ * `PACKET_ID_MSI`
+ */
+void tox_callback_friend_lossless_packet_per_pktid(Tox *tox, tox_friend_lossless_packet_cb *callback, uint8_t pktid);
+
+void tox_set_av_object(Tox *tox, void *object);
+void *tox_get_av_object(const Tox *tox);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // C_TOXCORE_TOXCORE_TOX_PRIVATE_H


### PR DESCRIPTION
This is to prepare for ToxAV becoming independent of toxcore internal calls.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1424)
<!-- Reviewable:end -->
