### PR TITLE
cleanup: Use `calloc` instead of `malloc` for struct allocations.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-35800dfd68ba005a6884d7fcf1d5a76614d7afa3d53a7bf12c6fd6398afa48fd  /usr/local/bin/tox-bootstrapd
+6ca8302e5d61c8b40f4c9eb14e16d4ff1e283fe594b90b268a8ad022d0c28128  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2503,7 +2503,7 @@ void dht_save(const DHT *dht, uint8_t *data)
     /* get right offset. we write the actual header later. */
     data = state_write_section_header(data, DHT_STATE_COOKIE_TYPE, 0, 0);
 
-    Node_format *clients = (Node_format *)malloc(MAX_SAVED_DHT_NODES * sizeof(Node_format));
+    Node_format *clients = (Node_format *)calloc(MAX_SAVED_DHT_NODES, sizeof(Node_format));
 
     if (clients == nullptr) {
         LOGGER_ERROR(dht->log, "could not allocate %u nodes", MAX_SAVED_DHT_NODES);

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -374,13 +374,13 @@ static int client_send_pending_data(TCP_Client_Connection *con)
     return -1;
 }
 
-/** return 0 on failure (only if malloc fails)
+/** return 0 on failure (only if calloc fails)
  * return 1 on success
  */
 static bool client_add_priority(TCP_Client_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
 {
     TCP_Priority_List *p = con->priority_queue_end;
-    TCP_Priority_List *new_list = (TCP_Priority_List *)malloc(sizeof(TCP_Priority_List) + size);
+    TCP_Priority_List *new_list = (TCP_Priority_List *)calloc(1, sizeof(TCP_Priority_List) + size);
 
     if (!new_list) {
         return 0;

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -429,13 +429,13 @@ static int send_pending_data(TCP_Secure_Connection *con)
     return -1;
 }
 
-/** return 0 on failure (only if malloc fails)
+/** return 0 on failure (only if calloc fails)
  * return 1 on success
  */
 static bool add_priority(TCP_Secure_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
 {
     TCP_Priority_List *p = con->priority_queue_end;
-    TCP_Priority_List *new_list = (TCP_Priority_List *)malloc(sizeof(TCP_Priority_List) + size);
+    TCP_Priority_List *new_list = (TCP_Priority_List *)calloc(1, sizeof(TCP_Priority_List) + size);
 
     if (!new_list) {
         return 0;

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -3339,7 +3339,7 @@ static State_Load_Status load_conferences(Group_Chats *g_c, const uint8_t *data,
         data += sizeof(uint32_t);
 
         if (g->numfrozen > 0) {
-            g->frozen = (Group_Peer *)malloc(sizeof(Group_Peer) * g->numfrozen);
+            g->frozen = (Group_Peer *)calloc(g->numfrozen, sizeof(Group_Peer));
 
             if (g->frozen == nullptr) {
                 return STATE_LOAD_STATUS_ERROR;

--- a/toxcore/mono_time.c
+++ b/toxcore/mono_time.c
@@ -100,13 +100,13 @@ static uint64_t current_time_monotonic_default(Mono_Time *mono_time, void *user_
 
 Mono_Time *mono_time_new(void)
 {
-    Mono_Time *mono_time = (Mono_Time *)malloc(sizeof(Mono_Time));
+    Mono_Time *mono_time = (Mono_Time *)calloc(1, sizeof(Mono_Time));
 
     if (mono_time == nullptr) {
         return nullptr;
     }
 
-    mono_time->time_update_lock = (pthread_rwlock_t *)malloc(sizeof(pthread_rwlock_t));
+    mono_time->time_update_lock = (pthread_rwlock_t *)calloc(1, sizeof(pthread_rwlock_t));
 
     if (mono_time->time_update_lock == nullptr) {
         free(mono_time);

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -749,7 +749,7 @@ static int add_data_to_buffer(const Logger *log, Packets_Array *array, uint32_t 
         return -1;
     }
 
-    Packet_Data *new_d = (Packet_Data *)malloc(sizeof(Packet_Data));
+    Packet_Data *new_d = (Packet_Data *)calloc(1, sizeof(Packet_Data));
 
     if (new_d == nullptr) {
         return -1;
@@ -802,7 +802,7 @@ static int64_t add_data_end_of_buffer(const Logger *log, Packets_Array *array, c
         return -1;
     }
 
-    Packet_Data *new_d = (Packet_Data *)malloc(sizeof(Packet_Data));
+    Packet_Data *new_d = (Packet_Data *)calloc(1, sizeof(Packet_Data));
 
     if (new_d == nullptr) {
         return -1;
@@ -1786,7 +1786,7 @@ static int create_crypto_connection(Net_Crypto *c)
         c->crypto_connections[id].last_packets_left_rem = 0;
         c->crypto_connections[id].packet_send_rate_requested = 0;
         c->crypto_connections[id].last_packets_left_requested_rem = 0;
-        c->crypto_connections[id].mutex = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+        c->crypto_connections[id].mutex = (pthread_mutex_t *)calloc(1, sizeof(pthread_mutex_t));
 
         if (c->crypto_connections[id].mutex == nullptr) {
             pthread_mutex_unlock(&c->connections_mutex);

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1370,7 +1370,7 @@ int32_t net_getipport(const char *node, IP_Port **res, int tox_type)
         return -1;
     }
 
-    // Used to avoid malloc parameter overflow
+    // Used to avoid calloc parameter overflow
     const size_t max_count = min_u64(SIZE_MAX, INT32_MAX) / sizeof(IP_Port);
     int type = make_socktype(tox_type);
     struct addrinfo *cur;
@@ -1395,7 +1395,7 @@ int32_t net_getipport(const char *node, IP_Port **res, int tox_type)
         return 0;
     }
 
-    *res = (IP_Port *)malloc(sizeof(IP_Port) * count);
+    *res = (IP_Port *)calloc(count, sizeof(IP_Port));
 
     if (*res == nullptr) {
         freeaddrinfo(infos);

--- a/toxcore/ping_array.c
+++ b/toxcore/ping_array.c
@@ -16,7 +16,7 @@
 #include "util.h"
 
 typedef struct Ping_Array_Entry {
-    void *data;
+    uint8_t *data;
     uint32_t length;
     uint64_t time;
     uint64_t ping_id;
@@ -112,7 +112,7 @@ uint64_t ping_array_add(Ping_Array *array, const Mono_Time *mono_time, const uin
         clear_entry(array, index);
     }
 
-    array->entries[index].data = malloc(length);
+    array->entries[index].data = (uint8_t *)malloc(length);
 
     if (array->entries[index].data == nullptr) {
         return 0;

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -516,7 +516,7 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
     }
 
     if (tox_options_get_experimental_thread_safety(opts)) {
-        tox->mutex = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+        tox->mutex = (pthread_mutex_t *)calloc(1, sizeof(pthread_mutex_t));
 
         if (tox->mutex == nullptr) {
             SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -98,7 +98,7 @@ void tox_options_default(struct Tox_Options *options)
 
 struct Tox_Options *tox_options_new(Tox_Err_Options_New *error)
 {
-    struct Tox_Options *options = (struct Tox_Options *)malloc(sizeof(struct Tox_Options));
+    struct Tox_Options *options = (struct Tox_Options *)calloc(1, sizeof(struct Tox_Options));
 
     if (options) {
         tox_options_default(options);

--- a/toxencryptsave/toxencryptsave.c
+++ b/toxencryptsave/toxencryptsave.c
@@ -137,7 +137,7 @@ Tox_Pass_Key *tox_pass_key_derive_with_salt(const uint8_t *passphrase, size_t pp
 
     crypto_memzero(passkey, crypto_hash_sha256_BYTES); /* wipe plaintext pw */
 
-    Tox_Pass_Key *out_key = (Tox_Pass_Key *)malloc(sizeof(Tox_Pass_Key));
+    Tox_Pass_Key *out_key = (Tox_Pass_Key *)calloc(1, sizeof(Tox_Pass_Key));
 
     if (!out_key) {
         SET_ERROR_PARAMETER(error, TOX_ERR_KEY_DERIVATION_FAILED);


### PR DESCRIPTION
`malloc` is used only for byte/int arrays. Also, we no longer allow plain
`void *` allocations. Every allocation should have a real value type.

See https://github.com/TokTok/hs-tokstyle/pull/103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1861)
<!-- Reviewable:end -->
