### PR TITLE
cleanup: fix format-source

### DIFF
--- a/other/astyle/format-source
+++ b/other/astyle/format-source
@@ -60,10 +60,6 @@ apidsl_curl() {
 
 # Check if apidsl generated sources are up to date.
 set +x
-"$APIDSL" toxcore/LAN_discovery.api.h >toxcore/LAN_discovery.h &
-"$APIDSL" toxcore/crypto_core.api.h >toxcore/crypto_core.h &
-"$APIDSL" toxcore/ping.api.h >toxcore/ping.h &
-"$APIDSL" toxcore/ping_array.api.h >toxcore/ping_array.h &
 "$APIDSL" toxcore/tox.api.h >toxcore/tox.h &
 "$APIDSL" toxav/toxav.api.h >toxav/toxav.h &
 "$APIDSL" toxencryptsave/toxencryptsave.api.h >toxencryptsave/toxencryptsave.h &


### PR DESCRIPTION
APIDSL no longer works with these header files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1783)
<!-- Reviewable:end -->
