### PR TITLE
fix: some friend connection issues

### DIFF
--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -109,7 +109,6 @@ typedef enum Connection_Status {
     CONNECTION_NONE,
     CONNECTION_TCP,
     CONNECTION_UDP,
-    CONNECTION_UNKNOWN,
 } Connection_Status;
 
 /* USERSTATUS -
@@ -225,7 +224,7 @@ typedef struct Friend {
     uint32_t message_id; // a semi-unique id used in read receipts.
     uint32_t friendrequest_nospam; // The nospam number used in the friend request.
     uint64_t last_seen_time;
-    uint8_t last_connection_udp_tcp;
+    Connection_Status last_connection_udp_tcp;
     struct File_Transfers file_sending[MAX_CONCURRENT_FILE_PIPES];
     uint32_t num_sending_files;
     struct File_Transfers file_receiving[MAX_CONCURRENT_FILE_PIPES];
@@ -360,7 +359,7 @@ int getfriendcon_id(const Messenger *m, int32_t friendnumber);
  */
 int m_delfriend(Messenger *m, int32_t friendnumber);
 
-/* Checks friend's connecting status.
+/* Checks friend's connection status.
  *
  *  return CONNECTION_UDP (2) if friend is directly connected to us (Online UDP).
  *  return CONNECTION_TCP (1) if friend is connected to us (Online TCP).

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2921,9 +2921,7 @@ bool crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, bool
 
         if ((UDP_DIRECT_TIMEOUT + conn->direct_lastrecv_timev4) > current_time) {
             *direct_connected = 1;
-        }
-
-        if ((UDP_DIRECT_TIMEOUT + conn->direct_lastrecv_timev6) > current_time) {
+        } else if ((UDP_DIRECT_TIMEOUT + conn->direct_lastrecv_timev6) > current_time) {
             *direct_connected = 1;
         }
     }


### PR DESCRIPTION
This fixes three issues:
1. Errors for `crypto_connection_status()` are now checked. If a valid connection status is not found, the friend is assigned a connection status of none.
2. It was possible for the API function `tox_friend_get_connection_status()` to return an incorrect friend connection status, because `m_get_friend_connectionstatus()` could return `UNKNOWN_STATUS`, which did not correspond to a value from the `Tox_Connection` enum, and was not checked for: https://github.com/TokTok/c-toxcore/blob/master/toxcore/tox.c#L1291
3. Per lines 902-909, It was possible for us to get a friend connection status callback erroneously reporting the friend's connection to have switched from NONE to TCP, even though a TCP connection had not really been established.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1699)
<!-- Reviewable:end -->
