### PR TITLE
refactor: Remove a bunch of useless group code from Messenger.c

### DIFF
--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -12,8 +12,6 @@
 
 #include "friend_connection.h"
 #include "friend_requests.h"
-#include "group_chats.h"
-#include "group_announce.h"
 #include "logger.h"
 #include "net_crypto.h"
 #include "state.h"
@@ -243,13 +241,6 @@ typedef struct Friend {
     struct Receipts *receipts_end;
 } Friend;
 
-typedef struct Group {
-    uint8_t real_pk[CRYPTO_PUBLIC_KEY_SIZE];
-    int friendcon_id;
-    uint8_t last_connection_udp_tcp;
-    bool active;  // true if group is active.
-} Group;
-
 struct Messenger {
     Logger *log;
     Mono_Time *mono_time;
@@ -276,9 +267,6 @@ struct Messenger {
 
     Friend *friendlist;
     uint32_t numfriends;
-
-    Group *grouplist;
-    uint32_t numgroups;
 
     time_t lastdump;
 
@@ -365,9 +353,17 @@ int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, u
  */
 int32_t m_addfriend_norequest(Messenger *m, const uint8_t *real_pk);
 
-int32_t m_add_group(Messenger *m, GC_Chat *chat);
+/* Initializes the friend connection and onion connection for a groupchat.
+ *
+ * Return 0 on success.
+ * Return -1 on failure.
+ */
+int32_t m_create_group_connection(Messenger *m, GC_Chat *chat);
 
-int32_t m_remove_group(Messenger *m, const GC_Chat *chat);
+/*
+ * Kills the friend connection for a groupchat.
+ */
+void m_kill_group_connection(Messenger *m, const GC_Chat *chat);
 
 /*  return the friend number associated to that client id.
  *  return -1 if no such friend.
@@ -393,13 +389,6 @@ int getfriendcon_id(const Messenger *m, int32_t friendnumber);
  *  return -1 if failure
  */
 int m_delfriend(Messenger *m, int32_t friendnumber);
-
-/* Remove a group.
- *
- * Return 0 if success.
- * Return -1 if failure.
- */
-int m_delgroup(Messenger *m, int32_t groupnumber);
 
 /* Checks friend's connecting status.
  *

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -318,10 +318,11 @@ typedef struct GC_Chat {
     int32_t     saved_invites[MAX_GC_SAVED_INVITES];
     uint8_t     saved_invites_index;
 
-    uint8_t     m_group_public_key[CRYPTO_PUBLIC_KEY_SIZE];    /* Identifier for group's messenger friend connection */
-
     bool        update_self_announces;     /* true if we should try to update our announcements */
     uint64_t    last_self_announce_check;  /* the last time we checked if we should update our announcements */
+
+    uint8_t     m_group_public_key[CRYPTO_PUBLIC_KEY_SIZE];    /* Public key for group's messenger friend connection */
+    int         friend_connection_id;   /* Identifier for group's messenger friend connection */
 
     Saved_Group *save;
 } GC_Chat;
@@ -658,7 +659,7 @@ int gc_group_add(GC_Session *c, uint8_t privacy_state, const uint8_t *group_name
  * Return -3 if nick is too long.
  * Return -4 if nick is empty or nick length is zero.
  * Return -5 if there is an error setting the group password.
- * Return -6 if there is an error adding a friend.
+ * Return -6 if the Messenger friend connection fails to initialize.
  */
 int gc_group_join(GC_Session *c, const uint8_t *chat_id, const uint8_t *nick, size_t nick_length, const uint8_t *passwd,
                   uint16_t passwd_len);


### PR DESCRIPTION
Everything the Messenger Group struct held is now taken care of by the
GC_Chat instance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1604)
<!-- Reviewable:end -->
