### PR TITLE
fix:revert regression causing handshakes to sometimes fail

### DIFF
--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -41,7 +41,10 @@ GC_Connection *gcc_get_connection(const GC_Chat *chat, int peer_number)
     return &chat->gcc[peer_number];
 }
 
-/* Returns true if ary entry does not contain an active packet. */
+/*
+ * Returns true if ary entry does not contain an active packet. Note: entries may contain
+ * empty data.
+ */
 static bool array_entry_is_empty(struct GC_Message_Array_Entry *array_entry)
 {
     return array_entry->time_added == 0;
@@ -86,18 +89,19 @@ static int create_array_entry(const Logger *logger, const Mono_Time *mono_time,
                               struct GC_Message_Array_Entry *array_entry, const uint8_t *data, uint32_t length, uint8_t packet_type,
                               uint64_t message_id)
 {
-    if (data == nullptr || length == 0) {
-        LOGGER_ERROR(logger, "Attempt to add empty packet for packet type %d", packet_type);
-        return -1;
+    if (length > 0) {
+        if (data == nullptr) {
+            return -1;
+        }
+
+        array_entry->data = (uint8_t *)malloc(sizeof(uint8_t) * length);
+
+        if (array_entry->data == nullptr) {
+            return -1;
+        }
+
+        memcpy(array_entry->data, data, length);
     }
-
-    array_entry->data = (uint8_t *)malloc(sizeof(uint8_t) * length);
-
-    if (array_entry->data == nullptr) {
-        return -1;
-    }
-
-    memcpy(array_entry->data, data, length);
 
     array_entry->data_length = length;
     array_entry->packet_type = packet_type;


### PR DESCRIPTION
create_array_entry() needs to handle inbound handshake acks which are empty

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1509)
<!-- Reviewable:end -->
