### PR TITLE
cleanup: Require `{}` around all switch case label statements.

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2948,10 +2948,11 @@ static State_Load_Status dht_load_state_callback(void *outer, const uint8_t *dat
             break;
         }
 
-        default:
+        default: {
             LOGGER_ERROR(dht->log, "Load state (DHT): contains unrecognized part (len %u, type %u)",
                          length, type);
             break;
+        }
     }
 
     return STATE_LOAD_STATUS_CONTINUE;

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -717,17 +717,19 @@ TCP_Client_Connection *new_TCP_connection(const Mono_Time *mono_time, IP_Port ip
     temp->proxy_info = *proxy_info;
 
     switch (proxy_info->proxy_type) {
-        case TCP_PROXY_HTTP:
+        case TCP_PROXY_HTTP: {
             temp->status = TCP_CLIENT_PROXY_HTTP_CONNECTING;
             proxy_http_generate_connection_request(temp);
             break;
+        }
 
-        case TCP_PROXY_SOCKS5:
+        case TCP_PROXY_SOCKS5: {
             temp->status = TCP_CLIENT_PROXY_SOCKS5_CONNECTING;
             proxy_socks5_generate_handshake(temp);
             break;
+        }
 
-        case TCP_PROXY_NONE:
+        case TCP_PROXY_NONE: {
             temp->status = TCP_CLIENT_CONNECTING;
 
             if (generate_handshake(temp) == -1) {
@@ -737,6 +739,7 @@ TCP_Client_Connection *new_TCP_connection(const Mono_Time *mono_time, IP_Port ip
             }
 
             break;
+        }
     }
 
     temp->kill_at = mono_time_get(mono_time) + TCP_CONNECTION_TIMEOUT;

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -2008,8 +2008,9 @@ static void handle_friend_invite_packet(Messenger *m, uint32_t friendnumber, con
             break;
         }
 
-        default:
+        default: {
             return;
+        }
     }
 }
 
@@ -2672,8 +2673,9 @@ static void handle_message_packet_group(Group_Chats *g_c, uint32_t groupnumber, 
     const bool direct_from_sender = id_equal(g->group[index].real_pk, real_pk);
 
     switch (message_id) {
-        case GROUP_MESSAGE_PING_ID:
+        case GROUP_MESSAGE_PING_ID: {
             break;
+        }
 
         case GROUP_MESSAGE_NEW_PEER_ID: {
             if (msg_data_len != GROUP_MESSAGE_NEW_PEER_LENGTH) {
@@ -2685,8 +2687,8 @@ static void handle_message_packet_group(Group_Chats *g_c, uint32_t groupnumber, 
             new_peer_number = net_ntohs(new_peer_number);
             addpeer(g_c, groupnumber, msg_data + sizeof(uint16_t), msg_data + sizeof(uint16_t) + CRYPTO_PUBLIC_KEY_SIZE,
                     new_peer_number, userdata, true, true);
+            break;
         }
-        break;
 
         case GROUP_MESSAGE_KILL_PEER_ID:
         case GROUP_MESSAGE_FREEZE_PEER_ID: {
@@ -2759,8 +2761,9 @@ static void handle_message_packet_group(Group_Chats *g_c, uint32_t groupnumber, 
             break;
         }
 
-        default:
+        default: {
             return;
+        }
     }
 
     /* If the packet was received from the peer who sent the message, relay it

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1239,7 +1239,7 @@ int addr_resolve(const char *address, IP *to, IP *extra)
 
     for (walker = server; (walker != nullptr) && !done; walker = walker->ai_next) {
         switch (walker->ai_family) {
-            case AF_INET:
+            case AF_INET: {
                 if (walker->ai_family == family) { /* AF_INET requested, done */
                     struct sockaddr_in *addr = (struct sockaddr_in *)(void *)walker->ai_addr;
                     get_ip4(&to->ip.v4, &addr->sin_addr);
@@ -1252,8 +1252,9 @@ int addr_resolve(const char *address, IP *to, IP *extra)
                 }
 
                 break; /* switch */
+            }
 
-            case AF_INET6:
+            case AF_INET6: {
                 if (walker->ai_family == family) { /* AF_INET6 requested, done */
                     if (walker->ai_addrlen == sizeof(struct sockaddr_in6)) {
                         struct sockaddr_in6 *addr = (struct sockaddr_in6 *)(void *)walker->ai_addr;
@@ -1270,6 +1271,7 @@ int addr_resolve(const char *address, IP *to, IP *extra)
                 }
 
                 break; /* switch */
+            }
         }
     }
 

--- a/toxcore/state.c
+++ b/toxcore/state.c
@@ -43,17 +43,20 @@ int state_load(const Logger *log, state_load_cb *state_load_callback, void *oute
         const uint16_t type = lendian_to_host16(cookie_type & 0xFFFF);
 
         switch (state_load_callback(outer, data, length_sub, type)) {
-            case STATE_LOAD_STATUS_CONTINUE:
+            case STATE_LOAD_STATUS_CONTINUE: {
                 data += length_sub;
                 length -= length_sub;
                 break;
+            }
 
-            case STATE_LOAD_STATUS_ERROR:
+            case STATE_LOAD_STATUS_ERROR: {
                 LOGGER_ERROR(log, "Error occcured in state file (type: %u).", type);
                 return -1;
+            }
 
-            case STATE_LOAD_STATUS_END:
+            case STATE_LOAD_STATUS_END: {
                 return 0;
+            }
         }
     }
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -397,13 +397,15 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
         default_options = tox_options_new(&err);
 
         switch (err) {
-            case TOX_ERR_OPTIONS_NEW_OK:
+            case TOX_ERR_OPTIONS_NEW_OK: {
                 break;
+            }
 
-            case TOX_ERR_OPTIONS_NEW_MALLOC:
+            case TOX_ERR_OPTIONS_NEW_MALLOC: {
                 SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);
                 free(tox);
                 return nullptr;
+            }
         }
     }
 
