### PR TITLE
refactor: Use bash arrays instead of strings for static analysis scripts.

### DIFF
--- a/other/analysis/gen-file.sh
+++ b/other/analysis/gen-file.sh
@@ -1,44 +1,51 @@
-#!/bin/sh
+#!/bin/bash
 
-CPPFLAGS="$CPPFLAGS -DMIN_LOGGER_LEVEL=LOGGER_LEVEL_TRACE"
-CPPFLAGS="$CPPFLAGS -isystem /usr/include/opus"
-CPPFLAGS="$CPPFLAGS -Iauto_tests"
-CPPFLAGS="$CPPFLAGS -Iother"
-CPPFLAGS="$CPPFLAGS -Iother/bootstrap_daemon/src"
-CPPFLAGS="$CPPFLAGS -Iother/fun"
-CPPFLAGS="$CPPFLAGS -Itesting"
-CPPFLAGS="$CPPFLAGS -Itoxcore"
-CPPFLAGS="$CPPFLAGS -Itoxav"
-CPPFLAGS="$CPPFLAGS -Itoxencryptsave"
+CPPFLAGS="-DMIN_LOGGER_LEVEL=LOGGER_LEVEL_TRACE"
+CPPFLAGS+=("-isystem" "/usr/include/opus")
+CPPFLAGS+=("-Iauto_tests")
+CPPFLAGS+=("-Iother")
+CPPFLAGS+=("-Iother/bootstrap_daemon/src")
+CPPFLAGS+=("-Iother/fun")
+CPPFLAGS+=("-Itesting")
+CPPFLAGS+=("-Itesting/groupchats")
+CPPFLAGS+=("-Itoxcore")
+CPPFLAGS+=("-Itoxav")
+CPPFLAGS+=("-Itoxencryptsave")
 
-LDFLAGS="$LDFLAGS -lopus -lsodium -lvpx -lpthread -lconfig"
+LDFLAGS=("-lopus" "-lsodium" "-lvpx" "-lpthread" "-lconfig")
+LDFLAGS+=("-fuse-ld=gold")
+LDFLAGS+=("-Wl,--detect-odr-violations")
+LDFLAGS+=("-Wl,--warn-common")
+LDFLAGS+=("-Wl,--warn-execstack")
+LDFLAGS+=("-Wl,-z,noexecstack")
+LDFLAGS+=("-Wl,-z,now")
 
 put() {
   if [ "$SKIP_LINES" = "" ]; then
-    echo "#line 1 \"$1\"" >> amalgamation.cc
+    echo "#line 1 \"$1\"" >>amalgamation.cc
   fi
-  cat "$1" >> amalgamation.cc
+  cat "$1" >>amalgamation.cc
 }
 
 putmain() {
-  echo "namespace $(echo "$1" | sed -e 's/[^a-zA-Z0-9_]/_/g') {" >> amalgamation.cc
+  echo "namespace ${1//[^a-zA-Z0-9_]/_} {" >>amalgamation.cc
   if [ "$SKIP_LINES" = "" ]; then
-    echo "#line 1 \"$1\"" >> amalgamation.cc
+    echo "#line 1 \"$1\"" >>amalgamation.cc
   fi
-  sed -e 's/^int main(/static &/' "$1" >> amalgamation.cc
-  echo "} //  namespace $(echo "$1" | sed -e 's/[^a-zA-Z0-9_]/_/g')" >> amalgamation.cc
+  sed -e 's/^int main(/static &/' "$1" >>amalgamation.cc
+  echo "} //  namespace ${1//[^a-zA-Z0-9_]/_}" >>amalgamation.cc
 }
 
 callmain() {
-  echo "  call($(echo "$1" | sed -e 's/[^a-zA-Z0-9_]/_/g')::main, argc, argv);" >> amalgamation.cc
+  echo "  call(${1//[^a-zA-Z0-9_]/_}::main, argc, argv);" >>amalgamation.cc
 }
 
-:> amalgamation.cc
+: >amalgamation.cc
 
