### PR TITLE
cleanup: Add nonnull annotations to function definitions.

### DIFF
--- a/.github/scripts/flags-clang.sh
+++ b/.github/scripts/flags-clang.sh
@@ -35,6 +35,8 @@ add_flag -Wno-reserved-id-macro
 # TODO(iphydf): Clean these up. They are likely not bugs, but still
 # potential issues and probably confusing.
 add_flag -Wno-sign-compare
+# __attribute__((nonnull)) causes this warning on defensive null checks.
+add_flag -Wno-tautological-pointer-compare
 # Our use of mutexes results in a false positive, see 1bbe446.
 add_flag -Wno-thread-safety-analysis
 # File transfer code has this.

--- a/.github/scripts/flags-gcc.sh
+++ b/.github/scripts/flags-gcc.sh
@@ -20,3 +20,5 @@ add_flag -Wno-unused-parameter
 # struct Foo foo = {0}; is a common idiom. Missing braces means we'd need to
 # write {{{0}}} in some cases, which is ugly and a maintenance burden.
 add_flag -Wno-missing-braces
+# __attribute__((nonnull)) causes this warning on defensive null checks.
+add_flag -Wno-nonnull-compare

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,9 @@
 [build]
 command = """\
   if cd doxygen-awesome-css; then \
-    git pull && cd ..; \
+    git pull --rebase && cd ..; \
   else \
-    git clone --depth=1 https://github.com/jothepro/doxygen-awesome-css.git;
+    git clone --depth=1 https://github.com/jothepro/doxygen-awesome-css;
   fi && \
   doxygen docs/Doxyfile \
   """

