### PR TITLE
cleanup: Don't pass the whole DHT object to lan discovery.

### DIFF
--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -230,7 +230,7 @@ int main(int argc, char *argv[])
         do_dht(dht);
 
         if (mono_time_is_timeout(mono_time, last_LANdiscovery, is_waiting_for_dht_connection ? 5 : LAN_DISCOVERY_INTERVAL)) {
-            lan_discovery_send(net_htons(PORT), dht);
+            lan_discovery_send(dht_get_net(dht), dht_get_self_public_key(dht), net_htons(PORT));
             last_LANdiscovery = mono_time_get(mono_time);
         }
 

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-87ab42da03d54cf33815b364a974d1548a2a673415bd82e86ffbd6511483eb81  /usr/local/bin/tox-bootstrapd
+de00572e0a22b67defb05759a4d5aac6bf0e107bfd6834a1edc20ffb0379528d  /usr/local/bin/tox-bootstrapd

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -503,7 +503,7 @@ int main(int argc, char *argv[])
         do_dht(dht);
 
         if (enable_lan_discovery && mono_time_is_timeout(mono_time, last_LANdiscovery, LAN_DISCOVERY_INTERVAL)) {
-            lan_discovery_send(net_htons_port, dht);
+            lan_discovery_send(dht_get_net(dht), dht_get_self_public_key(dht), net_htons_port);
             last_LANdiscovery = mono_time_get(mono_time);
         }
 

--- a/toxcore/LAN_discovery.h
+++ b/toxcore/LAN_discovery.h
@@ -18,8 +18,10 @@
 
 /**
  * Send a LAN discovery pcaket to the broadcast address with port port.
+ *
+ * @return true on success, false on failure.
  */
-int32_t lan_discovery_send(uint16_t port, const DHT *dht);
+bool lan_discovery_send(Networking_Core *net, const uint8_t *dht_pk, uint16_t port);
 
 /**
  * Sets up packet handlers.

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -897,11 +897,11 @@ static void lan_discovery(Friend_Connections *fr_c)
         last = last > TOX_PORTRANGE_TO ? TOX_PORTRANGE_TO : last;
 
         // Always send to default port
-        lan_discovery_send(net_htons(TOX_PORT_DEFAULT), fr_c->dht);
+        lan_discovery_send(dht_get_net(fr_c->dht), dht_get_self_public_key(fr_c->dht), net_htons(TOX_PORT_DEFAULT));
 
         // And check some extra ports
         for (uint16_t port = first; port < last; ++port) {
-            lan_discovery_send(net_htons(port), fr_c->dht);
+            lan_discovery_send(dht_get_net(fr_c->dht), dht_get_self_public_key(fr_c->dht), net_htons(port));
         }
 
         // Don't include default port in port range


### PR DESCRIPTION
It only needs net and dht public key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1964)
<!-- Reviewable:end -->