-echo "#include <algorithm>" >> amalgamation.cc
-echo "#include <cstdio>" >> amalgamation.cc
-echo "#include <memory>" >> amalgamation.cc
-echo "#include <random>" >> amalgamation.cc
+echo "#include <algorithm>" >>amalgamation.cc
+echo "#include <cstdio>" >>amalgamation.cc
+echo "#include <memory>" >>amalgamation.cc
+echo "#include <random>" >>amalgamation.cc
 
 put auto_tests/check_compat.h
 
@@ -53,33 +60,35 @@ FIND_QUERY="$FIND_QUERY -and -not -name av_test.c"
 FIND_QUERY="$FIND_QUERY -and -not -name dht_test.c"
 FIND_QUERY="$FIND_QUERY -and -not -name version_test.c"
 
-(for i in $(eval "$FIND_QUERY"); do
-  grep -o '#include <[^>]*>' "$i" \
-    | grep -E -v '<win|<ws|<iphlp|<libc|<mach/|<crypto_|<randombytes|<u.h>|<sys/filio|<linux'
-done) | sort -u >> amalgamation.cc
+readarray -t FILES <<<"$(eval "$FIND_QUERY")"
 
-echo 'namespace {' >> amalgamation.cc
-for i in $(eval "$FIND_QUERY"); do
+(for i in "${FILES[@]}"; do
+  grep -o '#include <[^>]*>' "$i" |
+    grep -E -v '<win|<ws|<iphlp|<libc|<mach/|<crypto_|<randombytes|<u.h>|<sys/filio|<linux'
+done) | sort -u >>amalgamation.cc
+
+echo 'namespace {' >>amalgamation.cc
+for i in "${FILES[@]}"; do
   if ! grep -q '^int main(' "$i"; then
     put "$i"
   fi
 done
 
-for i in $(eval "$FIND_QUERY"); do
+for i in "${FILES[@]}"; do
   if grep -q '^int main(' "$i"; then
     putmain "$i"
   fi
 done
 
-echo "static void call(int m(), int argc, char **argv) { m(); }" >> amalgamation.cc
-echo "static void call(int m(int, char **), int argc, char **argv) { m(argc, argv); }" >> amalgamation.cc
-echo '}  // namespace' >> amalgamation.cc
+echo "static void call(int m(), int argc, char **argv) { m(); }" >>amalgamation.cc
+echo "static void call(int m(int, char **), int argc, char **argv) { m(argc, argv); }" >>amalgamation.cc
+echo '}  // namespace' >>amalgamation.cc
 
-echo "int main(int argc, char **argv) {" >> amalgamation.cc
-for i in $(eval "$FIND_QUERY"); do
+echo "int main(int argc, char **argv) {" >>amalgamation.cc
+for i in "${FILES[@]}"; do
   if grep -q '^int main(' "$i"; then
     callmain "$i"
   fi
 done
-echo "  return 0;" >> amalgamation.cc
-echo "}" >> amalgamation.cc
+echo "  return 0;" >>amalgamation.cc
+echo "}" >>amalgamation.cc

--- a/other/analysis/run-clang
+++ b/other/analysis/run-clang
@@ -1,25 +1,25 @@
-#!/bin/sh
+#!/bin/bash
 
 . other/analysis/gen-file.sh
 
 echo "Running Clang compiler"
