### PR TITLE
cleanup: Ensure that error codes are always initialised.

### DIFF
--- a/other/analysis/run-gcc
+++ b/other/analysis/run-gcc
@@ -8,12 +8,13 @@ g++ -O3 -o /dev/null amalgamation.cc \
   "${CPPFLAGS[@]}" \
   "${LDFLAGS[@]}" \
   -std=c++11 \
-  -pedantic \
   -fdiagnostics-color=always \
   -Wall \
   -Wextra \
-  -Wno-aggregate-return \
+  -Werror \
   -Wno-aggressive-loop-optimizations \
+  -Wno-error=null-dereference \
+  -Wno-error=type-limits \
   -Wno-float-conversion \
   -Wno-format-signedness \
   -Wno-missing-field-initializers \

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1655,6 +1655,7 @@ bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number,
     }
 
     /* can't happen */
+    SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_CHUNK_OK);
     return 0;
 }
 


### PR DESCRIPTION
In this case, there was no way it would not be, but a code change down
the stack could cause a variable to become uninitialised. This avoids a
gcc warning and is more locally-correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1729)
<!-- Reviewable:end -->
