### PR TITLE
fix: bug causing API to report wrong self connection status

### DIFF
--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -1834,14 +1834,11 @@ void do_onion_client(Onion_Client *onion_c)
         }
     }
 
-    bool udp_connected = dht_non_lan_connected(onion_c->dht);
+    onion_c->udp_connected = dht_non_lan_connected(onion_c->dht);
 
     if (mono_time_is_timeout(onion_c->mono_time, onion_c->first_run, ONION_CONNECTION_SECONDS * 2)) {
-        set_tcp_onion_status(nc_get_tcp_c(onion_c->c), !udp_connected);
+        set_tcp_onion_status(nc_get_tcp_c(onion_c->c), !onion_c->udp_connected);
     }
-
-    onion_c->udp_connected = udp_connected
-                             || get_random_tcp_onion_conn_number(nc_get_tcp_c(onion_c->c)) == -1; /* Check if connected to any TCP relays. */
 
     if (onion_connection_status(onion_c)) {
         for (unsigned i = 0; i < onion_c->num_friends; ++i) {


### PR DESCRIPTION
The following line: 
`onion_c->udp_connected = udp_connected  || get_random_tcp_onion_conn_number(nc_get_tcp_c(onion_c->c)) == -1;`

sets our onion client connection status to UDP if we fail to find a random onion tcp connection number, regardless of whether or not we're actually connected to the DHT. This causes the API to sometimes incorrectly report our connection status as UDP. The main issue here is that this can occur when we explicitly force TCP connections, which may lead to some confusion for the end user.

The TCP connection check doesn't seem to be doing anything useful so I've removed it. The execution path of the proceeding call to `onion_connection_status()` on line 1843 is independent of the value of `onion_c->udp_connected` because the return value is treated as a boolean. Aside from that call, the only time `onion_connection_status()` is used is when exposing the self connection status to the API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1698)
<!-- Reviewable:end -->
