### PR TITLE
cleanup: Add some toxav bounds/sanity checks

### DIFF
--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -157,7 +157,7 @@ void ac_iterate(ACSession *ac)
             }
 
 #endif
-
+            assert(msg->len > 4);
 
             /* Pick up sampling rate from packet */
             memcpy(&ac->lp_sampling_rate, msg->data, 4);
@@ -210,10 +210,7 @@ void ac_iterate(ACSession *ac)
 int ac_queue_message(Mono_Time *mono_time, void *acp, struct RTPMessage *msg)
 {
     if (!acp || !msg) {
-        if (msg) {
-            free(msg);
-        }
-
+        free(msg);
         return -1;
     }
 
@@ -295,11 +292,8 @@ static struct JitterBuffer *jbuf_new(uint32_t capacity)
 static void jbuf_clear(struct JitterBuffer *q)
 {
     while (q->bottom != q->top) {
-        if (q->queue[q->bottom % q->size]) {
-            free(q->queue[q->bottom % q->size]);
-            q->queue[q->bottom % q->size] = nullptr;
-        }
-
+        free(q->queue[q->bottom % q->size]);
+        q->queue[q->bottom % q->size] = nullptr;
         ++q->bottom;
     }
 }

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -218,7 +218,7 @@ static struct RTPMessage *process_frame(const Logger *log, struct RTPWorkBufferL
     struct RTPMessage *const m_new = slot->buf;
     slot->buf = nullptr;
 
-    assert(wkbl->next_free_entry >= 1);
+    assert(wkbl->next_free_entry >= 1 && wkbl->next_free_entry <= USED_RTP_WORKBUFFER_COUNT);
 
     if (slot_id != wkbl->next_free_entry - 1) {
         // The slot is not the last slot, so we created a gap. We move all the


### PR DESCRIPTION
These showed up as false positives in sonar's static analysis, but it took long enough to figure that out that some extra sanity checks are warranted for readability purposes.

Also removed some unnecessary null checks before calling `free()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1942)
<!-- Reviewable:end -->
