### PR TITLE
Enable cimple tests by default but allow disabling them.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,15 +1,16 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.7
+    image: toxchat/toktok-stack:0.0.10
     cpu: 2
     memory: 2G
   configure_script:
     - /src/workspace/tools/inject-repo c-toxcore
   test_all_script:
     - bazel test -k
-        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
-        --config=ci
-        --config=docker
-        --config=release
-        //c-toxcore/...
+      --build_tag_filters=-haskell
+      --test_tag_filters=-haskell
+      --remote_download_minimal
+      --config=ci
+      --config=release
+      //c-toxcore/...

--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -139,5 +139,5 @@ sh_test(
     srcs = ["//hs-tokstyle/tools:check-cimple"],
     args = ["$(location %s)" % f for f in CIMPLE_SRCS],
     data = CIMPLE_SRCS,
-    tags = ["manual"],
+    tags = ["haskell"],
 )

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -33,6 +33,7 @@ cc_test(
     name = "crypto_core_test",
     size = "small",
     srcs = ["crypto_core_test.cc"],
+    flaky = True,
     deps = [
         ":crypto_core",
         "@com_google_googletest//:gtest_main",
@@ -296,5 +297,5 @@ sh_test(
     srcs = ["//hs-tokstyle/tools:check-cimple"],
     args = ["$(location %s)" % f for f in CIMPLE_SRCS],
     data = CIMPLE_SRCS,
-    tags = ["manual"],
+    tags = ["haskell"],
 )


### PR DESCRIPTION
Use `bazel test //c-toxcore/... --build_tag_filters=-haskell` to run all
tests except the ones that depend on Haskell (i.e. cimple tests).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1436)
<!-- Reviewable:end -->