--- a/other/analysis/run-clang
+++ b/other/analysis/run-clang
@@ -26,6 +26,7 @@ run() {
     -Wno-old-style-cast \
     -Wno-padded \
     -Wno-sign-compare \
+    -Wno-tautological-pointer-compare \
     -Wno-unreachable-code-return \
     -Wno-unused-parameter \
     -Wno-used-but-marked-unused \

--- a/other/analysis/run-clang-tidy
+++ b/other/analysis/run-clang-tidy
@@ -1,8 +1,13 @@
 #!/bin/bash
 
+CHECKS="*"
+
+# __attribute__((nonnull)) causes this warning on defensive null checks.
+CHECKS="$CHECKS,-clang-diagnostic-pointer-bool-conversion"
+CHECKS="$CHECKS,-clang-diagnostic-tautological-pointer-compare"
+
 # TODO(iphydf): We might want some of these. For the ones we don't want, add a
 # comment explaining why not.
-CHECKS="*"
 CHECKS="$CHECKS,-altera-unroll-loops"
 CHECKS="$CHECKS,-android-cloexec-accept"
 CHECKS="$CHECKS,-android-cloexec-fopen"

--- a/other/analysis/run-gcc
+++ b/other/analysis/run-gcc
@@ -22,6 +22,7 @@ run() {
     -Wno-float-conversion \
     -Wno-format-signedness \
     -Wno-missing-field-initializers \
+    -Wno-nonnull-compare \
     -Wno-padded \
     -Wno-sign-compare \
     -Wno-sign-conversion \
@@ -52,7 +53,6 @@ run() {
     -Wmemset-transposed-args \
     -Wmisleading-indentation \
     -Wnonnull \
-    -Wnonnull-compare \
     -Wnull-dereference \
     -Wodr \
     -Wredundant-decls \

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -8,9 +8,9 @@ RUN ["apk", "--no-cache", "add",\
  "linux-headers",\
  "libconfig-dev",\
  "libconfig-static",\
- "msgpack-c-dev",\
  "libsodium-dev",\
  "libsodium-static",\
+ "msgpack-c-dev",\
  "ninja",\
  "python3"\
 ]
@@ -33,10 +33,11 @@ COPY CMakeLists.txt so.version ./
 
 RUN cmake -B_build -H. \
       -GNinja \
-      -DCMAKE_C_FLAGS=-DTCP_SERVER_USE_EPOLL \
-      -DMIN_LOGGER_LEVEL=DEBUG \
+      -DCMAKE_C_FLAGS="-DTCP_SERVER_USE_EPOLL -fstack-protector-all -fisolate-erroneous-paths-attribute" \
+      -DCMAKE_UNITY_BUILD=ON \
       -DCMAKE_BUILD_TYPE=Release \
       -DFULLY_STATIC=ON \
+      -DMIN_LOGGER_LEVEL=DEBUG \
       -DBUILD_TOXAV=OFF \
       -DBOOTSTRAP_DAEMON=ON && \
     cmake --build _build --target install
@@ -72,6 +73,10 @@ RUN useradd --home-dir /var/lib/tox-bootstrapd --create-home \
 WORKDIR /var/lib/tox-bootstrapd
 
 USER tox-bootstrapd
+
+# Smoke-test: make sure the binary actually starts up.
+# hadolint ignore=DL4006
+RUN script /usr/local/bin/tox-bootstrapd --help | grep "Usage"
 
 ENTRYPOINT ["/usr/local/bin/tox-bootstrapd",\
  "--config", "/etc/tox-bootstrapd.conf",\

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-dd0f0cc84ecb5ce44ca56ff47793fca162e12b1a542c34e39fae4d3e53996874  /usr/local/bin/tox-bootstrapd
+30845d5b6a5a2606afccceff83c7f1089040a800eb138c9ad92932cea2447e30  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -107,67 +107,81 @@ struct DHT {
     unsigned int num_to_bootstrap;
 };
 
+non_null(1)
 const uint8_t *dht_friend_public_key(const DHT_Friend *dht_friend)
 {
     return dht_friend->public_key;
 }
 
+non_null(1)
 const Client_data *dht_friend_client(const DHT_Friend *dht_friend, size_t index)
 {
     return &dht_friend->client_list[index];
 }
 
+non_null(1)
 const uint8_t *dht_get_self_public_key(const DHT *dht)
 {
     return dht->self_public_key;
 }
+non_null(1)
 const uint8_t *dht_get_self_secret_key(const DHT *dht)
 {
     return dht->self_secret_key;
 }
 
+non_null(1, 2)
 void dht_set_self_public_key(DHT *dht, const uint8_t *key)
 {
     memcpy(dht->self_public_key, key, CRYPTO_PUBLIC_KEY_SIZE);
 }
+non_null(1, 2)
 void dht_set_self_secret_key(DHT *dht, const uint8_t *key)
 {
     memcpy(dht->self_secret_key, key, CRYPTO_SECRET_KEY_SIZE);
 }
 
+non_null(1)
 Networking_Core *dht_get_net(const DHT *dht)
 {
     return dht->net;
 }
+non_null(1)
 struct Ping *dht_get_ping(const DHT *dht)
 {
     return dht->ping;
 }
+non_null(1)
 const Client_data *dht_get_close_clientlist(const DHT *dht)
 {
     return dht->close_clientlist;
 }
+non_null(1)
 const Client_data *dht_get_close_client(const DHT *dht, uint32_t client_num)
 {
     assert(client_num < sizeof(dht->close_clientlist) / sizeof(dht->close_clientlist[0]));
     return &dht->close_clientlist[client_num];
 }
+non_null(1)
 uint16_t dht_get_num_friends(const DHT *dht)
 {
     return dht->num_friends;
 }
 
+non_null(1)
 DHT_Friend *dht_get_friend(DHT *dht, uint32_t friend_num)
 {
     assert(friend_num < dht->num_friends);
     return &dht->friends_list[friend_num];
 }
+non_null(1)
 const uint8_t *dht_get_friend_public_key(const DHT *dht, uint32_t friend_num)
 {
     assert(friend_num < dht->num_friends);
     return dht->friends_list[friend_num].public_key;
 }
 
+non_null(2)
 static bool assoc_timeout(uint64_t cur_time, const IPPTsPng *assoc)
 {
     return (assoc->timestamp + BAD_NODE_TIMEOUT) <= cur_time;
@@ -177,6 +191,7 @@ static bool assoc_timeout(uint64_t cur_time, const IPPTsPng *assoc)
  *
  * If the ip_port is already IPv4 this function returns a copy of the original ip_port.
  */
+non_null(1)
 static IP_Port ip_port_normalize(const IP_Port *ip_port)
 {
     IP_Port res = *ip_port;
@@ -195,6 +210,7 @@ static IP_Port ip_port_normalize(const IP_Port *ip_port)
  *  return 1 if pk1 is closer.
  *  return 2 if pk2 is closer.
  */
+non_null(1, 2, 3)
 int id_closest(const uint8_t *pk, const uint8_t *pk1, const uint8_t *pk2)
 {
     for (size_t i = 0; i < CRYPTO_PUBLIC_KEY_SIZE; ++i) {
@@ -215,6 +231,7 @@ int id_closest(const uint8_t *pk, const uint8_t *pk1, const uint8_t *pk2)
 
 /** Return index of first unequal bit number.
  */
+non_null(1, 2)
 static unsigned int bit_by_bit_cmp(const uint8_t *pk1, const uint8_t *pk2)
 {
     unsigned int i;
@@ -245,6 +262,7 @@ static unsigned int bit_by_bit_cmp(const uint8_t *pk1, const uint8_t *pk2)
  * If a shared key is already in shared_keys, copy it to shared_key.
  * Otherwise generate it into shared_key and copy it to shared_keys
  */
+non_null(1, 2, 3, 4, 5)
 void get_shared_key(const Mono_Time *mono_time, Shared_Keys *shared_keys, uint8_t *shared_key,
                     const uint8_t *secret_key, const uint8_t *public_key)
 {
@@ -293,6 +311,7 @@ void get_shared_key(const Mono_Time *mono_time, Shared_Keys *shared_keys, uint8_
 /** Copy shared_key to encrypt/decrypt DHT packet from public_key into shared_key
  * for packets that we receive.
  */
+non_null(1, 2, 3)
 void dht_get_shared_key_recv(DHT *dht, uint8_t *shared_key, const uint8_t *public_key)
 {
     get_shared_key(dht->mono_time, &dht->shared_keys_recv, shared_key, dht->self_secret_key, public_key);
@@ -301,6 +320,7 @@ void dht_get_shared_key_recv(DHT *dht, uint8_t *shared_key, const uint8_t *publi
 /** Copy shared_key to encrypt/decrypt DHT packet from public_key into shared_key
  * for packets that we send.
  */
+non_null(1, 2, 3)
 void dht_get_shared_key_sent(DHT *dht, uint8_t *shared_key, const uint8_t *public_key)
 {
     get_shared_key(dht->mono_time, &dht->shared_keys_sent, shared_key, dht->self_secret_key, public_key);
@@ -318,6 +338,7 @@ void dht_get_shared_key_sent(DHT *dht, uint8_t *shared_key, const uint8_t *publi
  *  return -1 on failure.
  *  return the length of the created packet on success.
  */
+non_null(1, 2, 3, 4, 5)
 int create_request(const uint8_t *send_public_key, const uint8_t *send_secret_key, uint8_t *packet,
                    const uint8_t *recv_public_key, const uint8_t *data, uint32_t length, uint8_t request_id)
 {
@@ -356,6 +377,7 @@ int create_request(const uint8_t *send_public_key, const uint8_t *send_secret_ke
  *
  *  return -1 if not valid request.
  */
+non_null(1, 2, 3, 4, 5, 6)
 int handle_request(const uint8_t *self_public_key, const uint8_t *self_secret_key, uint8_t *public_key, uint8_t *data,
                    uint8_t *request_id, const uint8_t *packet, uint16_t length)
 {
@@ -416,6 +438,7 @@ int packed_node_size(Family ip_family)
  * Returns size of packed IP_Port data on success
  * Return -1 on failure.
  */
+non_null(1, 3)
 int pack_ip_port(uint8_t *data, uint16_t length, const IP_Port *ip_port)
 {
     if (data == nullptr) {
@@ -467,6 +490,7 @@ int pack_ip_port(uint8_t *data, uint16_t length, const IP_Port *ip_port)
     }
 }
 
+non_null(1, 2, 4, 6)
 static int dht_create_packet(const uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE],
                              const uint8_t *shared_key, const uint8_t type,
                              const uint8_t *plain, size_t plain_length, uint8_t *packet)
@@ -497,6 +521,7 @@ static int dht_create_packet(const uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE],
  * Return size of unpacked ip_port on success.
  * Return -1 on failure.
  */
+non_null(1, 2)
 int unpack_ip_port(IP_Port *ip_port, const uint8_t *data, uint16_t length, bool tcp_enabled)
 {
     if (data == nullptr) {
@@ -564,6 +589,7 @@ int unpack_ip_port(IP_Port *ip_port, const uint8_t *data, uint16_t length, bool 
  * return length of packed nodes on success.
  * return -1 on failure.
  */
+non_null(1, 3)
 int pack_nodes(uint8_t *data, uint16_t length, const Node_format *nodes, uint16_t number)
 {
     uint32_t packed_length = 0;
@@ -600,6 +626,7 @@ int pack_nodes(uint8_t *data, uint16_t length, const Node_format *nodes, uint16_
  * return number of unpacked nodes on success.
  * return -1 on failure.
  */
+non_null(1, 4)
 int unpack_nodes(Node_format *nodes, uint16_t max_num_nodes, uint16_t *processed_data_len, const uint8_t *data,
                  uint16_t length, bool tcp_enabled)
 {
@@ -640,8 +667,11 @@ int unpack_nodes(Node_format *nodes, uint16_t max_num_nodes, uint16_t *processed
  *
  *  return index or UINT32_MAX if not found.
  */
+nullable(1) non_null(3)
 static uint32_t index_of_client_pk(const Client_data *array, uint32_t size, const uint8_t *pk)
 {
+    assert(size == 0 || array != nullptr);
+
     for (uint32_t i = 0; i < size; ++i) {
         if (id_equal(array[i].public_key, pk)) {
             return i;
@@ -651,8 +681,11 @@ static uint32_t index_of_client_pk(const Client_data *array, uint32_t size, cons
     return UINT32_MAX;
 }
 
+nullable(1) non_null(3)
 static uint32_t index_of_friend_pk(const DHT_Friend *array, uint32_t size, const uint8_t *pk)
 {
+    assert(size == 0 || array != nullptr);
+
     for (uint32_t i = 0; i < size; ++i) {
         if (id_equal(array[i].public_key, pk)) {
             return i;
@@ -662,8 +695,11 @@ static uint32_t index_of_friend_pk(const DHT_Friend *array, uint32_t size, const
     return UINT32_MAX;
 }
 
+nullable(1) non_null(3)
 static uint32_t index_of_node_pk(const Node_format *array, uint32_t size, const uint8_t *pk)
 {
+    assert(size == 0 || array != nullptr);
+
     for (uint32_t i = 0; i < size; ++i) {
         if (id_equal(array[i].public_key, pk)) {
             return i;
@@ -677,8 +713,11 @@ static uint32_t index_of_node_pk(const Node_format *array, uint32_t size, const 
  *
  * return index or UINT32_MAX if not found.
  */
+nullable(1) non_null(3)
 static uint32_t index_of_client_ip_port(const Client_data *array, uint32_t size, const IP_Port *ip_port)
 {
+    assert(size == 0 || array != nullptr);
+
     for (uint32_t i = 0; i < size; ++i) {
         if ((net_family_is_ipv4(ip_port->ip.family) && ipport_equal(&array[i].assoc4.ip_port, ip_port)) ||
                 (net_family_is_ipv6(ip_port->ip.family) && ipport_equal(&array[i].assoc6.ip_port, ip_port))) {
@@ -691,6 +730,7 @@ static uint32_t index_of_client_ip_port(const Client_data *array, uint32_t size,
 
 /** Update ip_port of client if it's needed.
  */
+non_null(1, 2, 4, 5)
 static void update_client(const Logger *log, const Mono_Time *mono_time, int index, Client_data *client,
                           const IP_Port *ip_port)
 {
@@ -732,6 +772,7 @@ static void update_client(const Logger *log, const Mono_Time *mono_time, int ind
  *
  *  return True(1) or False(0)
  */
+non_null(1, 2, 3, 5, 6)
 static int client_or_ip_port_in_list(const Logger *log, const Mono_Time *mono_time, Client_data *list, uint16_t length,
                                      const uint8_t *public_key, const IP_Port *ip_port)
 {
@@ -779,6 +820,7 @@ static int client_or_ip_port_in_list(const Logger *log, const Mono_Time *mono_ti
     return 1;
 }
 
+non_null(1, 3, 4, 5)
 bool add_to_list(Node_format *nodes_list, uint32_t length, const uint8_t *pk, const IP_Port *ip_port,
                  const uint8_t *cmp_pk)
 {
@@ -804,6 +846,7 @@ bool add_to_list(Node_format *nodes_list, uint32_t length, const uint8_t *pk, co
 /**
  * helper for get_close_nodes(). argument list is a monster :D
  */
+non_null(2, 3, 5, 7)
 static void get_close_nodes_inner(uint64_t cur_time, const uint8_t *public_key, Node_format *nodes_list,
                                   Family sa_family, const Client_data *client_list, uint32_t client_list_length,
                                   uint32_t *num_nodes_ptr, bool is_LAN)
@@ -862,6 +905,7 @@ static void get_close_nodes_inner(uint64_t cur_time, const uint8_t *public_key, 
  * TODO(irungentoo): For the love of based <your favorite deity, in doubt use
  * "love"> make this function cleaner and much more efficient.
  */
+non_null(1, 2, 3)
 static int get_somewhat_close_nodes(const DHT *dht, const uint8_t *public_key, Node_format *nodes_list,
                                     Family sa_family, bool is_LAN)
 {
@@ -878,6 +922,7 @@ static int get_somewhat_close_nodes(const DHT *dht, const uint8_t *public_key, N
     return num_nodes;
 }
 
+non_null(1, 2, 3)
 int get_close_nodes(const DHT *dht, const uint8_t *public_key, Node_format *nodes_list, Family sa_family,
                     bool is_LAN)
 {
@@ -891,6 +936,7 @@ typedef struct DHT_Cmp_Data {
     Client_data entry;
 } DHT_Cmp_Data;
 
+non_null(1, 2)
 static int dht_cmp_entry(const void *a, const void *b)
 {
     const DHT_Cmp_Data *cmp1 = (const DHT_Cmp_Data *)a;
@@ -932,6 +978,7 @@ static int dht_cmp_entry(const void *a, const void *b)
  * return 0 if node can't be stored.
  * return 1 if it can.
  */
+non_null(1, 3, 4)
 static unsigned int store_node_ok(const Client_data *client, uint64_t cur_time, const uint8_t *public_key,
                                   const uint8_t *comp_public_key)
 {
@@ -940,6 +987,7 @@ static unsigned int store_node_ok(const Client_data *client, uint64_t cur_time, 
            || id_closest(comp_public_key, client->public_key, public_key) == 2;
 }
 
+non_null(1, 4)
 static void sort_client_list(Client_data *list, uint64_t cur_time, unsigned int length,
                              const uint8_t *comp_public_key)
 {
@@ -960,6 +1008,7 @@ static void sort_client_list(Client_data *list, uint64_t cur_time, unsigned int 
     }
 }
 
+non_null(1, 2, 3)
 static void update_client_with_reset(const Mono_Time *mono_time, Client_data *client, const IP_Port *ip_port)
 {
     IPPTsPng *ipptp_write = nullptr;
@@ -998,6 +1047,7 @@ static void update_client_with_reset(const Mono_Time *mono_time, Client_data *cl
  *  than public_key.
  *
  *  returns true when the item was stored, false otherwise */
+non_null(1, 2, 4, 5, 6)
 static bool replace_all(const DHT *dht,
                         Client_data    *list,
                         uint16_t        length,
@@ -1030,6 +1080,7 @@ static bool replace_all(const DHT *dht,
  * return -1 on failure.
  * return 0 on success.
  */
+non_null(1, 2, 3)
 static int add_to_close(DHT *dht, const uint8_t *public_key, const IP_Port *ip_port, bool simulate)
 {
     unsigned int index = bit_by_bit_cmp(public_key, dht->self_public_key);
@@ -1062,11 +1113,13 @@ static int add_to_close(DHT *dht, const uint8_t *public_key, const IP_Port *ip_p
 
 /** Return 1 if node can be added to close list, 0 if it can't.
  */
+non_null(1, 2, 3)
 bool node_addable_to_close_list(DHT *dht, const uint8_t *public_key, const IP_Port *ip_port)
 {
     return add_to_close(dht, public_key, ip_port, 1) == 0;
 }
 
+non_null(1, 4, 5)
 static bool is_pk_in_client_list(const Client_data *list, unsigned int client_list_length, uint64_t cur_time,
                                  const uint8_t *public_key, const IP_Port *ip_port)
 {
@@ -1083,6 +1136,7 @@ static bool is_pk_in_client_list(const Client_data *list, unsigned int client_li
     return !assoc_timeout(cur_time, assoc);
 }
 
+non_null(1, 2, 3)
 static bool is_pk_in_close_list(const DHT *dht, const uint8_t *public_key, const IP_Port *ip_port)
 {
     unsigned int index = bit_by_bit_cmp(public_key, dht->self_public_key);
@@ -1101,6 +1155,7 @@ static bool is_pk_in_close_list(const DHT *dht, const uint8_t *public_key, const
  * return false if the node should not be pinged.
  * return true if it should.
  */
+non_null(1, 2, 3)
 static bool ping_node_from_getnodes_ok(DHT *dht, const uint8_t *public_key, const IP_Port *ip_port)
 {
     bool ret = false;
@@ -1166,6 +1221,7 @@ static bool ping_node_from_getnodes_ok(DHT *dht, const uint8_t *public_key, cons
  *
  *  returns 1+ if the item is used in any list, 0 else
  */
+non_null(1, 2, 3)
 uint32_t addto_lists(DHT *dht, const IP_Port *ip_port, const uint8_t *public_key)
 {
     IP_Port ipp_copy = ip_port_normalize(ip_port);
@@ -1217,6 +1273,7 @@ uint32_t addto_lists(DHT *dht, const IP_Port *ip_port, const uint8_t *public_key
     return used;
 }
 
+non_null(1, 2, 4, 5)
 static bool update_client_data(const Mono_Time *mono_time, Client_data *array, size_t size, const IP_Port *ip_port,
                                const uint8_t *pk, bool node_is_self)
 {
@@ -1248,6 +1305,7 @@ static bool update_client_data(const Mono_Time *mono_time, Client_data *array, s
 /** If public_key is a friend or us, update ret_ip_port
  * nodepublic_key is the id of the node that sent us this info.
  */
+non_null(1, 2, 3, 4)
 static void returnedip_ports(DHT *dht, const IP_Port *ip_port, const uint8_t *public_key, const uint8_t *nodepublic_key)
 {
     IP_Port ipp_copy = ip_port_normalize(ip_port);
@@ -1268,6 +1326,7 @@ static void returnedip_ports(DHT *dht, const IP_Port *ip_port, const uint8_t *pu
     }
 }
 
+non_null(1, 2, 3, 4)
 bool dht_getnodes(DHT *dht, const IP_Port *ip_port, const uint8_t *public_key, const uint8_t *client_id)
 {
     /* Check if packet is going to be sent to ourself. */
@@ -1319,6 +1378,7 @@ bool dht_getnodes(DHT *dht, const IP_Port *ip_port, const uint8_t *public_key, c
 }
 
 /** Send a send nodes response: message for IPv6 nodes */
+non_null(1, 2, 3, 4, 5, 7)
 static int sendnodes_ipv6(const DHT *dht, const IP_Port *ip_port, const uint8_t *public_key, const uint8_t *client_id,
                           const uint8_t *sendback_data, uint16_t length, const uint8_t *shared_encryption_key)
 {
@@ -1367,6 +1427,7 @@ static int sendnodes_ipv6(const DHT *dht, const IP_Port *ip_port, const uint8_t 
 
 #define CRYPTO_NODE_SIZE (CRYPTO_PUBLIC_KEY_SIZE + sizeof(uint64_t))
 
+non_null(1, 2, 3, 5)
 static int handle_getnodes(void *object, const IP_Port *source, const uint8_t *packet, uint16_t length, void *userdata)
 {
     if (length != (CRYPTO_SIZE + CRYPTO_MAC_SIZE + sizeof(uint64_t))) {
@@ -1406,6 +1467,7 @@ static int handle_getnodes(void *object, const IP_Port *source, const uint8_t *p
 }
 
 /** Return true if we sent a getnode packet to the peer associated with the supplied info. */
+non_null(1, 2, 3)
 static bool sent_getnode_to_node(DHT *dht, const uint8_t *public_key, const IP_Port *node_ip_port, uint64_t ping_id)
 {
     uint8_t data[sizeof(Node_format) * 2];
@@ -1427,6 +1489,7 @@ static bool sent_getnode_to_node(DHT *dht, const uint8_t *public_key, const IP_P
     return true;
 }
 
+non_null(1, 2, 3, 5, 7)
 static int handle_sendnodes_core(void *object, const IP_Port *source, const uint8_t *packet, uint16_t length,
                                  Node_format *plain_nodes, uint16_t size_plain_nodes, uint32_t *num_nodes_out)
 {
@@ -1497,6 +1560,7 @@ static int handle_sendnodes_core(void *object, const IP_Port *source, const uint
     return 0;
 }
 
+non_null(1, 2, 3, 5)
 static int handle_sendnodes_ipv6(void *object, const IP_Port *source, const uint8_t *packet, uint16_t length,
                                  void *userdata)
 {
@@ -1525,6 +1589,7 @@ static int handle_sendnodes_ipv6(void *object, const IP_Port *source, const uint
 /*----------------------------------------------------------------------------------*/
 /*------------------------END of packet handling functions--------------------------*/
 
+nullable(2, 3, 5) non_null(1)
 static void dht_friend_lock(DHT_Friend *const dht_friend, dht_ip_cb *ip_callback,
                             void *data, int32_t number, uint16_t *lock_count)
 {
@@ -1539,6 +1604,7 @@ static void dht_friend_lock(DHT_Friend *const dht_friend, dht_ip_cb *ip_callback
     }
 }
 
+nullable(3, 4, 6) non_null(1, 2)
 int dht_addfriend(DHT *dht, const uint8_t *public_key, dht_ip_cb *ip_callback,
                   void *data, int32_t number, uint16_t *lock_count)
 {
@@ -1578,6 +1644,7 @@ int dht_addfriend(DHT *dht, const uint8_t *public_key, dht_ip_cb *ip_callback,
     return 0;
 }
 
+non_null(1, 2)
 int dht_delfriend(DHT *dht, const uint8_t *public_key, uint16_t lock_count)
 {
     const uint32_t friend_num = index_of_friend_pk(dht->friends_list, dht->num_friends, public_key);
@@ -1620,6 +1687,7 @@ int dht_delfriend(DHT *dht, const uint8_t *public_key, uint16_t lock_count)
 }
 
 /* TODO(irungentoo): Optimize this. */
+non_null(1, 2, 3)
 int dht_getfriendip(const DHT *dht, const uint8_t *public_key, IP_Port *ip_port)
 {
     ip_reset(&ip_port->ip);
@@ -1654,6 +1722,7 @@ int dht_getfriendip(const DHT *dht, const uint8_t *public_key, IP_Port *ip_port)
 }
 
 /** returns number of nodes not in kill-timeout */
+non_null(1, 2, 3, 4, 6)
 static uint8_t do_ping_and_sendnode_requests(DHT *dht, uint64_t *lastgetnode, const uint8_t *public_key,
         Client_data *list, uint32_t list_count, uint32_t *bootstrap_times, bool sortable)
 {
@@ -1725,6 +1794,7 @@ static uint8_t do_ping_and_sendnode_requests(DHT *dht, uint64_t *lastgetnode, co
 /** Ping each client in the "friends" list every PING_INTERVAL seconds. Send a get nodes request
  * every GET_NODE_INTERVAL seconds to a random good node for each "friend" in our "friends" list.
  */
+non_null(1)
 static void do_dht_friends(DHT *dht)
 {
     for (size_t i = 0; i < dht->num_friends; ++i) {
@@ -1745,6 +1815,7 @@ static void do_dht_friends(DHT *dht)
 /** Ping each client in the close nodes list every PING_INTERVAL seconds.
  * Send a get nodes request every GET_NODE_INTERVAL seconds to a random good node in the list.
  */
+non_null(1)
 static void do_Close(DHT *dht)
 {
     for (size_t i = 0; i < dht->num_to_bootstrap; ++i) {
@@ -1784,11 +1855,13 @@ static void do_Close(DHT *dht)
     }
 }
 
+non_null(1, 2, 3)
 void dht_bootstrap(DHT *dht, const IP_Port *ip_port, const uint8_t *public_key)
 {
     dht_getnodes(dht, ip_port, public_key, dht->self_public_key);
 }
 
+non_null(1, 2, 5)
 int dht_bootstrap_from_address(DHT *dht, const char *address, uint8_t ipv6enabled,
                                uint16_t port, const uint8_t *public_key)
 {
@@ -1823,6 +1896,7 @@ int dht_bootstrap_from_address(DHT *dht, const char *address, uint8_t ipv6enable
  *
  *  return -1 if failure.
  */
+non_null(1, 2, 3)
 int route_packet(const DHT *dht, const uint8_t *public_key, const uint8_t *packet, uint16_t length)
 {
     for (uint32_t i = 0; i < LCLIENT_LIST; ++i) {
@@ -1852,6 +1926,7 @@ int route_packet(const DHT *dht, const uint8_t *public_key, const uint8_t *packe
  *  return 0 if we are connected to friend or if no ips were found.
  *  return -1 if no such friend.
  */
+non_null(1, 2)
 static int friend_iplist(const DHT *dht, IP_Port *ip_portlist, uint16_t friend_num)
 {
     if (friend_num >= dht->num_friends) {
@@ -1946,6 +2021,7 @@ typedef bool foreach_ip_port_cb(const DHT *dht, const IP_Port *ip_port, uint32_t
  * @param callback The callback to invoke for each IP/port.
  * @param userdata Extra pointer passed to the callback.
  */
+non_null(1, 2, 3, 4)
 static uint32_t foreach_ip_port(const DHT *dht, const DHT_Friend *dht_friend,
                                 foreach_ip_port_cb *callback, void *userdata)
 {
@@ -1977,6 +2053,7 @@ static uint32_t foreach_ip_port(const DHT *dht, const DHT_Friend *dht_friend,
     return n;
 }
 
+non_null(1, 2, 3, 4)
 static bool send_packet_to_friend(const DHT *dht, const IP_Port *ip_port, uint32_t *n, void *userdata)
 {
     const Packet *packet = (const Packet *)userdata;
@@ -1997,6 +2074,7 @@ static bool send_packet_to_friend(const DHT *dht, const IP_Port *ip_port, uint32
  *  return ip for friend.
  *  return number of nodes the packet was sent to. (Only works if more than (MAX_FRIEND_CLIENTS / 4).
  */
+non_null(1, 2, 3)
 uint32_t route_to_friend(const DHT *dht, const uint8_t *friend_id, const Packet *packet)
 {
     const uint32_t num = index_of_friend_pk(dht->friends_list, dht->num_friends, friend_id);
@@ -2019,6 +2097,7 @@ uint32_t route_to_friend(const DHT *dht, const uint8_t *friend_id, const Packet 
     return foreach_ip_port(dht, dht_friend, send_packet_to_friend, &packet_userdata);
 }
 
+non_null(1, 2, 3, 4)
 static bool get_ip_port(const DHT *dht, const IP_Port *ip_port, uint32_t *n, void *userdata)
 {
     IP_Port *ip_list = (IP_Port *)userdata;
@@ -2031,6 +2110,7 @@ static bool get_ip_port(const DHT *dht, const IP_Port *ip_port, uint32_t *n, voi
  *
  *  return number of nodes the packet was sent to.
  */
+non_null(1, 2, 3)
 static uint32_t routeone_to_friend(const DHT *dht, const uint8_t *friend_id, const Packet *packet)
 {
     const uint32_t num = index_of_friend_pk(dht->friends_list, dht->num_friends, friend_id);
@@ -2062,6 +2142,7 @@ static uint32_t routeone_to_friend(const DHT *dht, const uint8_t *friend_id, con
 /*----------------------------------------------------------------------------------*/
 /*---------------------BEGINNING OF NAT PUNCHING FUNCTIONS--------------------------*/
 
+non_null(1, 2)
 static int send_NATping(const DHT *dht, const uint8_t *public_key, uint64_t ping_id, uint8_t type)
 {
     uint8_t data[sizeof(uint64_t) + 1];
@@ -2096,6 +2177,7 @@ static int send_NATping(const DHT *dht, const uint8_t *public_key, uint64_t ping
 }
 
 /** Handle a received ping request for. */
+non_null(1, 2, 3, 4, 6)
 static int handle_NATping(void *object, const IP_Port *source, const uint8_t *source_pubkey, const uint8_t *packet,
                           uint16_t length, void *userdata)
 {
@@ -2139,6 +2221,7 @@ static int handle_NATping(void *object, const IP_Port *source, const uint8_t *so
  *
  *  return ip of 0 if failure.
  */
+non_null(1)
 static IP nat_commonip(const IP_Port *ip_portlist, uint16_t len, uint16_t min_num)
 {
     IP zero;
@@ -2171,6 +2254,7 @@ static IP nat_commonip(const IP_Port *ip_portlist, uint16_t len, uint16_t min_nu
  *
  *  return number of ports and puts the list of ports in portlist.
  */
+non_null(1, 2, 4)
 static uint16_t nat_getports(uint16_t *portlist, const IP_Port *ip_portlist, uint16_t len, const IP *ip)
 {
     uint16_t num = 0;
@@ -2185,6 +2269,7 @@ static uint16_t nat_getports(uint16_t *portlist, const IP_Port *ip_portlist, uin
     return num;
 }
 
+non_null(1, 2)
 static void punch_holes(DHT *dht, const IP *ip, const uint16_t *port_list, uint16_t numports, uint16_t friend_num)
 {
     if (!dht->hole_punching_enabled) {
@@ -2243,6 +2328,7 @@ static void punch_holes(DHT *dht, const IP *ip, const uint16_t *port_list, uint1
     ++dht->friends_list[friend_num].nat.tries;
 }
 
+non_null(1)
 static void do_NAT(DHT *dht)
 {
     const uint64_t temp_time = mono_time_get(dht->mono_time);
@@ -2294,6 +2380,7 @@ static void do_NAT(DHT *dht)
  *
  * return the number of nodes.
  */
+non_null(1, 4)
 static uint16_t list_nodes(const Client_data *list, size_t length, uint64_t cur_time,
                            Node_format *nodes, uint16_t max_num)
 {
@@ -2336,6 +2423,7 @@ static uint16_t list_nodes(const Client_data *list, size_t length, uint64_t cur_
  *
  * return the number of nodes.
  */
+non_null(1, 2)
 uint16_t randfriends_nodes(const DHT *dht, Node_format *nodes, uint16_t max_num)
 {
     if (max_num == 0) {
@@ -2361,6 +2449,7 @@ uint16_t randfriends_nodes(const DHT *dht, Node_format *nodes, uint16_t max_num)
  *
  * return the number of nodes.
  */
+non_null(1, 2)
 uint16_t closelist_nodes(const DHT *dht, Node_format *nodes, uint16_t max_num)
 {
     return list_nodes(dht->close_clientlist, LCLIENT_LIST, dht->cur_time, nodes, max_num);
@@ -2368,12 +2457,14 @@ uint16_t closelist_nodes(const DHT *dht, Node_format *nodes, uint16_t max_num)
 
 /*----------------------------------------------------------------------------------*/
 
+nullable(3, 4) non_null(1)
 void cryptopacket_registerhandler(DHT *dht, uint8_t byte, cryptopacket_handler_cb *cb, void *object)
 {
     dht->cryptopackethandlers[byte].function = cb;
     dht->cryptopackethandlers[byte].object = object;
 }
 
+non_null(1, 2, 3, 5)
 static int cryptopacket_handle(void *object, const IP_Port *source, const uint8_t *packet, uint16_t length,
                                void *userdata)
 {
@@ -2419,6 +2510,7 @@ static int cryptopacket_handle(void *object, const IP_Port *source, const uint8_
 
 /*----------------------------------------------------------------------------------*/
 
+non_null(1, 2, 3)
 DHT *new_dht(const Logger *log, Mono_Time *mono_time, Networking_Core *net, bool holepunching_enabled)
 {
     if (net == nullptr) {
@@ -2474,6 +2566,7 @@ DHT *new_dht(const Logger *log, Mono_Time *mono_time, Networking_Core *net, bool
     return dht;
 }
 
+non_null(1)
 void do_dht(DHT *dht)
 {
     const uint64_t cur_time = mono_time_get(dht->mono_time);
@@ -2495,6 +2588,7 @@ void do_dht(DHT *dht)
     ping_iterate(dht->ping);
 }
 
+non_null(1)
 void kill_dht(DHT *dht)
 {
     networking_registerhandler(dht->net, NET_PACKET_GET_NODES, nullptr, nullptr);
@@ -2520,6 +2614,7 @@ void kill_dht(DHT *dht)
 #define MAX_SAVED_DHT_NODES (((DHT_FAKE_FRIEND_NUMBER * MAX_FRIEND_CLIENTS) + LCLIENT_LIST) * 2)
 
 /** Get the size of the DHT (for saving). */
+non_null(1)
 uint32_t dht_size(const DHT *dht)
 {
     uint32_t numv4 = 0;
@@ -2551,6 +2646,7 @@ uint32_t dht_size(const DHT *dht)
 }
 
 /** Save the DHT in data where data is an array of size dht_size(). */
+non_null(1, 2)
 void dht_save(const DHT *dht, uint8_t *data)
 {
     host_to_lendian_bytes32(data, DHT_STATE_COOKIE_GLOBAL);
@@ -2621,6 +2717,7 @@ void dht_save(const DHT *dht, uint8_t *data)
  * returns 0 if successful
  * returns -1 otherwise
  */
+non_null(1)
 int dht_connect_after_load(DHT *dht)
 {
     if (dht == nullptr) {
@@ -2648,6 +2745,7 @@ int dht_connect_after_load(DHT *dht)
     return 0;
 }
 
+non_null(1, 2)
 static State_Load_Status dht_load_state_callback(void *outer, const uint8_t *data, uint32_t length, uint16_t type)
 {
     DHT *dht = (DHT *)outer;
@@ -2694,6 +2792,7 @@ static State_Load_Status dht_load_state_callback(void *outer, const uint8_t *dat
  *  return -1 if failure.
  *  return 0 if success.
  */
+non_null(1, 2)
 int dht_load(DHT *dht, const uint8_t *data, uint32_t length)
 {
     const uint32_t cookie_len = sizeof(uint32_t);
@@ -2714,6 +2813,7 @@ int dht_load(DHT *dht, const uint8_t *data, uint32_t length)
 /**  return false if we are not connected to the DHT.
  *  return true if we are.
  */
+non_null(1)
 bool dht_isconnected(const DHT *dht)
 {
     for (uint32_t i = 0; i < LCLIENT_LIST; ++i) {
@@ -2731,6 +2831,7 @@ bool dht_isconnected(const DHT *dht)
 /**  return false if we are not connected or only connected to lan peers with the DHT.
  *  return true if we are.
  */
+non_null(1)
 bool dht_non_lan_connected(const DHT *dht)
 {
     for (uint32_t i = 0; i < LCLIENT_LIST; ++i) {
@@ -2758,6 +2859,7 @@ bool dht_non_lan_connected(const DHT *dht)
  * Return 1 if IP is a WAN address.
  * Return 2 if IP is a LAN address.
  */
+non_null(1, 2)
 unsigned int ipport_self_copy(const DHT *dht, IP_Port *dest)
 {
     ipport_reset(dest);

--- a/toxcore/ccompat.h
+++ b/toxcore/ccompat.h
@@ -63,9 +63,13 @@ bool unused_for_tokstyle(void);
 
 #ifdef __GNUC__
 #define GNU_PRINTF(f, a) __attribute__((__format__(__printf__, f, a)))
+#define non_null(...) __attribute__((__nonnull__(__VA_ARGS__)))
 #else
 #define GNU_PRINTF(f, a)
+#define non_null(...)
 #endif
+
+#define nullable(...)
 
 //!TOKSTYLE+
 

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -80,6 +80,7 @@ static void crypto_free(uint8_t *ptr, size_t bytes)
 }
 #endif  // !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 
+non_null(1)
 void crypto_memzero(void *data, size_t length)
 {
 #ifndef VANILLA_NACL
@@ -89,6 +90,7 @@ void crypto_memzero(void *data, size_t length)
 #endif
 }
 
+non_null(1)
 bool crypto_memlock(void *data, size_t length)
 {
 #ifndef VANILLA_NACL
@@ -103,6 +105,7 @@ bool crypto_memlock(void *data, size_t length)
 #endif
 }
 
+non_null(1)
 bool crypto_memunlock(void *data, size_t length)
 {
 #ifndef VANILLA_NACL
@@ -117,6 +120,7 @@ bool crypto_memunlock(void *data, size_t length)
 #endif
 }
 
+non_null(1, 2)
 int32_t public_key_cmp(const uint8_t *pk1, const uint8_t *pk2)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
@@ -127,6 +131,7 @@ int32_t public_key_cmp(const uint8_t *pk1, const uint8_t *pk2)
 #endif
 }
 
+non_null(1, 2)
 int32_t crypto_sha512_cmp(const uint8_t *cksum1, const uint8_t *cksum2)
 {
 #ifndef VANILLA_NACL
@@ -173,6 +178,7 @@ uint32_t random_range_u32(uint32_t upper_bound)
 #endif  // VANILLA_NACL
 }
 
+non_null(1)
 bool public_key_valid(const uint8_t *public_key)
 {
     if (public_key[31] >= 128) { /* Last bit of key is always zero. */
@@ -182,12 +188,14 @@ bool public_key_valid(const uint8_t *public_key)
     return 1;
 }
 
+non_null(1, 2, 3)
 int32_t encrypt_precompute(const uint8_t *public_key, const uint8_t *secret_key,
                            uint8_t *shared_key)
 {
     return crypto_box_beforenm(shared_key, public_key, secret_key);
 }
 
+non_null(1, 2, 3, 5)
 int32_t encrypt_data_symmetric(const uint8_t *secret_key, const uint8_t *nonce,
                                const uint8_t *plain, size_t length, uint8_t *encrypted)
 {
@@ -239,6 +247,7 @@ int32_t encrypt_data_symmetric(const uint8_t *secret_key, const uint8_t *nonce,
     return length + crypto_box_MACBYTES;
 }
 
+non_null(1, 2, 3, 5)
 int32_t decrypt_data_symmetric(const uint8_t *secret_key, const uint8_t *nonce,
                                const uint8_t *encrypted, size_t length, uint8_t *plain)
 {
@@ -287,6 +296,7 @@ int32_t decrypt_data_symmetric(const uint8_t *secret_key, const uint8_t *nonce,
     return length - crypto_box_MACBYTES;
 }
 
+non_null(1, 2, 3, 4, 6)
 int32_t encrypt_data(const uint8_t *public_key, const uint8_t *secret_key, const uint8_t *nonce,
                      const uint8_t *plain, size_t length, uint8_t *encrypted)
 {
@@ -301,6 +311,7 @@ int32_t encrypt_data(const uint8_t *public_key, const uint8_t *secret_key, const
     return ret;
 }
 
+non_null(1, 2, 3, 4, 6)
 int32_t decrypt_data(const uint8_t *public_key, const uint8_t *secret_key, const uint8_t *nonce,
                      const uint8_t *encrypted, size_t length, uint8_t *plain)
 {
@@ -315,6 +326,7 @@ int32_t decrypt_data(const uint8_t *public_key, const uint8_t *secret_key, const
     return ret;
 }
 
+non_null(1)
 void increment_nonce(uint8_t *nonce)
 {
     /* TODO(irungentoo): use `increment_nonce_number(nonce, 1)` or
@@ -334,6 +346,7 @@ void increment_nonce(uint8_t *nonce)
     }
 }
 
+non_null(1)
 void increment_nonce_number(uint8_t *nonce, uint32_t increment)
 {
     /* NOTE don't use breaks inside this loop
@@ -356,16 +369,19 @@ void increment_nonce_number(uint8_t *nonce, uint32_t increment)
     }
 }
 
+non_null(1)
 void random_nonce(uint8_t *nonce)
 {
     random_bytes(nonce, crypto_box_NONCEBYTES);
 }
 
+non_null(1)
 void new_symmetric_key(uint8_t *key)
 {
     random_bytes(key, CRYPTO_SYMMETRIC_KEY_SIZE);
 }
 
+non_null(1, 2)
 int32_t crypto_new_keypair(uint8_t *public_key, uint8_t *secret_key)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
@@ -378,21 +394,25 @@ int32_t crypto_new_keypair(uint8_t *public_key, uint8_t *secret_key)
 #endif
 }
 
+non_null(1, 2)
 void crypto_derive_public_key(uint8_t *public_key, const uint8_t *secret_key)
 {
     crypto_scalarmult_curve25519_base(public_key, secret_key);
 }
 
+non_null(1, 2)
 void crypto_sha256(uint8_t *hash, const uint8_t *data, size_t length)
 {
     crypto_hash_sha256(hash, data, length);
 }
 
+non_null(1, 2)
 void crypto_sha512(uint8_t *hash, const uint8_t *data, size_t length)
 {
     crypto_hash_sha512(hash, data, length);
 }
 
+non_null(1)
 void random_bytes(uint8_t *data, size_t length)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -637,6 +637,7 @@ static void end_save(uint8_t *data)
     state_write_section_header(data, STATE_COOKIE_TYPE, 0, STATE_TYPE_END);
 }
 
+non_null(1)
 size_t tox_get_savedata_size(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -649,6 +650,7 @@ size_t tox_get_savedata_size(const Tox *tox)
     return ret;
 }
 
+non_null(1)
 void tox_get_savedata(const Tox *tox, uint8_t *savedata)
 {
     assert(tox != nullptr);
@@ -676,6 +678,7 @@ void tox_get_savedata(const Tox *tox, uint8_t *savedata)
     unlock(tox);
 }
 
+non_null(1)
 bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key, Tox_Err_Bootstrap *error)
 {
     assert(tox != nullptr);
@@ -727,6 +730,7 @@ bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t *pub
     return 0;
 }
 
+non_null(1)
 bool tox_add_tcp_relay(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key,
                        Tox_Err_Bootstrap *error)
 {
@@ -773,6 +777,7 @@ bool tox_add_tcp_relay(Tox *tox, const char *host, uint16_t port, const uint8_t 
     return 0;
 }
 
+non_null(1)
 Tox_Connection tox_self_get_connection_status(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -792,12 +797,14 @@ Tox_Connection tox_self_get_connection_status(const Tox *tox)
 }
 
 
+non_null(1)
 void tox_callback_self_connection_status(Tox *tox, tox_self_connection_status_cb *callback)
 {
     assert(tox != nullptr);
     tox->self_connection_status_callback = callback;
 }
 
+non_null(1)
 uint32_t tox_iteration_interval(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -807,6 +814,7 @@ uint32_t tox_iteration_interval(const Tox *tox)
     return ret;
 }
 
+non_null(1)
 void tox_iterate(Tox *tox, void *user_data)
 {
     assert(tox != nullptr);
@@ -821,6 +829,7 @@ void tox_iterate(Tox *tox, void *user_data)
     unlock(tox);
 }
 
+non_null(1)
 void tox_self_get_address(const Tox *tox, uint8_t *address)
 {
     assert(tox != nullptr);
@@ -832,6 +841,7 @@ void tox_self_get_address(const Tox *tox, uint8_t *address)
     }
 }
 
+non_null(1)
 void tox_self_set_nospam(Tox *tox, uint32_t nospam)
 {
     assert(tox != nullptr);
@@ -840,6 +850,7 @@ void tox_self_set_nospam(Tox *tox, uint32_t nospam)
     unlock(tox);
 }
 
+non_null(1)
 uint32_t tox_self_get_nospam(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -849,6 +860,7 @@ uint32_t tox_self_get_nospam(const Tox *tox)
     return ret;
 }
 
+non_null(1)
 void tox_self_get_public_key(const Tox *tox, uint8_t *public_key)
 {
     assert(tox != nullptr);
@@ -860,6 +872,7 @@ void tox_self_get_public_key(const Tox *tox, uint8_t *public_key)
     }
 }
 
+non_null(1)
 void tox_self_get_secret_key(const Tox *tox, uint8_t *secret_key)
 {
     assert(tox != nullptr);
@@ -871,6 +884,7 @@ void tox_self_get_secret_key(const Tox *tox, uint8_t *secret_key)
     }
 }
 
+non_null(1)
 bool tox_self_set_name(Tox *tox, const uint8_t *name, size_t length, Tox_Err_Set_Info *error)
 {
     assert(tox != nullptr);
@@ -895,6 +909,7 @@ bool tox_self_set_name(Tox *tox, const uint8_t *name, size_t length, Tox_Err_Set
     return 0;
 }
 
+non_null(1)
 size_t tox_self_get_name_size(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -904,6 +919,7 @@ size_t tox_self_get_name_size(const Tox *tox)
     return ret;
 }
 
+non_null(1)
 void tox_self_get_name(const Tox *tox, uint8_t *name)
 {
     assert(tox != nullptr);
@@ -915,6 +931,7 @@ void tox_self_get_name(const Tox *tox, uint8_t *name)
     }
 }
 
+non_null(1)
 bool tox_self_set_status_message(Tox *tox, const uint8_t *status_message, size_t length, Tox_Err_Set_Info *error)
 {
     assert(tox != nullptr);
@@ -937,6 +954,7 @@ bool tox_self_set_status_message(Tox *tox, const uint8_t *status_message, size_t
     return 0;
 }
 
+non_null(1)
 size_t tox_self_get_status_message_size(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -946,6 +964,7 @@ size_t tox_self_get_status_message_size(const Tox *tox)
     return ret;
 }
 
+non_null(1)
 void tox_self_get_status_message(const Tox *tox, uint8_t *status_message)
 {
     assert(tox != nullptr);
@@ -957,6 +976,7 @@ void tox_self_get_status_message(const Tox *tox, uint8_t *status_message)
     }
 }
 
+non_null(1)
 void tox_self_set_status(Tox *tox, Tox_User_Status status)
 {
     assert(tox != nullptr);
@@ -965,6 +985,7 @@ void tox_self_set_status(Tox *tox, Tox_User_Status status)
     unlock(tox);
 }
 
+non_null(1)
 Tox_User_Status tox_self_get_status(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -1020,6 +1041,7 @@ static void set_friend_error(const Logger *log, int32_t ret, Tox_Err_Friend_Add 
     }
 }
 
+non_null(1)
 uint32_t tox_friend_add(Tox *tox, const uint8_t *address, const uint8_t *message, size_t length,
                         Tox_Err_Friend_Add *error)
 {
@@ -1044,6 +1066,7 @@ uint32_t tox_friend_add(Tox *tox, const uint8_t *address, const uint8_t *message
     return UINT32_MAX;
 }
 
+non_null(1)
 uint32_t tox_friend_add_norequest(Tox *tox, const uint8_t *public_key, Tox_Err_Friend_Add *error)
 {
     assert(tox != nullptr);
@@ -1067,6 +1090,7 @@ uint32_t tox_friend_add_norequest(Tox *tox, const uint8_t *public_key, Tox_Err_F
     return UINT32_MAX;
 }
 
+non_null(1)
 bool tox_friend_delete(Tox *tox, uint32_t friend_number, Tox_Err_Friend_Delete *error)
 {
     assert(tox != nullptr);
@@ -1084,6 +1108,7 @@ bool tox_friend_delete(Tox *tox, uint32_t friend_number, Tox_Err_Friend_Delete *
     return 1;
 }
 
+non_null(1)
 uint32_t tox_friend_by_public_key(const Tox *tox, const uint8_t *public_key, Tox_Err_Friend_By_Public_Key *error)
 {
     assert(tox != nullptr);
@@ -1106,6 +1131,7 @@ uint32_t tox_friend_by_public_key(const Tox *tox, const uint8_t *public_key, Tox
     return ret;
 }
 
+non_null(1)
 bool tox_friend_get_public_key(const Tox *tox, uint32_t friend_number, uint8_t *public_key,
                                Tox_Err_Friend_Get_Public_Key *error)
 {
@@ -1128,6 +1154,7 @@ bool tox_friend_get_public_key(const Tox *tox, uint32_t friend_number, uint8_t *
     return 1;
 }
 
+non_null(1)
 bool tox_friend_exists(const Tox *tox, uint32_t friend_number)
 {
     assert(tox != nullptr);
@@ -1137,6 +1164,7 @@ bool tox_friend_exists(const Tox *tox, uint32_t friend_number)
     return ret;
 }
 
+non_null(1)
 uint64_t tox_friend_get_last_online(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Get_Last_Online *error)
 {
     assert(tox != nullptr);
@@ -1153,6 +1181,7 @@ uint64_t tox_friend_get_last_online(const Tox *tox, uint32_t friend_number, Tox_
     return timestamp;
 }
 
+non_null(1)
 size_t tox_self_get_friend_list_size(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -1162,6 +1191,7 @@ size_t tox_self_get_friend_list_size(const Tox *tox)
     return ret;
 }
 
+non_null(1)
 void tox_self_get_friend_list(const Tox *tox, uint32_t *friend_list)
 {
     assert(tox != nullptr);
@@ -1174,6 +1204,7 @@ void tox_self_get_friend_list(const Tox *tox, uint32_t *friend_list)
     }
 }
 
+non_null(1)
 size_t tox_friend_get_name_size(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error)
 {
     assert(tox != nullptr);
@@ -1190,6 +1221,7 @@ size_t tox_friend_get_name_size(const Tox *tox, uint32_t friend_number, Tox_Err_
     return ret;
 }
 
+non_null(1)
 bool tox_friend_get_name(const Tox *tox, uint32_t friend_number, uint8_t *name, Tox_Err_Friend_Query *error)
 {
     assert(tox != nullptr);
@@ -1212,12 +1244,14 @@ bool tox_friend_get_name(const Tox *tox, uint32_t friend_number, uint8_t *name, 
     return 1;
 }
 
+non_null(1)
 void tox_callback_friend_name(Tox *tox, tox_friend_name_cb *callback)
 {
     assert(tox != nullptr);
     tox->friend_name_callback = callback;
 }
 
+non_null(1)
 size_t tox_friend_get_status_message_size(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error)
 {
     assert(tox != nullptr);
@@ -1234,6 +1268,7 @@ size_t tox_friend_get_status_message_size(const Tox *tox, uint32_t friend_number
     return ret;
 }
 
+non_null(1)
 bool tox_friend_get_status_message(const Tox *tox, uint32_t friend_number, uint8_t *status_message,
                                    Tox_Err_Friend_Query *error)
 {
@@ -1261,12 +1296,14 @@ bool tox_friend_get_status_message(const Tox *tox, uint32_t friend_number, uint8
     return ret == size;
 }
 
+non_null(1)
 void tox_callback_friend_status_message(Tox *tox, tox_friend_status_message_cb *callback)
 {
     assert(tox != nullptr);
     tox->friend_status_message_callback = callback;
 }
 
+non_null(1)
 Tox_User_Status tox_friend_get_status(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error)
 {
     assert(tox != nullptr);
@@ -1283,12 +1320,14 @@ Tox_User_Status tox_friend_get_status(const Tox *tox, uint32_t friend_number, To
     return (Tox_User_Status)ret;
 }
 
+non_null(1)
 void tox_callback_friend_status(Tox *tox, tox_friend_status_cb *callback)
 {
     assert(tox != nullptr);
     tox->friend_status_callback = callback;
 }
 
+non_null(1)
 Tox_Connection tox_friend_get_connection_status(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error)
 {
     assert(tox != nullptr);
@@ -1305,12 +1344,14 @@ Tox_Connection tox_friend_get_connection_status(const Tox *tox, uint32_t friend_
     return (Tox_Connection)ret;
 }
 
+non_null(1)
 void tox_callback_friend_connection_status(Tox *tox, tox_friend_connection_status_cb *callback)
 {
     assert(tox != nullptr);
     tox->friend_connection_status_callback = callback;
 }
 
+non_null(1)
 bool tox_friend_get_typing(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error)
 {
     assert(tox != nullptr);
@@ -1327,12 +1368,14 @@ bool tox_friend_get_typing(const Tox *tox, uint32_t friend_number, Tox_Err_Frien
     return !!ret;
 }
 
+non_null(1)
 void tox_callback_friend_typing(Tox *tox, tox_friend_typing_cb *callback)
 {
     assert(tox != nullptr);
     tox->friend_typing_callback = callback;
 }
 
+non_null(1)
 bool tox_self_set_typing(Tox *tox, uint32_t friend_number, bool typing, Tox_Err_Set_Typing *error)
 {
     assert(tox != nullptr);
@@ -1390,6 +1433,7 @@ static void set_message_error(const Logger *log, int ret, Tox_Err_Friend_Send_Me
     }
 }
 
+non_null(1)
 uint32_t tox_friend_send_message(Tox *tox, uint32_t friend_number, Tox_Message_Type type, const uint8_t *message,
                                  size_t length, Tox_Err_Friend_Send_Message *error)
 {
@@ -1413,18 +1457,21 @@ uint32_t tox_friend_send_message(Tox *tox, uint32_t friend_number, Tox_Message_T
     return message_id;
 }
 
+non_null(1)
 void tox_callback_friend_read_receipt(Tox *tox, tox_friend_read_receipt_cb *callback)
 {
     assert(tox != nullptr);
     tox->friend_read_receipt_callback = callback;
 }
 
+non_null(1)
 void tox_callback_friend_request(Tox *tox, tox_friend_request_cb *callback)
 {
     assert(tox != nullptr);
     tox->friend_request_callback = callback;
 }
 
+non_null(1)
 void tox_callback_friend_message(Tox *tox, tox_friend_message_cb *callback)
 {
     assert(tox != nullptr);
@@ -1441,6 +1488,7 @@ bool tox_hash(uint8_t *hash, const uint8_t *data, size_t length)
     return 1;
 }
 
+non_null(1)
 bool tox_file_control(Tox *tox, uint32_t friend_number, uint32_t file_number, Tox_File_Control control,
                       Tox_Err_File_Control *error)
 {
@@ -1503,6 +1551,7 @@ bool tox_file_control(Tox *tox, uint32_t friend_number, uint32_t file_number, To
     return 0;
 }
 
+non_null(1)
 bool tox_file_seek(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position,
                    Tox_Err_File_Seek *error)
 {
@@ -1555,12 +1604,14 @@ bool tox_file_seek(Tox *tox, uint32_t friend_number, uint32_t file_number, uint6
     return 0;
 }
 
+non_null(1)
 void tox_callback_file_recv_control(Tox *tox, tox_file_recv_control_cb *callback)
 {
     assert(tox != nullptr);
     tox->file_recv_control_callback = callback;
 }
 
+non_null(1)
 bool tox_file_get_file_id(const Tox *tox, uint32_t friend_number, uint32_t file_number, uint8_t *file_id,
                           Tox_Err_File_Get *error)
 {
@@ -1589,6 +1640,7 @@ bool tox_file_get_file_id(const Tox *tox, uint32_t friend_number, uint32_t file_
     return 0;
 }
 
+non_null(1)
 uint32_t tox_file_send(Tox *tox, uint32_t friend_number, uint32_t kind, uint64_t file_size, const uint8_t *file_id,
                        const uint8_t *filename, size_t filename_length, Tox_Err_File_Send *error)
 {
@@ -1644,6 +1696,7 @@ uint32_t tox_file_send(Tox *tox, uint32_t friend_number, uint32_t kind, uint64_t
     return UINT32_MAX;
 }
 
+non_null(1)
 bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, const uint8_t *data,
                          size_t length, Tox_Err_File_Send_Chunk *error)
 {
@@ -1700,60 +1753,70 @@ bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number,
     return 0;
 }
 
+non_null(1)
 void tox_callback_file_chunk_request(Tox *tox, tox_file_chunk_request_cb *callback)
 {
     assert(tox != nullptr);
     tox->file_chunk_request_callback = callback;
 }
 
+non_null(1)
 void tox_callback_file_recv(Tox *tox, tox_file_recv_cb *callback)
 {
     assert(tox != nullptr);
     tox->file_recv_callback = callback;
 }
 
+non_null(1)
 void tox_callback_file_recv_chunk(Tox *tox, tox_file_recv_chunk_cb *callback)
 {
     assert(tox != nullptr);
     tox->file_recv_chunk_callback = callback;
 }
 
+non_null(1)
 void tox_callback_conference_invite(Tox *tox, tox_conference_invite_cb *callback)
 {
     assert(tox != nullptr);
     tox->conference_invite_callback = callback;
 }
 
+non_null(1)
 void tox_callback_conference_connected(Tox *tox, tox_conference_connected_cb *callback)
 {
     assert(tox != nullptr);
     tox->conference_connected_callback = callback;
 }
 
+non_null(1)
 void tox_callback_conference_message(Tox *tox, tox_conference_message_cb *callback)
 {
     assert(tox != nullptr);
     tox->conference_message_callback = callback;
 }
 
+non_null(1)
 void tox_callback_conference_title(Tox *tox, tox_conference_title_cb *callback)
 {
     assert(tox != nullptr);
     tox->conference_title_callback = callback;
 }
 
+non_null(1)
 void tox_callback_conference_peer_name(Tox *tox, tox_conference_peer_name_cb *callback)
 {
     assert(tox != nullptr);
     tox->conference_peer_name_callback = callback;
 }
 
+non_null(1)
 void tox_callback_conference_peer_list_changed(Tox *tox, tox_conference_peer_list_changed_cb *callback)
 {
     assert(tox != nullptr);
     tox->conference_peer_list_changed_callback = callback;
 }
 
+non_null(1)
 uint32_t tox_conference_new(Tox *tox, Tox_Err_Conference_New *error)
 {
     assert(tox != nullptr);
@@ -1770,6 +1833,7 @@ uint32_t tox_conference_new(Tox *tox, Tox_Err_Conference_New *error)
     return ret;
 }
 
+non_null(1)
 bool tox_conference_delete(Tox *tox, uint32_t conference_number, Tox_Err_Conference_Delete *error)
 {
     assert(tox != nullptr);
@@ -1786,6 +1850,7 @@ bool tox_conference_delete(Tox *tox, uint32_t conference_number, Tox_Err_Confere
     return true;
 }
 
+non_null(1)
 uint32_t tox_conference_peer_count(const Tox *tox, uint32_t conference_number, Tox_Err_Conference_Peer_Query *error)
 {
     assert(tox != nullptr);
@@ -1802,6 +1867,7 @@ uint32_t tox_conference_peer_count(const Tox *tox, uint32_t conference_number, T
     return ret;
 }
 
+non_null(1)
 size_t tox_conference_peer_get_name_size(const Tox *tox, uint32_t conference_number, uint32_t peer_number,
         Tox_Err_Conference_Peer_Query *error)
 {
@@ -1826,6 +1892,7 @@ size_t tox_conference_peer_get_name_size(const Tox *tox, uint32_t conference_num
     return ret;
 }
 
+non_null(1)
 bool tox_conference_peer_get_name(const Tox *tox, uint32_t conference_number, uint32_t peer_number, uint8_t *name,
                                   Tox_Err_Conference_Peer_Query *error)
 {
@@ -1850,6 +1917,7 @@ bool tox_conference_peer_get_name(const Tox *tox, uint32_t conference_number, ui
     return true;
 }
 
+non_null(1)
 bool tox_conference_peer_get_public_key(const Tox *tox, uint32_t conference_number, uint32_t peer_number,
                                         uint8_t *public_key, Tox_Err_Conference_Peer_Query *error)
 {
@@ -1874,6 +1942,7 @@ bool tox_conference_peer_get_public_key(const Tox *tox, uint32_t conference_numb
     return true;
 }
 
+non_null(1)
 bool tox_conference_peer_number_is_ours(const Tox *tox, uint32_t conference_number, uint32_t peer_number,
                                         Tox_Err_Conference_Peer_Query *error)
 {
@@ -1903,6 +1972,7 @@ bool tox_conference_peer_number_is_ours(const Tox *tox, uint32_t conference_numb
     return ret;
 }
 
+non_null(1)
 uint32_t tox_conference_offline_peer_count(const Tox *tox, uint32_t conference_number,
         Tox_Err_Conference_Peer_Query *error)
 {
@@ -1920,6 +1990,7 @@ uint32_t tox_conference_offline_peer_count(const Tox *tox, uint32_t conference_n
     return ret;
 }
 
+non_null(1)
 size_t tox_conference_offline_peer_get_name_size(const Tox *tox, uint32_t conference_number,
         uint32_t offline_peer_number,
         Tox_Err_Conference_Peer_Query *error)
@@ -1945,6 +2016,7 @@ size_t tox_conference_offline_peer_get_name_size(const Tox *tox, uint32_t confer
     return ret;
 }
 
+non_null(1)
 bool tox_conference_offline_peer_get_name(const Tox *tox, uint32_t conference_number, uint32_t offline_peer_number,
         uint8_t *name,
         Tox_Err_Conference_Peer_Query *error)
@@ -1970,6 +2042,7 @@ bool tox_conference_offline_peer_get_name(const Tox *tox, uint32_t conference_nu
     return true;
 }
 
+non_null(1)
 bool tox_conference_offline_peer_get_public_key(const Tox *tox, uint32_t conference_number,
         uint32_t offline_peer_number,
         uint8_t *public_key, Tox_Err_Conference_Peer_Query *error)
@@ -1995,6 +2068,7 @@ bool tox_conference_offline_peer_get_public_key(const Tox *tox, uint32_t confere
     return true;
 }
 
+non_null(1)
 uint64_t tox_conference_offline_peer_get_last_active(const Tox *tox, uint32_t conference_number,
         uint32_t offline_peer_number,
         Tox_Err_Conference_Peer_Query *error)
@@ -2022,6 +2096,7 @@ uint64_t tox_conference_offline_peer_get_last_active(const Tox *tox, uint32_t co
     return last_active;
 }
 
+non_null(1)
 bool tox_conference_set_max_offline(Tox *tox, uint32_t conference_number,
                                     uint32_t max_offline_peers,
                                     Tox_Err_Conference_Set_Max_Offline *error)
@@ -2040,6 +2115,7 @@ bool tox_conference_set_max_offline(Tox *tox, uint32_t conference_number,
     return true;
 }
 
+non_null(1)
 bool tox_conference_invite(Tox *tox, uint32_t friend_number, uint32_t conference_number,
                            Tox_Err_Conference_Invite *error)
 {
@@ -2069,6 +2145,7 @@ bool tox_conference_invite(Tox *tox, uint32_t friend_number, uint32_t conference
     return true;
 }
 
+non_null(1)
 uint32_t tox_conference_join(Tox *tox, uint32_t friend_number, const uint8_t *cookie, size_t length,
                              Tox_Err_Conference_Join *error)
 {
@@ -2113,6 +2190,7 @@ uint32_t tox_conference_join(Tox *tox, uint32_t friend_number, const uint8_t *co
     return ret;
 }
 
+non_null(1)
 bool tox_conference_send_message(Tox *tox, uint32_t conference_number, Tox_Message_Type type, const uint8_t *message,
                                  size_t length, Tox_Err_Conference_Send_Message *error)
 {
@@ -2154,6 +2232,7 @@ bool tox_conference_send_message(Tox *tox, uint32_t conference_number, Tox_Messa
     return true;
 }
 
+non_null(1)
 size_t tox_conference_get_title_size(const Tox *tox, uint32_t conference_number, Tox_Err_Conference_Title *error)
 {
     assert(tox != nullptr);
@@ -2177,6 +2256,7 @@ size_t tox_conference_get_title_size(const Tox *tox, uint32_t conference_number,
     return ret;
 }
 
+non_null(1)
 bool tox_conference_get_title(const Tox *tox, uint32_t conference_number, uint8_t *title,
                               Tox_Err_Conference_Title *error)
 {
@@ -2201,6 +2281,7 @@ bool tox_conference_get_title(const Tox *tox, uint32_t conference_number, uint8_
     return true;
 }
 
+non_null(1)
 bool tox_conference_set_title(Tox *tox, uint32_t conference_number, const uint8_t *title, size_t length,
                               Tox_Err_Conference_Title *error)
 {
@@ -2230,6 +2311,7 @@ bool tox_conference_set_title(Tox *tox, uint32_t conference_number, const uint8_
     return true;
 }
 
+non_null(1)
 size_t tox_conference_get_chatlist_size(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -2239,6 +2321,7 @@ size_t tox_conference_get_chatlist_size(const Tox *tox)
     return ret;
 }
 
+non_null(1)
 void tox_conference_get_chatlist(const Tox *tox, uint32_t *chatlist)
 {
     assert(tox != nullptr);
@@ -2248,6 +2331,7 @@ void tox_conference_get_chatlist(const Tox *tox, uint32_t *chatlist)
     unlock(tox);
 }
 
+non_null(1)
 Tox_Conference_Type tox_conference_get_type(const Tox *tox, uint32_t conference_number,
         Tox_Err_Conference_Get_Type *error)
 {
@@ -2265,6 +2349,7 @@ Tox_Conference_Type tox_conference_get_type(const Tox *tox, uint32_t conference_
     return (Tox_Conference_Type)ret;
 }
 
+non_null(1)
 bool tox_conference_get_id(const Tox *tox, uint32_t conference_number, uint8_t *id)
 {
     assert(tox != nullptr);
@@ -2275,12 +2360,14 @@ bool tox_conference_get_id(const Tox *tox, uint32_t conference_number, uint8_t *
 }
 
 // TODO(iphydf): Delete in 0.3.0.
+non_null(1)
 bool tox_conference_get_uid(const Tox *tox, uint32_t conference_number, uint8_t *uid)
 {
     assert(tox != nullptr);
     return tox_conference_get_id(tox, conference_number, uid);
 }
 
+non_null(1)
 uint32_t tox_conference_by_id(const Tox *tox, const uint8_t *id, Tox_Err_Conference_By_Id *error)
 {
     assert(tox != nullptr);
@@ -2304,6 +2391,7 @@ uint32_t tox_conference_by_id(const Tox *tox, const uint8_t *id, Tox_Err_Confere
 }
 
 // TODO(iphydf): Delete in 0.3.0.
+non_null(1)
 uint32_t tox_conference_by_uid(const Tox *tox, const uint8_t *uid, Tox_Err_Conference_By_Uid *error)
 {
     assert(tox != nullptr);
@@ -2365,6 +2453,7 @@ static void set_custom_packet_error(int ret, Tox_Err_Friend_Custom_Packet *error
     }
 }
 
+non_null(1)
 bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
                                   Tox_Err_Friend_Custom_Packet *error)
 {
@@ -2398,6 +2487,7 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
     return 0;
 }
 
+non_null(1)
 void tox_callback_friend_lossy_packet(Tox *tox, tox_friend_lossy_packet_cb *callback)
 {
     assert(tox != nullptr);
@@ -2408,6 +2498,7 @@ void tox_callback_friend_lossy_packet(Tox *tox, tox_friend_lossy_packet_cb *call
     }
 }
 
+non_null(1)
 void tox_callback_friend_lossy_packet_per_pktid(Tox *tox, tox_friend_lossy_packet_cb *callback, uint8_t pktid)
 {
     assert(tox != nullptr);
@@ -2417,6 +2508,7 @@ void tox_callback_friend_lossy_packet_per_pktid(Tox *tox, tox_friend_lossy_packe
     }
 }
 
+non_null(1)
 bool tox_friend_send_lossless_packet(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
                                      Tox_Err_Friend_Custom_Packet *error)
 {
@@ -2445,6 +2537,7 @@ bool tox_friend_send_lossless_packet(Tox *tox, uint32_t friend_number, const uin
     return 0;
 }
 
+non_null(1)
 void tox_callback_friend_lossless_packet(Tox *tox, tox_friend_lossless_packet_cb *callback)
 {
     assert(tox != nullptr);
@@ -2454,6 +2547,7 @@ void tox_callback_friend_lossless_packet(Tox *tox, tox_friend_lossless_packet_cb
     }
 }
 
+non_null(1)
 void tox_callback_friend_lossless_packet_per_pktid(Tox *tox, tox_friend_lossless_packet_cb *callback, uint8_t pktid)
 {
     assert(tox != nullptr);
@@ -2464,6 +2558,7 @@ void tox_callback_friend_lossless_packet_per_pktid(Tox *tox, tox_friend_lossless
     }
 }
 
+non_null(1)
 void tox_self_get_dht_id(const Tox *tox, uint8_t *dht_id)
 {
     assert(tox != nullptr);
@@ -2475,6 +2570,7 @@ void tox_self_get_dht_id(const Tox *tox, uint8_t *dht_id)
     }
 }
 
+non_null(1)
 void tox_set_av_object(Tox *tox, void *object)
 {
     assert(tox != nullptr);
@@ -2483,6 +2579,7 @@ void tox_set_av_object(Tox *tox, void *object)
     unlock(tox);
 }
 
+non_null(1)
 void *tox_get_av_object(const Tox *tox)
 {
     assert(tox != nullptr);
@@ -2492,6 +2589,7 @@ void *tox_get_av_object(const Tox *tox)
     return object;
 }
 
+non_null(1)
 uint16_t tox_self_get_udp_port(const Tox *tox, Tox_Err_Get_Port *error)
 {
     assert(tox != nullptr);
@@ -2508,6 +2606,7 @@ uint16_t tox_self_get_udp_port(const Tox *tox, Tox_Err_Get_Port *error)
     return port;
 }
 
+non_null(1)
 uint16_t tox_self_get_tcp_port(const Tox *tox, Tox_Err_Get_Port *error)
 {
     assert(tox != nullptr);


### PR DESCRIPTION
These help static analysis and ubsan. We should eventually have all
functions annotated like this with a cimple check to make sure every
pointer has an explicit nullability annotation. The `nullable`
annotation does nothing in GCC, but will be used by cimple to validate
that every parameter has defined nullability.

See https://github.com/TokTok/c-toxcore/issues/2004

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2002)
<!-- Reviewable:end -->
