### PR TITLE
chore: Disable `-Wmissing-braces`.

### DIFF
--- a/.travis/flags-clang.sh
+++ b/.travis/flags-clang.sh
@@ -9,8 +9,6 @@ add_flag -Weverything
 
 # Disable specific warning flags for both C and C++.
 
-# TODO(iphydf): Clean these up. Probably all of these are actual bugs.
-add_flag -Wno-cast-align
 # Very verbose, not very useful. This warns about things like int -> uint
 # conversions that change sign without a cast and narrowing conversions.
 add_flag -Wno-conversion
@@ -24,7 +22,9 @@ add_flag -Wno-disabled-macro-expansion
 add_flag -Wno-documentation-deprecated-sync
 # Bootstrap daemon does this.
 add_flag -Wno-format-nonliteral
-# struct Foo foo = {0}; is a common idiom.
+# struct Foo foo = {0}; is a common idiom. Missing braces means we'd need to
+# write {{{0}}} in some cases, which is ugly and a maintenance burden.
+add_flag -Wno-missing-braces
 add_flag -Wno-missing-field-initializers
 # Useful sometimes, but we accept padding in structs for clarity.
 # Reordering fields to avoid padding will reduce readability.

--- a/other/analysis/run-clang
+++ b/other/analysis/run-clang
@@ -17,6 +17,7 @@ clang++ -o /dev/null amalgamation.cc \
   -Wno-disabled-macro-expansion \
   -Wno-documentation-deprecated-sync \
   -Wno-global-constructors \
+  -Wno-missing-braces \
   -Wno-missing-field-initializers \
   -Wno-old-style-cast \
   -Wno-padded \

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -749,7 +749,9 @@ static int client_or_ip_port_in_list(const Logger *log, const Mono_Time *mono_ti
     LOGGER_DEBUG(log, "coipil[%u]: switching public_key (ipv%d)", index, ip_version);
 
     /* kill the other address, if it was set */
-    memset(assoc, 0, sizeof(IPPTsPng));
+    *assoc = (IPPTsPng) {
+        0
+    };
     return 1;
 }
 

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -670,7 +670,7 @@ TCP_Client_Connection *new_TCP_connection(const Mono_Time *mono_time, IP_Port ip
         return nullptr;
     }
 
-    const TCP_Proxy_Info default_proxyinfo = {{{{0}}}, TCP_PROXY_NONE};
+    const TCP_Proxy_Info default_proxyinfo = {0};
 
     if (proxy_info == nullptr) {
         proxy_info = &default_proxyinfo;

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -603,7 +603,7 @@ static int add_ip_port_connection(Net_Crypto *c, int crypt_connection_id, IP_Por
  */
 static IP_Port return_ip_port_connection(Net_Crypto *c, int crypt_connection_id)
 {
-    const IP_Port empty = {{{0}}};
+    const IP_Port empty = {0};
 
     Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);
 

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -1008,7 +1008,7 @@ static int handle_tcp_onion(void *object, const uint8_t *data, uint16_t length, 
         return 1;
     }
 
-    IP_Port ip_port = {{{0}}};
+    IP_Port ip_port = {0};
     ip_port.ip.family = net_family_tcp_family;
 
     if (data[0] == NET_PACKET_ANNOUNCE_RESPONSE) {


### PR DESCRIPTION
This flag isn't helpful for the most common case of aggregate
initialisation, namely `{0}`. We don't want to be writing `{{{0}}}` with
some brittle number of braces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1795)
<!-- Reviewable:end -->
