### PR TITLE
test: add ability for autotests to use TCP connections

### DIFF
--- a/auto_tests/conference_av_test.c
+++ b/auto_tests/conference_av_test.c
@@ -464,6 +464,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(NUM_AV_GROUP_TOX, test_groupav, true);
+    run_auto_test(nullptr, NUM_AV_GROUP_TOX, test_groupav, true);
     return 0;
 }

--- a/auto_tests/conference_double_invite_test.c
+++ b/auto_tests/conference_double_invite_test.c
@@ -79,6 +79,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(2, conference_double_invite_test, false);
+    run_auto_test(nullptr, 2, conference_double_invite_test, false);
     return 0;
 }

--- a/auto_tests/conference_invite_merge_test.c
+++ b/auto_tests/conference_invite_merge_test.c
@@ -237,6 +237,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(NUM_INVITE_MERGE_TOX, conference_invite_merge_test, true);
+    run_auto_test(nullptr, NUM_INVITE_MERGE_TOX, conference_invite_merge_test, true);
     return 0;
 }

--- a/auto_tests/conference_peer_nick_test.c
+++ b/auto_tests/conference_peer_nick_test.c
@@ -126,6 +126,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(2, conference_peer_nick_test, false);
+    run_auto_test(nullptr, 2, conference_peer_nick_test, false);
     return 0;
 }

--- a/auto_tests/conference_test.c
+++ b/auto_tests/conference_test.c
@@ -431,6 +431,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(NUM_GROUP_TOX, test_many_group, true);
+    run_auto_test(nullptr, NUM_GROUP_TOX, test_many_group, true);
     return 0;
 }

--- a/auto_tests/friend_connection_test.c
+++ b/auto_tests/friend_connection_test.c
@@ -23,6 +23,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(2, friend_connection_test, false);
+    run_auto_test(nullptr, 2, friend_connection_test, false);
     return 0;
 }

--- a/auto_tests/lossless_packet_test.c
+++ b/auto_tests/lossless_packet_test.c
@@ -57,6 +57,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(2, test_lossless_packet, false);
+    run_auto_test(nullptr, 2, test_lossless_packet, false);
     return 0;
 }

--- a/auto_tests/lossy_packet_test.c
+++ b/auto_tests/lossy_packet_test.c
@@ -53,6 +53,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(2, test_lossy_packet, false);
+    run_auto_test(nullptr, 2, test_lossy_packet, false);
     return 0;
 }

--- a/auto_tests/overflow_recvq_test.c
+++ b/auto_tests/overflow_recvq_test.c
@@ -58,6 +58,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(3, net_crypto_overflow_test, false);
+    run_auto_test(nullptr, 3, net_crypto_overflow_test, false);
     return 0;
 }

--- a/auto_tests/overflow_sendq_test.c
+++ b/auto_tests/overflow_sendq_test.c
@@ -43,6 +43,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(2, net_crypto_overflow_test, false);
+    run_auto_test(nullptr, 2, net_crypto_overflow_test, false);
     return 0;
 }

--- a/auto_tests/reconnect_test.c
+++ b/auto_tests/reconnect_test.c
@@ -97,6 +97,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(TOX_COUNT, test_reconnect, false);
+    run_auto_test(nullptr, TOX_COUNT, test_reconnect, false);
     return 0;
 }

--- a/auto_tests/send_message_test.c
+++ b/auto_tests/send_message_test.c
@@ -57,6 +57,6 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    run_auto_test(2, send_message_test, false);
+    run_auto_test(nullptr, 2, send_message_test, false);
     return 0;
 }

--- a/auto_tests/typing_test.c
+++ b/auto_tests/typing_test.c
@@ -55,6 +55,6 @@ static void test_typing(Tox **toxes, State *state)
 int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
-    run_auto_test(2, test_typing, false);
+    run_auto_test(nullptr, 2, test_typing, false);
     return 0;
 }


### PR DESCRIPTION
This also allows us to set other tox options. Currently it will only bootstrap to the testnet TCP node since none of the non-NGC tests use TCP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1815)
<!-- Reviewable:end -->
