### PR TITLE
refactor: remove tox_options_default(...)

### DIFF
--- a/auto_tests/save_compatibility_test.c
+++ b/auto_tests/save_compatibility_test.c
@@ -69,20 +69,19 @@ static uint8_t *read_save(const char *save_path, size_t *length)
 
 static void test_save_compatibility(const char *save_path)
 {
-    struct Tox_Options options = {0};
-    tox_options_default(&options);
+    struct Tox_Options *options = tox_options_new(nullptr);
+    ck_assert(options != nullptr);
 
     size_t size = 0;
     uint8_t *save_data = read_save(save_path, &size);
     ck_assert_msg(save_data != nullptr, "error while reading save file '%s'", save_path);
 
-    options.savedata_data = save_data;
-    options.savedata_length = size;
-    options.savedata_type = TOX_SAVEDATA_TYPE_TOX_SAVE;
+    tox_options_set_savedata_type(options, TOX_SAVEDATA_TYPE_TOX_SAVE);
+    tox_options_set_savedata_data(options, save_data, size);
 
     size_t index = 0;
     Tox_Err_New err;
-    Tox *tox = tox_new_log(&options, &err, &index);
+    Tox *tox = tox_new_log(options, &err, &index);
     ck_assert_msg(tox, "failed to create tox, error number: %d", err);
 
     free(save_data);
@@ -128,6 +127,7 @@ static void test_save_compatibility(const char *save_path)
     tox_iterate(tox, nullptr);
 
     tox_kill(tox);
+    tox_options_free(options);
 }
 
 int main(int argc, char *argv[])

--- a/auto_tests/tox_one_test.c
+++ b/auto_tests/tox_one_test.c
@@ -111,7 +111,10 @@ static void test_one(void)
     tox_self_get_secret_key(tox2, sk);
     tox_kill(tox2);
 
-    tox_options_default(options);
+    tox_options_free(options);
+    options = tox_options_new(nullptr);
+    ck_assert(options != nullptr);
+
     tox_options_set_savedata_type(options, TOX_SAVEDATA_TYPE_SECRET_KEY);
     tox_options_set_savedata_data(options, sk, sizeof(sk));
     tox2 = tox_new_log(options, &err_n, &index[1]);

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -745,19 +745,6 @@ bool tox_options_get_experimental_thread_safety(const struct Tox_Options *option
 
 void tox_options_set_experimental_thread_safety(struct Tox_Options *options, bool thread_safety);
 
-/**
- * Initialises a Tox_Options object with the default options.
- *
- * The result of this function is independent of the original options. All
- * values will be overwritten, no values will be read (so it is permissible
- * to pass an uninitialised object).
- *
- * If options is NULL, this function has no effect.
- *
- * @param options An options object to be filled with default options.
- */
-void tox_options_default(struct Tox_Options *options);
-
 typedef enum Tox_Err_Options_New {
 
     /**

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -82,32 +82,32 @@ void tox_options_set_savedata_data(struct Tox_Options *options, const uint8_t *d
     options->savedata_length = length;
 }
 
-void tox_options_default(struct Tox_Options *options)
-{
-    if (options) {
-        struct Tox_Options default_options = { 0 };
-        *options = default_options;
-        tox_options_set_ipv6_enabled(options, true);
-        tox_options_set_udp_enabled(options, true);
-        tox_options_set_proxy_type(options, TOX_PROXY_TYPE_NONE);
-        tox_options_set_hole_punching_enabled(options, true);
-        tox_options_set_local_discovery_enabled(options, true);
-        tox_options_set_experimental_thread_safety(options, false);
-    }
-}
-
 struct Tox_Options *tox_options_new(Tox_Err_Options_New *error)
 {
     struct Tox_Options *options = (struct Tox_Options *)malloc(sizeof(struct Tox_Options));
 
-    if (options) {
-        tox_options_default(options);
-        SET_ERROR_PARAMETER(error, TOX_ERR_OPTIONS_NEW_OK);
-        return options;
+    if (options == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_OPTIONS_NEW_MALLOC);
+        return nullptr;
     }
 
-    SET_ERROR_PARAMETER(error, TOX_ERR_OPTIONS_NEW_MALLOC);
-    return nullptr;
+    struct Tox_Options default_options = { 0 };
+
+    *options = default_options;
+
+    tox_options_set_ipv6_enabled(options, true);
+
+    tox_options_set_udp_enabled(options, true);
+
+    tox_options_set_proxy_type(options, TOX_PROXY_TYPE_NONE);
+
+    tox_options_set_hole_punching_enabled(options, true);
+
+    tox_options_set_local_discovery_enabled(options, true);
+
+    tox_options_set_experimental_thread_safety(options, false);
+
+    return options;
 }
 
 void tox_options_free(struct Tox_Options *options)


### PR DESCRIPTION
tox_options_new(...) already returns a default initialized options
struct and this function makes it impossible to malloc buffers in
Tox_Options, so remove it.

Required for #909

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1825)
<!-- Reviewable:end -->
