### PR TITLE
feat: Fix file permission issue with toxchat/bootstrap-node Docker container

### DIFF
--- a/.travis/tox-bootstrapd-docker
+++ b/.travis/tox-bootstrapd-docker
@@ -14,6 +14,7 @@ sudo useradd \
   --user-group tox-bootstrapd
 sudo chmod 700 /var/lib/tox-bootstrapd
 docker run -d --name tox-bootstrapd \
+  --user "$(id -u tox-bootstrapd):$(id -g tox-bootstrapd)" \
   -v /var/lib/tox-bootstrapd/:/var/lib/tox-bootstrapd/ \
   --ulimit nofile=32768:32768 \
   -p 443:443 \

--- a/other/bootstrap_daemon/README.md
+++ b/other/bootstrap_daemon/README.md
@@ -249,6 +249,7 @@ sudo useradd \
 sudo chmod 700 /var/lib/tox-bootstrapd
 
 docker run -d --name tox-bootstrapd --restart always \
+  --user "$(id -u tox-bootstrapd):$(id -g tox-bootstrapd)" \
   -v /var/lib/tox-bootstrapd/:/var/lib/tox-bootstrapd/ \
   --ulimit nofile=32768:32768 \
   -p 443:443 \
@@ -284,7 +285,9 @@ Then rebuild and run the image again:
 ```sh
 tar c $(git ls-files) | docker build -f other/bootstrap_daemon/docker/Dockerfile -t toxchat/bootstrap-node -
 docker run -d --name tox-bootstrapd --restart always \
+  --user "$(id -u tox-bootstrapd):$(id -g tox-bootstrapd)" \
   -v /var/lib/tox-bootstrapd/:/var/lib/tox-bootstrapd/ \
+  --ulimit nofile=32768:32768 \
   -p 443:443 \
   -p 3389:3389 \
   -p 33445:33445 \

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -1,6 +1,6 @@
 ###########################################################
 # Builder image: we compile the code here (static build)
-FROM alpine:3.11.5 AS build
+FROM alpine:3.15.0 AS build
 
 RUN ["apk", "--no-cache", "add",\
  "build-base",\
@@ -56,7 +56,7 @@ RUN ["other/bootstrap_daemon/docker/get-nodes.py", "other/bootstrap_daemon/tox-b
 
 ###########################################################
 # Final image build: this is what runs the bootstrap node
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 COPY --from=build /usr/local/bin/tox-bootstrapd /usr/local/bin/
 COPY --from=build /src/c-toxcore/other/bootstrap_daemon/tox-bootstrapd.conf /etc/tox-bootstrapd.conf

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -30,20 +30,19 @@ COPY toxcore toxcore
 COPY toxencryptsave toxencryptsave
 COPY CMakeLists.txt so.version ./
 
-RUN ["cmake", "-B_build", "-H.",\
- "-GNinja",\
- "-DCMAKE_BUILD_TYPE=Release",\
- "-DFULLY_STATIC=ON",\
- "-DBUILD_TOXAV=OFF",\
- "-DBOOTSTRAP_DAEMON=ON"\
-]
-RUN ["cmake", "--build", "_build", "--target", "install"]
+RUN cmake -B_build -H. \
+      -GNinja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DFULLY_STATIC=ON \
+      -DBUILD_TOXAV=OFF \
+      -DBOOTSTRAP_DAEMON=ON && \
+    cmake --build _build --target install
 
 # Verify checksum from dev-built binary, so we can be sure Docker Hub doesn't
 # mess with your binaries.
 COPY other/bootstrap_daemon/docker/tox-bootstrapd.sha256 other/bootstrap_daemon/docker/
-RUN ["sha256sum", "/usr/local/bin/tox-bootstrapd"]
-RUN ["sha256sum", "-c", "other/bootstrap_daemon/docker/tox-bootstrapd.sha256"]
+RUN sha256sum /usr/local/bin/tox-bootstrapd && \
+    sha256sum -c other/bootstrap_daemon/docker/tox-bootstrapd.sha256
 
 # Remove all the example bootstrap nodes from the config file.
 COPY other/bootstrap_daemon/tox-bootstrapd.conf other/bootstrap_daemon/
@@ -60,13 +59,12 @@ FROM debian:bullseye-slim
 
 COPY --from=build /usr/local/bin/tox-bootstrapd /usr/local/bin/
 COPY --from=build /src/c-toxcore/other/bootstrap_daemon/tox-bootstrapd.conf /etc/tox-bootstrapd.conf
-RUN ["useradd", "--home-dir", "/var/lib/tox-bootstrapd", "--create-home",\
- "--system", "--shell", "/sbin/nologin",\
- "--comment", "Account to run the Tox DHT bootstrap daemon",\
- "--user-group", "tox-bootstrapd"\
-]
-RUN ["chmod", "644", "/etc/tox-bootstrapd.conf"]
-RUN ["chmod", "700", "/var/lib/tox-bootstrapd"]
+RUN useradd --home-dir /var/lib/tox-bootstrapd --create-home \
+      --system --shell /sbin/nologin \
+      --comment "Account to run the Tox DHT bootstrap daemon" \
+      --user-group tox-bootstrapd && \
+    chmod 644 /etc/tox-bootstrapd.conf && \
+    chmod 700 /var/lib/tox-bootstrapd
 
 WORKDIR /var/lib/tox-bootstrapd
 

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-72f7fffc82c5074c94e13a6aee5d6231c4a063bef4338bae1f8d3ab4624c5582  /usr/local/bin/tox-bootstrapd
+ac14ae6877df0b2af683e9578cb7a548d755a3c78ceb26f169163c725963ff50  /usr/local/bin/tox-bootstrapd


### PR DESCRIPTION
/var/lib/tox-bootstrapd on the host is owned by hosts's tox-bootstrapd
and chowned 700, but the container attempts to access it as its own
tox-bootstrapd user with possibly different uid:gid, which will fail if
host's tox-bootstrapd user has different uid:gid than the tox-bootstrapd
user inside the container.

This change makes the container use host's tox-bootstrapd uid:gid, which
fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1765)
<!-- Reviewable:end -->
