### PR TITLE
cleanup: Comply with new cimple callback rules.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-64e519c68f23246ea4f490bdc2973d8bc1217da802596ad550048d3767b7214a  /usr/local/bin/tox-bootstrapd
+21bbf4e49911d31cef0f50195affe86138630703c7072c67ffd7802f7e588190  /usr/local/bin/tox-bootstrapd

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -854,7 +854,10 @@ static void set_friend_typing(const Messenger *m, int32_t friendnumber, uint8_t 
 /** Set the function that will be executed when a friend request is received. */
 void m_callback_friendrequest(Messenger *m, m_friend_request_cb *function)
 {
+    /* TODO(iphydf): Don't cast function pointers. */
+    //!TOKSTYLE-
     callback_friendrequest(m->fr, (fr_friend_request_cb *)function, m);
+    //!TOKSTYLE+
 }
 
 /** Set the function that will be executed when a message from a friend is received. */
@@ -2818,9 +2821,9 @@ static uint32_t m_state_plugins_size(const Messenger *m)
  * returns true on success
  * returns false on error
  */
-bool m_register_state_plugin(Messenger *m, State_Type type, m_state_size_cb size_callback,
-                             m_state_load_cb load_callback,
-                             m_state_save_cb save_callback)
+bool m_register_state_plugin(Messenger *m, State_Type type, m_state_size_cb *size_callback,
+                             m_state_load_cb *load_callback,
+                             m_state_save_cb *save_callback)
 {
     Messenger_State_Plugin *temp = (Messenger_State_Plugin *)realloc(m->options.state_plugins,
                                    sizeof(Messenger_State_Plugin) * (m->options.state_plugins_length + 1));

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -744,8 +744,8 @@ uint32_t messenger_run_interval(const Messenger *m);
  * returns true on success
  * returns false on error
  */
-bool m_register_state_plugin(Messenger *m, State_Type type, m_state_size_cb size_callback,
-                             m_state_load_cb load_callback, m_state_save_cb save_callback);
+bool m_register_state_plugin(Messenger *m, State_Type type, m_state_size_cb *size_callback,
+                             m_state_load_cb *load_callback, m_state_save_cb *save_callback);
 
 /** return size of the messenger data (for saving). */
 uint32_t messenger_size(const Messenger *m);

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -724,15 +724,14 @@ void networking_poll(const Networking_Core *net, void *userdata)
             continue;
         }
 
-        packet_handler_cb *const cb = net->packethandlers[data[0]].function;
-        void *const object = net->packethandlers[data[0]].object;
+        const Packet_Handler *const handler = &net->packethandlers[data[0]];
 
-        if (cb == nullptr) {
+        if (handler->function == nullptr) {
             LOGGER_WARNING(net->log, "[%02u] -- Packet has no handler", data[0]);
             continue;
         }
 
-        cb(object, &ip_port, data, length, userdata);
+        handler->function(handler->object, &ip_port, data, length, userdata);
     }
 }
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -452,7 +452,10 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
     m_options.hole_punching_enabled = tox_options_get_hole_punching_enabled(opts);
     m_options.local_discovery_enabled = tox_options_get_local_discovery_enabled(opts);
 
+    // TODO(iphydf): Don't cast function pointers.
+    //!TOKSTYLE-
     m_options.log_callback = (logger_cb *)tox_options_get_log_callback(opts);
+    //!TOKSTYLE+
     m_options.log_context = tox;
     m_options.log_user_data = tox_options_get_log_user_data(opts);
 


### PR DESCRIPTION
* Function arguments must use `foo_cb *p` and can't just use `foo_cb p`
* You can no longer cast function pointers (if it's incompatible, you
  must wrap the callback). I'm avoiding this with tokstyle exclusions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1987)
<!-- Reviewable:end -->
