### PR TITLE
Limit the number of friends you can have to ~4 billion.

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -161,6 +161,12 @@ static int m_handle_lossy_packet(void *object, int friend_num, const uint8_t *pa
 
 static int32_t init_new_friend(Messenger *m, const uint8_t *real_pk, uint8_t status)
 {
+    if (m->numfriends == UINT32_MAX) {
+        LOGGER_ERROR(m->log, "Friend list full: we have more than 4 billion friends");
+        /* This is technically incorrect, but close enough. */
+        return FAERR_NOMEM;
+    }
+
     /* Resize the friend list if necessary. */
     if (realloc_friendlist(m, m->numfriends + 1) != 0) {
         return FAERR_NOMEM;


### PR DESCRIPTION
If you have UINT32_MAX friends, then adding one more friend will cause an
overflow of the friend list (wrap to 0) and result in all friends being
deleted. This subsequently results in a null pointer dereference when
we're trying to add one friend to the deleted friend list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1456)
<!-- Reviewable:end -->
