### PR TITLE
fix:Improve ability to establish direct UDP connections in groups

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -3037,3 +3037,4 @@ int ipport_self_copy(const DHT *dht, IP_Port *dest)
 
     return 0;
 }
+

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -259,6 +259,7 @@ typedef struct GC_Chat {
     uint8_t confirmed_peers[MAX_GC_CONFIRMED_PEERS][ENC_PUBLIC_KEY];
     uint8_t confirmed_peers_index;
     Node_format announced_node;
+    IP_Port self_ip_port;
 
     Networking_Core *net;
     TCP_Connections *tcp_conn;

--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -26,7 +26,7 @@
 #ifndef VANILLA_NACL
 
 /* The time before the direct UDP connection is considered dead */
-#define GCC_UDP_DIRECT_TIMEOUT (GC_PING_INTERVAL * 2 + 2)
+#define GCC_UDP_DIRECT_TIMEOUT (GC_PING_INTERVAL + 2)
 
 
 /* Returns group connection object for peer_number.
@@ -206,10 +206,6 @@ int gcc_handle_received_message(GC_Chat *chat, uint32_t peer_number, const uint8
         return -1;
     }
 
-    if (direct_conn) {
-        gconn->last_received_direct_time = mono_time_get(chat->mono_time);
-    }
-
     /* Appears to be a duplicate packet so we discard it */
     if (message_id < gconn->received_message_id + 1) {
         return 0;
@@ -229,6 +225,10 @@ int gcc_handle_received_message(GC_Chat *chat, uint32_t peer_number, const uint8
         }
 
         return 1;
+    }
+
+    if (direct_conn) {
+        gconn->last_received_direct_time = mono_time_get(chat->mono_time);
     }
 
     ++gconn->received_message_id;

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -50,6 +50,7 @@ struct GC_Connection {
     int         tcp_connection_num;
     uint64_t    last_received_direct_time;   /* the last time we received a direct UDP packet from this connection */
     uint64_t    last_tcp_relays_shared;  /* the last time we tried to send this peer our tcp relays */
+    uint64_t    last_sent_ip_time;  /* the last time we sent our ip info to this peer in a ping packet */
 
     Node_format connected_tcp_relays[MAX_FRIEND_TCP_CONNECTIONS];
     int tcp_relays_index;


### PR DESCRIPTION
We now occasionally send our own IP info to a peer in a ping packet if we don't have a direct
connection established already. This fixes an issue where if two peers handshake via a
TCP connection, they would never be able to establish a direct connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1526)
<!-- Reviewable:end -->
