### PR TITLE
feat: Add username/password SOCKS5 auth

### DIFF
--- a/auto_tests/invalid_udp_proxy_test.c
+++ b/auto_tests/invalid_udp_proxy_test.c
@@ -24,7 +24,7 @@ int main(void)
 
     bootstrap_tox_live_network(tox, true);
 
-    printf("Waiting for connection...");
+    printf("Waiting for connection...\n");
 
     for (uint16_t i = 0; i < NUM_ITERATIONS; i++) {
         tox_iterate(tox, nullptr);

--- a/auto_tests/proxy_test.c
+++ b/auto_tests/proxy_test.c
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "auto_test_support.h"
 
@@ -16,18 +17,20 @@ static void *proxy_routine(void *arg)
     return nullptr;
 }
 
-static bool try_bootstrap(Tox *tox1, Tox *tox2, Tox *tox3, Tox *tox4)
+static bool try_bootstrap(Tox *tox1, Tox *tox2, Tox *tox3, Tox *tox4, Tox *tox5)
 {
     for (uint32_t i = 0; i < 400; ++i) {
         if (tox_self_get_connection_status(tox1) != TOX_CONNECTION_NONE &&
                 tox_self_get_connection_status(tox2) != TOX_CONNECTION_NONE &&
                 tox_self_get_connection_status(tox3) != TOX_CONNECTION_NONE &&
-                tox_self_get_connection_status(tox4) != TOX_CONNECTION_NONE) {
-            printf("%d %d %d %d\n",
+                tox_self_get_connection_status(tox4) != TOX_CONNECTION_NONE &&
+                tox_self_get_connection_status(tox5) != TOX_CONNECTION_NONE) {
+            printf("%d %d %d %d %d\n",
                    tox_self_get_connection_status(tox1),
                    tox_self_get_connection_status(tox2),
                    tox_self_get_connection_status(tox3),
-                   tox_self_get_connection_status(tox4));
+                   tox_self_get_connection_status(tox4),
+                   tox_self_get_connection_status(tox5));
             return true;
         }
 
@@ -35,13 +38,15 @@ static bool try_bootstrap(Tox *tox1, Tox *tox2, Tox *tox3, Tox *tox4)
         tox_iterate(tox2, nullptr);
         tox_iterate(tox3, nullptr);
         tox_iterate(tox4, nullptr);
+        tox_iterate(tox5, nullptr);
 
         if (i % 10 == 0) {
-            printf("%d %d %d %d\n",
+            printf("%d %d %d %d %d\n",
                    tox_self_get_connection_status(tox1),
                    tox_self_get_connection_status(tox2),
                    tox_self_get_connection_status(tox3),
-                   tox_self_get_connection_status(tox4));
+                   tox_self_get_connection_status(tox4),
+                   tox_self_get_connection_status(tox5));
         }
 
         c_sleep(tox_iteration_interval(tox1));
@@ -60,8 +65,8 @@ int main(int argc, char **argv)
         c_sleep(100);
     }
 
-    const uint16_t tcp_port = 7082;
-    uint32_t index[] = { 1, 2, 3, 4 };
+    const uint16_t tcp_port = 7083;
+    uint32_t index[] = { 1, 2, 3, 4, 5 };
 
     struct Tox_Options *tox_options = tox_options_new(nullptr);
     ck_assert(tox_options != nullptr);
@@ -69,6 +74,7 @@ int main(int argc, char **argv)
     // tox1 is a TCP server and has UDP enabled.
     tox_options_set_udp_enabled(tox_options, true);
     tox_options_set_tcp_port(tox_options, tcp_port);
+    tox_options_set_local_discovery_enabled(tox_options, false);
 
     Tox *tox1 = tox_new_log(tox_options, nullptr, &index[0]);
     ck_assert(tox1 != nullptr);
@@ -80,8 +86,10 @@ int main(int argc, char **argv)
     ck_assert(dht_port != 0);
 
     // tox2 is a regular DHT node bootstrapping against tox1.
+    tox_options_default(tox_options);
     tox_options_set_udp_enabled(tox_options, true);
     tox_options_set_tcp_port(tox_options, 0);
+    tox_options_set_local_discovery_enabled(tox_options, false);
 
     Tox *tox2 = tox_new_log(tox_options, nullptr, &index[1]);
     ck_assert(tox2 != nullptr);
@@ -90,36 +98,57 @@ int main(int argc, char **argv)
     ck_assert(tox_bootstrap(tox2, "127.0.0.1", dht_port, dht_pk, nullptr));
 
     // tox3 has UDP disabled and connects to tox1 via an HTTP proxy
+    tox_options_default(tox_options);
     tox_options_set_udp_enabled(tox_options, false);
     tox_options_set_proxy_host(tox_options, "127.0.0.1");
     tox_options_set_proxy_port(tox_options, 7080);
     tox_options_set_proxy_type(tox_options, TOX_PROXY_TYPE_HTTP);
+    tox_options_set_local_discovery_enabled(tox_options, false);
 
     Tox *tox3 = tox_new_log(tox_options, nullptr, &index[2]);
     ck_assert(tox3 != nullptr);
 
-    // tox4 has UDP disabled and connects to tox1 via a SOCKS5 proxy
+    // tox4 has UDP disabled and connects to tox1 via a SOCKS5 proxy with no auth
+    tox_options_default(tox_options);
     tox_options_set_udp_enabled(tox_options, false);
     tox_options_set_proxy_host(tox_options, "127.0.0.1");
     tox_options_set_proxy_port(tox_options, 7081);
     tox_options_set_proxy_type(tox_options, TOX_PROXY_TYPE_SOCKS5);
+    tox_options_set_local_discovery_enabled(tox_options, false);
 
     Tox *tox4 = tox_new_log(tox_options, nullptr, &index[3]);
     ck_assert(tox4 != nullptr);
 
-    // tox3 and tox4 bootstrap against tox1 and add it as a TCP relay
+    // tox5 has UDP disabled and connects to tox1 via a SOCKS5 proxy with username/password auth
+    tox_options_default(tox_options);
+    tox_options_set_udp_enabled(tox_options, false);
+    tox_options_set_proxy_host(tox_options, "127.0.0.1");
+    tox_options_set_proxy_port(tox_options, 7082);
+    tox_options_set_proxy_type(tox_options, TOX_PROXY_TYPE_SOCKS5);
+    tox_options_set_proxy_socks5_username(tox_options, (const uint8_t *) "nurupo", strlen("nurupo"));
+    tox_options_set_proxy_socks5_password(tox_options, (const uint8_t *) "hunter2", strlen("hunter2"));
+    tox_options_set_local_discovery_enabled(tox_options, false);
+
+    Tox *tox5 = tox_new_log(tox_options, nullptr, &index[4]);
+    ck_assert(tox5 != nullptr);
+
+    // tox3, tox4 and tox5 bootstrap against tox1 and add it as a TCP relay
     ck_assert(tox_bootstrap(tox3, "127.0.0.1", dht_port, dht_pk, nullptr));
     ck_assert(tox_add_tcp_relay(tox3, "127.0.0.1", tcp_port, dht_pk, nullptr));
 
     ck_assert(tox_bootstrap(tox4, "127.0.0.1", dht_port, dht_pk, nullptr));
     ck_assert(tox_add_tcp_relay(tox4, "127.0.0.1", tcp_port, dht_pk, nullptr));
 
+    ck_assert(tox_bootstrap(tox5, "127.0.0.1", dht_port, dht_pk, nullptr));
+    ck_assert(tox_add_tcp_relay(tox5, "127.0.0.1", tcp_port, dht_pk, nullptr));
+
     int ret = 1;
-    if (try_bootstrap(tox1, tox2, tox3, tox4)) {
+    if (try_bootstrap(tox1, tox2, tox3, tox4, tox5)) {
         ret = 0;
     }
 
     tox_options_free(tox_options);
+    tox_kill(tox5);
     tox_kill(tox4);
     tox_kill(tox3);
     tox_kill(tox2);

--- a/other/proxy/proxy_server.go
+++ b/other/proxy/proxy_server.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	debug      = false
-	httpAddr   = ":7080"
-	socks5Addr = ":7081"
+	debug                          = false
+	httpAddr                       = "127.0.0.1:7080"
+	socks5NoAuthAddr               = "127.0.0.1:7081"
+	socks5UsernamePasswordAuthAddr = "127.0.0.1:7082"
 )
 
 func handleTunneling(w http.ResponseWriter, r *http.Request) {
@@ -75,11 +76,19 @@ func main() {
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 	}
 
-	log.Printf("starting SOCKS5 proxy server on %s", socks5Addr)
-	socks5Server := socks5.NewServer(
-		socks5.WithLogger(socks5.NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
+	log.Printf("starting SOCKS5 no-auth proxy server on %s", socks5NoAuthAddr)
+	socks5NoAuthServer := socks5.NewServer(
+		socks5.WithLogger(socks5.NewLogger(log.New(os.Stdout, "socks5 no-auth: ", log.LstdFlags))),
 	)
 
-	go socks5Server.ListenAndServe("tcp", socks5Addr)
+	log.Printf("starting SOCKS5 username/password auth proxy server on %s", socks5UsernamePasswordAuthAddr)
+	authenticator := socks5.UserPassAuthenticator{socks5.StaticCredentials{"nurupo": "hunter2"}}
+	socks5UsernamePasswordAuthServer := socks5.NewServer(
+		socks5.WithAuthMethods([]socks5.Authenticator{authenticator}),
+		socks5.WithLogger(socks5.NewLogger(log.New(os.Stdout, "socks5 username/password auth: ", log.LstdFlags))),
+	)
+
+	go socks5NoAuthServer.ListenAndServe("tcp", socks5NoAuthAddr)
+	go socks5UsernamePasswordAuthServer.ListenAndServe("tcp", socks5UsernamePasswordAuthAddr)
 	log.Fatal(httpServer.ListenAndServe())
 }

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -204,29 +204,38 @@ static int proxy_http_read_connection_response(const Logger *logger, const TCP_C
 }
 
 enum Tcp_Socks5_Proxy_Hs {
-    TCP_SOCKS5_PROXY_HS_VERSION_SOCKS5          = 0x05,
-    TCP_SOCKS5_PROXY_HS_COMM_ESTABLISH_REQUEST  = 0x01,
-    TCP_SOCKS5_PROXY_HS_COMM_REQUEST_GRANTED    = 0x00,
-    TCP_SOCKS5_PROXY_HS_AUTH_METHODS_SUPPORTED  = 0x01,
-    TCP_SOCKS5_PROXY_HS_NO_AUTH                 = 0x00,
-    TCP_SOCKS5_PROXY_HS_RESERVED                = 0x00,
-    TCP_SOCKS5_PROXY_HS_ADDR_TYPE_IPV4          = 0x01,
-    TCP_SOCKS5_PROXY_HS_ADDR_TYPE_IPV6          = 0x04,
+    TCP_SOCKS5_PROXY_HS_VERSION_SOCKS5                 = 0x05,
+    TCP_SOCKS5_PROXY_HS_COMM_ESTABLISH_REQUEST         = 0x01,
+    TCP_SOCKS5_PROXY_HS_COMM_REQUEST_GRANTED           = 0x00,
+    TCP_SOCKS5_PROXY_HS_AUTH_METHODS_SUPPORTED         = 0x01,
+    TCP_SOCKS5_PROXY_HS_NO_AUTH                        = 0x00,
+    TCP_SOCKS5_PROXY_HS_USERNAME_PASSWORD_AUTH         = 0x02,
+    TCP_SOCKS5_PROXY_HS_USERNAME_PASSWORD_AUTH_VERSION = 0x01,
+    TCP_SOCKS5_PROXY_HS_USERNAME_PASSWORD_AUTH_SUCCESS = 0x00,
+    TCP_SOCKS5_PROXY_HS_RESERVED                       = 0x00,
+    TCP_SOCKS5_PROXY_HS_ADDR_TYPE_IPV4                 = 0x01,
+    TCP_SOCKS5_PROXY_HS_ADDR_TYPE_IPV6                 = 0x04,
 };
 
 non_null()
-static void proxy_socks5_generate_greetings(TCP_Client_Connection *tcp_conn)
+static void proxy_socks5_generate_handshake(TCP_Client_Connection *tcp_conn)
 {
     tcp_conn->con.last_packet[0] = TCP_SOCKS5_PROXY_HS_VERSION_SOCKS5;
     tcp_conn->con.last_packet[1] = TCP_SOCKS5_PROXY_HS_AUTH_METHODS_SUPPORTED;
-    tcp_conn->con.last_packet[2] = TCP_SOCKS5_PROXY_HS_NO_AUTH;
+
+    if (tcp_conn->proxy_info.socks5_username == nullptr || tcp_conn->proxy_info.socks5_password == nullptr) {
+        tcp_conn->con.last_packet[2] = TCP_SOCKS5_PROXY_HS_NO_AUTH;
+    } else {
+        tcp_conn->con.last_packet[2] = TCP_SOCKS5_PROXY_HS_USERNAME_PASSWORD_AUTH;
+    }
 
     tcp_conn->con.last_packet_length = 3;
     tcp_conn->con.last_packet_sent = 0;
 }
 
 /**
- * @retval 1 on success.
+ * @retval 2 on success, username/password auth.
+ * @retval 1 on success, no auth.
  * @retval 0 if no data received.
  * @retval -1 on failure (connection refused).
  */
@@ -241,7 +250,57 @@ static int socks5_read_handshake_response(const Logger *logger, const TCP_Client
         return 0;
     }
 
-    if (data[0] == TCP_SOCKS5_PROXY_HS_VERSION_SOCKS5 && data[1] == TCP_SOCKS5_PROXY_HS_COMM_REQUEST_GRANTED) {
+    if (data[0] == TCP_SOCKS5_PROXY_HS_VERSION_SOCKS5) {
+        if (tcp_conn->proxy_info.socks5_username == nullptr || tcp_conn->proxy_info.socks5_password == nullptr) {
+            if (data[1] == TCP_SOCKS5_PROXY_HS_NO_AUTH) {
+                return 1;
+            }
+        } else {
+            if (data[1] == TCP_SOCKS5_PROXY_HS_USERNAME_PASSWORD_AUTH) {
+                return 2;
+            }
+        }
+    }
+
+    return -1;
+}
+
+non_null()
+static void proxy_socks5_generate_authentication_request(TCP_Client_Connection *tcp_conn)
+{
+    tcp_conn->con.last_packet[0] = TCP_SOCKS5_PROXY_HS_USERNAME_PASSWORD_AUTH_VERSION;
+    tcp_conn->con.last_packet[1] = tcp_conn->proxy_info.socks5_username_length;
+    uint16_t length = 2;
+    memcpy(tcp_conn->con.last_packet + length, tcp_conn->proxy_info.socks5_username,
+           tcp_conn->proxy_info.socks5_username_length);
+    length += tcp_conn->proxy_info.socks5_username_length;
+    tcp_conn->con.last_packet[length] = tcp_conn->proxy_info.socks5_password_length;
+    ++length;
+    memcpy(tcp_conn->con.last_packet + length, tcp_conn->proxy_info.socks5_password,
+           tcp_conn->proxy_info.socks5_password_length);
+    length += tcp_conn->proxy_info.socks5_password_length;
+
+    tcp_conn->con.last_packet_length = length;
+    tcp_conn->con.last_packet_sent = 0;
+}
+
+/* return 1 on success.
+ * return 0 if no data received.
+ * return -1 on failure (connection refused).
+ */
+non_null()
+static int proxy_socks5_read_authentication_response(const Logger *logger, const TCP_Client_Connection *tcp_conn)
+{
+    uint8_t data[2];
+    const TCP_Connection *con = &tcp_conn->con;
+    const int ret = read_tcp_packet(logger, con->mem, con->ns, con->sock, data, sizeof(data), &con->ip_port);
+
+    if (ret == -1) {
+        return 0;
+    }
+
+    if (data[0] == TCP_SOCKS5_PROXY_HS_USERNAME_PASSWORD_AUTH_VERSION
+            && data[1] == TCP_SOCKS5_PROXY_HS_USERNAME_PASSWORD_AUTH_SUCCESS) {
         return 1;
     }
 
@@ -676,7 +735,7 @@ TCP_Client_Connection *new_tcp_connection(
 
         case TCP_PROXY_SOCKS5: {
             temp->status = TCP_CLIENT_PROXY_SOCKS5_CONNECTING;
-            proxy_socks5_generate_greetings(temp);
+            proxy_socks5_generate_handshake(temp);
             break;
         }
 
@@ -983,6 +1042,27 @@ void do_tcp_connection(const Logger *logger, const Mono_Time *mono_time,
     if (tcp_connection->status == TCP_CLIENT_PROXY_SOCKS5_CONNECTING) {
         if (send_pending_data(logger, &tcp_connection->con) == 0) {
             const int ret = socks5_read_handshake_response(logger, tcp_connection);
+
+            if (ret == -1) {
+                tcp_connection->kill_at = 0;
+                tcp_connection->status = TCP_CLIENT_DISCONNECTED;
+            }
+
+            if (ret == 1) { /* no auth */
+                proxy_socks5_generate_connection_request(tcp_connection);
+                tcp_connection->status = TCP_CLIENT_PROXY_SOCKS5_UNCONFIRMED;
+            }
+
+            if (ret == 2) { /* username/password */
+                proxy_socks5_generate_authentication_request(tcp_connection);
+                tcp_connection->status = TCP_CLIENT_PROXY_SOCKS5_AUTHENTICATING;
+            }
+        }
+    }
+
+    if (tcp_connection->status == TCP_CLIENT_PROXY_SOCKS5_AUTHENTICATING) {
+        if (send_pending_data(logger, &tcp_connection->con) == 0) {
+            const int ret = proxy_socks5_read_authentication_response(logger, tcp_connection);
 
             if (ret == -1) {
                 tcp_connection->kill_at = 0;

--- a/toxcore/TCP_client.h
+++ b/toxcore/TCP_client.h
@@ -29,12 +29,17 @@ typedef enum TCP_Proxy_Type {
 typedef struct TCP_Proxy_Info {
     IP_Port ip_port;
     uint8_t proxy_type; // a value from TCP_PROXY_TYPE
+    uint8_t *socks5_username;
+    size_t socks5_username_length;
+    uint8_t *socks5_password;
+    size_t socks5_password_length;
 } TCP_Proxy_Info;
 
 typedef enum TCP_Client_Status {
     TCP_CLIENT_NO_STATUS,
     TCP_CLIENT_PROXY_HTTP_CONNECTING,
     TCP_CLIENT_PROXY_SOCKS5_CONNECTING,
+    TCP_CLIENT_PROXY_SOCKS5_AUTHENTICATING,
     TCP_CLIENT_PROXY_SOCKS5_UNCONFIRMED,
     TCP_CLIENT_CONNECTING,
     TCP_CLIENT_UNCONFIRMED,

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -873,6 +873,32 @@ static Tox *tox_new_system(const struct Tox_Options *options, Tox_Err_New *error
         }
 
         m_options.proxy_info.ip_port.port = net_htons(tox_options_get_proxy_port(opts));
+
+        if (m_options.proxy_info.proxy_type == TCP_PROXY_SOCKS5) {
+            if (tox_options_get_proxy_socks5_username(opts) != nullptr &&
+                    (tox_options_get_proxy_socks5_username_length(opts) < 1 ||
+                     tox_options_get_proxy_socks5_username_length(opts) > TOX_MAX_PROXY_SOCKS5_USERNAME_LENGTH)) {
+                SET_ERROR_PARAMETER(error, TOX_ERR_NEW_PROXY_SOCKS5_BAD_USERNAME_LENGTH);
+                mem_delete(sys->mem, tox);
+                tox_options_free(default_options);
+                return nullptr;
+            }
+
+            m_options.proxy_info.socks5_username = tox_options_get_proxy_socks5_username(opts);
+            m_options.proxy_info.socks5_username_length = tox_options_get_proxy_socks5_username_length(opts);
+
+            if (tox_options_get_proxy_socks5_password(opts) != nullptr &&
+                    (tox_options_get_proxy_socks5_password_length(opts) < 1 ||
+                     tox_options_get_proxy_socks5_password_length(opts) > TOX_MAX_PROXY_SOCKS5_PASSWORD_LENGTH)) {
+                SET_ERROR_PARAMETER(error, TOX_ERR_NEW_PROXY_SOCKS5_BAD_PASSWORD_LENGTH);
+                mem_delete(sys->mem, tox);
+                tox_options_free(default_options);
+                return nullptr;
+            }
+
+            m_options.proxy_info.socks5_password = tox_options_get_proxy_socks5_password(opts);
+            m_options.proxy_info.socks5_password_length = tox_options_get_proxy_socks5_password_length(opts);
+        }
     }
 
     tox->mono_time = mono_time_new(tox->sys.mem, sys->mono_time_callback, sys->mono_time_user_data);

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -337,6 +337,24 @@ uint32_t tox_max_filename_length(void);
 
 uint32_t tox_max_hostname_length(void);
 
+/**
+ * Maximum length of a SOCKS5 proxy username in bytes.
+ *
+ * @deprecated The macro will be removed in 0.3.0. Use the function instead.
+ */
+#define TOX_MAX_PROXY_SOCKS5_USERNAME_LENGTH 255
+
+uint32_t tox_max_proxy_socks5_username_length(void);
+
+/**
+ * Maximum length of a SOCKS5 proxy password in bytes.
+ *
+ * @deprecated The macro will be removed in 0.3.0. Use the function instead.
+ */
+#define TOX_MAX_PROXY_SOCKS5_PASSWORD_LENGTH 255
+
+uint32_t tox_max_proxy_socks5_password_length(void);
+
 /** @} */
 
 /** @{
@@ -456,6 +474,16 @@ typedef enum Tox_Err_New {
      * causes this error.
      */
     TOX_ERR_NEW_LOAD_BAD_FORMAT,
+
+    /**
+     * The proxy_socks5_username_length is zero or too long.
+     */
+    TOX_ERR_NEW_PROXY_SOCKS5_BAD_USERNAME_LENGTH,
+
+    /**
+     * The proxy_socks5_password_length is zero or too long.
+     */
+    TOX_ERR_NEW_PROXY_SOCKS5_BAD_PASSWORD_LENGTH,
 
 } Tox_Err_New;
 

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -78,6 +78,14 @@ uint32_t tox_max_hostname_length(void)
 {
     return TOX_MAX_HOSTNAME_LENGTH;
 }
+uint32_t tox_max_proxy_socks5_username_length(void)
+{
+    return TOX_MAX_PROXY_SOCKS5_USERNAME_LENGTH;
+}
+uint32_t tox_max_proxy_socks5_password_length(void)
+{
+    return TOX_MAX_PROXY_SOCKS5_PASSWORD_LENGTH;
+}
 uint32_t tox_group_max_topic_length(void)
 {
     return TOX_GROUP_MAX_TOPIC_LENGTH;
@@ -228,6 +236,12 @@ const char *tox_err_new_to_string(Tox_Err_New value)
 
         case TOX_ERR_NEW_LOAD_BAD_FORMAT:
             return "TOX_ERR_NEW_LOAD_BAD_FORMAT";
+
+        case TOX_ERR_NEW_PROXY_SOCKS5_BAD_USERNAME_LENGTH:
+            return "TOX_ERR_NEW_PROXY_SOCKS5_BAD_USERNAME_LENGTH";
+
+        case TOX_ERR_NEW_PROXY_SOCKS5_BAD_PASSWORD_LENGTH:
+            return "TOX_ERR_NEW_PROXY_SOCKS5_BAD_PASSWORD_LENGTH";
     }
 
     return "<invalid Tox_Err_New>";

--- a/toxcore/tox_options.h
+++ b/toxcore/tox_options.h
@@ -175,6 +175,64 @@ struct Tox_Options {
     uint16_t proxy_port;
 
     /**
+     * @brief SOCKS5 proxy username.
+     *
+     * If set to NULL, the username/password authentication is disabled.
+     *
+     * This member is ignored (it can be NULL) if proxy_type is not
+     * TOX_PROXY_TYPE_SOCKS5.
+     *
+     * This member must be set using the corresponding function, it must not be
+     * set directly. The function always makes a copy of the provided data,
+     * regardless if experimental_owned_data is set or not, so it doesn't have
+     * to outlive the options object.
+     *
+     * @private
+     */
+    uint8_t *internal_do_not_set_directly_proxy_socks5_username;
+
+    /**
+     * @brief Length of the SOCKS5 proxy username.
+     *
+     * Must be at most TOX_MAX_PROXY_SOCKS5_USERNAME_LENGTH.
+     *
+     * This member must be set using the corresponding function, it must not be
+     * set directly.
+     *
+     * @private
+     */
+    size_t internal_do_not_set_directly_proxy_socks5_username_length;
+
+    /**
+     * @brief SOCKS5 proxy password.
+     *
+     * If set to NULL, the username/password authentication is disabled.
+     *
+     * This member is ignored (it can be NULL) if proxy_type is not
+     * TOX_PROXY_TYPE_SOCKS5.
+     *
+     * This member must be set using the corresponding function, it must not be
+     * set directly. The function always makes a copy of the provided data,
+     * regardless if experimental_owned_data is set or not, so it doesn't have
+     * to outlive the options object.
+     *
+     * @private
+     */
+    uint8_t *internal_do_not_set_directly_proxy_socks5_password;
+
+    /**
+     * @brief Length of the SOCKS5 proxy password.
+     *
+     * Must be at most TOX_MAX_PROXY_SOCKS5_PASSWORD_LENGTH.
+     *
+     * This member must be set using the corresponding function, it must not be
+     * set directly.
+     *
+     * @private
+     */
+    size_t internal_do_not_set_directly_proxy_socks5_password_length;
+
+    /**
      * The start port of the inclusive port range to attempt to use.
      *
      * If both start_port and end_port are 0, the default port range will be
@@ -341,6 +399,18 @@ bool tox_options_set_proxy_host(Tox_Options *options, const char *proxy_host);
 uint16_t tox_options_get_proxy_port(const Tox_Options *options);
 
 void tox_options_set_proxy_port(Tox_Options *options, uint16_t proxy_port);
+
+uint8_t *tox_options_get_proxy_socks5_username(const Tox_Options *options);
+
+bool tox_options_set_proxy_socks5_username(Tox_Options *options, const uint8_t username[], size_t length);
+
+size_t tox_options_get_proxy_socks5_username_length(const Tox_Options *options);
+
+uint8_t *tox_options_get_proxy_socks5_password(const Tox_Options *options);
+
+bool tox_options_set_proxy_socks5_password(Tox_Options *options, const uint8_t password[], size_t length);
+
+size_t tox_options_get_proxy_socks5_password_length(const Tox_Options *options);
 
 uint16_t tox_options_get_start_port(const Tox_Options *options);
 


### PR DESCRIPTION
Fixes #1682

Not tested. Can someone with a SOCKS5 proxy with username/password test this?

I'm not sure how to prevent APIDSL from generating `tox_options_set_proxy_socks5_username_length()` and `tox_options_set_proxy_socks5_password_length()` function declarations. Those seem pointless as the user already sets the length in `tox_options_set_proxy_socks5_username()` and `tox_options_set_proxy_socks5_password()`. Savedata has the same issue with a pointless `tox_options_set_savedata_length()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1683)
<!-- Reviewable:end -->
