### PR TITLE
refactor: Simplify and improve group handshake protocol

### DIFF
--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -33,7 +33,7 @@
 #define GC_PING_TIMEOUT 12
 #define GC_SEND_IP_PORT_INTERVAL (GC_PING_TIMEOUT * 5)
 #define GC_CONFIRMED_PEER_TIMEOUT (GC_PING_TIMEOUT * 6 + 10)
-#define GC_UNCONFIRMED_PEER_TIMEOUT (GC_PING_TIMEOUT * 2)
+#define GC_UNCONFIRMED_PEER_TIMEOUT GC_PING_TIMEOUT
 
 #define GC_JOIN_DATA_LENGTH (ENC_PUBLIC_KEY + CHAT_ID_SIZE)
 
@@ -133,8 +133,7 @@ typedef enum Group_Packet_Type {
     GP_TCP_RELAYS               = 4,
 
     /* lossless packets */
-    GP_CUSTOM_PACKET            = 241,
-    GP_PEER_ANNOUNCE            = 242,
+    GP_CUSTOM_PACKET            = 242,
     GP_BROADCAST                = 243,
     GP_PEER_INFO_REQUEST        = 244,
     GP_PEER_INFO_RESPONSE       = 245,
@@ -317,7 +316,7 @@ typedef struct GC_Chat {
 
     bool        update_self_announces;     /* true if we should try to update our announcements */
     uint64_t    last_self_announce_check;  /* the last time we checked if we should update our announcements */
-    uint64_t    last_self_announce_time;   /* the last time we attrpted to update our announcements */
+    uint64_t    last_self_announce_time;   /* the last time we attempted to update our announcements */
 
     Saved_Group *save;
 } GC_Chat;


### PR DESCRIPTION
- We no longer have the peer who receives a sync request send the requestor's
  info to the rest of the group as this was redundant (and broken)

- Lots of unnecessary/duplicate code pertaining to handshaking was removed

- Message ID's are set to a fixed number when we send/receive handshake
  packets instead of incrementing. This is because it's impossible to
  proceed with the connection if either of those first two packets
  are lost, so incrementing the counters just messes up the order

- Sync responses no longer contain the number of peers being sent
  in the series of peer announces as this was unnecessary

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1595)
<!-- Reviewable:end -->
