### PR TITLE
cleanup: use heap memory instead of stack for large variables

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-16d62d5c5aa261d6efefbe8e94cc25a68c76ea923ae92ce56b0d22b32326ae0b  /usr/local/bin/tox-bootstrapd
+ca03a05f92fb3169c588ff0894c7a1d4466d71c36e3a7ddbe804797f15d6c126  /usr/local/bin/tox-bootstrapd

--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -123,10 +123,15 @@ void ac_iterate(ACSession *ac)
         return;
     }
 
-    /* TODO(mannol): fix this and jitter buffering */
+    /* TODO: fix this and jitter buffering */
 
     /* Enough space for the maximum frame size (120 ms 48 KHz stereo audio) */
-    int16_t temp_audio_buffer[AUDIO_MAX_BUFFER_SIZE_PCM16 * AUDIO_MAX_CHANNEL_COUNT];
+    int16_t *temp_audio_buffer = (int16_t *)malloc(AUDIO_MAX_BUFFER_SIZE_PCM16 * AUDIO_MAX_CHANNEL_COUNT * sizeof(int16_t));
+
+    if (temp_audio_buffer == nullptr) {
+        LOGGER_ERROR(ac->log, "Failed to allocate memory for audio buffer");
+        return;
+    }
 
     pthread_mutex_lock(ac->queue_mutex);
     struct JitterBuffer *const j_buf = (struct JitterBuffer *)ac->j_buf;
@@ -195,10 +200,14 @@ void ac_iterate(ACSession *ac)
                     ac->lp_sampling_rate, ac->acb_user_data);
         }
 
+        free(temp_audio_buffer);
+
         return;
     }
 
     pthread_mutex_unlock(ac->queue_mutex);
+
+    free(temp_audio_buffer);
 }
 
 int ac_queue_message(Mono_Time *mono_time, void *acp, struct RTPMessage *msg)

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2830,7 +2830,12 @@ void dht_save(const DHT *dht, uint8_t *data)
     /* get right offset. we write the actual header later. */
     data = state_write_section_header(data, DHT_STATE_COOKIE_TYPE, 0, 0);
 
-    Node_format clients[MAX_SAVED_DHT_NODES];
+    Node_format *clients = (Node_format *)malloc(MAX_SAVED_DHT_NODES * sizeof(Node_format));
+
+    if (clients == nullptr) {
+        LOGGER_ERROR(dht->log, "could not allocate %u nodes", MAX_SAVED_DHT_NODES);
+        return;
+    }
 
     uint32_t num = 0;
 
@@ -2873,6 +2878,8 @@ void dht_save(const DHT *dht, uint8_t *data)
 
     state_write_section_header(old_data, DHT_STATE_COOKIE_TYPE, pack_nodes(data, sizeof(Node_format) * num, clients, num),
                                DHT_STATE_TYPE_NODES);
+
+    free(clients);
 }
 
 /* Bootstrap from this number of nodes every time dht_connect_after_load() is called */


### PR DESCRIPTION
The default stack size for musl-libc is 128kb, which is smaller than the largest stack allocations in toxcore. We should try to keep stack allocations well below this limit in order to avoid stack overflows on musl builds.

Using the compiler flag `-Wlarger-than=2000` we can see that after this change the largest stack allocation is now just over 2kb. 

It's worth noting that musl versions >= 1.22 allow us to increase the stack size by setting the LDFLAGS: `-Wl,-z,stack-size=<size>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1664)
<!-- Reviewable:end -->
