### PR TITLE
fix: Fix `toxav_basic_test` buffer overflow.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,8 +12,7 @@ branches:
     protection:
       required_status_checks:
         contexts:
-          # TODO(iphydf): Make asan required once errors are fixed.
-          #- "bazel-asan"
+          - "bazel-asan"
           - "bazel-debug"
           - "bazel-release"
           - "bazel-tsan"

--- a/auto_tests/toxav_basic_test.c
+++ b/auto_tests/toxav_basic_test.c
@@ -103,7 +103,7 @@ static void iterate_tox(Tox *bootstrap, Tox *Alice, Tox *Bob)
 static bool toxav_audio_send_frame_helper(ToxAV *av, uint32_t friend_number, Toxav_Err_Send_Frame *error)
 {
     static const int16_t PCM[960] = {0};
-    return toxav_audio_send_frame(av, 0, PCM, sizeof(PCM), 1, 48000, nullptr);
+    return toxav_audio_send_frame(av, 0, PCM, 960, 1, 48000, nullptr);
 }
 
 static void regular_call_flow(


### PR DESCRIPTION
We should pass the number of samples, not the byte size of `PCM`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1879)
<!-- Reviewable:end -->
