### PR TITLE
cleanup: Make LAN discovery thread-safe without data races.

### DIFF
--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
     int is_waiting_for_dht_connection = 1;
 
     uint64_t last_LANdiscovery = 0;
-    lan_discovery_init(dht);
+    Broadcast_Info *broadcast = lan_discovery_init(dht);
 
     while (1) {
         mono_time_update(mono_time);
@@ -230,7 +230,7 @@ int main(int argc, char *argv[])
         do_dht(dht);
 
         if (mono_time_is_timeout(mono_time, last_LANdiscovery, is_waiting_for_dht_connection ? 5 : LAN_DISCOVERY_INTERVAL)) {
-            lan_discovery_send(dht_get_net(dht), dht_get_self_public_key(dht), net_htons(PORT));
+            lan_discovery_send(dht_get_net(dht), broadcast, dht_get_self_public_key(dht), net_htons(PORT));
             last_LANdiscovery = mono_time_get(mono_time);
         }
 

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-21bbf4e49911d31cef0f50195affe86138630703c7072c67ffd7802f7e588190  /usr/local/bin/tox-bootstrapd
+dd0f0cc84ecb5ce44ca56ff47793fca162e12b1a542c34e39fae4d3e53996874  /usr/local/bin/tox-bootstrapd

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -474,8 +474,10 @@ int main(int argc, char *argv[])
 
     int waiting_for_dht_connection = 1;
 
+    Broadcast_Info *broadcast = nullptr;
+
     if (enable_lan_discovery) {
-        lan_discovery_init(dht);
+        broadcast = lan_discovery_init(dht);
         log_write(LOG_LEVEL_INFO, "Initialized LAN discovery successfully.\n");
     }
 
@@ -503,7 +505,7 @@ int main(int argc, char *argv[])
         do_dht(dht);
 
         if (enable_lan_discovery && mono_time_is_timeout(mono_time, last_LANdiscovery, LAN_DISCOVERY_INTERVAL)) {
-            lan_discovery_send(dht_get_net(dht), dht_get_self_public_key(dht), net_htons_port);
+            lan_discovery_send(dht_get_net(dht), broadcast, dht_get_self_public_key(dht), net_htons_port);
             last_LANdiscovery = mono_time_get(mono_time);
         }
 
@@ -535,7 +537,7 @@ int main(int argc, char *argv[])
     }
 
     if (enable_lan_discovery) {
-        lan_discovery_kill(dht);
+        lan_discovery_kill(dht, broadcast);
     }
 
     kill_TCP_server(tcp_server);

--- a/toxcore/LAN_discovery.h
+++ b/toxcore/LAN_discovery.h
@@ -16,22 +16,24 @@
  */
 #define LAN_DISCOVERY_INTERVAL         10
 
+typedef struct Broadcast_Info Broadcast_Info;
+
 /**
  * Send a LAN discovery pcaket to the broadcast address with port port.
  *
  * @return true on success, false on failure.
  */
-bool lan_discovery_send(Networking_Core *net, const uint8_t *dht_pk, uint16_t port);
+bool lan_discovery_send(Networking_Core *net, Broadcast_Info *broadcast, const uint8_t *dht_pk, uint16_t port);
 
 /**
  * Sets up packet handlers.
  */
-void lan_discovery_init(DHT *dht);
+Broadcast_Info *lan_discovery_init(DHT *dht);
 
 /**
  * Clear packet handlers.
  */
-void lan_discovery_kill(DHT *dht);
+void lan_discovery_kill(DHT *dht, Broadcast_Info *info);
 
 /**
  * Is IP a local ip or not.


### PR DESCRIPTION
It was kind of thread-safe, maybe, but there was a data race that makes
tsan unhappy. We now do interface detection once per Tox instance
instead of once per process.

Fixes #405.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/1988)
<!-- Reviewable:end -->