@@ -459,23 +461,27 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
     m_options.log_user_data = tox_options_get_log_user_data(opts);
 
     switch (tox_options_get_proxy_type(opts)) {
-        case TOX_PROXY_TYPE_HTTP:
+        case TOX_PROXY_TYPE_HTTP: {
             m_options.proxy_info.proxy_type = TCP_PROXY_HTTP;
             break;
+        }
 
-        case TOX_PROXY_TYPE_SOCKS5:
+        case TOX_PROXY_TYPE_SOCKS5: {
             m_options.proxy_info.proxy_type = TCP_PROXY_SOCKS5;
             break;
+        }
 
-        case TOX_PROXY_TYPE_NONE:
+        case TOX_PROXY_TYPE_NONE: {
             m_options.proxy_info.proxy_type = TCP_PROXY_NONE;
             break;
+        }
 
-        default:
+        default: {
             SET_ERROR_PARAMETER(error, TOX_ERR_NEW_PROXY_BAD_TYPE);
             tox_options_free(default_options);
             free(tox);
             return nullptr;
+        }
     }
 
     if (m_options.proxy_info.proxy_type != TCP_PROXY_NONE) {
@@ -971,38 +977,46 @@ Tox_User_Status tox_self_get_status(const Tox *tox)
 static void set_friend_error(const Logger *log, int32_t ret, Tox_Err_Friend_Add *error)
 {
     switch (ret) {
-        case FAERR_TOOLONG:
+        case FAERR_TOOLONG: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_TOO_LONG);
             break;
+        }
 
-        case FAERR_NOMESSAGE:
+        case FAERR_NOMESSAGE: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_NO_MESSAGE);
             break;
+        }
 
-        case FAERR_OWNKEY:
+        case FAERR_OWNKEY: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_OWN_KEY);
             break;
+        }
 
-        case FAERR_ALREADYSENT:
+        case FAERR_ALREADYSENT: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_ALREADY_SENT);
             break;
+        }
 
-        case FAERR_BADCHECKSUM:
+        case FAERR_BADCHECKSUM: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_BAD_CHECKSUM);
             break;
+        }
 
-        case FAERR_SETNEWNOSPAM:
+        case FAERR_SETNEWNOSPAM: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_SET_NEW_NOSPAM);
             break;
+        }
 
-        case FAERR_NOMEM:
+        case FAERR_NOMEM: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_MALLOC);
             break;
+        }
 
-        default:
+        default: {
             /* can't happen */
             LOGGER_FATAL(log, "impossible return value: %d", ret);
             break;
+        }
     }
 }
 
@@ -1338,34 +1352,41 @@ bool tox_self_set_typing(Tox *tox, uint32_t friend_number, bool typing, Tox_Err_
 static void set_message_error(const Logger *log, int ret, Tox_Err_Friend_Send_Message *error)
 {
     switch (ret) {
-        case 0:
+        case 0: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_SEND_MESSAGE_OK);
             break;
+        }
 
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_SEND_MESSAGE_FRIEND_NOT_FOUND);
             break;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_SEND_MESSAGE_TOO_LONG);
             break;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_SEND_MESSAGE_FRIEND_NOT_CONNECTED);
             break;
+        }
 
-        case -4:
+        case -4: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_SEND_MESSAGE_SENDQ);
             break;
+        }
 
-        case -5:
+        case -5: {
             LOGGER_FATAL(log, "impossible: Messenger and Tox disagree on message types");
             break;
+        }
 
-        default:
+        default: {
             /* can't happen */
             LOGGER_FATAL(log, "impossible return value: %d", ret);
             break;
+        }
     }
 }
 
