### PR TITLE
Skip invalid TCP relays and DHT nodes when loading save data.

### DIFF
--- a/auto_tests/save_compatibility_test.c
+++ b/auto_tests/save_compatibility_test.c
@@ -124,6 +124,9 @@ static void test_save_compatibility(const char *save_path)
     ck_assert_msg(strncmp(tox_id_str, EXPECTED_TOX_ID, TOX_ADDRESS_SIZE * 2) == 0,
                   "tox ids do not match, expected %s got %s", EXPECTED_TOX_ID, tox_id_str);
 
+    /* Giving the tox a chance to error on iterate due to corrupted loaded structures */
+    tox_iterate(tox, nullptr);
+
     tox_kill(tox);
 }
 

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -3160,7 +3160,14 @@ static uint8_t *save_tcp_relays(const Messenger *m, uint8_t *data)
 static State_Load_Status load_tcp_relays(Messenger *m, const uint8_t *data, uint32_t length)
 {
     if (length != 0) {
-        m->num_loaded_relays = unpack_nodes(m->loaded_relays, NUM_SAVED_TCP_RELAYS, nullptr, data, length, 1);
+        const int num = unpack_nodes(m->loaded_relays, NUM_SAVED_TCP_RELAYS, nullptr, data, length, 1);
+
+        if (num == -1) {
+            m->num_loaded_relays = 0;
+            return STATE_LOAD_STATUS_CONTINUE;
+        }
+
+        m->num_loaded_relays = num;
         m->has_added_relays = false;
     }
 
@@ -3197,6 +3204,10 @@ static State_Load_Status load_path_nodes(Messenger *m, const uint8_t *data, uint
 
     if (length != 0) {
         const int num = unpack_nodes(nodes, NUM_SAVED_PATH_NODES, nullptr, data, length, 0);
+
+        if (num == -1) {
+            return STATE_LOAD_STATUS_CONTINUE;
+        }
 
         for (int i = 0; i < num; ++i) {
             onion_add_bs_path_node(m->onion_c, nodes[i].ip_port, nodes[i].public_key);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1434)
<!-- Reviewable:end -->
