### PR TITLE
fix:More small fixes

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2862,11 +2862,6 @@ static void try_pack_gc_data(const Messenger *m, GC_Chat *chat, Onion_Friend *on
         }
 
         onion_friend_set_gc_data(onion_friend, gc_data, (int16_t)length);
-
-        if (tcp_num > 0) {
-            memcpy((void *)&chat->announced_node, &announce.base_announce.tcp_relays[0], sizeof(Node_format));
-        }
-
         gca_add_announce(m->mono_time, m->group_announce, &announce);
     } else {
         // new gc - no connected relays yet and no ip/port

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -259,7 +259,7 @@ typedef struct GC_Chat {
     const Logger *logger;
     uint8_t confirmed_peers[MAX_GC_CONFIRMED_PEERS][ENC_PUBLIC_KEY];
     uint8_t confirmed_peers_index;
-    Node_format announced_node;
+
     IP_Port self_ip_port;
 
     Networking_Core *net;
@@ -287,6 +287,7 @@ typedef struct GC_Chat {
     uint32_t    self_public_key_hash;
 
     uint8_t     connection_state;
+    uint64_t    time_connected;
     uint64_t    last_join_attempt;
     uint64_t    last_ping_interval;
     uint8_t     join_type;   /* How we joined the group (invite or DHT) */


### PR DESCRIPTION
- Remove unused variable announced_node
- Fix bug causing self_join callback to be triggered when it shouldn't be (this also fixes a toxic bug where the peer join after a timeout doesn't always trigger) 
- Some renames and cleanup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1536)
<!-- Reviewable:end -->
