### PR TITLE
perf: fix filetransfer callback loop

### DIFF
--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -143,7 +143,7 @@ typedef enum Filestatus {
 } Filestatus;
 
 typedef enum File_Pause {
-    FILE_PAUSE_NOT,
+    FILE_PAUSE_NONE,
     FILE_PAUSE_US,
     FILE_PAUSE_OTHER,
     FILE_PAUSE_BOTH,


### PR DESCRIPTION
The exit conditions inside do_all_filetransfers(...) are broken and
didn't cause the early exit which was probably intended. This caused
excessive CPU load when no files are transferred.

### Measurements

![Before](https://camo.githubusercontent.com/ebae9480ec280e7e2e90dc2ecbfcc46c029b0ebcc2022b60a2d7207b7f854ebc/68747470733a2f2f692e696d6775722e636f6d2f557151613074612e706e67) Before this PR

![Screenshot_20211129_195518](https://user-images.githubusercontent.com/5585762/143926230-da77759b-1ba9-428c-b5a5-8d4e867a03b1.png) With this PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1711)
<!-- Reviewable:end -->