-clang++ -o /dev/null amalgamation.cc		\
-	$CPPFLAGS				\
-	$LDFLAGS				\
-	-std=c++11				\
-	-Werror					\
-	-Weverything				\
-	-Wno-c++98-compat-pedantic		\
-	-Wno-c99-extensions			\
-	-Wno-cast-align				\
-	-Wno-conversion				\
-	-Wno-covered-switch-default		\
-	-Wno-disabled-macro-expansion		\
-	-Wno-documentation-deprecated-sync	\
-	-Wno-missing-field-initializers		\
-	-Wno-old-style-cast			\
-	-Wno-padded				\
-	-Wno-sign-compare			\
-	-Wno-unreachable-code-return		\
-	-Wno-unused-parameter			\
-	-Wno-used-but-marked-unused		\
+clang++ -o /dev/null amalgamation.cc \
+  "${CPPFLAGS[@]}" \
+  "${LDFLAGS[@]}" \
+  -std=c++11 \
+  -Werror \
+  -Weverything \
+  -Wno-c++98-compat-pedantic \
+  -Wno-c99-extensions \
+  -Wno-cast-align \
+  -Wno-conversion \
+  -Wno-covered-switch-default \
+  -Wno-disabled-macro-expansion \
+  -Wno-documentation-deprecated-sync \
+  -Wno-missing-field-initializers \
+  -Wno-old-style-cast \
+  -Wno-padded \
+  -Wno-sign-compare \
+  -Wno-unreachable-code-return \
+  -Wno-unused-parameter \
+  -Wno-used-but-marked-unused

--- a/other/analysis/run-clang-analyze
+++ b/other/analysis/run-clang-analyze
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 . other/analysis/gen-file.sh
 
 echo "Running Clang static analyzer"
-clang++ --analyze amalgamation.cc		\
-	$CPPFLAGS				\
-	-std=c++11
+clang++ --analyze amalgamation.cc \
+  "${CPPFLAGS[@]}" \
+  -std=c++11

--- a/other/analysis/run-cppcheck
+++ b/other/analysis/run-cppcheck
@@ -1,5 +1,5 @@
-#!/bin/sh
+#!/bin/bash
 
 . other/analysis/gen-file.sh
 
-cppcheck amalgamation.cc $CPPFLAGS
+cppcheck amalgamation.cc "${CPPFLAGS[@]}"

--- a/other/analysis/run-gcc
+++ b/other/analysis/run-gcc
@@ -1,63 +1,63 @@
-#!/bin/sh
+#!/bin/bash
 
 . other/analysis/gen-file.sh
 
 echo "Running GCC"
 # TODO(iphydf): Get rid of all VLAs, then enable -fstack-protector -Wstack-protector
