### PR TITLE
chore: Rename bazel-release to -opt and -debug to -dbg.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 ---
-bazel-release_task:
+bazel-opt_task:
   container:
     image: toxchat/toktok-stack:0.0.31-release
     cpu: 2
@@ -16,7 +16,7 @@ bazel-release_task:
         //c-toxcore/...
         -//c-toxcore/auto_tests:tcp_relay_test # TODO(robinlinden): Why does this pass locally but not in Cirrus?
 
-bazel-debug_task:
+bazel-dbg_task:
   container:
     image: toxchat/toktok-stack:0.0.31-debug
     cpu: 2

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -13,9 +13,9 @@ branches:
       required_status_checks:
         contexts:
           - "bazel-asan"
-          - "bazel-debug"
+          - "bazel-dbg"
           - "bazel-msan"
-          - "bazel-release"
+          - "bazel-opt"
           - "bazel-tsan"
           - "bazel-valgrind"
           - "build-bootstrapd-docker"


### PR DESCRIPTION
See https://github.com/TokTok/toktok-stack/pull/327

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1939)
<!-- Reviewable:end -->
