### PR TITLE
chore: Exclude imported libsodium sources from restyled.

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,9 +1,17 @@
 ---
+exclude:
+  - "**/*.api.h"
+  - "toxencryptsave/crypto_pwhash_scryptsalsa208sha256/**/*"
+
 restylers:
   - astyle:
       arguments: ["--options=other/astyle/astylerc"]
   - autopep8
   - black
+  - clang-format:
+      arguments: ["-style={BasedOnStyle: Google, ColumnLimit: 100}"]
+      include:
+        - "**/*.cc"
   - prettier-yaml
   - reorder-python-imports
   - shellharden


### PR DESCRIPTION
Also limit clang-format to .cc files. Don't apply it to .c files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1495)
<!-- Reviewable:end -->
