### PR TITLE
chore: Cygwin build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -155,7 +155,40 @@ msbuild ALL_BUILD.vcxproj
 
 ###### MSYS/Cygwin
 
-There are currently no instructions on how to build toxcore on Windows host in MSYS/Cygwin. Contribution of the instructions is welcome!
+Download Cygwin ([32-bit](https://cygwin.com/setup-x86.exe)/[64-bit](https://cygwin.com/setup-x86_64.exe))
+
+Search and select exactly these packages in Devel category:
+
+  - mingw64-i686-gcc-core (32-bit) / mingw64-x86_64-gcc-core (64-bit)
+  - mingw64-i686-gcc-g++ (32-bit) / mingw64-x86_64-gcc-g++ (64-bit)
+  - make
+  - cmake
+  - libtool
+  - autoconf
+  - automake
+  - tree
+  - curl
+  - perl
+  - yasm
+  - pkg-config
+
+To handle Windows EOL correctly run the following in the Cygwin Terminal:
+
+```sh
+echo '
+export SHELLOPTS
+set -o igncr
+' > ~/.bash_profile
+```
+
+Download toxcore source code and extract it to a folder.
+
+Open Cygwin Terminal in the toxcore folder and run `./other/windows_build_script_toxcore.sh` to start the build process.
+
+Toxcore build result files will appear in `/root/prefix/` relatively to Cygwin folder (default `C:\cygwin64`).
+
+Dependency versions can be customized in `./other/windows_build_script_toxcore.sh` and described in the section below.
+
 
 ##### Cross-compiling from Linux
 
@@ -179,6 +212,7 @@ Build the container image based on the Dockerfile. The following options are ava
 | `SUPPORT_ARCH_i686`   | Support building 32-bit toxcore.                               | "true" or "false" (case sensitive). | true          |
 | `SUPPORT_ARCH_x86_64` | Support building 64-bit toxcore.                               | "true" or "false" (case sensitive). | true          |
 | `SUPPORT_TEST`        | Support running toxcore automated tests.                       | "true" or "false" (case sensitive). | false         |
+| `CROSS_COMPILE`       | Cross-compiling. True for Docker, false for Cygwin.            | "true" or "false" (case sensitive). | true          |
 | `VERSION_OPUS`        | Version of libopus to build toxcore with.                      | Git branch name.                    | v1.2.1        |
 | `VERSION_SODIUM`      | Version of libsodium to build toxcore with.                    | Git branch name.                    | 1.0.18        |
 | `VERSION_VPX`         | Version of libvpx to build toxcore with.                       | Git branch name.                    | v1.6.1        |
@@ -201,7 +235,8 @@ Run the container to build toxcore. The following options are available to custo
 | `ENABLE_ARCH_i686`   | Build 32-bit toxcore. The image should have been built with `SUPPORT_ARCH_i686` enabled.   | "true" or "false" (case sensitive). | `true`                                                             |
 | `ENABLE_ARCH_x86_64` | Build 64-bit toxcore. The image should have been built with `SUPPORT_ARCH_x86_64` enabled. | "true" or "false" (case sensitive). | `true`                                                             |
 | `ENABLE_TEST`        | Run the test suite. The image should have been built with `SUPPORT_TEST` enabled.          | "true" or "false" (case sensitive). | `false`                                                            |
-| `EXTRA_CMAKE_FLAGS`  | Extra arguments to pass to the CMake command when building toxcore.                        | CMake options.                      | `-DWARNINGS=OFF -DBOOTSTRAP_DAEMON=OFF -DTEST_TIMEOUT_SECONDS=300` |
+| `EXTRA_CMAKE_FLAGS`  | Extra arguments to pass to the CMake command when building toxcore.                        | CMake options.                      | `-DTEST_TIMEOUT_SECONDS=90`                                        |
+| `CROSS_COMPILE`      | Cross-compiling. True for Docker, false for Cygwin.                                        | "true" or "false" (case sensitive). | `true`                                                             |
 
 Example of running the container with options
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -213,9 +213,9 @@ Build the container image based on the Dockerfile. The following options are ava
 | `SUPPORT_ARCH_x86_64` | Support building 64-bit toxcore.                               | "true" or "false" (case sensitive). | true          |
 | `SUPPORT_TEST`        | Support running toxcore automated tests.                       | "true" or "false" (case sensitive). | false         |
 | `CROSS_COMPILE`       | Cross-compiling. True for Docker, false for Cygwin.            | "true" or "false" (case sensitive). | true          |
-| `VERSION_OPUS`        | Version of libopus to build toxcore with.                      | Git branch name.                    | v1.2.1        |
-| `VERSION_SODIUM`      | Version of libsodium to build toxcore with.                    | Git branch name.                    | 1.0.18        |
-| `VERSION_VPX`         | Version of libvpx to build toxcore with.                       | Git branch name.                    | v1.6.1        |
+| `VERSION_OPUS`        | Version of libopus to build toxcore with.                      | Numeric version number.             | 1.3.1         |
+| `VERSION_SODIUM`      | Version of libsodium to build toxcore with.                    | Numeric version number.             | 1.0.18        |
+| `VERSION_VPX`         | Version of libvpx to build toxcore with.                       | Numeric version number.             | 1.9.0         |
 
 Example of building a container image with options
 

--- a/other/docker/windows/Dockerfile
+++ b/other/docker/windows/Dockerfile
@@ -8,24 +8,26 @@ ARG VERSION_VPX=v1.6.1
 ARG SUPPORT_TEST=false
 ARG SUPPORT_ARCH_i686=true
 ARG SUPPORT_ARCH_x86_64=true
+ARG CROSS_COMPILE=true
 
 # Make those available when running the container
 ENV SUPPORT_TEST=${SUPPORT_TEST}
 ENV SUPPORT_ARCH_i686=${SUPPORT_ARCH_i686}
 ENV SUPPORT_ARCH_x86_64=${SUPPORT_ARCH_x86_64}
+ENV CROSS_COMPILE=${CROSS_COMPILE}
 
-ADD get_packages.sh .
+COPY get_packages.sh .
 RUN sh ./get_packages.sh
 
-ADD build_dependencies.sh .
+COPY build_dependencies.sh .
 RUN sh ./build_dependencies.sh
 
-ADD build_toxcore.sh .
+COPY build_toxcore.sh .
 
 ENV ENABLE_TEST=false
 ENV ALLOW_TEST_FAILURE=false
 ENV ENABLE_ARCH_i686=true
 ENV ENABLE_ARCH_x86_64=true
-ENV EXTRA_CMAKE_FLAGS="-DWARNINGS=OFF -DBOOTSTRAP_DAEMON=OFF -DTEST_TIMEOUT_SECONDS=300"
+ENV EXTRA_CMAKE_FLAGS="-DTEST_TIMEOUT_SECONDS=90"
 
-CMD sh ./build_toxcore.sh
+ENTRYPOINT ["sh", "./build_toxcore.sh"]

--- a/other/docker/windows/Dockerfile
+++ b/other/docker/windows/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Build-time environment variables
 ARG VERSION_SODIUM=1.0.18
-ARG VERSION_OPUS=v1.2.1
-ARG VERSION_VPX=v1.6.1
+ARG VERSION_OPUS=1.3.1
+ARG VERSION_VPX=1.9.0
 
 ARG SUPPORT_TEST=false
 ARG SUPPORT_ARCH_i686=true

--- a/other/docker/windows/build_dependencies.sh
+++ b/other/docker/windows/build_dependencies.sh
@@ -1,73 +1,83 @@
 #!/usr/bin/env sh
 
-set -e -x
+# disable on Cygwin otherwise some builds fail
+if [ "$CROSS_COMPILE" = "true" ]; then
+  set -e -x
+fi
 
 #=== Cross-Compile Dependencies ===
 
-build()
-{
-    ARCH=${1}
+build() {
+  ARCH=${1}
 
-    echo "Building for ${ARCH} architecture"
+  echo "Building for $ARCH architecture"
 
-    # set some things
-    WINDOWS_TOOLCHAIN=${ARCH}-w64-mingw32
+  # set some things
+  WINDOWS_TOOLCHAIN=$ARCH-w64-mingw32
 
-    # prefix that we will copy to the user
-    PREFIX_DIR="/root/prefix/${ARCH}"
-    # prefix for things that shouldn't be copied to the user
-    EXTRA_PREFIX_DIR="/root/extra-prefix/${ARCH}"
-    mkdir -p "${PREFIX_DIR}" "${EXTRA_PREFIX_DIR}"
+  # prefix that we will copy to the user
+  PREFIX_DIR="/root/prefix/$ARCH"
+  rm -rf "$PREFIX_DIR"
+  mkdir -p "$PREFIX_DIR"
 
-    export MAKEFLAGS=j$(nproc)
-    export CFLAGS=-O3
+  export MAKEFLAGS=j"$(nproc)"
+  export CFLAGS=-O3
 
-    cd /tmp
+  cd /tmp
+  rm -rf /tmp/*
 
-    echo
-    echo "=== Building Sodium ${VERSION_SODIUM} ${ARCH} ==="
-    git clone --depth=1 --branch="${VERSION_SODIUM}" https://github.com/jedisct1/libsodium
-    cd libsodium
-    ./autogen.sh
-    ./configure --host="${WINDOWS_TOOLCHAIN}" --prefix="${PREFIX_DIR}" --disable-shared --enable-static
-    make
-    make install
-    cd ..
+  echo
+  echo "=== Building Sodium $VERSION_SODIUM $ARCH ==="
+  git clone --depth=1 --branch="$VERSION_SODIUM" https://github.com/jedisct1/libsodium
+  cd libsodium
+  ./autogen.sh
+  ./configure --host="$WINDOWS_TOOLCHAIN" --prefix="$PREFIX_DIR" --disable-shared --enable-static
+  make
+  make install
+  cd ..
 
-    echo
-    echo "=== Building Opus ${VERSION_OPUS} ${ARCH} ==="
-    git clone --depth=1 --branch="${VERSION_OPUS}" https://github.com/xiph/opus
+  echo
+  echo "=== Building Opus $VERSION_OPUS $ARCH ==="
+  if [ "$CROSS_COMPILE" = "true" ]; then
+    git clone --depth=1 --branch="$VERSION_OPUS" https://github.com/xiph/opus
     cd opus
     ./autogen.sh
-    ./configure --host="${WINDOWS_TOOLCHAIN}" --prefix="${PREFIX_DIR}" --disable-extra-programs --disable-doc --disable-shared --enable-static
-    make
-    make install
-    cd ..
+  else
+    # autogen.sh failed on Cygwin due to ltmain.sh symlink
+    VERSION_OPUS="${VERSION_OPUS#?}" # remove first 'v'
+    curl "https://archive.mozilla.org/pub/opus/opus-$VERSION_OPUS.tar.gz" -o opus.tar.gz
+    tar xzf opus.tar.gz
+    cd "opus-$VERSION_OPUS"
+  fi
+  ./configure --host="$WINDOWS_TOOLCHAIN" --prefix="$PREFIX_DIR" --disable-extra-programs --disable-doc --disable-shared --enable-static
+  make
+  make install
+  cd ..
 
-    echo
-    echo "=== Building VPX ${VERSION_VPX} ${ARCH} ==="
-    LIB_VPX_TARGET=""
-    if [ "${ARCH}" = "i686" ]; then
-        LIB_VPX_TARGET=x86-win32-gcc
-    else
-        LIB_VPX_TARGET=x86_64-win64-gcc
-    fi
-    git clone --depth=1 --branch="${VERSION_VPX}" https://github.com/webmproject/libvpx
-    cd libvpx
-    CROSS="${WINDOWS_TOOLCHAIN}"- ./configure --target="${LIB_VPX_TARGET}" --prefix="${PREFIX_DIR}" --disable-examples --disable-unit-tests --disable-shared --enable-static
-    make
-    make install
-    cd ..
+  echo
+  echo "=== Building VPX $VERSION_VPX $ARCH ==="
+  LIB_VPX_TARGET=""
+  if [ "$ARCH" = "i686" ]; then
+    LIB_VPX_TARGET=x86-win32-gcc
+  else
+    LIB_VPX_TARGET=x86_64-win64-gcc
+  fi
+  git clone --depth=1 --branch="$VERSION_VPX" https://github.com/webmproject/libvpx
+  cd libvpx
+  CROSS="$WINDOWS_TOOLCHAIN"- ./configure --target="$LIB_VPX_TARGET" --prefix="$PREFIX_DIR" --disable-examples --disable-unit-tests --disable-shared --enable-static
+  make
+  make install
+  cd ..
 
-    rm -rf /tmp/*
+  rm -rf /tmp/*
 }
 
-if [ "${SUPPORT_ARCH_i686}" = "true" ]; then
-    build i686
+if [ "$SUPPORT_ARCH_i686" = "true" ]; then
+  build i686
 fi
 
-if [ "${SUPPORT_ARCH_x86_64}" = "true" ]; then
-    build x86_64
+if [ "$SUPPORT_ARCH_x86_64" = "true" ]; then
+  build x86_64
 fi
 
 tree /root

--- a/other/docker/windows/build_toxcore.sh
+++ b/other/docker/windows/build_toxcore.sh
@@ -4,159 +4,176 @@ set -e -x
 
 #=== Cross-Compile Toxcore ===
 
-build()
-{
-    ARCH=${1}
+build() {
+  ARCH=${1}
 
-    echo "Building for ${ARCH} architecture"
+  echo "Building for $ARCH architecture"
 
-    # set some things
+  # set some things
 
-    WINDOWS_TOOLCHAIN=${ARCH}-w64-mingw32
+  WINDOWS_TOOLCHAIN=$ARCH-w64-mingw32
 
-    # toxcore dependencies that we will copy to the user for static build of toxcore (e.g. vpx, opus, sodium)
-    DEP_PREFIX_DIR="/root/prefix/${ARCH}"
+  # toxcore dependencies that we will copy to the user for static build of toxcore (e.g. vpx, opus, sodium)
+  DEP_PREFIX_DIR="/root/prefix/$ARCH"
 
-    # toxcore dependencies that user doesn't need in build result
-    EXTRA_DEP_PREFIX_DIR="/root/extra-prefix/${ARCH}"
-    mkdir -p "${EXTRA_DEP_PREFIX_DIR}"
+  # where to put the result of this particular build
+  RESULT_PREFIX_DIR="/prefix/$ARCH"
+  rm -rf "$RESULT_PREFIX_DIR"
+  mkdir -p "$RESULT_PREFIX_DIR"
 
-    # where to put the result of this particular build
-    RESULT_PREFIX_DIR="/prefix/${ARCH}"
-    mkdir -p "${RESULT_PREFIX_DIR}"
+  rm -rf /tmp/*
 
-    # where to install static/shared toxcores before deciding whether they should be copied over to the user
-    STATIC_TOXCORE_PREFIX_DIR="/tmp/static_prefix"
-    SHARED_TOXCORE_PREFIX_DIR="/tmp/shared_prefix"
-    mkdir -p "${STATIC_TOXCORE_PREFIX_DIR}" "${SHARED_TOXCORE_PREFIX_DIR}"
+  # where to install static/shared toxcores before deciding whether they should be copied over to the user
+  STATIC_TOXCORE_PREFIX_DIR="/tmp/static_prefix"
+  SHARED_TOXCORE_PREFIX_DIR="/tmp/shared_prefix"
+  mkdir -p "$STATIC_TOXCORE_PREFIX_DIR" "$SHARED_TOXCORE_PREFIX_DIR"
 
-    export MAKEFLAGS=j$(nproc)
-    export CFLAGS=-O3
+  export MAKEFLAGS=j"$(nproc)"
+  export CFLAGS=-O3
 
-    echo
-    echo "=== Building toxcore ${ARCH} ==="
-    export PKG_CONFIG_PATH="${DEP_PREFIX_DIR}/lib/pkgconfig:${EXTRA_DEP_PREFIX_DIR}/lib/pkgconfig"
+  echo
+  echo "=== Building toxcore $ARCH ==="
+  export PKG_CONFIG_PATH="$DEP_PREFIX_DIR/lib/pkgconfig"
 
-    cp /toxcore /tmp/toxcore -R
-    cd /tmp/toxcore/build
-    echo "
+  if [ "$CROSS_COMPILE" = "true" ]; then
+    TOXCORE_DIR="/toxcore"
+  else
+    # get Toxcore root
+    cd "$(cd "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)"
+    cd ../../../
+    TOXCORE_DIR="$PWD"
+  fi
+
+  cp -a "$TOXCORE_DIR" /tmp/toxcore
+  cd /tmp/toxcore/build
+
+  echo "
         SET(CMAKE_SYSTEM_NAME Windows)
 
-        SET(CMAKE_C_COMPILER   ${WINDOWS_TOOLCHAIN}-gcc)
-        SET(CMAKE_CXX_COMPILER ${WINDOWS_TOOLCHAIN}-g++)
-        SET(CMAKE_RC_COMPILER  ${WINDOWS_TOOLCHAIN}-windres)
+        SET(CMAKE_C_COMPILER   $WINDOWS_TOOLCHAIN-gcc)
+        SET(CMAKE_CXX_COMPILER $WINDOWS_TOOLCHAIN-g++)
+        SET(CMAKE_RC_COMPILER  $WINDOWS_TOOLCHAIN-windres)
 
-        SET(CMAKE_FIND_ROOT_PATH /usr/${WINDOWS_TOOLCHAIN} ${DEP_PREFIX_DIR} ${EXTRA_DEP_PREFIX_DIR})
+        SET(CMAKE_FIND_ROOT_PATH /usr/$WINDOWS_TOOLCHAIN $DEP_PREFIX_DIR)
     " > windows_toolchain.cmake
 
-    if [ "${ENABLE_TEST}" = "true" ]; then
-        echo "SET(CROSSCOMPILING_EMULATOR /usr/bin/wine)" >> windows_toolchain.cmake
+  if [ "$ENABLE_TEST" = "true" ]; then
+    echo "SET(CROSSCOMPILING_EMULATOR /usr/bin/wine)" >> windows_toolchain.cmake
+  fi
+
+  cmake -DCMAKE_TOOLCHAIN_FILE=windows_toolchain.cmake \
+    -DCMAKE_INSTALL_PREFIX="$STATIC_TOXCORE_PREFIX_DIR" \
+    -DENABLE_SHARED=OFF \
+    -DENABLE_STATIC=ON \
+    -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" \
+    -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+    -DCMAKE_EXE_LINKER_FLAGS="$CMAKE_EXE_LINKER_FLAGS -fstack-protector" \
+    -DCMAKE_SHARED_LINKER_FLAGS="$CMAKE_SHARED_LINKER_FLAGS" \
+    $EXTRA_CMAKE_FLAGS \
+    ..
+  cmake --build . --target install -- -j"$(nproc)"
+
+  if [ "$ENABLE_TEST" = "true" ]; then
+    rm -rf /root/.wine
+
+    # setup wine
+    if [ "$ARCH" = "i686" ]; then
+      export WINEARCH=win32
+    else
+      export WINEARCH=win64
     fi
 
-    cmake -DCMAKE_TOOLCHAIN_FILE=windows_toolchain.cmake \
-        -DCMAKE_INSTALL_PREFIX="${STATIC_TOXCORE_PREFIX_DIR}" \
-        -DENABLE_SHARED=OFF \
-        -DENABLE_STATIC=ON \
-        -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS}" \
-        -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" \
-        -DCMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS}" \
-        -DCMAKE_SHARED_LINKER_FLAGS="${CMAKE_SHARED_LINKER_FLAGS}" \
-        ${EXTRA_CMAKE_FLAGS} \
-        ..
-    cmake --build . --target install -- -j$(nproc)
+    winecfg
+    export CTEST_OUTPUT_ON_FAILURE=1
+    # add libgcc_s_sjlj-1.dll libwinpthread-1.dll into PATH env var of wine
+    export WINEPATH="$(
+      cd /usr/lib/gcc/"$WINDOWS_TOOLCHAIN"/*posix/
+      winepath -w "$PWD"
+    )"\;"$(winepath -w /usr/"$WINDOWS_TOOLCHAIN"/lib/)"
 
-    if [ "${ENABLE_TEST}" = "true" ]; then
-        rm -rf /root/.wine
-
-        # setup wine
-        if [ "${ARCH}" = "i686" ]; then
-            export WINEARCH=win32
-        else
-            export WINEARCH=win64
-        fi
-
-        winecfg
-        export CTEST_OUTPUT_ON_FAILURE=1
-        # add libgcc_s_sjlj-1.dll libwinpthread-1.dll into PATH env var of wine
-        export WINEPATH=`cd /usr/lib/gcc/${WINDOWS_TOOLCHAIN}/*posix/ ; winepath -w $(pwd)`\;`winepath -w /usr/${WINDOWS_TOOLCHAIN}/lib/`\;`winepath -w ${EXTRA_DEP_PREFIX_DIR}/bin`
-
-        if [ "${ALLOW_TEST_FAILURE}" = "true" ]; then
-            set +e
-        fi
-        cmake --build . --target test -- ARGS="-j50"
-        if [ "${ALLOW_TEST_FAILURE}" = "true" ]; then
-            set -e
-        fi
+    if [ "$ALLOW_TEST_FAILURE" = "true" ]; then
+      set +e
     fi
+    cmake --build . --target test -- ARGS="-j50"
+    if [ "$ALLOW_TEST_FAILURE" = "true" ]; then
+      set -e
+    fi
+  fi
 
-    # move static dependencies
-    cp "${STATIC_TOXCORE_PREFIX_DIR}"/* "${RESULT_PREFIX_DIR}" -R
-    cp "${DEP_PREFIX_DIR}"/* "${RESULT_PREFIX_DIR}" -R
+  # move static dependencies
+  cp -a "$STATIC_TOXCORE_PREFIX_DIR"/* "$RESULT_PREFIX_DIR"
+  cp -a "$DEP_PREFIX_DIR"/* "$RESULT_PREFIX_DIR"
 
-    # make libtox.dll
-    cd "${SHARED_TOXCORE_PREFIX_DIR}"
-    for archive in ${STATIC_TOXCORE_PREFIX_DIR}/lib/libtox*.a
-    do
-        ${WINDOWS_TOOLCHAIN}-ar xv ${archive}
-    done
-    ${WINDOWS_TOOLCHAIN}-gcc -Wl,--export-all-symbols \
-                             -Wl,--out-implib=libtox.dll.a \
-                             -shared \
-                             -o libtox.dll \
-                             *.obj \
-                             ${STATIC_TOXCORE_PREFIX_DIR}/lib/*.a \
-                             ${DEP_PREFIX_DIR}/lib/*.a \
-                             /usr/${WINDOWS_TOOLCHAIN}/lib/libwinpthread.a \
-                             -liphlpapi \
-                             -lws2_32 \
-                             -static-libgcc
-    cp libtox.dll.a ${RESULT_PREFIX_DIR}/lib
-    mkdir -p ${RESULT_PREFIX_DIR}/bin
-    cp libtox.dll ${RESULT_PREFIX_DIR}/bin
+  # make libtox.dll
+  cd "$SHARED_TOXCORE_PREFIX_DIR"
+  for archive in "$STATIC_TOXCORE_PREFIX_DIR"/lib/libtox*.a; do
+    "$WINDOWS_TOOLCHAIN"-ar xv "$archive"
+  done
 
-    rm -rf /tmp/*
+  if [ "$CROSS_COMPILE" = "true" ]; then
+    LIBWINPTHREAD="/usr/$WINDOWS_TOOLCHAIN/lib/libwinpthread.a"
+  else
+    LIBWINPTHREAD="/usr/$WINDOWS_TOOLCHAIN/sys-root/mingw/lib/libwinpthread.a"
+  fi
 
-    # remove everything from include directory except tox headers
-    mv ${RESULT_PREFIX_DIR}/include/tox ${RESULT_PREFIX_DIR}/tox
-    rm -rf ${RESULT_PREFIX_DIR}/include/*
-    mv ${RESULT_PREFIX_DIR}/tox ${RESULT_PREFIX_DIR}/include/tox
+  "$WINDOWS_TOOLCHAIN"-gcc -Wl,--export-all-symbols \
+    -Wl,--out-implib=libtox.dll.a \
+    -shared \
+    -o libtox.dll \
+    *.obj \
+    "$STATIC_TOXCORE_PREFIX_DIR"/lib/*.a \
+    "$DEP_PREFIX_DIR"/lib/*.a \
+    "$LIBWINPTHREAD" \
+    -liphlpapi \
+    -lws2_32 \
+    -static-libgcc \
+    -lssp
+  cp libtox.dll.a "$RESULT_PREFIX_DIR"/lib
+  mkdir -p "$RESULT_PREFIX_DIR"/bin
+  cp libtox.dll "$RESULT_PREFIX_DIR"/bin
 
-    sed -i "s|^prefix=.*|prefix=${RESULT_PREFIX_DIR}|g" ${RESULT_PREFIX_DIR}/lib/pkgconfig/*.pc
-    sed -i "s|^libdir=.*|libdir=${RESULT_PREFIX_DIR}/lib|g" ${RESULT_PREFIX_DIR}/lib/*.la
+  rm -rf /tmp/*
+
+  # remove everything from include directory except tox headers
+  mv "$RESULT_PREFIX_DIR"/include/tox "$RESULT_PREFIX_DIR"/tox
+  rm -rf "$RESULT_PREFIX_DIR"/include/*
+  mv "$RESULT_PREFIX_DIR"/tox "$RESULT_PREFIX_DIR"/include/tox
+
+  sed -i "s|^prefix=.*|prefix=$RESULT_PREFIX_DIR|g" "$RESULT_PREFIX_DIR"/lib/pkgconfig/*.pc
+  sed -i "s|^libdir=.*|libdir=$RESULT_PREFIX_DIR/lib|g" "$RESULT_PREFIX_DIR"/lib/*.la
 }
 
 #=== Test Supported vs. Enabled ===
 
-if [ "${ENABLE_ARCH_i686}" != "true" ] && [ "${ENABLE_ARCH_x86_64}" != "true" ]; then
-    echo "Error: No architecture specified. Set either ENABLE_ARCH_i686 or ENABLE_ARCH_x86_64 or both."
-    exit 1
+if [ "$ENABLE_ARCH_i686" != "true" ] && [ "$ENABLE_ARCH_x86_64" != "true" ]; then
+  echo "Error: No architecture specified. Set either ENABLE_ARCH_i686 or ENABLE_ARCH_x86_64 or both."
+  exit 1
 fi
 
-if [ "${ENABLE_ARCH_i686}" = "true" ] && [ "${SUPPORT_ARCH_i686}" != "true" ]; then
-    echo "Error: Can't build for i686 architecture because the image was created without SUPPORT_ARCH_i686 set"
-    exit 1
+if [ "$ENABLE_ARCH_i686" = "true" ] && [ "$SUPPORT_ARCH_i686" != "true" ]; then
+  echo "Error: Can't build for i686 architecture because the image was created without SUPPORT_ARCH_i686 set"
+  exit 1
 fi
 
-if [ "${ENABLE_ARCH_x86_64}" = "true" ] && [ "${SUPPORT_ARCH_x86_64}" != "true" ]; then
-    echo "Error: Can't build for x86_64 architecture because the image was created without SUPPORT_ARCH_x86_64 set"
-    exit 1
+if [ "$ENABLE_ARCH_x86_64" = "true" ] && [ "$SUPPORT_ARCH_x86_64" != "true" ]; then
+  echo "Error: Can't build for x86_64 architecture because the image was created without SUPPORT_ARCH_x86_64 set"
+  exit 1
 fi
 
-if [ "${ENABLE_TEST}" = "true" ] && [ "${SUPPORT_TEST}" != "true" ]; then
-    echo "Error: Can't build with tests because the image was created without SUPPORT_TEST set"
-    exit 1
+if [ "$ENABLE_TEST" = "true" ] && [ "$SUPPORT_TEST" != "true" ]; then
+  echo "Error: Can't build with tests because the image was created without SUPPORT_TEST set"
+  exit 1
 fi
 
 #=== Build ===
 
-if [ "${ENABLE_ARCH_i686}" = "true" ]; then
-    build i686
+if [ "$ENABLE_ARCH_i686" = "true" ]; then
+  build i686
 fi
 
-if [ "${ENABLE_ARCH_x86_64}" = "true" ]; then
-    build x86_64
+if [ "$ENABLE_ARCH_x86_64" = "true" ]; then
+  build x86_64
 fi
-
 
 tree -h /prefix
 
@@ -165,4 +182,6 @@ echo "Built toxcore successfully!"
 echo
 
 # since we are building as root
-chmod 777 /prefix -R
+if [ "$CROSS_COMPILE" = "true" ]; then
+  chmod 777 /prefix -R
+fi

--- a/other/docker/windows/build_toxcore.sh
+++ b/other/docker/windows/build_toxcore.sh
@@ -55,10 +55,10 @@ build() {
         SET(CMAKE_RC_COMPILER  $WINDOWS_TOOLCHAIN-windres)
 
         SET(CMAKE_FIND_ROOT_PATH /usr/$WINDOWS_TOOLCHAIN $DEP_PREFIX_DIR)
-    " > windows_toolchain.cmake
+    " >windows_toolchain.cmake
 
   if [ "$ENABLE_TEST" = "true" ]; then
-    echo "SET(CROSSCOMPILING_EMULATOR /usr/bin/wine)" >> windows_toolchain.cmake
+    echo "SET(CROSSCOMPILING_EMULATOR /usr/bin/wine)" >>windows_toolchain.cmake
   fi
 
   cmake -DCMAKE_TOOLCHAIN_FILE=windows_toolchain.cmake \

--- a/other/docker/windows/get_packages.sh
+++ b/other/docker/windows/get_packages.sh
@@ -8,62 +8,47 @@ apt-get update
 
 # Arch-independent packages required for building toxcore's dependencies and toxcore itself
 apt-get install -y \
-    autoconf \
-    automake \
-    ca-certificates \
-    cmake \
-    curl \
-    git \
-    libtool \
-    libc-dev \
-    make \
-    pkg-config \
-    tree \
-    yasm
+  autoconf \
+  automake \
+  ca-certificates \
+  cmake \
+  curl \
+  libtool \
+  libc-dev \
+  make \
+  pkg-config \
+  tree \
+  yasm
 
 # Arch-dependent packages required for building toxcore's dependencies and toxcore itself
 if [ "$SUPPORT_ARCH_i686" = "true" ]; then
-    apt-get install -y \
-        g++-mingw-w64-i686 \
-        gcc-mingw-w64-i686
+  apt-get install -y \
+    g++-mingw-w64-i686 \
+    gcc-mingw-w64-i686
 fi
 
 if [ "$SUPPORT_ARCH_x86_64" = "true" ]; then
-    apt-get install -y \
-        g++-mingw-w64-x86-64 \
-        gcc-mingw-w64-x86-64
+  apt-get install -y \
+    g++-mingw-w64-x86-64 \
+    gcc-mingw-w64-x86-64
 fi
 
 # Packages needed for running toxcore tests
 if [ "$SUPPORT_TEST" = "true" ]; then
-    apt-get install -y \
-        apt-transport-https \
-        curl \
-        gnupg \
-        texinfo
+  apt-get install -y \
+    texinfo
 
-    # Add Wine package repository to use the latest Wine
-    echo "deb https://dl.winehq.org/wine-builds/debian/ stretch main" >> /etc/apt/sources.list
-    curl -o Release.key https://dl.winehq.org/wine-builds/winehq.key
-    # Verify against a known good key fingerprint. --dry-run makes it so we don't actually import the key.
-    if ! gpg --batch --dry-run --import --import-options import-show --fingerprint Release.key | grep 'D43F 6401 4536 9C51 D786  DDEA 76F1 A20F F987 672F'; then
-        echo "Error: WineHQ's Debian package repository key fingerprint didn't match the expected one. Exiting."
-        exit 1
-    fi
-    apt-key add Release.key
-
-    dpkg --add-architecture i386
-    apt-get update
-    apt-get install -y \
-        wine-devel \
-        wine-devel-amd64 \
-        wine-devel-dbg \
-        winehq-devel
+  dpkg --add-architecture i386
+  apt-get update
+  apt-get install -y \
+    wine \
+    wine32 \
+    wine64
 fi
 
 # Clean up to reduce image size
 apt-get clean
 rm -rf \
-    /var/lib/apt/lists/* \
-    /tmp/* \
-    /var/tmp/*
+  /var/lib/apt/lists/* \
+  /tmp/* \
+  /var/tmp/*

--- a/other/docker/windows/get_packages.sh
+++ b/other/docker/windows/get_packages.sh
@@ -12,6 +12,7 @@ apt-get install -y \
     automake \
     ca-certificates \
     cmake \
+    curl \
     git \
     libtool \
     libc-dev \
@@ -21,20 +22,20 @@ apt-get install -y \
     yasm
 
 # Arch-dependent packages required for building toxcore's dependencies and toxcore itself
-if [ "${SUPPORT_ARCH_i686}" = "true" ]; then
+if [ "$SUPPORT_ARCH_i686" = "true" ]; then
     apt-get install -y \
         g++-mingw-w64-i686 \
         gcc-mingw-w64-i686
 fi
 
-if [ "${SUPPORT_ARCH_x86_64}" = "true" ]; then
+if [ "$SUPPORT_ARCH_x86_64" = "true" ]; then
     apt-get install -y \
         g++-mingw-w64-x86-64 \
         gcc-mingw-w64-x86-64
 fi
 
 # Packages needed for running toxcore tests
-if [ "${SUPPORT_TEST}" = "true" ]; then
+if [ "$SUPPORT_TEST" = "true" ]; then
     apt-get install -y \
         apt-transport-https \
         curl \

--- a/other/windows_build_script_toxcore.sh
+++ b/other/windows_build_script_toxcore.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 export VERSION_SODIUM="1.0.18"
-export VERSION_OPUS="v1.2.1"
-export VERSION_VPX="v1.6.1"
+export VERSION_OPUS="1.3.1"
+export VERSION_VPX="1.9.0"
 
 export SUPPORT_TEST=false
 export SUPPORT_ARCH_i686=true

--- a/other/windows_build_script_toxcore.sh
+++ b/other/windows_build_script_toxcore.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+export VERSION_SODIUM="1.0.18"
+export VERSION_OPUS="v1.2.1"
+export VERSION_VPX="v1.6.1"
+
+export SUPPORT_TEST=false
+export SUPPORT_ARCH_i686=true
+export SUPPORT_ARCH_x86_64=true
+export CROSS_COMPILE=false
+
+sh ./other/docker/windows/build_dependencies.sh
+
+export ENABLE_TEST=false
+export ALLOW_TEST_FAILURE=false
+export ENABLE_ARCH_i686=true
+export ENABLE_ARCH_x86_64=true
+export EXTRA_CMAKE_FLAGS="-DTEST_TIMEOUT_SECONDS=90"
+
+sh ./other/docker/windows/build_toxcore.sh


### PR DESCRIPTION
Based on Windows docker scripts with some tweaks:
* add parameter `CROSS_COMPILE` for switching between Cygwin and Docker:
  * `true` for Docker
  * `false` for Cygwin
* disable `set -e -x` because some dependencies builds fail due to that
* remove prefix and tmp folders to run a clean build each time
* build **Opus** from tarball not from git clone because `autogen.sh` failed on Cygwin due to some error with `ltmain.sh` symlink:
  ```bash
  Updating build configuration files, please wait....
  libtoolize: putting auxiliary files in '.'.
  libtoolize: linking file './ltmain.sh'
  autoreconf-2.69: libtoolize failed with exit status: 1
  ```
* add `-fstack-protector` to `CMAKE_EXE_LINKER_FLAGS` and `-lssp` when creating `libtox.dll` to fix (https://github.com/msys2/MINGW-packages/issues/5868)
* change `libwinpthread.a` folder for `libtox.dll`
* disable chmod

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1537)
<!-- Reviewable:end -->
