### PR TITLE
cleanup: remove brackets from ip_ntoa ipv6 formatting

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-0edccd9abfeac725152b708b805ab9880a57398ef9e83a814256893c52fef3c0  /usr/local/bin/tox-bootstrapd
+4bf8ff0a64f54bd11be8def3a00fb7d57fbc1a8c639eefdce9ccae91abcdf0a5  /usr/local/bin/tox-bootstrapd

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -353,9 +353,6 @@ static int handle_LANdiscovery(void *object, IP_Port source, const uint8_t *pack
 {
     DHT *dht = (DHT *)object;
 
-    char ip_str[IP_NTOA_LEN] = { 0 };
-    ip_ntoa(&source.ip, ip_str, sizeof(ip_str));
-
     if (!ip_is_lan(source.ip)) {
         return 1;
     }

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1209,7 +1209,6 @@ void ipport_copy(IP_Port *target, const IP_Port *source)
  *   converts ip into a string
  *   ip_str must be of length at least IP_NTOA_LEN
  *
- *   IPv6 addresses are enclosed into square brackets, i.e. "[IPv6]"
  *   writes error message into the buffer on error
  *
  *   returns ip_str
@@ -1235,12 +1234,8 @@ const char *ip_ntoa(const IP *ip, char *ip_str, size_t length)
             struct in6_addr addr;
             fill_addr6(ip->ip.v6, &addr);
 
-            ip_str[0] = '[';
             assert(make_family(ip->family) == AF_INET6);
-            inet_ntop6(&addr, &ip_str[1], length - 3);
-            const size_t len = strlen(ip_str);
-            ip_str[len] = ']';
-            ip_str[len + 1] = '\0';
+            inet_ntop6(&addr, ip_str, length);
         } else {
             snprintf(ip_str, length, "(IP invalid, family %u)", ip->family.value);
         }

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -217,7 +217,6 @@ bool ipv6_ipv4_in_v6(IP6 a);
  *   converts ip into a string
  *   ip_str must be of length at least IP_NTOA_LEN
  *
- *   IPv6 addresses are enclosed into square brackets, i.e. "[IPv6]"
  *   writes error message into the buffer on error
  *
  *   returns ip_str

--- a/toxcore/network_test.cc
+++ b/toxcore/network_test.cc
@@ -13,7 +13,7 @@ TEST(IpNtoa, DoesntWriteOutOfBounds) {
 
   ip_ntoa(&ip, ip_str, sizeof(ip_str));
 
-  EXPECT_EQ(std::string(ip_str), "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]");
+  EXPECT_EQ(std::string(ip_str), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
   EXPECT_LT(std::string(ip_str).length(), IP_NTOA_LEN);
 }
 


### PR DESCRIPTION
The brackets serve no purpose and make us do extra string parsing when using the output for other things.

Also removed a useless call to ip_ntoa in LAN_discovery.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1937)
<!-- Reviewable:end -->
