### PR TITLE
refactor: invite sending and main do_gc loop

### DIFF
--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -94,8 +94,6 @@ typedef enum Group_Peer_Status {
 
 typedef enum Group_Connection_State {
     CS_NONE,
-    CS_FAILED,
-    CS_MANUALLY_DISCONNECTED,
     CS_DISCONNECTED,
     CS_CONNECTING,
     CS_CONNECTED,
@@ -299,7 +297,6 @@ typedef struct GC_Chat {
 
     uint8_t     connection_state;
     uint64_t    time_connected;
-    uint64_t    last_join_attempt;
     uint64_t    last_ping_interval;
     uint64_t    last_sync_request;
     uint8_t     join_type;   /* How we joined the group (invite or DHT) */
@@ -314,7 +311,6 @@ typedef struct GC_Chat {
 
     uint8_t m_group_public_key[CRYPTO_PUBLIC_KEY_SIZE];  /* Identifier for group's messenger friend connection */
     bool should_update_self_announces;
-    bool should_start_sending_handshakes;
 
     Saved_Group *save;
 } GC_Chat;

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -65,7 +65,7 @@ struct GC_Connection {
     uint64_t    last_requested_packet_time;  /* The last time we requested a missing packet from this peer */
     uint64_t    last_sent_ping_time;
     bool        handshaked; /* true if we've successfully handshaked with this peer */
-    uint64_t    pending_handshake;
+    uint64_t    last_handshake_attempt;
     uint8_t     pending_handshake_type;
     bool        is_pending_handshake_response;
     bool        is_oob_handshake;

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -2798,7 +2798,7 @@ bool tox_group_is_connected(Tox *tox, uint32_t group_number, Tox_Err_Group_Is_Co
 
     SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_IS_CONNECTED_OK);
 
-    return chat->connection_state != CS_MANUALLY_DISCONNECTED;
+    return chat->connection_state == CS_CONNECTED;
 }
 
 bool tox_group_disconnect(Tox *tox, uint32_t group_number, Tox_Err_Group_Disconnect *error)
@@ -2810,7 +2810,7 @@ bool tox_group_disconnect(Tox *tox, uint32_t group_number, Tox_Err_Group_Disconn
         return 0;
     }
 
-    if (chat->connection_state == CS_MANUALLY_DISCONNECTED) {
+    if (chat->connection_state == CS_DISCONNECTED) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_DISCONNECT_ALREADY_DISCONNECTED);
         return 0;
     }
@@ -3130,7 +3130,7 @@ bool tox_group_set_topic(Tox *tox, uint32_t group_number, const uint8_t *topic, 
         return 0;
     }
 
-    if (chat->connection_state == CS_MANUALLY_DISCONNECTED) {
+    if (chat->connection_state == CS_DISCONNECTED) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_TOPIC_SET_GROUP_IS_DISCONNECTED);
         return 0;
     }
@@ -3309,7 +3309,7 @@ bool tox_group_send_message(Tox *tox, uint32_t group_number, Tox_Message_Type ty
         return 0;
     }
 
-    if (chat->connection_state == CS_MANUALLY_DISCONNECTED) {
+    if (chat->connection_state == CS_DISCONNECTED) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SEND_MESSAGE_GROUP_IS_DISCONNECTED);
         return 0;
     }
@@ -3356,7 +3356,7 @@ bool tox_group_send_private_message(Tox *tox, uint32_t group_number, uint32_t pe
         return 0;
     }
 
-    if (chat->connection_state == CS_MANUALLY_DISCONNECTED) {
+    if (chat->connection_state == CS_DISCONNECTED) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SEND_PRIVATE_MESSAGE_GROUP_IS_DISCONNECTED);
         return 0;
     }
@@ -3407,7 +3407,7 @@ bool tox_group_send_custom_packet(Tox *tox, uint32_t group_number, bool lossless
         return 0;
     }
 
-    if (chat->connection_state == CS_MANUALLY_DISCONNECTED) {
+    if (chat->connection_state == CS_DISCONNECTED) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SEND_CUSTOM_PACKET_GROUP_IS_DISCONNECTED);
         return 0;
     }
@@ -3446,7 +3446,7 @@ bool tox_group_invite_friend(Tox *tox, uint32_t group_number, uint32_t friend_nu
         return 0;
     }
 
-    if (chat->connection_state == CS_MANUALLY_DISCONNECTED) {
+    if (chat->connection_state == CS_DISCONNECTED) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_INVITE_FRIEND_GROUP_IS_DISCONNECTED);
         return 0;
     }
@@ -3537,7 +3537,7 @@ bool tox_group_founder_set_password(Tox *tox, uint32_t group_number, const uint8
         return 0;
     }
 
-    if (chat->connection_state == CS_MANUALLY_DISCONNECTED) {
+    if (chat->connection_state == CS_DISCONNECTED) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_GROUP_IS_DISCONNECTED);
         return 0;
     }
@@ -3615,7 +3615,7 @@ bool tox_group_founder_set_peer_limit(Tox *tox, uint32_t group_number, uint32_t 
         return 0;
     }
 
-    if (chat->connection_state == CS_MANUALLY_DISCONNECTED) {
+    if (chat->connection_state == CS_DISCONNECTED) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_GROUP_IS_DISCONNECTED);
         return 0;
     }


### PR DESCRIPTION
Instead of spamming peers for invites for 15 seconds straight in intervals we now
have a simple timer and make one request per n seconds.

In addition, the CS_MANUALLY_DISCONNECTED and CS_FAILED states were merged
with CS_DISCONNECTED and state logic was simplified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1579)
<!-- Reviewable:end -->
