### PR TITLE
cleanup: Split msi callback array into 1 member per callback

### DIFF
--- a/toxav/msi.h
+++ b/toxav/msi.h
@@ -101,7 +101,13 @@ typedef struct MSISession {
     Messenger      *messenger;
 
     pthread_mutex_t mutex[1];
-    msi_action_cb *callbacks[7];
+
+    msi_action_cb *invite_callback;
+    msi_action_cb *start_callback;
+    msi_action_cb *end_callback;
+    msi_action_cb *error_callback;
+    msi_action_cb *peertimeout_callback;
+    msi_action_cb *capabilities_callback;
 } MSISession;
 
 /**


### PR DESCRIPTION
Fixes #1977

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1985)
<!-- Reviewable:end -->
