### PR TITLE
chore: Don't run CI on master branch pushes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: ci
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
All pushes have already been checked in the pull request. This is just
duplicate work, wasting GH action runners.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1807)
<!-- Reviewable:end -->
