### PR TITLE
fix: Make save format moderator list a fixed size

### DIFF
--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -212,6 +212,7 @@ typedef struct GC_TopicInfo {
 typedef struct GC_Connection GC_Connection;
 
 #define GROUP_SAVE_MAX_PEERS MAX_GC_PEER_ADDRS
+#define GROUP_SAVE_MAX_MODERATORS 128  // must be <= MAX_GC_MODERATORS (temporary fix to prevent save format breakage)
 
 struct Saved_Group {
     /* Group shared state */
@@ -239,7 +240,7 @@ struct Saved_Group {
     uint16_t  num_addrs;
     GC_SavedPeerInfo addrs[GROUP_SAVE_MAX_PEERS];
     uint16_t  num_mods;
-    uint8_t   mod_list[GC_MOD_LIST_ENTRY_SIZE * MAX_GC_MODERATORS];
+    uint8_t   mod_list[GC_MOD_LIST_ENTRY_SIZE * GROUP_SAVE_MAX_MODERATORS];
     uint8_t   group_connection_state;
 
     /* self info */


### PR DESCRIPTION
This allows us to change the max number of moderators without breaking
the save format. This should be a temporary fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1551)
<!-- Reviewable:end -->
