### PR TITLE
cleanup: Avoid endian-specific code in `crypto_core`.

### DIFF
--- a/toxcore/crypto_core.api.h
+++ b/toxcore/crypto_core.api.h
@@ -237,7 +237,7 @@ static void increment_nonce(uint8_t[CRYPTO_NONCE_SIZE] nonce);
  * Increment the given nonce by a given number. The number should be in host
  * byte order.
  */
-static void increment_nonce_number(uint8_t[CRYPTO_NONCE_SIZE] nonce, uint32_t host_order_num);
+static void increment_nonce_number(uint8_t[CRYPTO_NONCE_SIZE] nonce, uint32_t increment);
 
 /**
  * Fill a key CRYPTO_SYMMETRIC_KEY_SIZE big with random bytes.

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -246,33 +246,19 @@ void increment_nonce(uint8_t *nonce)
     }
 }
 
-static uint32_t host_to_network(uint32_t x)
-{
-#if !defined(BYTE_ORDER) || BYTE_ORDER == LITTLE_ENDIAN
-    return ((x >> 24) & 0x000000FF) |  // move byte 3 to byte 0
-           ((x >> 8) & 0x0000FF00) |   // move byte 2 to byte 1
-           ((x << 8) & 0x00FF0000) |   // move byte 1 to byte 2
-           ((x << 24) & 0xFF000000);   // move byte 0 to byte 3
-#else
-    return x;
-#endif
-}
-
 /* increment the given nonce by num */
-void increment_nonce_number(uint8_t *nonce, uint32_t host_order_num)
+void increment_nonce_number(uint8_t *nonce, uint32_t increment)
 {
     /* NOTE don't use breaks inside this loop
      * In particular, make sure, as far as possible,
      * that loop bounds and their potential underflow or overflow
      * are independent of user-controlled input (you may have heard of the Heartbleed bug).
      */
-    const uint32_t big_endian_num = host_to_network(host_order_num);
-    const uint8_t *const num_vec = (const uint8_t *)&big_endian_num;
     uint8_t num_as_nonce[crypto_box_NONCEBYTES] = {0};
-    num_as_nonce[crypto_box_NONCEBYTES - 4] = num_vec[0];
-    num_as_nonce[crypto_box_NONCEBYTES - 3] = num_vec[1];
-    num_as_nonce[crypto_box_NONCEBYTES - 2] = num_vec[2];
-    num_as_nonce[crypto_box_NONCEBYTES - 1] = num_vec[3];
+    num_as_nonce[crypto_box_NONCEBYTES - 4] = increment >> 24;
+    num_as_nonce[crypto_box_NONCEBYTES - 3] = increment >> 16;
+    num_as_nonce[crypto_box_NONCEBYTES - 2] = increment >> 8;
+    num_as_nonce[crypto_box_NONCEBYTES - 1] = increment;
 
     uint32_t i = crypto_box_NONCEBYTES;
     uint_fast16_t carry = 0U;

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -223,7 +223,7 @@ void increment_nonce(uint8_t *nonce);
  * Increment the given nonce by a given number. The number should be in host
  * byte order.
  */
-void increment_nonce_number(uint8_t *nonce, uint32_t host_order_num);
+void increment_nonce_number(uint8_t *nonce, uint32_t increment);
 
 /**
  * Fill a key CRYPTO_SYMMETRIC_KEY_SIZE big with random bytes.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1727)
<!-- Reviewable:end -->
