### PR TITLE
Remove tokstyle exemptions from build files.

### DIFF
--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -45,8 +45,8 @@ cc_library(
     hdrs = ["bwcontroller.h"],
     deps = [
         ":ring_buffer",
+        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:Messenger",
-        "//c-toxcore/toxcore:toxcore",
     ],
 )
 
@@ -130,10 +130,7 @@ CIMPLE_SRCS = glob(
         "*.c",
         "*.h",
     ],
-    exclude = [
-        "*.api.h",
-        "toxav.h",
-    ],
+    exclude = ["*.api.h"],
 )
 
 sh_test(

--- a/toxav/toxav.api.h
+++ b/toxav/toxav.api.h
@@ -10,6 +10,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+//!TOKSTYLE-
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -685,6 +687,8 @@ typedef TOXAV_ERR_CALL_CONTROL Toxav_Err_Call_Control;
 typedef TOXAV_ERR_BIT_RATE_SET Toxav_Err_Bit_Rate_Set;
 typedef TOXAV_ERR_SEND_FRAME Toxav_Err_Send_Frame;
 typedef TOXAV_CALL_CONTROL Toxav_Call_Control;
+
+//!TOKSTYLE+
 
 #endif // C_TOXCORE_TOXAV_TOXAV_H
 %}

--- a/toxav/toxav.h
+++ b/toxav/toxav.h
@@ -9,6 +9,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+//!TOKSTYLE-
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -814,5 +816,7 @@ typedef TOXAV_ERR_CALL_CONTROL Toxav_Err_Call_Control;
 typedef TOXAV_ERR_BIT_RATE_SET Toxav_Err_Bit_Rate_Set;
 typedef TOXAV_ERR_SEND_FRAME Toxav_Err_Send_Frame;
 typedef TOXAV_CALL_CONTROL Toxav_Call_Control;
+
+//!TOKSTYLE+
 
 #endif // C_TOXCORE_TOXAV_TOXAV_H

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -286,14 +286,7 @@ CIMPLE_SRCS = glob(
         "*.c",
         "*.h",
     ],
