### PR TITLE
chore: Remove apidsl comment from tox.h.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.30-third_party
+    image: toxchat/toktok-stack:0.0.31-third_party
     cpu: 2
     memory: 2G
   configure_script:
@@ -19,7 +19,7 @@ cirrus-ci_task:
 
 cimple_task:
   container:
-    image: toxchat/toktok-stack:0.0.30-third_party
+    image: toxchat/toktok-stack:0.0.31-third_party
     cpu: 2
     memory: 4G
   configure_script:

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -109,14 +109,6 @@ extern "C" {
 #endif
 
 
-/*******************************************************************************
- * `tox.h` SHOULD NOT BE EDITED MANUALLY – any changes should be made to
- * `tox.api.h`, located in `toxcore/`. For instructions on how to
- * generate `tox.h` from `tox.api.h` please refer to `docs/apidsl.md`
- ******************************************************************************/
-
-
-
 /**
  * The Tox instance type. All the state associated with a connection is held
  * within the instance. Multiple instances can exist and operate concurrently.


### PR DESCRIPTION
There is no more apidsl, so you can edit tox.h manually now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1810)
<!-- Reviewable:end -->
