### PR TITLE
Enable TCP relay test in Bazel and autotools build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,6 @@ jobs:
 
 cache:
   directories:
-    - $HOME/.cache/bazel
     - $HOME/cache
     - /opt/freebsd/cache
 

--- a/auto_tests/BUILD.bazel
+++ b/auto_tests/BUILD.bazel
@@ -15,7 +15,6 @@ cc_library(
 flaky_tests = {
     "crypto_core_test": True,
     "lan_discovery_test": True,
-    "tcp_relay_test": True,
 }
 
 [cc_test(
@@ -37,8 +36,4 @@ flaky_tests = {
         "//c-toxcore/toxcore:DHT_srcs",
         "//c-toxcore/toxencryptsave",
     ],
-) for src in glob(
-    ["*_test.c"],
-    # TODO(iphydf): Fix this test and re-enable it.
-    exclude = ["tcp_relay_test.c"],
-)]
+) for src in glob(["*_test.c"])]

--- a/auto_tests/Makefile.inc
+++ b/auto_tests/Makefile.inc
@@ -34,15 +34,13 @@ TESTS = \
 	set_status_message_test \
 	skeleton_test \
 	TCP_test \
+	tcp_relay_test \
 	tox_many_tcp_test \
 	tox_many_test \
 	tox_one_test \
 	tox_strncasecmp_test \
 	typing_test \
 	version_test
-
-# TODO(iphydf): Fix this test and re-enable it.
-#	tcp_relay_test
 
 AUTOTEST_CFLAGS = \
 	$(LIBSODIUM_CFLAGS) \

--- a/other/fun/BUILD.bazel
+++ b/other/fun/BUILD.bazel
@@ -8,6 +8,7 @@ cc_binary(
         "@libsodium",
     ],
 )
+
 cc_binary(
     name = "minimal-save-generator",
     srcs = ["minimal-save-generator.c"],
@@ -15,7 +16,6 @@ cc_binary(
         "@libsodium",
     ],
 )
-
 
 cc_binary(
     name = "sign",

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -272,8 +272,8 @@ cc_library(
     srcs = [
         "tox.c",
         "tox.h",
-        "tox_private.h",
         "tox_api.c",
+        "tox_private.h",
     ],
     visibility = ["//c-toxcore:__subpackages__"],
     deps = [


### PR DESCRIPTION
This test was fixed by @robinlinden, but not enabled in all builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1435)
<!-- Reviewable:end -->
