### PR TITLE
fix: shared toxcore autotools build failing 

### DIFF
--- a/auto_tests/Makefile.inc
+++ b/auto_tests/Makefile.inc
@@ -51,19 +51,16 @@ endif
 
 AUTOTEST_CFLAGS = \
 	$(LIBSODIUM_CFLAGS) \
-	$(MSGPACK_CFLAGS) \
 	$(NACL_CFLAGS)
 
 AUTOTEST_LDADD = \
 	$(LIBSODIUM_LDFLAGS) \
-	$(MSGPACK_LDFLAGS) \
 	$(NACL_LDFLAGS) \
 	libmisc_tools.la \
 	libauto_test_support.la \
 	libtoxcore.la \
 	libtoxencryptsave.la \
 	$(LIBSODIUM_LIBS) \
-	$(MSGPACK_LIBS) \
 	$(NACL_OBJECTS) \
 	$(NACL_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -189,6 +189,8 @@ LIBSODIUM_SEARCH_HEADERS=
 LIBSODIUM_SEARCH_LIBS=
 NACL_SEARCH_HEADERS=
 NACL_SEARCH_LIBS=
+MSGPACK_SEARCH_HEADERS=
+MSGPACK_SEARCH_LIBS=
 
 AC_ARG_WITH(dependency-search,
     AC_HELP_STRING([--with-dependency-search=DIR],
@@ -239,6 +241,24 @@ AC_ARG_WITH(libsodium-libs,
         [
             LIBSODIUM_SEARCH_LIBS="$withval"
             AC_MSG_NOTICE([will search for libsodium libraries in $withval])
+        ]
+)
+
+AC_ARG_WITH(msgpack-headers,
+        AC_HELP_STRING([--with-msgpack-headers=DIR],
+                       [search for libmsgpackc header files in DIR]),
+        [
+            MSGPACK_SEARCH_HEADERS="$withval"
+            AC_MSG_NOTICE([will search for libmsgpackc header files in $withval])
+        ]
+)
+
+AC_ARG_WITH(msgpack-libs,
+        AC_HELP_STRING([--with-msgpack-libs=DIR],
+                       [search for libmsgpackc libraries in DIR]),
+        [
+            MSGPACK_SEARCH_LIBS="$withval"
+            AC_MSG_NOTICE([will search for libmsgpackc libraries in $withval])
         ]
 )
 
@@ -300,14 +320,6 @@ PKG_CHECK_MODULES([LIBSODIUM], [libsodium],
     ],
     [
         LIBSODIUM_FOUND="no"
-    ])
-
-PKG_CHECK_MODULES([MSGPACK], [msgpack],
-    [
-        MSGPACK_FOUND="yes"
-    ],
-    [
-        MSGPACK_FOUND="no"
     ])
 
 if test "x$WANT_NACL" = "xyes"; then
@@ -439,6 +451,71 @@ elif test "x$LIBSODIUM_FOUND" = "xno"; then
     CFLAGS="$CFLAGS_SAVE"
     CPPFLAGS="$CPPFLAGS_SAVE"
     AC_SUBST(LIBSODIUM_CFLAGS)
+fi
+
+PKG_CHECK_MODULES([MSGPACK], [msgpack],
+    [
+        MSGPACK_FOUND="yes"
+    ],
+    [
+        MSGPACK_FOUND="no"
+    ])
+
+if test "x$MSGPACK_FOUND" = "xno"; then
+    MSGPACK_LIBS=
+    MSGPACK_LDFLAGS=
+    LDFLAGS_SAVE="$LDFLAGS"
+    if test -n "$MSGPACK_SEARCH_LIBS"; then
+        LDFLAGS="-L$MSGPACK_SEARCH_LIBS $LDFLAGS"
+        AC_CHECK_LIB(msgpackc, msgpack_sbuffer_init,
+            [
+                MSGPACK_LDFLAGS="-L$MSGPACK_SEARCH_LIBS"
+                MSGPACK_LIBS="-lmsgpackc"
+            ],
+            [
+                AC_MSG_ERROR([required library libmsgpackc was not found in requested location $MSGPACK_SEARCH_LIBS or library version is too old])
+            ]
+        )
+    else
+        AC_CHECK_LIB(msgpackc, msgpack_sbuffer_init,
+            [],
+            [
+                AC_MSG_ERROR([required library libmsgpackc was not found on your system, please check https://github.com/msgpack/msgpack-c or library version is too old])
+            ]
+        )
+    fi
+
+    LDFLAGS="$LDFLAGS_SAVE"
+    AC_SUBST(MSGPACK_LIBS)
+    AC_SUBST(MSGPACK_LDFLAGS)
+fi
+
+if test "x$MSGPACK_FOUND" = "xno"; then
+    MSGPACK_CFLAGS=
+    CFLAGS_SAVE="$CFLAGS"
+    CPPFLAGS_SAVE="$CPPFLAGS"
+    if test -n "$MSGPACK_SEARCH_HEADERS"; then
+        CFLAGS="-I$MSGPACK_SEARCH_HEADERS $CFLAGS"
+        CPPFLAGS="-I$MSGPACK_SEARCH_HEADERS $CPPFLAGS"
+        AC_CHECK_HEADER(msgpack.h,
+            [
+                MSGPACK_CFLAGS="-I$MSGPACK_SEARCH_HEADERS"
+            ],
+            [
+                AC_MSG_ERROR([header files for required library libmsgpackc were not found in requested location $MSGPACK_SEARCH_HEADERS])
+            ]
+        )
+    else
+        AC_CHECK_HEADER(msgpack.h,
+            [],
+            [
+                AC_MSG_ERROR([header files for required library libmsgpackc was not found on your system, please check https://github.com/msgpack/msgpack-c])
+            ]
+        )
+    fi
+    CFLAGS="$CFLAGS_SAVE"
+    CPPFLAGS="$CPPFLAGS_SAVE"
+    AC_SUBST(MSGPACK_CFLAGS)
 fi
 
 # Checks for library functions.

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -92,12 +92,14 @@ libtoxcore_la_CFLAGS =  -I$(top_srcdir) \
                         -I$(top_srcdir)/toxcore \
                         $(LIBSODIUM_CFLAGS) \
                         $(NACL_CFLAGS) \
+                        $(MSGPACK_CFLAGS) \
                         $(PTHREAD_CFLAGS)
 
 libtoxcore_la_LDFLAGS = $(LT_LDFLAGS) \
                         $(EXTRA_LT_LDFLAGS) \
                         $(LIBSODIUM_LDFLAGS) \
                         $(NACL_LDFLAGS) \
+                        $(MSGPACK_LDFLAGS) \
                         $(MATH_LDFLAGS) \
                         $(RT_LIBS) \
                         $(WINSOCK2_LIBS)
@@ -105,6 +107,7 @@ libtoxcore_la_LDFLAGS = $(LT_LDFLAGS) \
 libtoxcore_la_LIBADD =  $(LIBSODIUM_LIBS) \
                         $(NACL_OBJECTS) \
                         $(NACL_LIBS) \
+                        $(MSGPACK_LIBS) \
                         $(PTHREAD_LIBS)
 
 if SET_SO_VERSION


### PR DESCRIPTION
Fixes https://github.com/TokTok/c-toxcore/pull/2010#issuecomment-1033844777.

Turns out libtoxcore.so wasn't being linked against libmsgpackc.

Also adds ability to set custom paths for headers and libs. Basically the libsodium copy-pasta.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2015)
<!-- Reviewable:end -->
