### PR TITLE
cleanup: Fix last instance of `-Wcast-align` and enable the warning.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -386,7 +386,7 @@ static uint8_t response_callback_connection_id;
 static uint8_t response_callback_public_key[CRYPTO_PUBLIC_KEY_SIZE];
 static int response_callback(void *object, uint8_t connection_id, const uint8_t *public_key)
 {
-    if (set_tcp_connection_number((TCP_Client_Connection *)((char *)object - 2), connection_id, 7) != 0) {
+    if (set_tcp_connection_number((TCP_Client_Connection *)(void *)((char *)object - 2), connection_id, 7) != 0) {
         return 1;
     }
 

--- a/other/analysis/run-clang
+++ b/other/analysis/run-clang
@@ -12,7 +12,6 @@ clang++ -o /dev/null amalgamation.cc \
   -Wno-alloca \
   -Wno-c++98-compat-pedantic \
   -Wno-c99-extensions \
-  -Wno-cast-align \
   -Wno-conversion \
   -Wno-covered-switch-default \
   -Wno-disabled-macro-expansion \


### PR DESCRIPTION
We used to have lots of these in the code, but now that all the endian
stuff is no longer dependent on host byte order, we can re-enable the
warning flag and catch any future violations.