### PR TITLE
fix:Refactor peer list syncing

### DIFF
--- a/auto_tests/group_message_test.c
+++ b/auto_tests/group_message_test.c
@@ -93,7 +93,7 @@ static void group_message_handler(Tox *tox, uint32_t groupnumber, uint32_t peer_
     ck_assert(s_err == TOX_ERR_GROUP_SELF_QUERY_OK);
     ck_assert(memcmp(self_name, PEER1_NICK, self_name_len) == 0);
 
-    printf("%s sent message to %s: %s\n\n", peer_name, self_name, message_buf);
+    printf("%s sent message to %s: %s\n", peer_name, self_name, message_buf);
     ck_assert(memcmp(message_buf, TEST_MESSAGE, length) == 0);
 
     State *state = (State *)user_data;

--- a/toxcore/group_announce.c
+++ b/toxcore/group_announce.c
@@ -261,14 +261,14 @@ int gca_pack_announces_list(uint8_t *data, uint16_t length, GC_Announce *announc
     for (i = 0; i < announces_count; ++i) {
         int packed_length = gca_pack_announce(data + offset, length - offset, &announces[i]);
 
-        if (packed_length == -1) {
+        if (packed_length < 0) {
             return -1;
         }
 
         offset += packed_length;
     }
 
-    if (processed) {
+    if (processed != nullptr) {
         *processed = offset;
     }
 

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -33,7 +33,6 @@
 #define GC_SEND_IP_PORT_INTERVAL (GC_PING_TIMEOUT * 5)
 #define GC_CONFIRMED_PEER_TIMEOUT (GC_PING_TIMEOUT * 4 + 10)
 #define GC_UNCONFIRMED_PEER_TIMEOUT (GC_PING_TIMEOUT * 2)
-#define MAX_GC_CONFIRMED_PEERS 100  // todo: what is this for?
 
 #define GC_JOIN_DATA_LENGTH (ENC_PUBLIC_KEY + CHAT_ID_SIZE)
 
@@ -256,12 +255,9 @@ typedef struct Saved_Group Saved_Group;
 
 typedef struct GC_Chat {
     const Mono_Time *mono_time;
-    const Logger *logger;
-    uint8_t confirmed_peers[MAX_GC_CONFIRMED_PEERS][ENC_PUBLIC_KEY];
-    uint8_t confirmed_peers_index;
+    const Logger    *logger;
 
-    IP_Port self_ip_port;
-
+    IP_Port         self_ip_port;
     Networking_Core *net;
     TCP_Connections *tcp_conn;
 

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -33,7 +33,7 @@
 #define GC_SEND_IP_PORT_INTERVAL (GC_PING_TIMEOUT * 5)
 #define GC_CONFIRMED_PEER_TIMEOUT (GC_PING_TIMEOUT * 4 + 10)
 #define GC_UNCONFIRMED_PEER_TIMEOUT (GC_PING_TIMEOUT * 2)
-#define MAX_GC_CONFIRMED_PEERS 20
+#define MAX_GC_CONFIRMED_PEERS 100  // todo: what is this for?
 
 #define GC_JOIN_DATA_LENGTH (ENC_PUBLIC_KEY + CHAT_ID_SIZE)
 
@@ -275,6 +275,7 @@ typedef struct GC_Chat {
     GC_TopicInfo    topic_info;
     uint8_t         topic_sig[SIGNATURE_SIZE];    /* Signed by a moderator or the founder */
 
+    uint32_t    peers_checksum;   /* A sum of the public key hash of every confirmed peer in the group */
     uint32_t    numpeers;
     int         group_number;
 

--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -192,6 +192,24 @@ void gcc_set_ip_port(GC_Connection *gconn, const IP_Port *ipp)
     }
 }
 
+/*
+ * Copies a TCP relay node from gconn to node.
+ *
+ * Return 0 on success.
+ * Return -1 on failure.
+ */
+int gcc_copy_tcp_relay(GC_Connection *gconn, Node_format *node)
+{
+    if (gconn == nullptr || node == nullptr) {
+        return -1;
+    }
+
+    int index = (gconn->tcp_relays_index - 1 + MAX_FRIEND_TCP_CONNECTIONS) % MAX_FRIEND_TCP_CONNECTIONS;
+    memcpy(node, &gconn->connected_tcp_relays[index], sizeof(Node_format));
+
+    return 0;
+}
+
 /* Decides if message need to be put in received_array or immediately handled.
  *
  * Return 2 if message is in correct sequence and may be handled immediately.

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -59,8 +59,6 @@ struct GC_Connection {
 
     uint64_t    last_received_ping_time;
     uint64_t    last_sent_ping_time;
-    bool        pending_sync_request;   /* true if we have sent this peer a sync request and have not received a reply*/
-    bool        pending_state_sync;    /* used for group state syncing */
     bool        handshaked; /* true if we've successfully handshaked with this peer */
     uint64_t    pending_handshake;
     uint8_t     pending_handshake_type;

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -119,6 +119,14 @@ bool gcc_ip_port_is_set(GC_Connection *gconn);
  */
 void gcc_set_ip_port(GC_Connection *gconn, const IP_Port *ipp);
 
+/*
+ * Copies a TCP relay node from gconn to node.
+ *
+ * Return 0 on success.
+ * Return -1 on failure.
+ */
+int gcc_copy_tcp_relay(GC_Connection *gconn, Node_format *node);
+
 /* Checks for and handles messages that are in proper sequence in gconn's received_array.
  * This should always be called after a new packet is successfully handled.
  *


### PR DESCRIPTION
We now send each peer in a single packet instead of the entire
peer list in one big packet. This removes a theoretical hard
limit on the number of peers that can join a group and ensures
that the maximum packet size doesn't exceed the MTU of common
network media.                                                         
      
Some unnecessary syncing logic was removed. This will increase
the aggressiveness of syncing with more redundancy, but should
improve overall syncing speed.
                              
Additionally, the ping packet now contains a checksum of the
public key hash of all confirmed peers instead of just the peer
count. This will ensure that sync requests will be made in
the case that all group peers have the same peer count, but a
different set of peers (i.e. group splits).
                                           
Finally - an unused 32-bit uint was removed from the sync request
packet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1539)
<!-- Reviewable:end -->
