### PR TITLE
fix: Make group TCP relay connections more robust

### DIFF
--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -63,7 +63,6 @@ uint32_t tcp_connections_count(const TCP_Connections *tcp_c)
     return tcp_c->tcp_connections_length;
 }
 
-
 /* Set the size of the array to num.
  *
  *  return -1 if realloc fails.
@@ -272,6 +271,26 @@ static TCP_con *get_tcp_connection(const TCP_Connections *tcp_c, int tcp_connect
     }
 
     return &tcp_c->tcp_connections[tcp_connections_number];
+}
+
+/* Returns the number of connected TCP relays */
+uint32_t tcp_connected_relays_count(const TCP_Connections *tcp_c)
+{
+    uint32_t count = 0;
+
+    for (uint32_t i = 0; i < tcp_c->tcp_connections_length; ++i) {
+        TCP_con *tcp_con = get_tcp_connection(tcp_c, i);
+
+        if (!tcp_con) {
+            continue;
+        }
+
+        if (tcp_con->status == TCP_CONN_CONNECTED) {
+            ++count;
+        }
+    }
+
+    return count;
 }
 
 /* Send a packet to the TCP connection.

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -72,6 +72,8 @@ const uint8_t *tcp_connections_public_key(const TCP_Connections *tcp_c);
 
 uint32_t tcp_connections_count(const TCP_Connections *tcp_c);
 
+/* Returns the number of connected TCP relays */
+uint32_t tcp_connected_relays_count(const TCP_Connections *tcp_c);
 
 /* Send a packet to the TCP connection.
  *

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -272,6 +272,7 @@ typedef struct GC_Chat {
     IP_Port         self_ip_port;
     Networking_Core *net;
     TCP_Connections *tcp_conn;
+    uint64_t        last_checked_tcp_relays;
 
     GC_GroupPeer    *group;
     GC_Connection   *gcc;


### PR DESCRIPTION
We now periodically check that we're connected to at least one TCP relay, and
if not, we attempt to add relays. Previously we never checked our
connections with relays if the group state was connected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1568)
<!-- Reviewable:end -->
