### PR TITLE
chore: Add sonar-scan analysis on pushes.

### DIFF
--- a/.github/scripts/cmake-freebsd-stage2
+++ b/.github/scripts/cmake-freebsd-stage2
@@ -26,8 +26,6 @@ scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P "$SSH_PORT" -
 RUN ls -lh
 
 cd /c-toxcore
-CACHEDIR=/opt/cache
-mkdir "$CACHEDIR"
 . ".github/scripts/flags-clang.sh"
 
 add_ld_flag -Wl,-z,defs

--- a/.github/scripts/cmake-osx
+++ b/.github/scripts/cmake-osx
@@ -2,7 +2,6 @@
 
 set -eu
 
-CACHEDIR="$HOME/cache"
 NPROC=$(sysctl -n hw.physicalcpu)
 
 # Workaround for bug in Homebrew where it only finds an old Ruby version.

--- a/.github/scripts/cmake-windows.sh
+++ b/.github/scripts/cmake-windows.sh
@@ -4,7 +4,6 @@ ACTION="$1"
 
 set -eu
 
-CACHEDIR="$HOME/cache"
 NPROC=$(nproc)
 
 ci_install() {

--- a/.github/scripts/flags.sh
+++ b/.github/scripts/flags.sh
@@ -9,9 +9,6 @@ add_flag() {
   add_cxx_flag "$@"
 }
 
-export LD_LIBRARY_PATH="$CACHEDIR/lib"
-export PKG_CONFIG_PATH="$CACHEDIR/lib/pkgconfig"
-
 # Our own flags which we can insert in the correct place. We don't use CFLAGS
 # and friends here (we unset them below), because they influence config tests
 # such as ./configure and cmake tests. Our warning flags break those tests, so

--- a/.github/scripts/sonar-build
+++ b/.github/scripts/sonar-build
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+. ".github/scripts/flags-gcc.sh"
+
+cmake --build _build --parallel "$(nproc)" --target install -- -k 0

--- a/.github/scripts/sonar-prepare
+++ b/.github/scripts/sonar-prepare
@@ -2,19 +2,14 @@
 
 set -eu
 
-NPROC=$(nproc)
+sudo apt-get install -y --no-install-recommends libconfig-dev libopus-dev libsodium-dev libvpx-dev ninja-build
 
-sudo apt-get install -y --no-install-recommends libopus-dev libsodium-dev libvpx-dev ninja-build
-
-. ".github/scripts/flags-$CC.sh"
+. ".github/scripts/flags-gcc.sh"
 
 add_ld_flag -Wl,-z,defs
 
 # Make compilation error on a warning
 add_flag -Werror
-
-# Coverage flags.
-add_flag -fprofile-arcs -ftest-coverage
 
 cmake -B_build -H. -GNinja \
   -DCMAKE_C_FLAGS="$C_FLAGS" \
@@ -28,11 +23,5 @@ cmake -B_build -H. -GNinja \
   -DSTRICT_ABI=ON \
   -DTEST_TIMEOUT_SECONDS=120 \
   -DUSE_IPV6=OFF \
-  -DAUTOTEST=ON
-
-cmake --build _build --parallel "$NPROC" --target install -- -k 0
-
-cd _build # pushd
-ctest -j50 --output-on-failure ||
-  ctest -j50 --output-on-failure --rerun-failed
-cd - # popd
+  -DAUTOTEST=ON \
+  -DENABLE_SHARED=OFF

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: ${{ github.event_name == 'push' }}
+        if: github.event_name == 'push'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -22,8 +22,8 @@ jobs:
       - name: Docker Build
         run: .github/scripts/tox-bootstrapd-docker local
       - name: Push latest image to DockerHub
-        if: ${{ github.event_name == 'push' }}
+        if: github.event_name == 'push'
         run: docker push toxchat/bootstrap-node:latest
       - name: Push versioned image to DockerHub
-        if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         run: docker push toxchat/bootstrap-node:"$(other/print-version)"

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,0 +1,52 @@
+name: sonar-scan
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  sonar-scan:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      SONAR_SCANNER_VERSION: 4.4.0.2170
+      SONAR_SERVER_URL: "https://sonarcloud.io"
+      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Download and set up sonar-scanner
+        env:
+          SONAR_SCANNER_DOWNLOAD_URL: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}-linux.zip
+        run: |
+          mkdir -p $HOME/.sonar
+          curl -sSLo $HOME/.sonar/sonar-scanner.zip ${{ env.SONAR_SCANNER_DOWNLOAD_URL }}
+          unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
+          echo "$HOME/.sonar/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin" >> $GITHUB_PATH
+      - name: Download and set up build-wrapper
+        env:
+          BUILD_WRAPPER_DOWNLOAD_URL: ${{ env.SONAR_SERVER_URL }}/static/cpp/build-wrapper-linux-x86.zip
+        run: |
+          curl -sSLo $HOME/.sonar/build-wrapper-linux-x86.zip ${{ env.BUILD_WRAPPER_DOWNLOAD_URL }}
+          unzip -o $HOME/.sonar/build-wrapper-linux-x86.zip -d $HOME/.sonar/
+          echo "$HOME/.sonar/build-wrapper-linux-x86" >> $GITHUB_PATH
+      - name: Install dependencies and prepare build
+        run: |
+          .github/scripts/sonar-prepare
+      - name: Run build-wrapper
+        run: |
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} .github/scripts/sonar-build
+      - name: Run sonar-scanner
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          sonar-scanner --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=toxcore
+sonar.organization=toktok
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=c-toxcore
+sonar.projectVersion=0.2.12
+
+# Path is relative to the sonar-project.properties file.
+sonar.sources=.
+
+# Encoding of the source code.
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
We can't run this on pull requests because it needs access to the
`SONAR_TOKEN` secret. Perhaps in the future we can make it a
`pull_request_target` workflow, but then we can't use cmake to initialise
the environment, meaning we need to specify the inputs manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1883)
<!-- Reviewable:end -->
