### PR TITLE
cleanup: Fix some clang-tidy warnings and make them errors.

### DIFF
--- a/other/analysis/run-clang-tidy
+++ b/other/analysis/run-clang-tidy
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 CHECKS="*"
+CHECKS="$CHECKS,-android-cloexec-accept"
+CHECKS="$CHECKS,-android-cloexec-fopen"
 CHECKS="$CHECKS,-bugprone-not-null-terminated-result"
 CHECKS="$CHECKS,-bugprone-reserved-identifier"
 CHECKS="$CHECKS,-bugprone-sizeof-expression"
@@ -18,24 +20,24 @@ CHECKS="$CHECKS,-misc-unused-parameters"
 CHECKS="$CHECKS,-readability-else-after-return"
 CHECKS="$CHECKS,-readability-inconsistent-declaration-parameter-name"
 CHECKS="$CHECKS,-readability-magic-numbers"
+CHECKS="$CHECKS,-readability-redundant-control-flow"
 
 ERRORS="*"
+# TODO(iphydf): Maybe fix these? Otherwise don't show them, if they are useless.
 ERRORS="$ERRORS,-bugprone-branch-clone"
 ERRORS="$ERRORS,-bugprone-integer-division"
 ERRORS="$ERRORS,-bugprone-narrowing-conversions"
 ERRORS="$ERRORS,-clang-analyzer-core.NonNullParamChecker"
 ERRORS="$ERRORS,-clang-analyzer-core.NullDereference"
 ERRORS="$ERRORS,-clang-analyzer-optin.portability.UnixAPI"
+ERRORS="$ERRORS,-clang-analyzer-unix.Malloc"
 ERRORS="$ERRORS,-clang-analyzer-valist.Uninitialized"
 ERRORS="$ERRORS,-cppcoreguidelines-avoid-non-const-global-variables"
 ERRORS="$ERRORS,-cppcoreguidelines-narrowing-conversions"
 ERRORS="$ERRORS,-google-readability-casting"
 ERRORS="$ERRORS,-misc-no-recursion"
-ERRORS="$ERRORS,-readability-redundant-control-flow"
 
 # TODO(iphydf): Fix these.
-ERRORS="$ERRORS,-android-cloexec-accept"
-ERRORS="$ERRORS,-android-cloexec-fopen"
 ERRORS="$ERRORS,-bugprone-macro-parentheses"
 ERRORS="$ERRORS,-bugprone-posix-return"
 ERRORS="$ERRORS,-bugprone-signed-char-misuse"
@@ -43,7 +45,6 @@ ERRORS="$ERRORS,-cert-err34-c"
 ERRORS="$ERRORS,-cert-str34-c"
 ERRORS="$ERRORS,-clang-analyzer-security.insecureAPI.strcpy"
 ERRORS="$ERRORS,-hicpp-uppercase-literal-suffix"
-ERRORS="$ERRORS,-readability-non-const-parameter"
 ERRORS="$ERRORS,-readability-uppercase-literal-suffix"
 
 set -eux

--- a/other/bootstrap_daemon/src/log.c
+++ b/other/bootstrap_daemon/src/log.c
@@ -11,7 +11,7 @@
 #include "log_backend_stdout.h"
 #include "log_backend_syslog.h"
 
-#define INVALID_BACKEND (LOG_BACKEND)-1u
+#define INVALID_BACKEND ((LOG_BACKEND)-1u)
 static LOG_BACKEND current_backend = INVALID_BACKEND;
 
 bool log_open(LOG_BACKEND backend)

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -42,7 +42,13 @@
 #include "log.h"
 
 
-#define SLEEP_MILLISECONDS(MS) usleep(1000*MS)
+static void sleep_milliseconds(uint32_t ms)
+{
+    struct timespec req;
+    req.tv_sec = ms / 1000;
+    req.tv_nsec = (long)ms % 1000 * 1000 * 1000;
+    nanosleep(&req, nullptr);
+}
 
 // Uses the already existing key or creates one if it didn't exist
 //
@@ -514,7 +520,7 @@ int main(int argc, char *argv[])
             waiting_for_dht_connection = 0;
         }
 
