### PR TITLE
chore: Add asan/tsan bazel builds.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,6 +33,40 @@ bazel-debug_task:
         //c-toxcore/...
         -//c-toxcore/auto_tests:tcp_relay_test # TODO(robinlinden): Why does this pass locally but not in Cirrus?
 
+bazel-asan_task:
+  container:
+    image: toxchat/toktok-stack:0.0.31-asan
+    cpu: 2
+    memory: 2G
+  configure_script:
+    - /src/workspace/tools/inject-repo c-toxcore
+  test_all_script:
+    - cd /src/workspace && bazel test -k
+        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+        --build_tag_filters=-haskell
+        --test_tag_filters=-haskell
+        --remote_download_minimal
+        --
+        //c-toxcore/...
+        -//c-toxcore/auto_tests:tcp_relay_test # TODO(robinlinden): Why does this pass locally but not in Cirrus?
+
+bazel-tsan_task:
+  container:
+    image: toxchat/toktok-stack:0.0.31-tsan
+    cpu: 2
+    memory: 2G
+  configure_script:
+    - /src/workspace/tools/inject-repo c-toxcore
+  test_all_script:
+    - cd /src/workspace && bazel test -k
+        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+        --build_tag_filters=-haskell
+        --test_tag_filters=-haskell
+        --remote_download_minimal
+        --
+        //c-toxcore/...
+        -//c-toxcore/auto_tests:tcp_relay_test # TODO(robinlinden): Why does this pass locally but not in Cirrus?
+
 cimple_task:
   container:
     image: toxchat/toktok-stack:0.0.31-release

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -12,7 +12,10 @@ sh_test(
     name = "cimple_test",
     size = "small",
     srcs = ["//hs-tokstyle/tools:check-cimple"],
-    args = ["$(locations %s)" % f for f in CIMPLE_FILES] + ["+RTS", "-N3"],
+    args = ["$(locations %s)" % f for f in CIMPLE_FILES] + [
+        "+RTS",
+        "-N3",
+    ],
     data = CIMPLE_FILES,
     tags = ["haskell"],
 )


### PR DESCRIPTION
These have all dependencies built with asan/tsan, so they can do deeper
sanity checks such as checking what opus is doing with our buffers.

The asan check currently fails for me locally, so these are not yet set
to be required for PRs to be merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1875)
<!-- Reviewable:end -->
