### PR TITLE
fix: potential freeing of an immutable static buffer

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-de00572e0a22b67defb05759a4d5aac6bf0e107bfd6834a1edc20ffb0379528d  /usr/local/bin/tox-bootstrapd
+746158481ebd16d70aadc0bf4d2dc6da6a2f3ac4eb12d219b49fc6fd7e60d149  /usr/local/bin/tox-bootstrapd


### PR DESCRIPTION
strerror_r() has two versions: GNU-specific and XSI-compliant. The XSI
version always stores the string in the provided buffer, but the GNU
version might store it in the provided buffer or it might use some
immutable static buffer instead. Since we always free the error string,
we might end up freeing the immutable static buffer.

https://man7.org/linux/man-pages/man3/strerror.3.html

Fixes #1967

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1948)
<!-- Reviewable:end -->
