### PR TITLE
fix: a double-unlocking mutex in toxav

### DIFF
--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -170,6 +170,7 @@ void ac_iterate(ACSession *ac)
             if (!reconfigure_audio_decoder(ac, ac->lp_sampling_rate, ac->lp_channel_count)) {
                 LOGGER_WARNING(ac->log, "Failed to reconfigure decoder!");
                 free(msg);
+                pthread_mutex_lock(ac->queue_mutex);
                 continue;
             }
 

--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -151,7 +151,8 @@ void ac_iterate(ACSession *ac)
                 cs->last_packet_sampling_rate = rc;
             } else {
                 LOGGER_WARNING(ac->log, "Failed to load packet values!");
-                rtp_free_msg(msg);
+                free(msg);
+                pthread_mutex_lock(ac->queue_mutex);
                 continue;
             }
 


### PR DESCRIPTION
Fixes #1694

Thanks to @ryancaicse for the pointer!

---

That for loop is so filthy, it needs to be re-written as a while loop, but I don't want to even touch that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1832)
<!-- Reviewable:end -->
