### PR TITLE
Stop using the "inline namespace" feature of apidsl.

### DIFF
--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -854,7 +854,7 @@ enum class CONNECTION {
 }
 
 
-inline namespace self {
+namespace self {
 
   CONNECTION connection_status {
     /**
@@ -908,7 +908,7 @@ void iterate(any user_data);
  ******************************************************************************/
 
 
-inline namespace self {
+namespace self {
 
   uint8_t[ADDRESS_SIZE] address {
     /**
@@ -986,7 +986,7 @@ error for set_info {
 }
 
 
-inline namespace self {
+namespace self {
 
   uint8_t[length <= MAX_NAME_LENGTH] name {
     /**
@@ -1226,7 +1226,7 @@ namespace friend {
 
 }
 
-inline namespace self {
+namespace self {
 
   uint32_t[size] friend_list {
     /**
@@ -1514,8 +1514,14 @@ namespace friend {
  *
  ******************************************************************************/
 
+error for set_typing {
+  /**
+   * The friend number did not designate a valid friend.
+   */
+  FRIEND_NOT_FOUND,
+}
 
-inline namespace self {
+namespace self {
 
   bool typing {
     /**
@@ -1528,12 +1534,7 @@ inline namespace self {
      *
      * @return true on success.
      */
-    set(uint32_t friend_number) {
-      /**
-       * The friend number did not designate a valid friend.
-       */
-      FRIEND_NOT_FOUND,
-    }
+    set(uint32_t friend_number) with error for set_typing;
   }
 
 }
@@ -2655,36 +2656,36 @@ namespace conference {
 
 namespace friend {
 
-  inline namespace send {
+  error for custom_packet {
+    NULL,
+    /**
+     * The friend number did not designate a valid friend.
+     */
+    FRIEND_NOT_FOUND,
+    /**
+     * This client is currently not connected to the friend.
+     */
+    FRIEND_NOT_CONNECTED,
+    /**
+     * The first byte of data was not in the specified range for the packet type.
+     * This range is 200-254 for lossy, and 160-191 for lossless packets.
+     */
+    INVALID,
+    /**
+     * Attempted to send an empty packet.
+     */
+    EMPTY,
+    /**
+     * Packet data length exceeded $MAX_CUSTOM_PACKET_SIZE.
+     */
+    TOO_LONG,
+    /**
+     * Packet queue is full.
+     */
+    SENDQ,
+  }
 
-    error for custom_packet {
-      NULL,
-      /**
-       * The friend number did not designate a valid friend.
-       */
-      FRIEND_NOT_FOUND,
-      /**
-       * This client is currently not connected to the friend.
-       */
-      FRIEND_NOT_CONNECTED,
-      /**
-       * The first byte of data was not in the specified range for the packet type.
-       * This range is 200-254 for lossy, and 160-191 for lossless packets.
-       */
-      INVALID,
-      /**
-       * Attempted to send an empty packet.
-       */
-      EMPTY,
-      /**
-       * Packet data length exceeded $MAX_CUSTOM_PACKET_SIZE.
-       */
-      TOO_LONG,
-      /**
-       * Packet queue is full.
-       */
-      SENDQ,
-    }
+  namespace send {
 
     /**
      * Send a custom lossy packet to a friend.
@@ -2762,7 +2763,14 @@ namespace friend {
  ******************************************************************************/
 
 
-inline namespace self {
+error for get_port {
+  /**
+   * The instance was not bound to any port.
+   */
+  NOT_BOUND,
+}
+
+namespace self {
 
   uint8_t[PUBLIC_KEY_SIZE] dht_id {
     /**
@@ -2780,13 +2788,6 @@ inline namespace self {
     get();
   }
 
-
-  error for get_port {
-    /**
-     * The instance was not bound to any port.
-     */
-    NOT_BOUND,
-  }
 
 
   uint16_t udp_port {

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -3168,20 +3168,6 @@ void tox_callback_friend_lossless_packet(Tox *tox, tox_friend_lossless_packet_cb
 
 
 
-/**
- * Writes the temporary DHT public key of this instance to a byte array.
- *
- * This can be used in combination with an externally accessible IP address and
- * the bound port (from tox_self_get_udp_port) to run a temporary bootstrap node.
- *
- * Be aware that every time a new instance is created, the DHT public key
- * changes, meaning this cannot be used to run a permanent bootstrap node.
- *
- * @param dht_id A memory region of at least TOX_PUBLIC_KEY_SIZE bytes. If this
- *   parameter is NULL, this function has no effect.
- */
-void tox_self_get_dht_id(const Tox *tox, uint8_t *dht_id);
-
 typedef enum TOX_ERR_GET_PORT {
 
     /**
@@ -3196,6 +3182,20 @@ typedef enum TOX_ERR_GET_PORT {
 
 } TOX_ERR_GET_PORT;
 
+
+/**
+ * Writes the temporary DHT public key of this instance to a byte array.
+ *
+ * This can be used in combination with an externally accessible IP address and
+ * the bound port (from tox_self_get_udp_port) to run a temporary bootstrap node.
+ *
+ * Be aware that every time a new instance is created, the DHT public key
+ * changes, meaning this cannot be used to run a permanent bootstrap node.
+ *
+ * @param dht_id A memory region of at least TOX_PUBLIC_KEY_SIZE bytes. If this
+ *   parameter is NULL, this function has no effect.
+ */
+void tox_self_get_dht_id(const Tox *tox, uint8_t *dht_id);
 
 /**
  * Return the UDP port this Tox instance is bound to.


### PR DESCRIPTION
This adds complexity for very little value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1425)
<!-- Reviewable:end -->
