### PR TITLE
perf: Take advantage of fast networks for file transfers

### DIFF
--- a/auto_tests/set_name_test.c
+++ b/auto_tests/set_name_test.c
@@ -16,7 +16,9 @@
 
 static void nickchange_callback(Tox *tox, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata)
 {
-    ck_assert_msg(length == sizeof(NICKNAME) && memcmp(string, NICKNAME, sizeof(NICKNAME)) == 0, "Name not correct");
+    ck_assert_msg(length == sizeof(NICKNAME), "Name length not correct: %d != %d", (uint16_t)length,
+                  (uint16_t)sizeof(NICKNAME));
+    ck_assert_msg(memcmp(string, NICKNAME, sizeof(NICKNAME)) == 0, "Name not correct: %s", (const char *)string);
     bool *nickname_updated = (bool *)userdata;
     *nickname_updated = true;
 }

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -259,6 +259,7 @@ struct Messenger {
     uint32_t numfriends;
 
     time_t lastdump;
+    uint8_t is_receiving_file;
 
     bool has_added_relays; // If the first connection has occurred in do_messenger
 
@@ -817,5 +818,8 @@ uint32_t count_friendlist(const Messenger *m);
  * of out_list will be truncated to list_size. */
 non_null()
 uint32_t copy_friendlist(const Messenger *m, uint32_t *out_list, uint32_t list_size);
+
+non_null()
+bool is_receiving_file(Messenger *m);
 
 #endif

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -852,6 +852,11 @@ uint32_t tox_iteration_interval(const Tox *tox)
     assert(tox != nullptr);
     lock(tox);
     uint32_t ret = messenger_run_interval(tox->m);
+
+    if (is_receiving_file(tox->m)) {
+        ret = 1;
+    }
+
     unlock(tox);
     return ret;
 }


### PR DESCRIPTION
[this is a copy of the branch at git://expert.chickenkiller.com/c-toxcore.git ;
the actual submitter wants to avoid using github, so I (zugz) made this pr for them]

- Make sender send more data per iteration.
- Make receiver iterate more often while receiving.

Before this commit tox would send at maximum around 4MiB/s. With this
patch sustained speeds of up to 100MiB/s were observed on a
low-latency, high-bandwidth network.

As a consequence of iterating more frequently the receiver's CPU usage
is increased for the duration of the transfer. The data structures
used to represent friends and file transfers cause the sender code use
costly loops that do little real work. This patch makes this problem
more visible: the sender uses more CPU while sending.

Poor network conditions were simulated using the netem kernel
facility: $ tc qdisc add dev lo root netem delay 100ms 50ms \
loss 1% duplicate 1% corrupt 1% reorder 25% 50%
and no adverse behavior was encountered. Tests were conducted
using toxic using both UDP and TCP.

Fixes #236.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1668)
<!-- Reviewable:end -->
