### PR TITLE
fix: Kill tcp connection when peer is marked for deletion

### DIFF
--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -82,7 +82,8 @@ struct GC_Connection {
 GC_Connection *gcc_get_connection(const GC_Chat *chat, int peer_number);
 
 /* Marks a peer for deletion. If gconn is null this function has no effect. */
-void gcc_mark_for_deletion(GC_Connection *gconn, Group_Exit_Type type, const uint8_t *part_message, size_t length);
+void gcc_mark_for_deletion(GC_Connection *gconn, TCP_Connections *tcp_conn, Group_Exit_Type type,
+                           const uint8_t *part_message, size_t length);
 
 /* Adds data of length to gconn's send_array.
  *


### PR DESCRIPTION
This fixes an issue where a tcp connection number was being killed twice which
would occasionally cause buggy behaviour if a new peer was assigned that same
id (e.g. on a rejoin or reconnect)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1584)
<!-- Reviewable:end -->
