### PR TITLE
chore: tox_new() should return null when savedata loading fails

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-9bec65f2a3093ebb49c3751dfad267482bc80d4b29ef9171f11d5ba53058d713  /usr/local/bin/tox-bootstrapd
+8942735f04e41962bbcfaeccbfa6487424ad78c910e932d93b5b6f56a6e852b7  /usr/local/bin/tox-bootstrapd

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -890,9 +890,6 @@ typedef enum Tox_Err_New {
  * This function will bring the instance into a valid state. Running the event
  * loop with a new instance will operate correctly.
  *
- * If loading failed or succeeded only partially, the new or partially loaded
- * instance is returned and an error code is set.
- *
  * @param options An options object as described above. If this parameter is
  *   NULL, the default options are used.
  *


### PR DESCRIPTION
Returning a valid tox instance when loading a corrupt savefile is probably not desired behaviour

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1944)
<!-- Reviewable:end -->
