### PR TITLE
Include `<string.h>` for `explicit_bzero`.

### DIFF
--- a/toxcore/crypto_core_mem.c
+++ b/toxcore/crypto_core_mem.c
@@ -29,6 +29,8 @@
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 #include <windows.h>
 #include <wincrypt.h>
+#elif defined(HAVE_EXPLICIT_BZERO)
+#include <string.h>
 #endif
 #endif
 


### PR DESCRIPTION
We need this for vanilla nacl builds on Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1462)
<!-- Reviewable:end -->
