### PR TITLE
chore: Add missing `sudo` to coverity apt-get calls.

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install libraries
         run:
-          apt-get update &&
-          apt-get install -y --no-install-recommends
+          sudo apt-get update &&
+          sudo apt-get install -y --no-install-recommends
             libopus-dev
             libsodium-dev
             libvpx-dev


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1738)
<!-- Reviewable:end -->
