### PR TITLE
refactor: Self-announce/self-connection refactor

### DIFF
--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -427,12 +427,12 @@ bool dht_non_lan_connected(const DHT *dht);
 
 uint32_t addto_lists(DHT *dht, IP_Port ip_port, const uint8_t *public_key);
 
-/* Copies your own ip_port structure to dest. If allow_LAN is false an error will be returned
- * if the result is a LAN address.
+/* Copies our own ip_port structure to dest. WAN addresses take priority over LAN addresses.
  *
- * Return 0 on success.
- * Return -1 on failure.
+ * Return -1 if our ip port can't be found (this usually means we're not connected to the DHT).
+ * Return 0 if IP is a WAN address.
+ * Return 1 if IP is a LAN address.
  */
-int ipport_self_copy(const DHT *dht, IP_Port *dest, bool allow_LAN);
+int ipport_self_copy(const DHT *dht, IP_Port *dest);
 
 #endif

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -42,9 +42,6 @@ struct TCP_Connections {
     tcp_onion_cb *tcp_onion_callback;
     void *tcp_onion_callback_object;
 
-    tcp_connection_status_updated_cb *tcp_connection_status_updated_callback;
-    void *tcp_connection_status_updated_callback_object;
-
     TCP_Proxy_Info proxy_info;
 
     bool onion_status;
@@ -490,15 +487,6 @@ void set_onion_packet_tcp_connection_callback(TCP_Connections *tcp_c, tcp_onion_
     tcp_c->tcp_onion_callback_object = object;
 }
 
-void set_connection_status_updated_callback(TCP_Connections *tcp_c,
-        tcp_connection_status_updated_cb *connection_status_updated_callback,
-        void *object)
-{
-    tcp_c->tcp_connection_status_updated_callback = connection_status_updated_callback;
-    tcp_c->tcp_connection_status_updated_callback_object = object;
-}
-
-
 /* Find the TCP connection with public_key.
  *
  * return connections_number on success.
@@ -777,12 +765,6 @@ static int set_tcp_connection_status(TCP_Connections *tcp_c, TCP_Connection_to *
 
             con_to->connections[i].status = status;
             con_to->connections[i].connection_id = connection_id;
-
-            if (tcp_c->tcp_connection_status_updated_callback) {
-                tcp_c->tcp_connection_status_updated_callback(tcp_c->tcp_connection_status_updated_callback_object,
-                        tcp_c, status);
-            }
-
             return i;
         }
     }

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -132,12 +132,6 @@ typedef int tcp_onion_cb(void *object, const uint8_t *data, uint16_t length, voi
  */
 void set_onion_packet_tcp_connection_callback(TCP_Connections *tcp_c, tcp_onion_cb *tcp_onion_callback, void *object);
 
-typedef void tcp_connection_status_updated_cb(void *object, TCP_Connections *tcp_c, int status);
-
-void set_connection_status_updated_callback(TCP_Connections *tcp_c,
-        tcp_connection_status_updated_cb *connection_status_updated_callback,
-        void *object);
-
 typedef int tcp_oob_cb(void *object, const uint8_t *public_key, unsigned int tcp_connections_number,
                        const uint8_t *data, uint16_t length, void *userdata);
 

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -37,6 +37,11 @@
 
 #define GC_JOIN_DATA_LENGTH (ENC_PUBLIC_KEY + CHAT_ID_SIZE)
 
+typedef enum Self_UDP_Status {
+    SELF_UDP_STATUS_NONE = -1,
+    SELF_UDP_STATUS_WAN =   0,
+    SELF_UDP_STATUS_LAN =   1,
+} Self_UDP_Status;
 
 typedef enum Group_Privacy_State {
     GI_PUBLIC,
@@ -266,13 +271,14 @@ typedef struct GC_Chat {
     const Mono_Time *mono_time;
     const Logger    *logger;
 
+    Self_UDP_Status self_ip_port_status;
     IP_Port         self_ip_port;
-    bool            self_ip_port_set;
+
 
     Networking_Core *net;
     TCP_Connections *tcp_conn;
     uint64_t        last_checked_tcp_relays;
-    int             tcp_connection_status;
+    uint16_t        tcp_connections; // the number of global TCP relays we're connected to
 
     GC_GroupPeer    *group;
     GC_Connection   *gcc;
@@ -316,7 +322,6 @@ typedef struct GC_Chat {
 
     bool        update_self_announces;     /* true if we should try to update our announcements */
     uint64_t    last_self_announce_check;  /* the last time we checked if we should update our announcements */
-    uint64_t    last_self_announce_time;   /* the last time we attempted to update our announcements */
 
     Saved_Group *save;
 } GC_Chat;


### PR DESCRIPTION
- Remove a TCP callback that wasn't doing what it was supposed to be doing
- We now update our UDP and TCP connection status from the main loop
- Properly keep track of our TCP connection status: previously we were
  updating our announcement every time we connected to an individual
  peer via TCP, now we update it when we add or remove a TCP relay
- UDP status now differentiates between LAN and WAN
- Remove the recently added self announcement refresh (it's probably
  unnecessary)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1601)
<!-- Reviewable:end -->
