### PR TITLE
fix: bug sometimes preventing handshakes from taking place

### DIFF
--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -156,7 +156,7 @@ int gcc_handle_ack(GC_Connection *gconn, uint64_t message_id)
     GC_Message_Array_Entry *array_entry = &gconn->send_array[idx];
 
     if (array_entry_is_empty(array_entry)) {
-        return -1;
+        return 0;
     }
 
     if (array_entry->message_id != message_id) {  // wrap-around indicates a connection problem


### PR DESCRIPTION
The problem: Peer A joins group and makes announcement. Peer A closes client. Peer B gets Peer A's stale announcement and attempts to handshake. Peer A opens client and tries to join the group (same public key). Peer B ignores Peer A's new announcement because he already has that public key in his peer list, and both peers' handshake attempts fail because they no longer have the same shared session key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1567)
<!-- Reviewable:end -->