@@ -1434,38 +1455,46 @@ bool tox_file_control(Tox *tox, uint32_t friend_number, uint32_t file_number, To
     }
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_FRIEND_NOT_FOUND);
             return 0;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_FRIEND_NOT_CONNECTED);
             return 0;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_NOT_FOUND);
             return 0;
+        }
 
-        case -4:
+        case -4: {
             /* can't happen (this code is returned if `control` is invalid type) */
             LOGGER_FATAL(tox->m->log, "impossible return value: %d", ret);
             return 0;
+        }
 
-        case -5:
+        case -5: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_ALREADY_PAUSED);
             return 0;
+        }
 
-        case -6:
+        case -6: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_DENIED);
             return 0;
+        }
 
-        case -7:
+        case -7: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_NOT_PAUSED);
             return 0;
+        }
 
-        case -8:
+        case -8: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_SENDQ);
             return 0;
+        }
     }
 
     /* can't happen */
@@ -1488,30 +1517,36 @@ bool tox_file_seek(Tox *tox, uint32_t friend_number, uint32_t file_number, uint6
     }
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEEK_FRIEND_NOT_FOUND);
             return 0;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEEK_FRIEND_NOT_CONNECTED);
             return 0;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEEK_NOT_FOUND);
             return 0;
+        }
 
         case -4: // fall-through
-        case -5:
+        case -5: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEEK_DENIED);
             return 0;
+        }
 
-        case -6:
+        case -6: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEEK_INVALID_POSITION);
             return 0;
+        }
 
-        case -8:
+        case -8: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEEK_SENDQ);
             return 0;
+        }
     }
 
     /* can't happen */
@@ -1582,21 +1617,25 @@ uint32_t tox_file_send(Tox *tox, uint32_t friend_number, uint32_t kind, uint64_t
     }
 
     switch (file_num) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_FRIEND_NOT_FOUND);
             return UINT32_MAX;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_NAME_TOO_LONG);
             return UINT32_MAX;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_TOO_MANY);
             return UINT32_MAX;
+        }
 
-        case -4:
+        case -4: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_FRIEND_NOT_CONNECTED);
             return UINT32_MAX;
+        }
     }
 
     /* can't happen */
@@ -1619,33 +1658,40 @@ bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number,
     }
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_CHUNK_FRIEND_NOT_FOUND);
             return 0;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_CHUNK_FRIEND_NOT_CONNECTED);
             return 0;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_CHUNK_NOT_FOUND);
             return 0;
+        }
 
-        case -4:
+        case -4: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_CHUNK_NOT_TRANSFERRING);
             return 0;
+        }
 
-        case -5:
+        case -5: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_CHUNK_INVALID_LENGTH);
             return 0;
+        }
 
-        case -6:
+        case -6: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_CHUNK_SENDQ);
             return 0;
+        }
 
-        case -7:
+        case -7: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_CHUNK_WRONG_POSITION);
             return 0;
+        }
     }
 
     /* can't happen */
@@ -1765,13 +1811,15 @@ size_t tox_conference_peer_get_name_size(const Tox *tox, uint32_t conference_num
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_CONFERENCE_NOT_FOUND);
             return -1;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_PEER_NOT_FOUND);
             return -1;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_OK);
@@ -1787,13 +1835,15 @@ bool tox_conference_peer_get_name(const Tox *tox, uint32_t conference_number, ui
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_CONFERENCE_NOT_FOUND);
             return false;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_PEER_NOT_FOUND);
             return false;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_OK);
@@ -1809,13 +1859,15 @@ bool tox_conference_peer_get_public_key(const Tox *tox, uint32_t conference_numb
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_CONFERENCE_NOT_FOUND);
             return false;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_PEER_NOT_FOUND);
             return false;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_OK);
@@ -1831,17 +1883,20 @@ bool tox_conference_peer_number_is_ours(const Tox *tox, uint32_t conference_numb
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_CONFERENCE_NOT_FOUND);
             return false;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_PEER_NOT_FOUND);
             return false;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_NO_CONNECTION);
             return false;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_OK);
@@ -1875,13 +1930,15 @@ size_t tox_conference_offline_peer_get_name_size(const Tox *tox, uint32_t confer
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_CONFERENCE_NOT_FOUND);
             return -1;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_PEER_NOT_FOUND);
             return -1;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_OK);
@@ -1898,13 +1955,15 @@ bool tox_conference_offline_peer_get_name(const Tox *tox, uint32_t conference_nu
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_CONFERENCE_NOT_FOUND);
             return false;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_PEER_NOT_FOUND);
             return false;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_OK);
@@ -1921,13 +1980,15 @@ bool tox_conference_offline_peer_get_public_key(const Tox *tox, uint32_t confere
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_CONFERENCE_NOT_FOUND);
             return false;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_PEER_NOT_FOUND);
             return false;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_OK);
