### PR TITLE
chore: Enable cimple tests on cirrus build.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.11
+    image: toxchat/toktok-stack:0.0.13
     cpu: 2
-    memory: 4G
+    memory: 2G
   configure_script:
     - /src/workspace/tools/inject-repo c-toxcore
     # Work around "FATAL: corrupt installation: file '/home/builder/.cache/bazel/_bazel_builder/install/f439a981a1e06f45be981c123f9858d5/A-server.jar' is missing or modified"
@@ -19,3 +19,18 @@ cirrus-ci_task:
         --
         //c-toxcore/...
         -//c-toxcore/auto_tests:tcp_relay_test # TODO(robinlinden): Why does this pass locally but not in Cirrus?
+
+cimple_task:
+  container:
+    image: toxchat/toktok-stack:0.0.13
+    cpu: 2
+    memory: 4G
+  configure_script:
+    - /src/workspace/tools/inject-repo c-toxcore
+  test_all_script:
+    - bazel test -k
+        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+        --build_tag_filters=haskell
+        --test_tag_filters=haskell
+        --
+        //c-toxcore/...

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -17,6 +17,7 @@ branches:
           - "ci/circleci: asan"
           # TODO(iphydf): Find out why dht_test times out under tsan.
           #- "ci/circleci: tsan"
+          - cimple
           - cirrus-ci
           - code-review/reviewable
           - continuous-integration/appveyor/pr


### PR DESCRIPTION
This ensures that we don't break Cimple compatibility despite Travis
being gone (which used to test this).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1706)
<!-- Reviewable:end -->
