### PR TITLE
cleanup: Use a `switch` statement for the TCP client state machine.

### DIFF
--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -474,7 +474,7 @@ static int handle_data_request(void *object, const IP_Port *source, const uint8_
         return 1;
     }
 
-    int index = in_entries(onion_a, packet + 1);
+    const int index = in_entries(onion_a, packet + 1);
 
     if (index == -1) {
         return 1;


### PR DESCRIPTION
It doesn't technically do the same thing now, because previously it would
possibly do multiple actions in the same iteration if the state switch
happens to be in order of the if statements. This way is cleaner, though,
as every iteration performs one action and possible state change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1913)
<!-- Reviewable:end -->
