### PR TITLE
fix: Fix file tests on windows

### DIFF
--- a/auto_tests/file_saving_test.c
+++ b/auto_tests/file_saving_test.c
@@ -35,7 +35,7 @@ static void save_data_encrypted(void)
 
     tox_self_set_name(t, (const uint8_t *)name, strlen(name), nullptr);
 
-    FILE *f = fopen(savefile, "w");
+    FILE *f = fopen(savefile, "wb");
 
     size_t size = tox_get_savedata_size(t);
     uint8_t *clear = (uint8_t *)malloc(size);
@@ -63,7 +63,7 @@ static void save_data_encrypted(void)
 
 static void load_data_decrypted(void)
 {
-    FILE *f = fopen(savefile, "r");
+    FILE *f = fopen(savefile, "rb");
     ck_assert(f != nullptr);
     fseek(f, 0, SEEK_END);
     int64_t size = ftell(f);

--- a/auto_tests/save_compatibility_test.c
+++ b/auto_tests/save_compatibility_test.c
@@ -21,7 +21,7 @@
 
 static size_t get_file_size(const char *save_path)
 {
-    FILE *const fp = fopen(save_path, "r");
+    FILE *const fp = fopen(save_path, "rb");
 
     if (fp == nullptr) {
         return 0;
@@ -42,7 +42,7 @@ static uint8_t *read_save(const char *save_path, size_t *length)
         return nullptr;
     }
 
-    FILE *const fp = fopen(save_path, "r");
+    FILE *const fp = fopen(save_path, "rb");
 
     if (!fp) {
         return nullptr;


### PR DESCRIPTION
The issue was that fopen with r or w without the b flag on Windows does LF
and CR translations when reading and writing. Not good for binary files.

I'm not making the Windows tests required for merge yet as conference_av
still fails sometimes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1663)
<!-- Reviewable:end -->
