### PR TITLE
fix: Improve group TCP connections

### DIFF
--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -49,6 +49,7 @@ struct GC_Connection {
     uint8_t     shared_key[CRYPTO_SHARED_KEY_SIZE];  /* made with our session sk and peer's session pk */
 
     int         tcp_connection_num;
+    uint64_t    last_sent_tcp_relays_time;  /* the last time we attempted to send this peer our tcp relays */
     uint64_t    last_received_direct_time;   /* the last time we received a direct UDP packet from this connection */
     uint64_t    last_sent_ip_time;  /* the last time we sent our ip info to this peer in a ping packet */
 


### PR DESCRIPTION
We now continually attempt to send peers our TCP relays on a timer if we currenlty have no
TCP connections with them. This prevents situations where we may never establish shared
TCP relays with a peer in the case of packet loss or other temporary connection issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1620)
<!-- Reviewable:end -->
