### PR TITLE
cleanup: Stop using `strerror` directly.

### DIFF
--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -28,7 +28,7 @@ START_TEST(test_addr_resolv_localhost)
     int res = addr_resolve(localhost, &ip, nullptr);
 
     int error = net_error();
-    const char *strerror = net_new_strerror(error);
+    char *strerror = net_new_strerror(error);
     ck_assert_msg(res > 0, "Resolver failed: %d, %s", error, strerror);
     net_kill_strerror(strerror);
 

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-7f4c96481e30156e3c2e7e448e70faaaa12911694390374ae09bd53d5d7b4f9c  /usr/local/bin/tox-bootstrapd
+fc6b060abddd1898d97b0cf067d19c7a9d68999469690d91e7cf59327e700dbf  /usr/local/bin/tox-bootstrapd

--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -148,9 +148,11 @@ static void send_update(BWController *bwc)
             assert(offset == sizeof(bwc_packet));
 
             if (bwc_send_custom_lossy_packet(bwc->tox, bwc->friend_number, bwc_packet, sizeof(bwc_packet)) == -1) {
-                const char *netstrerror = net_new_strerror(net_error());
+                char *netstrerror = net_new_strerror(net_error());
+                char *stdstrerror = net_new_strerror(errno);
                 LOGGER_WARNING(bwc->m->log, "BWC send failed (len: %u)! std error: %s, net error %s",
-                               (unsigned)sizeof(bwc_packet), strerror(errno), netstrerror);
+                               (unsigned)sizeof(bwc_packet), stdstrerror, netstrerror);
+                net_kill_strerror(stdstrerror);
                 net_kill_strerror(netstrerror);
             }
         }

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -813,9 +813,9 @@ int rtp_send_data(RTPSession *session, const uint8_t *data, uint32_t length,
         memcpy(rdata + 1 + RTP_HEADER_SIZE, data, length);
 
         if (-1 == rtp_send_custom_lossy_packet(session->tox, session->friend_number, rdata, SIZEOF_VLA(rdata))) {
-            const char *netstrerror = net_new_strerror(net_error());
-            LOGGER_WARNING(session->m->log, "RTP send failed (len: %u)! std error: %s, net error: %s",
-                           (unsigned)SIZEOF_VLA(rdata), strerror(errno), netstrerror);
+            char *netstrerror = net_new_strerror(net_error());
+            LOGGER_WARNING(session->m->log, "RTP send failed (len: %u)! net error: %s",
+                           (unsigned)SIZEOF_VLA(rdata), netstrerror);
             net_kill_strerror(netstrerror);
         }
     } else {
@@ -832,9 +832,9 @@ int rtp_send_data(RTPSession *session, const uint8_t *data, uint32_t length,
 
             if (-1 == rtp_send_custom_lossy_packet(session->tox, session->friend_number,
                                                    rdata, piece + RTP_HEADER_SIZE + 1)) {
-                const char *netstrerror = net_new_strerror(net_error());
-                LOGGER_WARNING(session->m->log, "RTP send failed (len: %d)! std error: %s, net error: %s",
-                               piece + RTP_HEADER_SIZE + 1, strerror(errno), netstrerror);
+                char *netstrerror = net_new_strerror(net_error());
+                LOGGER_WARNING(session->m->log, "RTP send failed (len: %d)! net error: %s",
+                               piece + RTP_HEADER_SIZE + 1, netstrerror);
                 net_kill_strerror(netstrerror);
             }
 
@@ -852,9 +852,9 @@ int rtp_send_data(RTPSession *session, const uint8_t *data, uint32_t length,
 
             if (-1 == rtp_send_custom_lossy_packet(session->tox, session->friend_number, rdata,
                                                    piece + RTP_HEADER_SIZE + 1)) {
-                const char *netstrerror = net_new_strerror(net_error());
-                LOGGER_WARNING(session->m->log, "RTP send failed (len: %d)! std error: %s, net error: %s",
-                               piece + RTP_HEADER_SIZE + 1, strerror(errno), netstrerror);
+                char *netstrerror = net_new_strerror(net_error());
+                LOGGER_WARNING(session->m->log, "RTP send failed (len: %d)! net error: %s",
+                               piece + RTP_HEADER_SIZE + 1, netstrerror);
                 net_kill_strerror(netstrerror);
             }
         }

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -911,7 +911,9 @@ static Toxav_Err_Send_Frame send_frames(const Logger *log, ToxAVCall *call)
         LOGGER_DEBUG(log, "+ _sending_FRAME_ b0=%d b1=%d", buf[0], buf[1]);
 
         if (res < 0) {
-            LOGGER_WARNING(log, "Could not send video frame: %s", strerror(errno));
+            char *netstrerror = net_new_strerror(net_error());
+            LOGGER_WARNING(log, "Could not send video frame: %s", netstrerror);
+            net_kill_strerror(netstrerror);
             return TOXAV_ERR_SEND_FRAME_RTP_FAILED;
         }
     }

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -161,7 +161,7 @@ static int proxy_http_read_connection_response(const Logger *logger, TCP_Client_
 
     data[sizeof(data) - 1] = 0;
 
-    if (strstr((char *)data, success)) {
+    if (strstr((const char *)data, success)) {
         // drain all data
         unsigned int data_left = net_socket_data_recv_buffer(tcp_conn->sock);
 

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -430,13 +430,13 @@ int net_error(void);
  * return pointer to a NULL-terminated string describing the error code on
  * success. The returned string must be freed using net_kill_strerror().
  */
-const char *net_new_strerror(int error);
+char *net_new_strerror(int error);
 
 /** Frees the string returned by net_new_strerror().
  * It's valid to pass NULL as the argument, the function does nothing in this
  * case.
  */
-void net_kill_strerror(const char *strerror);
+void net_kill_strerror(char *strerror);
 
 /** Initialize networking.
  * Added for reverse compatibility with old new_networking calls.


### PR DESCRIPTION
We have a more portable wrapper that is now also thread-safe. Also
stopped using sprintf in the one place we used it. This doesn't really
help much, but it allows us to forbid sprintf globally.

See https://github.com/TokTok/hs-tokstyle/pull/110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1889)
<!-- Reviewable:end -->
