### PR TITLE
cleanup: replace all instances of atoi with strtol

### DIFF
--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -8,6 +8,7 @@
  *
  * A simple DHT boostrap node for tox.
  */
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -193,7 +194,16 @@ int main(int argc, char *argv[])
 
     if (argc > argvoffset + 3) {
         printf("Trying to bootstrap into the network...\n");
-        uint16_t port = net_htons(atoi(argv[argvoffset + 2]));
+
+        const long int port_conv = strtol(argv[argvoffset + 2], nullptr, 10);
+
+        if (port_conv <= 0 || port_conv > UINT16_MAX) {
+            printf("Failed to convert \"%s\" into a valid port. Exiting...\n", argv[argvoffset + 2]);
+            exit(1);
+        }
+
+        const uint16_t port = net_htons((uint16_t)port_conv);
+
         uint8_t *bootstrap_key = hex_string_to_bin(argv[argvoffset + 3]);
         int res = dht_bootstrap_from_address(dht, argv[argvoffset + 1],
                                              ipv6enabled, port, bootstrap_key);

--- a/other/fun/BUILD.bazel
+++ b/other/fun/BUILD.bazel
@@ -48,6 +48,8 @@ cc_binary(
     srcs = ["strkey.c"],
     copts = ["-w"],
     deps = [
+        "//c-toxcore/toxcore",
+        "//c-toxcore/toxcore:ccompat",
         "@libsodium",
     ],
 )

--- a/other/fun/strkey.c
+++ b/other/fun/strkey.c
@@ -41,6 +41,8 @@
 
 #include <sodium.h>
 
+#include "../../toxcore/ccompat.h"
+
 #define PRINT_TRIES_COUNT
 
 static void print_key(unsigned char *key)
@@ -60,12 +62,18 @@ int main(int argc, char *argv[])
 {
     unsigned char public_key[crypto_box_PUBLICKEYBYTES]; // null terminator
     unsigned char secret_key[crypto_box_SECRETKEYBYTES];
-    int offset = 0;
+    long int offset = 0;
     size_t len;
     unsigned char desired_bin[crypto_box_PUBLICKEYBYTES]; // null terminator
 
     if (argc == 3) {
-        offset = atoi(argv[1]);
+        offset = strtol(argv[1], nullptr, 10);
+
+        if (offset <= 0) {
+            fprintf(stderr, "strtol() failed to convert \"%s\" into an integer\n", argv[1]);
+            exit(1);
+        }
+
         char *desired_hex = argv[2];
         len = strlen(desired_hex);
 

--- a/testing/DHT_test.c
+++ b/testing/DHT_test.c
@@ -18,6 +18,7 @@
 #endif
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -189,7 +190,14 @@ int main(int argc, char *argv[])
 
     perror("Initialization");
 
-    uint16_t port = net_htons(atoi(argv[argvoffset + 2]));
+    const long int port_conv = strtol(argv[argvoffset + 2], nullptr, 10);
+
+    if (port_conv <= 0 || port_conv > UINT16_MAX) {
+        printf("Failed to convert \"%s\" into a valid port. Exiting...\n", argv[argvoffset + 2]);
+        return 1;
+    }
+
+    const uint16_t port = net_htons((uint16_t)port_conv);
     unsigned char *binary_string = hex_string_to_bin(argv[argvoffset + 3]);
     int res = dht_bootstrap_from_address(dht, argv[argvoffset + 1], ipv6enabled, port, binary_string);
     free(binary_string);

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -23,6 +23,7 @@
  *
  * EX: ./test Save.bak
  */
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -107,7 +108,14 @@ int main(int argc, char *argv[])
     }
 
     if (argc == argvoffset + 4) {
-        uint16_t port = net_htons(atoi(argv[argvoffset + 2]));
+        const long int port_conv = strtol(argv[argvoffset + 2], nullptr, 10);
+
+        if (port_conv <= 0 || port_conv > UINT16_MAX) {
+            printf("Failed to convert \"%s\" into a valid port. Exiting...\n", argv[argvoffset + 2]);
+            exit(1);
+        }
+
+        const uint16_t port = net_htons((uint16_t)port_conv);
         uint8_t *bootstrap_key = hex_string_to_bin(argv[argvoffset + 3]);
         int res = dht_bootstrap_from_address(m->dht, argv[argvoffset + 1],
                                              ipv6enabled, port, bootstrap_key);


### PR DESCRIPTION
atoi doesn't check if the conversion from string to int succeeded which doesn't allow us to do proper error handling.

We also now make sure that the port argument is a valid port in addition to being properly converted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1874)
<!-- Reviewable:end -->
