### PR TITLE
cleanup: Don't include `"config.h"` unless needed.

### DIFF
--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -2,10 +2,6 @@
  * Copyright © 2016-2018 The TokTok team.
  * Copyright © 2013-2015 Tox project.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif /* HAVE_CONFIG_H */
-
 #include "audio.h"
 
 #include <stdlib.h>

--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -2,10 +2,6 @@
  * Copyright © 2016-2018 The TokTok team.
  * Copyright © 2013-2015 Tox project.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif /* HAVE_CONFIG_H */
-
 #include "bwcontroller.h"
 
 #include <assert.h>

--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -2,10 +2,6 @@
  * Copyright © 2016-2018 The TokTok team.
  * Copyright © 2014 Tox project.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif /* HAVE_CONFIG_H */
-
 #include "groupav.h"
 
 #include <stdlib.h>

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -2,10 +2,6 @@
  * Copyright © 2016-2018 The TokTok team.
  * Copyright © 2013-2015 Tox project.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif /* HAVE_CONFIG_H */
-
 #include "msi.h"
 
 #include "../toxcore/logger.h"

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -2,10 +2,6 @@
  * Copyright © 2016-2018 The TokTok team.
  * Copyright © 2013-2015 Tox project.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif /* HAVE_CONFIG_H */
-
 #include "rtp.h"
 
 #include <assert.h>

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -2,10 +2,6 @@
  * Copyright © 2016-2018 The TokTok team.
  * Copyright © 2013-2015 Tox project.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif /* HAVE_CONFIG_H */
-
 #include "toxav.h"
 
 #include "msi.h"

--- a/toxav/video.c
+++ b/toxav/video.c
@@ -2,10 +2,6 @@
  * Copyright © 2016-2018 The TokTok team.
  * Copyright © 2013-2015 Tox project.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif /* HAVE_CONFIG_H */
-
 #include "video.h"
 
 #include <assert.h>

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -6,10 +6,6 @@
 /*
  * An implementation of the DHT as seen in docs/updates/DHT.md
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "DHT.h"
 
 #include "LAN_discovery.h"

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -6,10 +6,6 @@
 /*
  * LAN discovery implementation.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "LAN_discovery.h"
 
 #include <string.h>

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -6,10 +6,6 @@
 /*
  * An implementation of a simple text chat only messenger on the tox network core.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "Messenger.h"
 
 #include <assert.h>

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -6,10 +6,6 @@
 /*
  * Implementation of the TCP relay client part of Tox.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "TCP_client.h"
 
 #include <stdio.h>

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -6,10 +6,6 @@
 /*
  * Handles TCP relay connections between two Tox clients.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "TCP_connection.h"
 
 #include <assert.h>

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -6,10 +6,6 @@
 /*
  * Implementation of the TCP relay server part of Tox.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "TCP_server.h"
 
 #include <stdlib.h>

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -8,10 +8,6 @@
  *
  * NOTE: This code has to be perfect. We don't mess around with encryption.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "crypto_core.h"
 
 #include <stdlib.h>

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -6,10 +6,6 @@
 /*
  * Connection to friends.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "friend_connection.h"
 
 #include <stdlib.h>

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -6,10 +6,6 @@
 /*
  * Handle friend requests.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "friend_requests.h"
 
 #include <stdlib.h>

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -6,10 +6,6 @@
 /*
  * Slightly better groupchats implementation.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "group.h"
 
 #include <assert.h>

--- a/toxcore/list.c
+++ b/toxcore/list.c
@@ -8,10 +8,6 @@
  * -Allows for finding ids associated with data such as IPs or public keys in a short time
  * -Should only be used if there are relatively few add/remove calls to the list
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "list.h"
 
 #include <stdbool.h>

--- a/toxcore/logger.c
+++ b/toxcore/logger.c
@@ -6,10 +6,6 @@
 /*
  * Text logging abstraction.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "logger.h"
 
 #include <assert.h>

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -8,10 +8,6 @@
  *
  * NOTE: This code has to be perfect. We don't mess around with encryption.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "net_crypto.h"
 
 #include <math.h>

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -6,10 +6,6 @@
 /*
  * Functions for the core networking.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #ifdef __APPLE__
 #define _DARWIN_C_SOURCE
 #endif

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -6,10 +6,6 @@
 /*
  * Implementation of the onion part of docs/Prevent_Tracking.txt
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "onion.h"
 
 #include <stdlib.h>

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -6,10 +6,6 @@
 /*
  * Implementation of the announce part of docs/Prevent_Tracking.txt
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "onion_announce.h"
 
 #include <stdlib.h>

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -7,10 +7,6 @@
  * Implementation of the client part of docs/Prevent_Tracking.txt (The part that
  * uses the onion stuff to connect to the friend)
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "onion_client.h"
 
 #include <stdlib.h>

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -7,10 +7,6 @@
 /*
  * Buffered pinging using cyclic arrays.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "ping.h"
 
 #include <stdlib.h>

--- a/toxcore/ping_array.c
+++ b/toxcore/ping_array.c
@@ -6,10 +6,6 @@
 /*
  * Implementation of an efficient array to store that we pinged something.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "ping_array.h"
 
 #include <stdlib.h>

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -6,10 +6,6 @@
 /*
  * The Tox public API.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #ifndef __cplusplus
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -7,10 +7,6 @@
 /*
  * Utilities.
  */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
 #endif


### PR DESCRIPTION
Currently only `crypto_core_mem.c` needs this. We should try not to
depend on configure'd values. Also note: config.h is only created and
used in the autotools build. In CMake, we pass `-D` flags directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1761)
<!-- Reviewable:end -->