@@ -1946,13 +2007,15 @@ uint64_t tox_conference_offline_peer_get_last_active(const Tox *tox, uint32_t co
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_CONFERENCE_NOT_FOUND);
             return UINT64_MAX;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_PEER_NOT_FOUND);
             return UINT64_MAX;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_PEER_QUERY_OK);
@@ -1986,17 +2049,20 @@ bool tox_conference_invite(Tox *tox, uint32_t friend_number, uint32_t conference
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_INVITE_CONFERENCE_NOT_FOUND);
             return false;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_INVITE_FAIL_SEND);
             return false;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_INVITE_NO_CONNECTION);
             return false;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_INVITE_OK);
@@ -2012,29 +2078,35 @@ uint32_t tox_conference_join(Tox *tox, uint32_t friend_number, const uint8_t *co
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_JOIN_INVALID_LENGTH);
             return UINT32_MAX;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_JOIN_WRONG_TYPE);
             return UINT32_MAX;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_JOIN_FRIEND_NOT_FOUND);
             return UINT32_MAX;
+        }
 
-        case -4:
+        case -4: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_JOIN_DUPLICATE);
             return UINT32_MAX;
+        }
 
-        case -5:
+        case -5: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_JOIN_INIT_FAIL);
             return UINT32_MAX;
+        }
 
-        case -6:
+        case -6: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_JOIN_FAIL_SEND);
             return UINT32_MAX;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_JOIN_OK);
@@ -2057,21 +2129,25 @@ bool tox_conference_send_message(Tox *tox, uint32_t conference_number, Tox_Messa
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_SEND_MESSAGE_CONFERENCE_NOT_FOUND);
             return false;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_SEND_MESSAGE_TOO_LONG);
             return false;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_SEND_MESSAGE_NO_CONNECTION);
             return false;
+        }
 
-        case -4:
+        case -4: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_SEND_MESSAGE_FAIL_SEND);
             return false;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_SEND_MESSAGE_OK);
@@ -2086,13 +2162,15 @@ size_t tox_conference_get_title_size(const Tox *tox, uint32_t conference_number,
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_CONFERENCE_NOT_FOUND);
             return -1;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_INVALID_LENGTH);
             return -1;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_OK);
@@ -2108,13 +2186,15 @@ bool tox_conference_get_title(const Tox *tox, uint32_t conference_number, uint8_
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_CONFERENCE_NOT_FOUND);
             return false;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_INVALID_LENGTH);
             return false;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_OK);
@@ -2130,17 +2210,20 @@ bool tox_conference_set_title(Tox *tox, uint32_t conference_number, const uint8_
     unlock(tox);
 
     switch (ret) {
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_CONFERENCE_NOT_FOUND);
             return false;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_INVALID_LENGTH);
             return false;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_FAIL_SEND);
             return false;
+        }
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_TITLE_OK);
@@ -2230,17 +2313,20 @@ uint32_t tox_conference_by_uid(const Tox *tox, const uint8_t *uid, Tox_Err_Confe
     const uint32_t res = tox_conference_by_id(tox, uid, &id_error);
 
     switch (id_error) {
-        case TOX_ERR_CONFERENCE_BY_ID_OK:
+        case TOX_ERR_CONFERENCE_BY_ID_OK: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_BY_UID_OK);
             break;
+        }
 
-        case TOX_ERR_CONFERENCE_BY_ID_NULL:
+        case TOX_ERR_CONFERENCE_BY_ID_NULL: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_BY_UID_NULL);
             break;
+        }
 
-        case TOX_ERR_CONFERENCE_BY_ID_NOT_FOUND:
+        case TOX_ERR_CONFERENCE_BY_ID_NOT_FOUND: {
             SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_BY_UID_NOT_FOUND);
             break;
+        }
     }
 
     return res;
@@ -2249,29 +2335,35 @@ uint32_t tox_conference_by_uid(const Tox *tox, const uint8_t *uid, Tox_Err_Confe
 static void set_custom_packet_error(int ret, Tox_Err_Friend_Custom_Packet *error)
 {
     switch (ret) {
-        case 0:
+        case 0: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_OK);
             break;
+        }
 
-        case -1:
+        case -1: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_FRIEND_NOT_FOUND);
             break;
+        }
 
-        case -2:
+        case -2: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_TOO_LONG);
             break;
+        }
 
-        case -3:
+        case -3: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_INVALID);
             break;
+        }
 
-        case -4:
+        case -4: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_FRIEND_NOT_CONNECTED);
             break;
+        }
 
-        case -5:
+        case -5: {
             SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_SENDQ);
             break;
+        }
     }
 }
 


### PR DESCRIPTION
Except for single return-with-value statements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1749)
<!-- Reviewable:end -->
