### PR TITLE
chore: Disable some cimple warnings for now.

### DIFF
--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -13,7 +13,10 @@ sh_test(
     size = "small",
     srcs = ["//hs-tokstyle/tools:check-cimple"],
     args = ["$(locations %s)" % f for f in CIMPLE_FILES] + [
+        "-Wno-callback-names",
         "-Wno-enum-names",
+        "-Wno-large-struct-params",
+        "-Wno-memcpy-structs",
         "+RTS",
         "-N3",
     ],


### PR DESCRIPTION
So we can push the latest cimple to toktok-stack and then start fixing
the warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1956)
<!-- Reviewable:end -->
