### PR TITLE
feat: add bash-completion for tox-bootstrapd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,6 +555,7 @@ if(BOOTSTRAP_DAEMON)
       other/bootstrap_node_packets.h)
     target_link_modules(tox-bootstrapd toxcore ${LIBCONFIG_LIBRARIES})
     install(TARGETS tox-bootstrapd RUNTIME DESTINATION bin)
+    install(FILES other/bootstrap_daemon/bash-completion/completions/tox-bootstrapd DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/bash-completion/completions")
   endif()
 endif()
 

--- a/other/bootstrap_daemon/bash-completion/completions/tox-bootstrapd
+++ b/other/bootstrap_daemon/bash-completion/completions/tox-bootstrapd
@@ -1,0 +1,27 @@
+# tox-bootstrapd completion                              -*- shell-script -*-
+
+_tox_bootstrapd()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+
+    case $prev in
+        --config)
+            _filedir
+            return
+            ;;
+        --log-backend)
+            COMPREPLY=($(compgen -W 'stdout syslog' -- "$cur"))
+            return
+            ;;
+    esac
+
+    $split && return
+
+    if type _bashcomp_try_faketty &>/dev/null; then
+        COMPREPLY=($(compgen -W '$(_parse_help _bashcomp_try_faketty "$1" --help)' -- "$cur"))
+        [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
+    fi
+} && complete -F _tox_bootstrapd tox-bootstrapd
+
+# ex: filetype=sh

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /src/c-toxcore
 # lying around. In particular, we don't need to rebuild the docker image when
 # toxav changes or the Dockerfile changes down from the build.
 COPY cmake cmake
+COPY other/bootstrap_daemon/bash-completion other/bootstrap_daemon/bash-completion
 COPY other/bootstrap_daemon/src other/bootstrap_daemon/src
 COPY other/bootstrap_node_packets.[ch] other/
 COPY other/DHT_bootstrap.c other/

--- a/other/bootstrap_daemon/src/Makefile.inc
+++ b/other/bootstrap_daemon/src/Makefile.inc
@@ -36,10 +36,12 @@ tox_bootstrapd_LDADD = \
                         $(NACL_OBJECTS) \
                         $(NACL_LIBS)
 
-endif
+bashcompdir = $(datarootdir)/bash-completion/completions
+dist_bashcomp_DATA = $(top_builddir)/other/bootstrap_daemon/bash-completion/completions/tox-bootstrapd
 
 EXTRA_DIST += \
     $(top_srcdir)/other/bootstrap_daemon/tox-bootstrapd.conf \
     $(top_srcdir)/other/bootstrap_daemon/tox-bootstrapd.service \
     $(top_srcdir)/other/bootstrap_daemon/tox-bootstrapd.sh
-    
+
+endif


### PR DESCRIPTION
Uses bash coding style of https://github.com/scop/bash-completion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2007)
<!-- Reviewable:end -->
