### PR TITLE
fix: Connected peers don't need to receive group announcements

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -6458,6 +6458,10 @@ int add_peers_from_announces(const GC_Session *gc_session, GC_Chat *chat, GC_Ann
         return -1;
     }
 
+    if (chat->connection_state == CS_CONNECTED && chat->numpeers > 1) {
+        return 0;
+    }
+
     int added_peers = 0;
 
     for (uint8_t i = 0; i < gc_announces_count; ++i) {


### PR DESCRIPTION
This would normally result in lot of unnecessary invite and sync requests which
would either fail or supply bad group info

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1609)
<!-- Reviewable:end -->
