### PR TITLE
fix: issue with save_load autotest

### DIFF
--- a/auto_tests/save_load_test.c
+++ b/auto_tests/save_load_test.c
@@ -46,7 +46,7 @@ static void tox_connection_status(Tox *tox, Tox_Connection connection_status, vo
         ck_abort_msg("Tox went offline");
     }
 
-    ck_assert_msg(connection_status == TOX_CONNECTION_UDP, "wrong status %d", connection_status);
+    ck_assert_msg(connection_status != TOX_CONNECTION_NONE, "wrong status %d", connection_status);
 
     connected_t1 = connection_status;
 }


### PR DESCRIPTION
The test explicitly wanted a UDP connection when a TCP connection would suffice. This was a remnant of back when the test was part of a multi-purpose autotest (https://github.com/TokTok/c-toxcore/commit/c3515c49e012f76c5d2ca104476e372d924a79f9) that didn't attempt to connect to TCP relays and needed a UDP connection specifically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1705)
<!-- Reviewable:end -->
