### PR TITLE
cleanup: make struct typedefs have the same name as their struct

### DIFF
--- a/toxav/audio.h
+++ b/toxav/audio.h
@@ -34,7 +34,7 @@
 #define AUDIO_MAX_BUFFER_SIZE_PCM16 ((AUDIO_MAX_SAMPLE_RATE * AUDIO_MAX_FRAME_DURATION_MS) / 1000)
 #define AUDIO_MAX_BUFFER_SIZE_BYTES (AUDIO_MAX_BUFFER_SIZE_PCM16 * 2)
 
-typedef struct ACSession_s {
+typedef struct ACSession {
     Mono_Time *mono_time;
     const Logger *log;
 

--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -34,7 +34,7 @@ typedef struct BWCRcvPkt {
     RingBuffer *rb;
 } BWCRcvPkt;
 
-struct BWController_s {
+struct BWController {
     m_cb *mcb;
     void *mcb_user_data;
 
@@ -62,7 +62,7 @@ static void send_update(BWController *bwc);
 BWController *bwc_new(Messenger *m, Tox *tox, uint32_t friendnumber, m_cb *mcb, void *mcb_user_data,
                       Mono_Time *bwc_mono_time)
 {
-    BWController *retu = (BWController *)calloc(sizeof(struct BWController_s), 1);
+    BWController *retu = (BWController *)calloc(sizeof(BWController), 1);
 
     if (retu == nullptr) {
         return nullptr;

--- a/toxav/bwcontroller.h
+++ b/toxav/bwcontroller.h
@@ -8,7 +8,7 @@
 #include "../toxcore/Messenger.h"
 #include "../toxcore/tox.h"
 
-typedef struct BWController_s BWController;
+typedef struct BWController BWController;
 
 typedef void m_cb(BWController *bwc, uint32_t friend_number, float todo, void *user_data);
 

--- a/toxav/msi.h
+++ b/toxav/msi.h
@@ -64,8 +64,8 @@ typedef enum MSICallbackID {
 /**
  * The call struct. Please do not modify outside msi.c
  */
-typedef struct MSICall_s {
-    struct MSISession_s *session;           /* Session pointer */
+typedef struct MSICall {
+    struct MSISession *session;           /* Session pointer */
 
     MSICallState         state;
     uint8_t              peer_capabilities; /* Peer capabilities */
@@ -74,10 +74,10 @@ typedef struct MSICall_s {
     uint32_t             friend_number;     /* Index of this call in MSISession */
     MSIError             error;             /* Last error */
 
-    struct ToxAVCall_s  *av_call;           /* Pointer to av call handler */
+    struct ToxAVCall     *av_call;           /* Pointer to av call handler */
 
-    struct MSICall_s    *next;
-    struct MSICall_s    *prev;
+    struct MSICall       *next;
+    struct MSICall       *prev;
 } MSICall;
 
 
@@ -91,7 +91,7 @@ typedef int msi_action_cb(void *av, MSICall *call);
 /**
  * Control session struct. Please do not modify outside msi.c
  */
-typedef struct MSISession_s {
+typedef struct MSISession {
     /* Call handlers */
     MSICall       **calls;
     uint32_t        calls_tail;

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -34,7 +34,7 @@
 // iteration interval that is used when no call is active
 #define IDLE_ITERATION_INTERVAL_MS 200
 
-typedef struct ToxAVCall_s {
+typedef struct ToxAVCall {
     ToxAV *av;
 
     pthread_mutex_t mutex_audio[1];
@@ -59,13 +59,13 @@ typedef struct ToxAVCall_s {
 
     pthread_mutex_t toxav_call_mutex[1];
 
-    struct ToxAVCall_s *prev;
-    struct ToxAVCall_s *next;
+    struct ToxAVCall *prev;
+    struct ToxAVCall *next;
 } ToxAVCall;
 
 
 /** Decode time statistics */
-typedef struct DecodeTimeStats_s {
+typedef struct DecodeTimeStats {
     /** Measure count */
     int32_t count;
     /** Last cycle total */

--- a/toxav/video.h
+++ b/toxav/video.h
@@ -22,7 +22,7 @@
 
 #include <pthread.h>
 
-typedef struct VCSession_s {
+typedef struct VCSession {
     /* encoding */
     vpx_codec_ctx_t encoder[1];
     uint32_t frame_counter;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1844)
<!-- Reviewable:end -->
