### PR TITLE
chore: get skeletons out of the closet

### DIFF
--- a/auto_tests/Makefile.inc
+++ b/auto_tests/Makefile.inc
@@ -192,10 +192,6 @@ set_status_message_test_SOURCES = ../auto_tests/set_status_message_test.c
 set_status_message_test_CFLAGS = $(AUTOTEST_CFLAGS)
 set_status_message_test_LDADD = $(AUTOTEST_LDADD)
 
-skeleton_test_SOURCES = ../auto_tests/skeleton_test.c
-skeleton_test_CFLAGS = $(AUTOTEST_CFLAGS)
-skeleton_test_LDADD = $(AUTOTEST_LDADD)
-
 TCP_test_SOURCES = ../auto_tests/TCP_test.c
 TCP_test_CFLAGS = $(AUTOTEST_CFLAGS)
 TCP_test_LDADD = $(AUTOTEST_LDADD)

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.65])
 AC_INIT([tox], [0.2.15])
 AC_CONFIG_AUX_DIR(configure_aux)
 AC_CONFIG_SRCDIR([toxcore/net_crypto.c])
-AM_INIT_AUTOMAKE([foreign 1.10 -Wall subdir-objects tar-ustar])
+AM_INIT_AUTOMAKE([foreign 1.10 -Wall -Werror subdir-objects tar-ustar])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_MACRO_DIR([m4])
 


### PR DESCRIPTION
The test was removed in c7ecee7c150617723faa434d70e5647e76f5a53f but
the entries in the build system remained, causing autotools to spit out
warnings.

```
$ ./autogen.sh 
Running autoreconf -if...
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'configure_aux'.
libtoolize: copying file 'configure_aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:258: installing 'configure_aux/ar-lib'
configure.ac:174: installing 'configure_aux/compile'
configure.ac:259: installing 'configure_aux/config.guess'
configure.ac:259: installing 'configure_aux/config.sub'
configure.ac:8: installing 'configure_aux/install-sh'
configure.ac:8: installing 'configure_aux/missing'
build/Makefile.am: installing 'configure_aux/depcomp'
parallel-tests: installing 'configure_aux/test-driver'
build/../auto_tests/Makefile.inc:193: warning: variable 'skeleton_test_SOURCES' is defined but no program or
build/../auto_tests/Makefile.inc:193: library has 'skeleton_test' as canonical name (possible typo)
build/Makefile.am:26:   'build/../auto_tests/Makefile.inc' included from here
build/../auto_tests/Makefile.inc:195: warning: variable 'skeleton_test_LDADD' is defined but no program or

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2008)
<!-- Reviewable:end -->
