### PR TITLE
fix: Conan build link failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,12 @@
 ---
 cache:
-  - '%USERPROFILE%\.conan'
+  - '%USERPROFILE%\.conan -> conanfile.py'
 
 install:
   - set PATH=C:\Python38-x64\Scripts;%PATH%
   - py -3 -m pip install conan
 
 before_build:
-  - conan remote add -i 0 conancenter https://center.conan.io
   - conan install -if _build .
 
 build_script:

--- a/conanfile.py
+++ b/conanfile.py
@@ -30,6 +30,8 @@ class ToxConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["AUTOTEST"] = self.options.with_tests
         self._cmake.definitions["BUILD_MISC_TESTS"] = self.options.with_tests
+        self._cmake.definitions["ENABLE_SHARED"] = False
+        self._cmake.definitions["ENABLE_STATIC"] = True
         self._cmake.definitions["MUST_BUILD_TOXAV"] = True
         if self.settings.compiler == "Visual Studio":
             self._cmake.definitions["MSVC_STATIC_SODIUM"] = True


### PR DESCRIPTION
The issue was that the build was getting mixed up with us building both the static and shared library at the same time. Normally in CMake, you only build one at a time, controlled by `BUILD_SHARED_LIBS`, so now we only build a static library in the Conan build to match what it expects.

I also ran into 
```
conan remote add -i 0 conancenter https://center.conan.io
ERROR: Remote 'conancenter' already exists in remotes (use update to modify)
Command exited with code 1
```
which I think was working around a stale cache, so I added that the cache should be dropped whenever the conanfile.py changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2011)
<!-- Reviewable:end -->
