### PR TITLE
fix: bug causing invalid tcp relays to be copied to peer relay lists

### DIFF
--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -134,7 +134,7 @@ void gcc_set_ip_port(GC_Connection *gconn, const IP_Port *ipp);
  * Return 0 on success.
  * Return -1 on failure.
  */
-int gcc_copy_tcp_relay(const GC_Connection *gconn, Node_format *node);
+int gcc_copy_tcp_relay(Node_format *tcp_node, const GC_Connection *gconn);
 
 /* Saves tcp_node to gconn's list of connected tcp relays.
  *
@@ -142,7 +142,6 @@ int gcc_copy_tcp_relay(const GC_Connection *gconn, Node_format *node);
  *
  * Return 0 on success.
  * Return -1 on failure.
- * Return -2 if relays list is full.
  */
 int gcc_save_tcp_relay(GC_Connection *gconn, const Node_format *tcp_node);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1603)
<!-- Reviewable:end -->
