### PR TITLE
chore: Enable c-toxcore conan packaging

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,19 +5,17 @@ cache:
 install:
   - set PATH=C:\Python38-x64\Scripts;%PATH%
   - py -3 -m pip install conan
-  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan --force
 
 before_build:
   - ps: |
-      mkdir _build
-      cd _build
-      conan install ..
+      conan install -if _build .
 
 build_script:
-  - conan build .. --configure --build
+  - conan build -bf _build -if _build .
 
 test_script:
   # TODO(iphydf): Tests are unstable and slow on windows at the moment.
   - set CONAN_CPU_COUNT=50
-  - conan build .. --test &
+  - conan install -if _build -o with_tests=True .
+  - conan build -bf _build -if _build . &
     exit 0

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,33 +1,73 @@
 # pylint: disable=not-callable
+import os
+import re
+
 from conans import CMake
 from conans import ConanFile
+from conans.tools import collect_libs
+from conans.tools import load
 
 
 class ToxConan(ConanFile):
+    name = "c-toxcore"
+    url = "https://tox.chat"
+    description = "The future of online communications."
+    license = "GPL-3.0-only"
     settings = "os", "compiler", "build_type", "arch"
-    requires = "libsodium/1.0.18", "opus/1.3.1", "libvpx/1.8.0@bincrafters/stable"
+    requires = "libsodium/1.0.18", "opus/1.3.1", "libvpx/1.9.0"
     generators = "cmake_find_package"
+    scm = {"type": "git", "url": "auto", "revision": "auto"}
+
+    options = {"with_tests": [True, False]}
+    default_options = {"with_tests": False}
+
+    _cmake = None
+
+    def _create_cmake(self):
+        if self._cmake is not None:
+            return self._cmake
+
+        self._cmake = CMake(self)
+        self._cmake.definitions["AUTOTEST"] = self.options.with_tests
+        self._cmake.definitions["BUILD_MISC_TESTS"] = self.options.with_tests
+        self._cmake.definitions["MUST_BUILD_TOXAV"] = True
+        if self.settings.compiler == "Visual Studio":
+            self._cmake.definitions["MSVC_STATIC_SODIUM"] = True
+
+        self._cmake.configure()
+        return self._cmake
+
+    def set_version(self):
+        content = load(os.path.join(self.recipe_folder, "CMakeLists.txt"))
+        version_major = re.search(r"set\(PROJECT_VERSION_MAJOR \"(.*)\"\)",
+                                  content).group(1)
+        version_minor = re.search(r"set\(PROJECT_VERSION_MINOR \"(.*)\"\)",
+                                  content).group(1)
+        version_patch = re.search(r"set\(PROJECT_VERSION_PATCH \"(.*)\"\)",
+                                  content).group(1)
+        self.version = "%s.%s.%s" % (
+            version_major.strip(),
+            version_minor.strip(),
+            version_patch.strip(),
+        )
 
     def requirements(self):
         if self.settings.os == "Windows":
             self.requires("pthreads4w/3.0.0")
 
-    def source(self):
-        self.run("git clone https://github.com/toktok/c-toxcore.git")
-
     def build(self):
-        cmake = CMake(self)
-        cmake.definitions["AUTOTEST"] = True
-        cmake.definitions["BUILD_MISC_TESTS"] = True
-        cmake.definitions["MUST_BUILD_TOXAV"] = True
-        if self.settings.compiler == "Visual Studio":
-            cmake.definitions["MSVC_STATIC_SODIUM"] = True
+        cmake = self._create_cmake()
+        cmake.build()
 
-        if self.should_configure:
-            cmake.configure()
-
-        if self.should_build:
-            cmake.build()
-
-        if self.should_test:
+        if self.options.with_tests:
             cmake.test()
+
+    def package(self):
+        cmake = self._create_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = collect_libs(self)
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["Ws2_32", "Iphlpapi"]


### PR DESCRIPTION
This PR allow c-toxcore to be build as a conan package.
So client can use "c-toxcore/0.2.12" as requirements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1686)
<!-- Reviewable:end -->
