### PR TITLE
chore: Disable the OpenMP cracker in bazel for now.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,6 @@ bazel-release_task:
         --build_tag_filters=-haskell
         --test_tag_filters=-haskell
         --remote_download_minimal
-        --config=release
         --
         //c-toxcore/...
         -//c-toxcore/auto_tests:tcp_relay_test # TODO(robinlinden): Why does this pass locally but not in Cirrus?
@@ -30,7 +29,6 @@ bazel-debug_task:
         --build_tag_filters=-haskell
         --test_tag_filters=-haskell
         --remote_download_minimal
-        --config=debug
         --
         //c-toxcore/...
         -//c-toxcore/auto_tests:tcp_relay_test # TODO(robinlinden): Why does this pass locally but not in Cirrus?
@@ -47,6 +45,5 @@ cimple_task:
         --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --build_tag_filters=haskell
         --test_tag_filters=haskell
-        --config=release
         --
         //c-toxcore/...

--- a/other/fun/BUILD.bazel
+++ b/other/fun/BUILD.bazel
@@ -1,15 +1,15 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
-cc_binary(
-    name = "cracker",
-    srcs = ["cracker.c"],
-    copts = ["-fopenmp"],
-    linkopts = ["-fopenmp"],
-    deps = [
-        "//c-toxcore/toxcore:ccompat",
-        "@libsodium",
-    ],
-)
+#cc_binary(
+#    name = "cracker",
+#    srcs = ["cracker.c"],
+#    copts = ["-fopenmp"],
+#    linkopts = ["-fopenmp"],
+#    deps = [
+#        "//c-toxcore/toxcore:ccompat",
+#        "@libsodium",
+#    ],
+#)
 
 cc_binary(
     name = "cracker_simple",


### PR DESCRIPTION
I broke it. I'll re-enable it if/when I fix omp support in the bazel
build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1870)
<!-- Reviewable:end -->
