### PR TITLE
chore: Add a GH Actions code coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,18 @@ jobs:
       - name: Build and test
         run: .travis/cmake-osx
 
+  coverage-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and test
+        run: .travis/cmake-linux
+        env:
+          CC: gcc
+          CXX: g++
+      - name: Upload coverage
+        run: .travis/upload-coverage
+
   build-tcc:
     runs-on: ubuntu-latest
     steps:

--- a/.travis/cmake-linux
+++ b/.travis/cmake-linux
@@ -1,94 +1,39 @@
 #!/bin/bash
 
-ACTION="$1"
-
 set -eu
 
 CACHEDIR="$HOME/cache"
 NPROC=$(nproc)
-ASTYLE="$CACHEDIR/astyle/build/gcc/bin/astyle"
-ASTYLE_VERSION=3.1
-TRAVIS_TOOL="https://raw.githubusercontent.com/TokTok/ci-tools/master/bin/travis-haskell"
 
-travis_install() {
-  bash <(curl -s "$TRAVIS_TOOL") download
-  travis-haskell download TokTok/hs-tokstyle tokstyle "$HOME/.local"
+sudo apt-get install -y --no-install-recommends libopus-dev libsodium-dev libvpx-dev ninja-build
 
-  which coveralls || {
-    # Install cpp-coveralls to upload test coverage results.
-    pip install --user ndg-httpsclient urllib3[secure] cpp-coveralls
+. ".travis/flags-$CC.sh"
 
-    # Work around https://github.com/eddyxu/cpp-coveralls/issues/108 by manually
-    # installing the pyOpenSSL module and injecting it into urllib3 as per
-    # https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
-    sed -i -e '/^import sys$/a import urllib3.contrib.pyopenssl\nurllib3.contrib.pyopenssl.inject_into_urllib3()' "$(which coveralls)"
-  }
+add_ld_flag -Wl,-z,defs
 
-  # Install astyle (version in ubuntu-precise too old).
-  ([ -f "$ASTYLE" ] && "$ASTYLE" --version | grep "$ASTYLE_VERSION" >/dev/null) || {
-    wget -O ../astyle.tar.gz "https://deb.debian.org/debian/pool/main/a/astyle/astyle_$ASTYLE_VERSION.orig.tar.gz"
-    tar -xf ../astyle.tar.gz -C "$CACHEDIR"
-    make -C "$CACHEDIR/astyle/build/gcc" clean
-    make -C "$CACHEDIR/astyle/build/gcc" "-j$NPROC"
-  }
-}
+# Make compilation error on a warning
+add_flag -Werror
 
-run_static_analysis() {
-  pylint3 -E other/analysis/check_recursion
+# Coverage flags.
+add_flag -fprofile-arcs -ftest-coverage
 
-  export CPPFLAGS="-isystem $CACHEDIR/include"
-  export LDFLAGS="-L$CACHEDIR/lib"
-  other/analysis/run-check_recursion
-  other/analysis/run-clang
-  other/analysis/run-clang-analyze
-}
+cmake -B_build -H. -GNinja \
+  -DCMAKE_C_FLAGS="$C_FLAGS" \
+  -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
+  -DCMAKE_EXE_LINKER_FLAGS="$LD_FLAGS" \
+  -DCMAKE_SHARED_LINKER_FLAGS="$LD_FLAGS" \
+  -DCMAKE_INSTALL_PREFIX:PATH="$PWD/_install" \
+  -DMIN_LOGGER_LEVEL=TRACE \
+  -DMUST_BUILD_TOXAV=ON \
+  -DNON_HERMETIC_TESTS=OFF \
+  -DSTRICT_ABI=ON \
+  -DTEST_TIMEOUT_SECONDS=120 \
+  -DUSE_IPV6=OFF \
+  -DAUTOTEST=ON
 
-travis_script() {
-  . ".travis/flags-$CC.sh"
+cmake --build _build --parallel "$NPROC" --target install -- -k 0
 
-  add_ld_flag -Wl,-z,defs
-
-  # Make compilation error on a warning
-  add_flag -Werror
-
-  # Coverage flags.
-  add_flag -fprofile-arcs -ftest-coverage
-
-  "$ASTYLE" --version
-  other/astyle/format-source . "$ASTYLE"
-
-  echo "Running TokTok style checker"
-  "$HOME/.local/bin/check-cimple"
-
-  # Use () to run in a separate process so the exports are local.
-  (run_static_analysis)
-
-  other/analysis/check_logger_levels
-
-  cmake -B_build -H. -GNinja \
-    -DCMAKE_C_FLAGS="$C_FLAGS" \
-    -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
-    -DCMAKE_EXE_LINKER_FLAGS="$LD_FLAGS" \
-    -DCMAKE_SHARED_LINKER_FLAGS="$LD_FLAGS" \
-    -DCMAKE_INSTALL_PREFIX:PATH="$PWD/_install" \
-    -DMIN_LOGGER_LEVEL=TRACE \
-    -DMUST_BUILD_TOXAV=ON \
-    -DNON_HERMETIC_TESTS=ON \
-    -DSTRICT_ABI=ON \
-    -DTEST_TIMEOUT_SECONDS=120 \
-    -DUSE_IPV6=OFF \
-    -DAUTOTEST=ON
-
-  cmake --build _build --parallel "$NPROC" --target install -- -k 0
-
-  cd _build # pushd
-  ctest -j50 --output-on-failure ||
-    ctest -j50 --output-on-failure --rerun-failed
-  cd - # popd
-}
-
-if [ "-z" "$ACTION" ]; then
-  "travis_script"
-else
-  "travis_$ACTION"
-fi
+cd _build # pushd
+ctest -j50 --output-on-failure ||
+  ctest -j50 --output-on-failure --rerun-failed
+cd - # popd


### PR DESCRIPTION
Since all of the checks from the old `.travis/cmake-linux` (as far as I can tell) have been added to e.g. Circle CI, I nuked most of the file similarly to how it was done in 8ce2ae0fcbc4bb4d2952fb1245a72b408d8f3170.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1850)
<!-- Reviewable:end -->
