### PR TITLE
chore: Add docker image for running circleci/cmake-{asan,tsan}.

### DIFF
--- a/other/docker/circleci/Dockerfile
+++ b/other/docker/circleci/Dockerfile
@@ -1,0 +1,28 @@
+################################################
+# cmake-asan
+FROM ubuntu:20.04
+
+RUN apt-get update && \
+ DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
+ clang \
+ cmake \
+ libconfig-dev \
+ libopus-dev \
+ libsodium-dev \
+ libvpx-dev \
+ ninja-build \
+ pkg-config \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /
+RUN ["chmod", "755", "/entrypoint.sh"]
+
+WORKDIR /home/builder
+RUN groupadd -r -g 1000 builder \
+ && useradd --no-log-init -r -g builder -u 1000 builder \
+ && chown builder:builder /home/builder
+USER builder
+
+ENV CC=clang CXX=clang++
+ENTRYPOINT ["/entrypoint.sh"]

--- a/other/docker/circleci/entrypoint.sh
+++ b/other/docker/circleci/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+SANITIZER="${1:-asan}"
+
+cp -a /c-toxcore .
+cd c-toxcore
+.circleci/cmake-"$SANITIZER"


### PR DESCRIPTION
Use `make asan` or `make tsan` to run a similar setup to the one we run
on circleci.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1804)
<!-- Reviewable:end -->