-    exclude = [
-        "*.api.h",
-        "ccompat.h",
-        "crypto_core_mem.c",
-        "ping_array.h",
-        "tox.h",
-        "tox_api.c",
-    ],
+    exclude = ["*.api.h"],
 )
 
 sh_test(

--- a/toxcore/ccompat.h
+++ b/toxcore/ccompat.h
@@ -4,6 +4,8 @@
 #ifndef C_TOXCORE_TOXCORE_CCOMPAT_H
 #define C_TOXCORE_TOXCORE_CCOMPAT_H
 
+//!TOKSTYLE-
+
 // Variable length arrays.
 // VLA(type, name, size) allocates a variable length array with automatic
 // storage duration. VLA_SIZE(name) evaluates to the runtime size of that array
@@ -47,5 +49,7 @@
 #else
 #define GNU_PRINTF(f, a)
 #endif
+
+//!TOKSTYLE+
 
 #endif // C_TOXCORE_TOXCORE_CCOMPAT_H

--- a/toxcore/crypto_core.api.h
+++ b/toxcore/crypto_core.api.h
@@ -69,7 +69,7 @@ const CRYPTO_SHA512_SIZE = 64;
  * "aaaa" and "baaa" also takes 4 time. With a regular `memcmp`, the latter may
  * take 1 time, because it immediately knows that the two strings are not equal.
  */
-static int32_t crypto_memcmp(const void *p1, const void *p2, size_t length);
+static int32_t crypto_memcmp(const uint8_t *p1, const uint8_t *p2, size_t length);
 
 /**
  * A `bzero`-like function which won't be optimised away by the compiler. Some

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -83,7 +83,7 @@ uint32_t crypto_sha512_size(void);
  * "aaaa" and "baaa" also takes 4 time. With a regular `memcmp`, the latter may
  * take 1 time, because it immediately knows that the two strings are not equal.
  */
-int32_t crypto_memcmp(const void *p1, const void *p2, size_t length);
+int32_t crypto_memcmp(const uint8_t *p1, const uint8_t *p2, size_t length);
 
 /**
  * A `bzero`-like function which won't be optimised away by the compiler. Some

--- a/toxcore/crypto_core_mem.c
+++ b/toxcore/crypto_core_mem.c
@@ -37,8 +37,7 @@ void crypto_memzero(void *data, size_t length)
 {
 #ifndef VANILLA_NACL
     sodium_memzero(data, length);
-#else
-#ifdef _WIN32
+#elif defined(_WIN32)
     SecureZeroMemory(data, length);
 #elif defined(HAVE_MEMSET_S)
 
@@ -53,32 +52,33 @@ void crypto_memzero(void *data, size_t length)
 #elif defined(HAVE_EXPLICIT_BZERO)
     explicit_bzero(data, length);
 #else
-    volatile unsigned char *volatile pnt =
-        (volatile unsigned char *volatile) data;
+    //!TOKSTYLE-
+    volatile uint8_t *volatile pnt = data;
+    //!TOKSTYLE+
     size_t i = (size_t) 0U;
 
     while (i < length) {
-        pnt[i++] = 0U;
+        pnt[i] = 0U;
+        ++i;
     }
 
 #endif
-#endif
 }
 
-int32_t crypto_memcmp(const void *p1, const void *p2, size_t length)
+int32_t crypto_memcmp(const uint8_t *p1, const uint8_t *p2, size_t length)
 {
 #ifndef VANILLA_NACL
     return sodium_memcmp(p1, p2, length);
 #else
-    const volatile unsigned char *volatile b1 =
-        (const volatile unsigned char *volatile) p1;
-    const volatile unsigned char *volatile b2 =
-        (const volatile unsigned char *volatile) p2;
+    //!TOKSTYLE-
+    const volatile uint8_t *volatile b1 = p1;
+    const volatile uint8_t *volatile b2 = p2;
+    //!TOKSTYLE+
 
     size_t i;
-    unsigned char d = (unsigned char) 0U;
+    uint8_t d = (uint8_t) 0U;
 
-    for (i = 0U; i < length; i++) {
+    for (i = 0U; i < length; ++i) {
         d |= b1[i] ^ b2[i];
     }
 

--- a/toxcore/ping_array.api.h
+++ b/toxcore/ping_array.api.h
@@ -20,7 +20,7 @@ extern "C" {
 
 class mono_Time { struct this; }
 
-class ping_Array {
+class ping { class array {
 
 struct this;
 
@@ -55,7 +55,7 @@ uint64_t add(const mono_Time::this *mono_time, const uint8_t *data, uint32_t len
  */
 int32_t check(const mono_Time::this *mono_time, uint8_t[length] data, uint64_t ping_id);
 
-}
+} }
 
 %{
 #ifdef __cplusplus

--- a/toxcore/ping_array.h
+++ b/toxcore/ping_array.h
@@ -39,14 +39,14 @@ struct Ping_Array *ping_array_new(uint32_t size, uint32_t timeout);
 /**
  * Free all the allocated memory in a Ping_Array.
  */
-void ping_array_kill(struct Ping_Array *_array);
+void ping_array_kill(struct Ping_Array *array);
 
 /**
  * Add a data with length to the Ping_Array list and return a ping_id.
  *
  * @return ping_id on success, 0 on failure.
  */
-uint64_t ping_array_add(struct Ping_Array *_array, const struct Mono_Time *mono_time, const uint8_t *data,
+uint64_t ping_array_add(struct Ping_Array *array, const struct Mono_Time *mono_time, const uint8_t *data,
                         uint32_t length);
 
 /**
@@ -56,7 +56,7 @@ uint64_t ping_array_add(struct Ping_Array *_array, const struct Mono_Time *mono_
  *
  * @return length of data copied on success, -1 on failure.
  */
-int32_t ping_array_check(struct Ping_Array *_array, const struct Mono_Time *mono_time, uint8_t *data, size_t length,
+int32_t ping_array_check(struct Ping_Array *array, const struct Mono_Time *mono_time, uint8_t *data, size_t length,
                          uint64_t ping_id);
 
 #ifdef __cplusplus

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -14,6 +14,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+//!TOKSTYLE-
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -2853,6 +2855,8 @@ typedef TOX_LOG_LEVEL Tox_Log_Level;
 typedef TOX_CONNECTION Tox_Connection;
 typedef TOX_FILE_CONTROL Tox_File_Control;
 typedef TOX_CONFERENCE_TYPE Tox_Conference_Type;
+
+//!TOKSTYLE+
 
 #endif // C_TOXCORE_TOXCORE_TOX_H
 %}

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -13,6 +13,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+//!TOKSTYLE-
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -3250,5 +3252,7 @@ typedef TOX_LOG_LEVEL Tox_Log_Level;
 typedef TOX_CONNECTION Tox_Connection;
 typedef TOX_FILE_CONTROL Tox_File_Control;
 typedef TOX_CONFERENCE_TYPE Tox_Conference_Type;
+
+//!TOKSTYLE+
 
 #endif // C_TOXCORE_TOXCORE_TOX_H

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -7,6 +7,7 @@
 
 #define SET_ERROR_PARAMETER(param, x) do { if (param) { *param = x; } } while (0)
 
+//!TOKSTYLE-
 
 #define CONST_FUNCTION(lowercase, uppercase) \
 uint32_t tox_##lowercase(void) \
@@ -59,6 +60,8 @@ ACCESSORS(tox_log_cb *, log_, callback)
 ACCESSORS(void *, log_, user_data)
 ACCESSORS(bool,, local_discovery_enabled)
 ACCESSORS(bool,, experimental_thread_safety)
+
+//!TOKSTYLE+
 
 const uint8_t *tox_options_get_savedata_data(const struct Tox_Options *options)
 {

--- a/toxencryptsave/crypto_pwhash_scryptsalsa208sha256/pwhash_scryptsalsa208sha256.c
+++ b/toxencryptsave/crypto_pwhash_scryptsalsa208sha256/pwhash_scryptsalsa208sha256.c
@@ -201,7 +201,7 @@ crypto_pwhash_scryptsalsa208sha256_str_verify(const char str[crypto_pwhash_scryp
         return -1;
     }
     escrypt_free_local(&escrypt_local);
-    ret = crypto_memcmp(wanted, str, sizeof wanted);
+    ret = crypto_memcmp((const uint8_t *) wanted, (const uint8_t *) str, sizeof wanted);
     crypto_memzero(wanted, sizeof wanted);
 
     return ret;

--- a/toxencryptsave/defines.h
+++ b/toxencryptsave/defines.h
@@ -1,7 +1,7 @@
 #ifndef C_TOXCORE_TOXENCRYPTSAVE_DEFINES_H
 #define C_TOXCORE_TOXENCRYPTSAVE_DEFINES_H
 
-#define TOX_ENC_SAVE_MAGIC_NUMBER "toxEsave"
+#define TOX_ENC_SAVE_MAGIC_NUMBER ((const uint8_t *)"toxEsave")
 #define TOX_ENC_SAVE_MAGIC_LENGTH 8
 
 #endif


### PR DESCRIPTION
We put some tokstyle exemptions into the source files themselves,
instead. This way we can check some of the code in those files, and more
in the future when tokstyle supports more constructs (like apidsl).

Also: hacked ping_array.api.h to not emit `_array` as parameter names.
We'll need to fix apidsl to do this better. This works for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1426)
<!-- Reviewable:end -->