-g++ -O3 -o /dev/null amalgamation.cc		\
-	$CPPFLAGS				\
-	$LDFLAGS				\
-	-std=c++11				\
-	-pedantic				\
-	-fdiagnostics-color=always		\
-	-Wall					\
-	-Wextra					\
-	-Wno-aggregate-return			\
-	-Wno-aggressive-loop-optimizations	\
-	-Wno-float-conversion			\
-	-Wno-format-signedness			\
-	-Wno-missing-field-initializers		\
-	-Wno-padded				\
-	-Wno-sign-compare			\
-	-Wno-sign-conversion			\
-	-Wno-switch-default			\
-	-Wno-unused-parameter			\
-	-Wstrict-aliasing=0			\
-	-Wstrict-overflow=1			\
-						\
-	-Wmissing-declarations			\
-	-Wbool-compare				\
-	-Wcast-align				\
-	-Wcast-qual				\
-	-Wchar-subscripts			\
-	-Wdouble-promotion			\
-	-Wduplicated-cond			\
-	-Wempty-body				\
-	-Wenum-compare				\
-	-Wfloat-equal				\
-	-Wformat=2				\
-	-Wframe-address				\
-	-Wframe-larger-than=133168		\
-	-Wignored-qualifiers			\
-	-Wignored-attributes			\
-	-Winit-self				\
-	-Winline				\
-	-Wlarger-than=133120			\
-	-Wmaybe-uninitialized			\
-	-Wmemset-transposed-args		\
-	-Wmisleading-indentation		\
-	-Wnonnull				\
-	-Wnonnull-compare			\
-	-Wnull-dereference			\
-	-Wodr					\
-	-Wredundant-decls			\
-	-Wreturn-type				\
-	-Wshadow				\
-	-Wsuggest-attribute=format		\
-	-Wundef					\
-	-Wunsafe-loop-optimizations		\
-	-Wunused-label				\
-	-Wunused-local-typedefs			\
-	-Wunused-value				\
-	-Wunused-but-set-parameter		\
-	-Wunused-but-set-variable		\
+g++ -O3 -o /dev/null amalgamation.cc \
+  "${CPPFLAGS[@]}" \
+  "${LDFLAGS[@]}" \
+  -std=c++11 \
+  -pedantic \
+  -fdiagnostics-color=always \
+  -Wall \
+  -Wextra \
+  -Wno-aggregate-return \
+  -Wno-aggressive-loop-optimizations \
+  -Wno-float-conversion \
+  -Wno-format-signedness \
+  -Wno-missing-field-initializers \
+  -Wno-padded \
+  -Wno-sign-compare \
+  -Wno-sign-conversion \
+  -Wno-switch-default \
+  -Wno-unused-parameter \
+  -Wstrict-aliasing=0 \
+  -Wstrict-overflow=1 \
+  \
+  -Wmissing-declarations \
+  -Wbool-compare \
+  -Wcast-align \
+  -Wcast-qual \
+  -Wchar-subscripts \
+  -Wdouble-promotion \
+  -Wduplicated-cond \
+  -Wempty-body \
+  -Wenum-compare \
+  -Wfloat-equal \
+  -Wformat=2 \
+  -Wframe-address \
+  -Wframe-larger-than=133168 \
+  -Wignored-qualifiers \
+  -Wignored-attributes \
+  -Winit-self \
+  -Winline \
+  -Wlarger-than=133120 \
+  -Wmaybe-uninitialized \
+  -Wmemset-transposed-args \
+  -Wmisleading-indentation \
+  -Wnonnull \
+  -Wnonnull-compare \
+  -Wnull-dereference \
+  -Wodr \
+  -Wredundant-decls \
+  -Wreturn-type \
+  -Wshadow \
+  -Wsuggest-attribute=format \
+  -Wundef \
+  -Wunsafe-loop-optimizations \
+  -Wunused-label \
+  -Wunused-local-typedefs \
+  -Wunused-value \
+  -Wunused-but-set-parameter \
+  -Wunused-but-set-variable

--- a/other/analysis/run-infer
+++ b/other/analysis/run-infer
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 # Infer ignores everything that's not in the "current file".
 SKIP_LINES=1
 
 . other/analysis/gen-file.sh
 
-infer -- clang++ -fsyntax-only amalgamation.cc $CPPFLAGS
+infer -- clang++ -fsyntax-only amalgamation.cc "${CPPFLAGS[@]}"

--- a/other/bootstrap_daemon/docker/update-sha256
+++ b/other/bootstrap_daemon/docker/update-sha256
@@ -1,9 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eux
 
 docker_build() {
-  tar c $(git ls-files) | docker build -f other/bootstrap_daemon/docker/Dockerfile -t toxchat/bootstrap-node -
+  readarray -t FILES <<<"$(git ls-files)"
+  tar c "${FILES[@]}" | docker build -f other/bootstrap_daemon/docker/Dockerfile -t toxchat/bootstrap-node -
 }
 
 # Run Docker build once. If it succeeds, we're good.
@@ -17,7 +18,7 @@ OUTPUT=$(docker_build || true 2>&1)
 if echo "$OUTPUT" | grep '/usr/local/bin/tox-bootstrapd: FAILED'; then
   # This is a checksum warning, so we need to update it.
   IMAGE=$(echo "$OUTPUT" | grep '^ ---> [0-9a-f]*$' | grep -o '[0-9a-f]*$' | tail -n1)
-  docker run --rm "$IMAGE" sha256sum /usr/local/bin/tox-bootstrapd > other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+  docker run --rm "$IMAGE" sha256sum /usr/local/bin/tox-bootstrapd >other/bootstrap_daemon/docker/tox-bootstrapd.sha256
 fi
 
 # Run once last time to complete the build.


### PR DESCRIPTION
These are more robust wrt. spaces in names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1497)
<!-- Reviewable:end -->
