### PR TITLE
cleanup: address some unused return values

### DIFF
--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -115,6 +115,7 @@ static int connect_sock_to(Socket sock, IP_Port ip_port, const TCP_Proxy_Info *p
 
     /* nonblocking socket, connect will never return success */
     net_connect(sock, ip_port);
+
     return 1;
 }
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -798,12 +798,21 @@ Networking_Core *new_networking_ex(const Logger *log, IP ip, uint16_t port_from,
     /* Functions to increase the size of the send and receive UDP buffers.
      */
     int n = 1024 * 1024 * 2;
-    setsockopt(temp->sock.socket, SOL_SOCKET, SO_RCVBUF, (const char *)&n, sizeof(n));
-    setsockopt(temp->sock.socket, SOL_SOCKET, SO_SNDBUF, (const char *)&n, sizeof(n));
+
+    if (setsockopt(temp->sock.socket, SOL_SOCKET, SO_RCVBUF, (const char *)&n, sizeof(n)) != 0) {
+        LOGGER_WARNING(log, "Failed to set socket option %d", SO_RCVBUF);
+    }
+
+    if (setsockopt(temp->sock.socket, SOL_SOCKET, SO_SNDBUF, (const char *)&n, sizeof(n)) != 0) {
+        LOGGER_WARNING(log, "Failed to set socket option %d", SO_SNDBUF);
+    }
 
     /* Enable broadcast on socket */
     int broadcast = 1;
-    setsockopt(temp->sock.socket, SOL_SOCKET, SO_BROADCAST, (const char *)&broadcast, sizeof(broadcast));
+
+    if (setsockopt(temp->sock.socket, SOL_SOCKET, SO_BROADCAST, (const char *)&broadcast, sizeof(broadcast)) != 0) {
+        LOGGER_WARNING(log, "Failed to set socket option %d", SO_BROADCAST);
+    }
 
     /* iOS UDP sockets are weird and apparently can SIGPIPE */
     if (!set_socket_nosigpipe(temp->sock)) {

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -373,7 +373,11 @@ void networking_registerhandler(Networking_Core *net, uint8_t byte, packet_handl
 /* Call this several times a second. */
 void networking_poll(Networking_Core *net, void *userdata);
 
-/* Connect a socket to the address specified by the ip_port. */
+/* Connect a socket to the address specified by the ip_port.
+ *
+ * Return 0 on success.
+ * Return -1 on failure.
+ */
 int net_connect(Socket sock, IP_Port ip_port);
 
 /* High-level getaddrinfo implementation.

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -45,14 +45,14 @@ struct Ping {
 #define DHT_PING_SIZE (1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE + PING_PLAIN_SIZE + CRYPTO_MAC_SIZE)
 #define PING_DATA_SIZE (CRYPTO_PUBLIC_KEY_SIZE + sizeof(IP_Port))
 
-int32_t ping_send_request(Ping *ping, IP_Port ipp, const uint8_t *public_key)
+void ping_send_request(Ping *ping, IP_Port ipp, const uint8_t *public_key)
 {
     uint8_t   pk[DHT_PING_SIZE];
     int       rc;
     uint64_t  ping_id;
 
     if (id_equal(public_key, dht_get_self_public_key(ping->dht))) {
-        return 1;
+        return;
     }
 
     uint8_t shared_key[CRYPTO_SHARED_KEY_SIZE];
@@ -67,7 +67,7 @@ int32_t ping_send_request(Ping *ping, IP_Port ipp, const uint8_t *public_key)
 
     if (ping_id == 0) {
         crypto_memzero(shared_key, sizeof(shared_key));
-        return 1;
+        return;
     }
 
     uint8_t ping_plain[PING_PLAIN_SIZE];
@@ -87,10 +87,11 @@ int32_t ping_send_request(Ping *ping, IP_Port ipp, const uint8_t *public_key)
     crypto_memzero(shared_key, sizeof(shared_key));
 
     if (rc != PING_PLAIN_SIZE + CRYPTO_MAC_SIZE) {
-        return 1;
+        return;
     }
 
-    return sendpacket(dht_get_net(ping->dht), ipp, pk, sizeof(pk));
+    // We never check this return value and failures in sendpacket are already logged
+    sendpacket(dht_get_net(ping->dht), ipp, pk, sizeof(pk));
 }
 
 static int ping_send_response(Ping *ping, IP_Port ipp, const uint8_t *public_key, uint64_t ping_id,

--- a/toxcore/ping.h
+++ b/toxcore/ping.h
@@ -53,6 +53,6 @@ int32_t ping_add(Ping *ping, const uint8_t *public_key, struct IP_Port ip_port);
 
 void ping_iterate(Ping *ping);
 
-int32_t ping_send_request(Ping *ping, struct IP_Port ipp, const uint8_t *public_key);
+void ping_send_request(Ping *ping, struct IP_Port ipp, const uint8_t *public_key);
 
 #endif // C_TOXCORE_TOXCORE_PING_H


### PR DESCRIPTION
We now either log errors or properly propagate them. In the case of ping_send_request we make the function return void because it doesn't seem to matter whether or not it succeeds (none of its callers check the return value).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1759)
<!-- Reviewable:end -->
