### PR TITLE
cleanup: Remove our only use of flexible array members in toxcore.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-01ff907eae6d12ec2fb597bc0d7bf2549aadf40a8b6bc608f0e910feabb97eec  /usr/local/bin/tox-bootstrapd
+8802a0afed0bcd3acaafebe22faf1f758935e3914d52472fc3e0c74e055fbc38  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -1614,7 +1614,7 @@ int dht_getfriendip(const DHT *dht, const uint8_t *public_key, IP_Port *ip_port)
         return -1;
     }
 
-    DHT_Friend *const frnd = &dht->friends_list[friend_index];
+    const DHT_Friend *const frnd = &dht->friends_list[friend_index];
     const uint32_t client_index = index_of_client_pk(frnd->client_list, MAX_FRIEND_CLIENTS, public_key);
 
     if (client_index == -1) {

--- a/toxcore/TCP_common.h
+++ b/toxcore/TCP_common.h
@@ -14,7 +14,7 @@ struct TCP_Priority_List {
     TCP_Priority_List *next;
     uint16_t size;
     uint16_t sent;
-    uint8_t data[];
+    uint8_t *data;
 };
 
 void wipe_priority_list(TCP_Priority_List *p);

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -191,9 +191,7 @@ static int add_accepted(TCP_Server *tcp_server, const Mono_Time *mono_time, TCP_
 
         index = tcp_server->num_accepted_connections;
     } else {
-        uint32_t i;
-
-        for (i = tcp_server->size_accepted_connections; i != 0; --i) {
+        for (uint32_t i = tcp_server->size_accepted_connections; i != 0; --i) {
             if (tcp_server->accepted_connection_array[i - 1].status == TCP_STATUS_NO_STATUS) {
                 index = i - 1;
                 break;

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -1069,7 +1069,7 @@ static int add_conn_to_groupchat(Group_Chats *g_c, int friendcon_id, Group_c *g,
     return ind;
 }
 
-static unsigned int send_peer_introduced(Group_Chats *g_c, int friendcon_id, uint16_t group_num);
+static unsigned int send_peer_introduced(const Group_Chats *g_c, int friendcon_id, uint16_t group_num);
 
 /** Removes reason for keeping connection.
  *
@@ -1483,7 +1483,7 @@ static bool try_send_rejoin(Group_Chats *g_c, Group_c *g, const uint8_t *real_pk
     return true;
 }
 
-static unsigned int send_peer_query(Group_Chats *g_c, int friendcon_id, uint16_t group_num);
+static unsigned int send_peer_query(const Group_Chats *g_c, int friendcon_id, uint16_t group_num);
 
 static bool send_invite_response(Group_Chats *g_c, int groupnumber, uint32_t friendnumber, const uint8_t *data,
                                  uint16_t length);
@@ -2168,7 +2168,7 @@ static int handle_packet_rejoin(Group_Chats *g_c, int friendcon_id, const uint8_
 /** return 1 on success.
  * return 0 on failure
  */
-static unsigned int send_peer_introduced(Group_Chats *g_c, int friendcon_id, uint16_t group_num)
+static unsigned int send_peer_introduced(const Group_Chats *g_c, int friendcon_id, uint16_t group_num)
 {
     uint8_t packet[1];
     packet[0] = PEER_INTRODUCED_ID;
@@ -2179,7 +2179,7 @@ static unsigned int send_peer_introduced(Group_Chats *g_c, int friendcon_id, uin
 /** return 1 on success.
  * return 0 on failure
  */
-static unsigned int send_peer_query(Group_Chats *g_c, int friendcon_id, uint16_t group_num)
+static unsigned int send_peer_query(const Group_Chats *g_c, int friendcon_id, uint16_t group_num)
 {
     uint8_t packet[1];
     packet[0] = PEER_QUERY_ID;
@@ -2189,7 +2189,7 @@ static unsigned int send_peer_query(Group_Chats *g_c, int friendcon_id, uint16_t
 /** return number of peers sent on success.
  * return 0 on failure.
  */
-static unsigned int send_peers(Group_Chats *g_c, const Group_c *g, int friendcon_id, uint16_t group_num)
+static unsigned int send_peers(const Group_Chats *g_c, const Group_c *g, int friendcon_id, uint16_t group_num)
 {
     uint8_t response_packet[MAX_CRYPTO_DATA_SIZE - (1 + sizeof(uint16_t))];
     response_packet[0] = PEER_RESPONSE_ID;


### PR DESCRIPTION
We still have them in toxav. That will need to be cleaned up later.
Flexible array members have very limited usefulness. In this particular
case, it's almost entirely useless. It confuses static analysers and is
yet one more C feature we need to understand and support. It is also the
only reason we need special support in tokstyle for calloc with a `+`
operator in the member size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1910)
<!-- Reviewable:end -->
