### PR TITLE
fix: bug causing topic callback to sometimes give client the wrong peer id

### DIFF
--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -3468,7 +3468,8 @@ namespace group {
   event topic const {
     /**
      * @param group_number The group number of the group the topic change is intended for.
-     * @param peer_id The ID of the peer who changed the topic.
+     * @param peer_id The ID of the peer who changed the topic. If the peer who set the topic
+     *   is not present in our peer list this value will be set to 0.
      * @param topic The topic data.
      * @param length The topic length.
      */

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -4032,7 +4032,8 @@ bool tox_group_get_topic(const Tox *tox, uint32_t group_number, uint8_t *topic, 
 
 /**
  * @param group_number The group number of the group the topic change is intended for.
- * @param peer_id The ID of the peer who changed the topic.
+ * @param peer_id The ID of the peer who changed the topic. If the peer who set the topic
+ *   is not present in our peer list this value will be set to 0.
  * @param topic The topic data.
  * @param length The topic length.
  */


### PR DESCRIPTION
If we received the topic in a sync request the callback would give the client the peer id of the syncer rather than the peer who actually set the topic. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1544)
<!-- Reviewable:end -->
