### PR TITLE
cleanup: Use pointer cast instead of memcpy in qsort callback.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-3bb1a531f1d83467a39d2203c8f45041b3361a3003dabe4d8c9439579d1b78bc  /usr/local/bin/tox-bootstrapd
+058c26e86ce3fcdd5d32850f46434e618bec6b122288fbdbc7cf9a9d23ee1d9c  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -868,24 +868,22 @@ int get_close_nodes(const DHT *dht, const uint8_t *public_key, Node_format *node
     return get_somewhat_close_nodes(dht, public_key, nodes_list, sa_family, is_LAN);
 }
 
-typedef struct DHT_Cmp_data {
+typedef struct DHT_Cmp_Data {
     uint64_t cur_time;
     const uint8_t *base_public_key;
     Client_data entry;
-} DHT_Cmp_data;
+} DHT_Cmp_Data;
 
-static int cmp_dht_entry(const void *a, const void *b)
+static int dht_cmp_entry(const void *a, const void *b)
 {
-    DHT_Cmp_data cmp1;
-    DHT_Cmp_data cmp2;
-    memcpy(&cmp1, a, sizeof(DHT_Cmp_data));
-    memcpy(&cmp2, b, sizeof(DHT_Cmp_data));
-    const Client_data entry1 = cmp1.entry;
-    const Client_data entry2 = cmp2.entry;
-    const uint8_t *cmp_public_key = cmp1.base_public_key;
+    const DHT_Cmp_Data *cmp1 = (const DHT_Cmp_Data *)a;
+    const DHT_Cmp_Data *cmp2 = (const DHT_Cmp_Data *)b;
+    const Client_data entry1 = cmp1->entry;
+    const Client_data entry2 = cmp2->entry;
+    const uint8_t *cmp_public_key = cmp1->base_public_key;
 
-    bool t1 = assoc_timeout(cmp1.cur_time, &entry1.assoc4) && assoc_timeout(cmp1.cur_time, &entry1.assoc6);
-    bool t2 = assoc_timeout(cmp2.cur_time, &entry2.assoc4) && assoc_timeout(cmp2.cur_time, &entry2.assoc6);
+    const bool t1 = assoc_timeout(cmp1->cur_time, &entry1.assoc4) && assoc_timeout(cmp1->cur_time, &entry1.assoc6);
+    const bool t2 = assoc_timeout(cmp2->cur_time, &entry2.assoc4) && assoc_timeout(cmp2->cur_time, &entry2.assoc6);
 
     if (t1 && t2) {
         return 0;
@@ -930,7 +928,7 @@ static void sort_client_list(Client_data *list, uint64_t cur_time, unsigned int 
 {
     // Pass comp_public_key to qsort with each Client_data entry, so the
     // comparison function can use it as the base of comparison.
-    VLA(DHT_Cmp_data, cmp_list, length);
+    VLA(DHT_Cmp_Data, cmp_list, length);
 
     for (uint32_t i = 0; i < length; ++i) {
         cmp_list[i].cur_time = cur_time;
@@ -938,7 +936,7 @@ static void sort_client_list(Client_data *list, uint64_t cur_time, unsigned int 
         cmp_list[i].entry = list[i];
     }
 
-    qsort(cmp_list, length, sizeof(DHT_Cmp_data), cmp_dht_entry);
+    qsort(cmp_list, length, sizeof(DHT_Cmp_Data), dht_cmp_entry);
 
     for (uint32_t i = 0; i < length; ++i) {
         list[i] = cmp_list[i].entry;

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -256,24 +256,22 @@ static int in_entries(const Onion_Announce *onion_a, const uint8_t *public_key)
     return -1;
 }
 
-typedef struct Cmp_data {
+typedef struct Cmp_Data {
     const Mono_Time *mono_time;
     const uint8_t *base_public_key;
     Onion_Announce_Entry entry;
-} Cmp_data;
+} Cmp_Data;
 
 static int cmp_entry(const void *a, const void *b)
 {
-    Cmp_data cmp1;
-    Cmp_data cmp2;
-    memcpy(&cmp1, a, sizeof(Cmp_data));
-    memcpy(&cmp2, b, sizeof(Cmp_data));
-    Onion_Announce_Entry entry1 = cmp1.entry;
-    Onion_Announce_Entry entry2 = cmp2.entry;
-    const uint8_t *cmp_public_key = cmp1.base_public_key;
+    const Cmp_Data *cmp1 = (const Cmp_Data *)a;
+    const Cmp_Data *cmp2 = (const Cmp_Data *)b;
+    const Onion_Announce_Entry entry1 = cmp1->entry;
+    const Onion_Announce_Entry entry2 = cmp2->entry;
+    const uint8_t *cmp_public_key = cmp1->base_public_key;
 
-    int t1 = mono_time_is_timeout(cmp1.mono_time, entry1.time, ONION_ANNOUNCE_TIMEOUT);
-    int t2 = mono_time_is_timeout(cmp1.mono_time, entry2.time, ONION_ANNOUNCE_TIMEOUT);
+    const int t1 = mono_time_is_timeout(cmp1->mono_time, entry1.time, ONION_ANNOUNCE_TIMEOUT);
+    const int t2 = mono_time_is_timeout(cmp1->mono_time, entry2.time, ONION_ANNOUNCE_TIMEOUT);
 
     if (t1 && t2) {
         return 0;
@@ -287,7 +285,7 @@ static int cmp_entry(const void *a, const void *b)
         return 1;
     }
 
-    int close = id_closest(cmp_public_key, entry1.public_key, entry2.public_key);
+    const int close = id_closest(cmp_public_key, entry1.public_key, entry2.public_key);
 
     if (close == 1) {
         return 1;
@@ -305,7 +303,7 @@ static void sort_onion_announce_list(Onion_Announce_Entry *list, unsigned int le
 {
     // Pass comp_public_key to qsort with each Client_data entry, so the
     // comparison function can use it as the base of comparison.
-    VLA(Cmp_data, cmp_list, length);
+    VLA(Cmp_Data, cmp_list, length);
 
     for (uint32_t i = 0; i < length; ++i) {
         cmp_list[i].mono_time = mono_time;
@@ -313,7 +311,7 @@ static void sort_onion_announce_list(Onion_Announce_Entry *list, unsigned int le
         cmp_list[i].entry = list[i];
     }
 
-    qsort(cmp_list, length, sizeof(Cmp_data), cmp_entry);
+    qsort(cmp_list, length, sizeof(Cmp_Data), cmp_entry);
 
     for (uint32_t i = 0; i < length; ++i) {
         list[i] = cmp_list[i].entry;

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -595,24 +595,22 @@ static int client_send_announce_request(Onion_Client *onion_c, uint32_t num, IP_
     return send_onion_packet_tcp_udp(onion_c, &path, dest, request, len);
 }
 
-typedef struct Onion_Client_Cmp_data {
+typedef struct Onion_Client_Cmp_Data {
     const Mono_Time *mono_time;
     const uint8_t *base_public_key;
     Onion_Node entry;
-} Onion_Client_Cmp_data;
+} Onion_Client_Cmp_Data;
 
 static int onion_client_cmp_entry(const void *a, const void *b)
 {
-    Onion_Client_Cmp_data cmp1;
-    Onion_Client_Cmp_data cmp2;
-    memcpy(&cmp1, a, sizeof(Onion_Client_Cmp_data));
-    memcpy(&cmp2, b, sizeof(Onion_Client_Cmp_data));
-    Onion_Node entry1 = cmp1.entry;
-    Onion_Node entry2 = cmp2.entry;
-    const uint8_t *cmp_public_key = cmp1.base_public_key;
+    const Onion_Client_Cmp_Data *cmp1 = (const Onion_Client_Cmp_Data *)a;
+    const Onion_Client_Cmp_Data *cmp2 = (const Onion_Client_Cmp_Data *)b;
+    const Onion_Node entry1 = cmp1->entry;
+    const Onion_Node entry2 = cmp2->entry;
+    const uint8_t *cmp_public_key = cmp1->base_public_key;
 
-    int t1 = onion_node_timed_out(&entry1, cmp1.mono_time);
-    int t2 = onion_node_timed_out(&entry2, cmp2.mono_time);
+    const int t1 = onion_node_timed_out(&entry1, cmp1->mono_time);
+    const int t2 = onion_node_timed_out(&entry2, cmp2->mono_time);
 
     if (t1 && t2) {
         return 0;
@@ -626,7 +624,7 @@ static int onion_client_cmp_entry(const void *a, const void *b)
         return 1;
     }
 
-    int close = id_closest(cmp_public_key, entry1.public_key, entry2.public_key);
+    const int close = id_closest(cmp_public_key, entry1.public_key, entry2.public_key);
 
     if (close == 1) {
         return 1;
@@ -644,7 +642,7 @@ static void sort_onion_node_list(Onion_Node *list, unsigned int length, const Mo
 {
     // Pass comp_public_key to qsort with each Client_data entry, so the
     // comparison function can use it as the base of comparison.
-    VLA(Onion_Client_Cmp_data, cmp_list, length);
+    VLA(Onion_Client_Cmp_Data, cmp_list, length);
 
     for (uint32_t i = 0; i < length; ++i) {
         cmp_list[i].mono_time = mono_time;
@@ -652,7 +650,7 @@ static void sort_onion_node_list(Onion_Node *list, unsigned int length, const Mo
         cmp_list[i].entry = list[i];
     }
 
-    qsort(cmp_list, length, sizeof(Onion_Client_Cmp_data), onion_client_cmp_entry);
+    qsort(cmp_list, length, sizeof(Onion_Client_Cmp_Data), onion_client_cmp_entry);
 
     for (uint32_t i = 0; i < length; ++i) {
         list[i] = cmp_list[i].entry;


### PR DESCRIPTION
No need to make copies of the data. There is no concurrency in qsort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1898)
<!-- Reviewable:end -->