-        SLEEP_MILLISECONDS(30);
+        sleep_milliseconds(30);
     }
 
     switch (caught_signal) {

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -620,30 +620,37 @@ int unpack_nodes(Node_format *nodes, uint16_t max_num_nodes, uint16_t *processed
  *
  *  return index or UINT32_MAX if not found.
  */
-#define INDEX_OF_PK(array, size, pk)               \
-  do {                                             \
-      for (uint32_t i = 0; i < size; ++i) {        \
-          if (id_equal(array[i].public_key, pk)) { \
-              return i;                            \
-          }                                        \
-      }                                            \
-                                                   \
-      return UINT32_MAX;                           \
-  } while (0)
-
 static uint32_t index_of_client_pk(const Client_data *array, uint32_t size, const uint8_t *pk)
 {
-    INDEX_OF_PK(array, size, pk);
+    for (uint32_t i = 0; i < size; ++i) {
+        if (id_equal(array[i].public_key, pk)) {
+            return i;
+        }
+    }
+
+    return UINT32_MAX;
 }
 
 static uint32_t index_of_friend_pk(const DHT_Friend *array, uint32_t size, const uint8_t *pk)
 {
-    INDEX_OF_PK(array, size, pk);
+    for (uint32_t i = 0; i < size; ++i) {
+        if (id_equal(array[i].public_key, pk)) {
+            return i;
+        }
+    }
+
+    return UINT32_MAX;
 }
 
 static uint32_t index_of_node_pk(const Node_format *array, uint32_t size, const uint8_t *pk)
 {
-    INDEX_OF_PK(array, size, pk);
+    for (uint32_t i = 0; i < size; ++i) {
+        if (id_equal(array[i].public_key, pk)) {
+            return i;
+        }
+    }
+
+    return UINT32_MAX;
 }
 
 /* Find index of Client_data with ip_port equal to param ip_port.
@@ -2181,7 +2188,7 @@ static uint16_t nat_getports(uint16_t *portlist, IP_Port *ip_portlist, uint16_t 
     return num;
 }
 
-static void punch_holes(DHT *dht, IP ip, uint16_t *port_list, uint16_t numports, uint16_t friend_num)
+static void punch_holes(DHT *dht, IP ip, const uint16_t *port_list, uint16_t numports, uint16_t friend_num)
 {
     if (!dht->hole_punching_enabled) {
         return;

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -30,7 +30,12 @@
 
 #include "../toxencryptsave/defines.h"
 
-#define SET_ERROR_PARAMETER(param, x) do { if (param) { *param = x; } } while (0)
+#define SET_ERROR_PARAMETER(param, x) \
+    do {                              \
+        if (param) {                  \
+            *param = x;               \
+        }                             \
+    } while (0)
 
 //!TOKSTYLE-
 static_assert(TOX_HASH_LENGTH == CRYPTO_SHA256_SIZE,

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -5,7 +5,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define SET_ERROR_PARAMETER(param, x) do { if (param) { *param = x; } } while (0)
+#define SET_ERROR_PARAMETER(param, x) \
+    do {                              \
+        if (param) {                  \
+            *param = x;               \
+        }                             \
+    } while (0)
 
 //!TOKSTYLE-
 

--- a/toxencryptsave/toxencryptsave.c
+++ b/toxencryptsave/toxencryptsave.c
@@ -14,7 +14,6 @@
 #include "../toxcore/crypto_core.h"
 #include "defines.h"
 #include "toxencryptsave.h"
-#define SET_ERROR_PARAMETER(param, x) do { if (param) { *param = x; } } while (0)
 
 #ifdef VANILLA_NACL
 #include <crypto_box.h>
@@ -37,6 +36,13 @@ static_assert(TOX_PASS_ENCRYPTION_EXTRA_LENGTH == (crypto_box_MACBYTES + crypto_
               crypto_pwhash_scryptsalsa208sha256_SALTBYTES + TOX_ENC_SAVE_MAGIC_LENGTH),
               "TOX_PASS_ENCRYPTION_EXTRA_LENGTH is assumed to be equal to (crypto_box_MACBYTES + crypto_box_NONCEBYTES + crypto_pwhash_scryptsalsa208sha256_SALTBYTES + TOX_ENC_SAVE_MAGIC_LENGTH)");
 //!TOKSTYLE+
+
+#define SET_ERROR_PARAMETER(param, x) \
+    do {                              \
+        if (param) {                  \
+            *param = x;               \
+        }                             \
+    } while (0)
 
 uint32_t tox_pass_salt_length(void)
 {


### PR DESCRIPTION
The android warnings are disabled now because they suggest using
linux-only extensions of libc. Useful for android indeed, but we're
targeting non-android and non-linux systems as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1747)
<!-- Reviewable:end -->
