### PR TITLE
chore: Add bazel-debug build.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,6 +17,24 @@ bazel-release_task:
         //c-toxcore/...
         -//c-toxcore/auto_tests:tcp_relay_test # TODO(robinlinden): Why does this pass locally but not in Cirrus?
 
+bazel-debug_task:
+  container:
+    image: toxchat/toktok-stack:0.0.31-debug
+    cpu: 2
+    memory: 2G
+  configure_script:
+    - /src/workspace/tools/inject-repo c-toxcore
+  test_all_script:
+    - cd /src/workspace && bazel test -k
+        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+        --build_tag_filters=-haskell
+        --test_tag_filters=-haskell
+        --remote_download_minimal
+        --config=debug
+        --
+        //c-toxcore/...
+        -//c-toxcore/auto_tests:tcp_relay_test # TODO(robinlinden): Why does this pass locally but not in Cirrus?
+
 cimple_task:
   container:
     image: toxchat/toktok-stack:0.0.31-release

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,6 +12,7 @@ branches:
     protection:
       required_status_checks:
         contexts:
+          - "bazel-debug"
           - "bazel-release"
           - "build-bootstrapd-docker"
           - "build-compcert"


### PR DESCRIPTION
This has in the already found real bugs that only happen when compiling
with stack protector and no optimisations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1837)
<!-- Reviewable:end -->
