### PR TITLE
chore: Run tokstyle with 3 cores.

### DIFF
--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -12,7 +12,7 @@ sh_test(
     name = "cimple_test",
     size = "small",
     srcs = ["//hs-tokstyle/tools:check-cimple"],
-    args = ["$(locations %s)" % f for f in CIMPLE_FILES],
+    args = ["$(locations %s)" % f for f in CIMPLE_FILES] + ["+RTS", "-N3"],
     data = CIMPLE_FILES,
     tags = ["haskell"],
 )

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -20,10 +20,8 @@
 #include "state.h"
 #include "util.h"
 
-//!TOKSTYLE-
 static_assert(MAX_CONCURRENT_FILE_PIPES <= UINT8_MAX + 1,
               "uint8_t cannot represent all file transfer numbers");
-//!TOKSTYLE+
 
 static int write_cryptpacket_id(const Messenger *m, int32_t friendnumber, uint8_t packet_id, const uint8_t *data,
                                 uint32_t length, uint8_t congestion_control);


### PR DESCRIPTION
This seems to be the sweet spot for the current tokstyle implementation.
4 cores gives the same speedup, 5 also, 6 makes it slower, and 2 also
makes it slower.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1866)
<!-- Reviewable:end -->
