### PR TITLE
fix: corruption in key files, making it unable to load when node starts.

### DIFF
--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -44,7 +44,7 @@ static void manage_keys(DHT *dht)
     enum { KEYS_SIZE = CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_SECRET_KEY_SIZE };
     uint8_t keys[KEYS_SIZE];
 
-    FILE *keys_file = fopen("key", "r");
+    FILE *keys_file = fopen("key", "rb");
 
     if (keys_file != nullptr) {
         /* If file was opened successfully -- load keys,
@@ -62,7 +62,7 @@ static void manage_keys(DHT *dht)
     } else {
         memcpy(keys, dht_get_self_public_key(dht), CRYPTO_PUBLIC_KEY_SIZE);
         memcpy(keys + CRYPTO_PUBLIC_KEY_SIZE, dht_get_self_secret_key(dht), CRYPTO_SECRET_KEY_SIZE);
-        keys_file = fopen("key", "w");
+        keys_file = fopen("key", "wb");
 
         if (keys_file == nullptr) {
             printf("Error opening key file in write mode.\nKeys will not be saved.\n");

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-edd2f14612df27c7211c2b0c87e714341c4cf4ada868741b2e7f73e1539f30e7  /usr/local/bin/tox-bootstrapd
+bfccf7abbe1105994711289ce930ce8f082027ea1370248f2d2d4528dd471b99  /usr/local/bin/tox-bootstrapd

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -62,7 +62,7 @@ static int manage_keys(DHT *dht, char *keys_file_path)
     FILE *keys_file;
 
     // Check if file exits, proceed to open and load keys
-    keys_file = fopen(keys_file_path, "r");
+    keys_file = fopen(keys_file_path, "rb");
 
     if (keys_file != nullptr) {
         const size_t read_size = fread(keys, sizeof(uint8_t), KEYS_SIZE, keys_file);
@@ -79,7 +79,7 @@ static int manage_keys(DHT *dht, char *keys_file_path)
         memcpy(keys, dht_get_self_public_key(dht), CRYPTO_PUBLIC_KEY_SIZE);
         memcpy(keys + CRYPTO_PUBLIC_KEY_SIZE, dht_get_self_secret_key(dht), CRYPTO_SECRET_KEY_SIZE);
 
-        keys_file = fopen(keys_file_path, "w");
+        keys_file = fopen(keys_file_path, "wb");
 
         if (!keys_file) {
             return 0;

--- a/other/fun/save-generator.c
+++ b/other/fun/save-generator.c
@@ -16,7 +16,7 @@
 
 static bool write_save(const uint8_t *data, size_t length)
 {
-    FILE *fp = fopen(GENERATED_SAVE_FILE, "w");
+    FILE *fp = fopen(GENERATED_SAVE_FILE, "wb");
 
     if (!fp) {
         return false;


### PR DESCRIPTION
This is a small change to fix a reproducible problem of DHT_Bootstrap.exe being unable to read the data from the key file. Seems to be an issue with EOL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1923)
<!-- Reviewable:end -->
