### PR TITLE
chore: Add "tcc" and "compcert" compiler targets.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
-cirrus-ci_task:
+bazel-release_task:
   container:
-    image: toxchat/toktok-stack:0.0.31-third_party
+    image: toxchat/toktok-stack:0.0.31-release
     cpu: 2
     memory: 2G
   configure_script:
@@ -19,7 +19,7 @@ cirrus-ci_task:
 
 cimple_task:
   container:
-    image: toxchat/toktok-stack:0.0.31-third_party
+    image: toxchat/toktok-stack:0.0.31-release
     cpu: 2
     memory: 4G
   configure_script:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -13,11 +13,12 @@ branches:
       required_status_checks:
         contexts:
           - build-bootstrapd-docker
+          - build-compcert
           - build-macos
           - build-nacl
+          - build-tcc
           - build-win32
           - build-win64
-          - Codacy Static Code Analysis
           - CodeFactor
           - "ci/circleci: asan"
           - "ci/circleci: clang-tidy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,54 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build and test
         run: .travis/cmake-osx
+
+  build-tcc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run:
+          sudo apt-get install -y --no-install-recommends
+            tcc
+            libconfig-dev
+            libopus-dev
+            libsodium-dev
+            libvpx-dev
+      - name: Build with TCC
+        run:
+          tcc
+            -o send_message_test
+            -Wall -Werror
+            -bench -g
+            auto_tests/send_message_test.c
+            testing/misc_tools.c
+            toxav/*.c
+            toxcore/*.c
+            toxencryptsave/*.c
+            $(pkg-config --cflags --libs libsodium opus vpx)
+      - name: Run the test
+        run: "./send_message_test | grep 'tox clients connected'"
+
+  build-compcert:
+    runs-on: ubuntu-latest
+    container: toxchat/compcert
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build with CompCert
+        run:
+          ccomp
+            -o send_message_test
+            -Wall -Werror
+            -Wno-c11-extensions
+            -Wno-unknown-pragmas
+            -Wno-unused-variable
+            -fstruct-passing -fno-unprototyped -g
+            auto_tests/send_message_test.c
+            testing/misc_tools.c
+            toxav/*.c
+            toxcore/*.c
+            toxencryptsave/*.c
+            -D__COMPCERT__ -DDISABLE_VLA
+            -lpthread $(pkg-config --cflags --libs libsodium opus vpx)
+      - name: Run the test
+        run: "./send_message_test | grep 'tox clients connected'"

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-7cce630be98faab64c804255e060c85a63ea9f4401ffd1f12122ba1c5cfc45ce  /usr/local/bin/tox-bootstrapd
+f0f315faebe7fc88b15ba656c5866c3932b5495c23ee99bdac539ba986688c92  /usr/local/bin/tox-bootstrapd

--- a/toxcore/ccompat.h
+++ b/toxcore/ccompat.h
@@ -33,6 +33,11 @@ bool unused_for_tokstyle(void);
 // Emulation using alloca.
 #ifdef _WIN32
 #include <malloc.h>
+#elif defined(__COMPCERT__)
+// TODO(iphydf): This leaks memory like crazy, so compcert is useless for now.
+// Once we're rid of VLAs, we can remove this and compcert becomes useful.
+#define alloca malloc
+#include <stdlib.h>
 #elif defined(__linux__)
 #include <alloca.h>
 #else


### PR DESCRIPTION
It's nice we are able to compile with `tcc`. Let's not break that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1830)
<!-- Reviewable:end -->
