### PR TITLE
Fix: A couple small fixes 

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -4408,7 +4408,7 @@ static int handle_gc_handshake_request(Messenger *m, int group_number, const IP_
         }
 
         if (gconn->handshaked) {
-            return send_gc_handshake_response(chat, peer_number, request_type);
+            return 0;
         }
     }
 

--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -437,6 +437,10 @@ void gcc_mark_for_deletion(GC_Connection *gconn, TCP_Connections *tcp_conn, Grou
         return;
     }
 
+    if (gconn->pending_delete) {
+        return;
+    }
+
     if (type >= GC_EXIT_TYPE_INVALID) {
         type = GC_EXIT_TYPE_QUIT;
     }

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -81,7 +81,7 @@ struct GC_Connection {
  */
 GC_Connection *gcc_get_connection(const GC_Chat *chat, int peer_number);
 
-/* Marks a peer for deletion. If gconn is null this function has no effect. */
+/* Marks a peer for deletion. If gconn is null or already marked for deletion this function has no effect. */
 void gcc_mark_for_deletion(GC_Connection *gconn, TCP_Connections *tcp_conn, Group_Exit_Type type,
                            const uint8_t *part_message, size_t length);
 


### PR DESCRIPTION
- Make sure peers can't be marked for deletion twice
- Ignore handshake packets from peers we've already handshaked with
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1593)
<!-- Reviewable:end -->
