### PR TITLE
fix: bug causing invalid TCP nodes to be copied to group announcements

### DIFF
--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -196,8 +196,7 @@ void gcc_set_ip_port(GC_Connection *gconn, const IP_Port *ipp)
     }
 }
 
-/*
- * Copies a TCP relay node from gconn to node.
+/* Copies a random TCP relay node from gconn to node.
  *
  * Return 0 on success.
  * Return -1 on failure.
@@ -208,8 +207,12 @@ int gcc_copy_tcp_relay(const GC_Connection *gconn, Node_format *node)
         return -1;
     }
 
-    int index = (gconn->tcp_relays_index - 1 + MAX_FRIEND_TCP_CONNECTIONS) % MAX_FRIEND_TCP_CONNECTIONS;
-    memcpy(node, &gconn->connected_tcp_relays[index], sizeof(Node_format));
+    if (gconn->tcp_relays_count == 0) {
+        return -1;
+    }
+
+    uint32_t rand_idx = random_u32() % gconn->tcp_relays_count;
+    memcpy(node, &gconn->connected_tcp_relays[rand_idx], sizeof(Node_format));
 
     return 0;
 }

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -59,8 +59,7 @@ struct GC_Connection {
     uint64_t    last_sent_ip_time;  /* the last time we sent our ip info to this peer in a ping packet */
 
     Node_format connected_tcp_relays[MAX_FRIEND_TCP_CONNECTIONS];
-    int tcp_relays_index;
-    bool any_tcp_connections;
+    uint16_t    tcp_relays_count;
 
     uint64_t    last_received_ping_time;
     uint64_t    last_requested_packet_time;  /* The last time we requested a missing packet from this peer */
@@ -129,8 +128,7 @@ bool gcc_ip_port_is_set(const GC_Connection *gconn);
  */
 void gcc_set_ip_port(GC_Connection *gconn, const IP_Port *ipp);
 
-/*
- * Copies a TCP relay node from gconn to node.
+/* Copies a random TCP relay node from gconn to node.
  *
  * Return 0 on success.
  * Return -1 on failure.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1572)
<!-- Reviewable:end -->
