### PR TITLE
fix: Add sanctions list entry purging

### DIFF
--- a/toxcore/group_moderation.c
+++ b/toxcore/group_moderation.c
@@ -682,7 +682,8 @@ static int sanctions_list_sign_entry(const GC_Chat *chat, struct GC_Sanction *sa
 int sanctions_list_add_entry(GC_Chat *chat, struct GC_Sanction *sanction, struct GC_Sanction_Creds *creds)
 {
     if (chat->moderation.num_sanctions >= MAX_GC_SANCTIONS) {
-        return -1;   // TODO(JFreegman): remove oldest entry and continue
+        LOGGER_ERROR(chat->logger, "num_sanctions %d exceeds maximum", chat->moderation.num_sanctions);
+        return -1;
     }
 
     if (sanctions_list_validate_entry(chat, sanction) < 0) {

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -4164,8 +4164,8 @@ namespace group {
        */
       ASSIGNMENT,
       /**
-       * The role was not successfully set. This may occur if something goes wrong with role setting,
-       * or if the packet fails to send.
+       * The role was not successfully set. This may occur if the packet failed to send, or
+       * if the role limit has been reached.
        */
       FAIL_ACTION,
       /**

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -4912,8 +4912,8 @@ typedef enum TOX_ERR_GROUP_MOD_SET_ROLE {
     TOX_ERR_GROUP_MOD_SET_ROLE_ASSIGNMENT,
 
     /**
-     * The role was not successfully set. This may occur if something goes wrong with role setting,
-     * or if the packet fails to send.
+     * The role was not successfully set. This may occur if the packet failed to send, or
+     * if the role limit has been reached.
      */
     TOX_ERR_GROUP_MOD_SET_ROLE_FAIL_ACTION,
 


### PR DESCRIPTION
When the list is full it will attempt to remove an entry for an offline peer.
If all sanctioned peers are online an error will be returned and the situation
can be dealt with manually by the caller

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1550)
<!-- Reviewable:end -->
