### PR TITLE
fix: Sec/fix crypto size compute

### DIFF
--- a/other/bootstrap_daemon/src/global.h
+++ b/other/bootstrap_daemon/src/global.h
@@ -36,7 +36,7 @@
 // than some binary format that needs to be parsed before being shown to users
 // so we decided to keep this display format compatibility and adopted this
 // weird scheme with a leading 1.
-#define DAEMON_VERSION_NUMBER 1000000000UL + DAEMON_VERSION_MAJOR*1000000UL + DAEMON_VERSION_MINOR*1000UL + DAEMON_VERSION_PATCH*1UL
+#define DAEMON_VERSION_NUMBER (1000000000UL + DAEMON_VERSION_MAJOR*1000000UL + DAEMON_VERSION_MINOR*1000UL + DAEMON_VERSION_PATCH*1UL)
 
 #define MIN_ALLOWED_PORT 1
 #define MAX_ALLOWED_PORT 65535

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -295,7 +295,7 @@ void dht_get_shared_key_sent(DHT *dht, uint8_t *shared_key, const uint8_t *publi
     get_shared_key(dht->mono_time, &dht->shared_keys_sent, shared_key, dht->self_secret_key, public_key);
 }
 
-#define CRYPTO_SIZE 1 + CRYPTO_PUBLIC_KEY_SIZE * 2 + CRYPTO_NONCE_SIZE
+#define CRYPTO_SIZE (1 + CRYPTO_PUBLIC_KEY_SIZE * 2 + CRYPTO_NONCE_SIZE)
 
 /* Create a request to peer.
  * send_public_key and send_secret_key are the pub/secret keys of the sender.


### PR DESCRIPTION
This PR fixes a stack based buffer overflow in the DHT packet handler which is . I don't know if it's exploitable because I patched away the crypto layer, but I'd choose to error safe side here and assume yes until proven otherwise.

I'll open a PR to discuss how to prevent issues with computed values in macros in the future.

ASAN Report leading to this find:

```
=================================================================
==23521==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffdc4aad100 at pc 0x0000002eafea bp 0x7ffdc4aacb50 sp 0x7ffdc4aac318
WRITE of size 1029 at 0x7ffdc4aad100 thread T0
    #0 0x2eafe9 in __asan_memcpy /home/abuild/rpmbuild/BUILD/llvm-11.0.1.src/build/../projects/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:22:3
    #1 0x3711d2 in decrypt_data_symmetric /home/chr/build/sudden6/c-toxcore/toxcore/crypto_core.c:196:5
    #2 0x3711d2 in decrypt_data /home/chr/build/sudden6/c-toxcore/toxcore/crypto_core.c:253:15
    #3 0x3e3541 in handle_request /home/chr/build/sudden6/c-toxcore/toxcore/DHT.c:366:16
    #4 0x3e3541 in cryptopacket_handle /home/chr/build/sudden6/c-toxcore/toxcore/DHT.c:2663:25
    #5 0x3410c6 in networking_poll /home/chr/build/sudden6/c-toxcore/toxcore/network.c:693:9
    #6 0x36a070 in do_messenger /home/chr/build/sudden6/c-toxcore/toxcore/Messenger.c:2538:9
    #7 0x329c33 in tox_iterate /home/chr/build/sudden6/c-toxcore/toxcore/tox.c:833:5
    #8 0x321fc9 in LLVMFuzzerTestOneInput /home/chr/build/sudden6/c-toxcore/testing/fuzzing/bootstrap_harness.cc:23:9
    #9 0x31ea15 in ExecuteFilesOnyByOne /home/chr/build/AFLplusplus/utils/aflpp_driver/aflpp_driver.c:191:7
    #10 0x31e885 in main /home/chr/build/AFLplusplus/utils/aflpp_driver/aflpp_driver.c
    #11 0x7f55460f934c in __libc_start_main (/lib64/libc.so.6+0x2534c)
    #12 0x271989 in _start /home/abuild/rpmbuild/BUILD/glibc-2.31/csu/../sysdeps/x86_64/start.S:120

Address 0x7ffdc4aad100 is located in stack of thread T0 at offset 1184 in frame
    #0 0x3e2f1f in cryptopacket_handle /home/chr/build/sudden6/c-toxcore/toxcore/DHT.c:2648

  This frame has 5 object(s):
    [32, 64) 'source.byval'
    [96, 120) 'assocs.i' (line 1870)
    [160, 1184) 'temp.i' (line 365)
    [1312, 1344) 'public_key' (line 2660) <== Memory access at offset 1184 partially underflows this variable
    [1376, 2400) 'data' (line 2661) <== Memory access at offset 1184 partially underflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /home/abuild/rpmbuild/BUILD/llvm-11.0.1.src/build/../projects/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:22:3 in __asan_memcpy
Shadow bytes around the buggy address:
  0x10003894d9d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003894d9e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003894d9f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003894da00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003894da10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x10003894da20:[f2]f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2
  0x10003894da30: 00 00 00 00 f2 f2 f2 f2 00 00 00 00 00 00 00 00
  0x10003894da40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003894da50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003894da60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003894da70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==23521==ABORTING
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1718)
<!-- Reviewable:end -->
