### PR TITLE
chore: Silence clang compile warnings causing circle-ci/asan to fail

### DIFF
--- a/.github/scripts/flags-clang.sh
+++ b/.github/scripts/flags-clang.sh
@@ -48,6 +48,8 @@ add_flag -Wno-unused-parameter
 add_flag -Wno-used-but-marked-unused
 # We use variable length arrays a lot.
 add_flag -Wno-vla
+# Disable warning about Doxygen retval tag
+add_flag -fcomment-block-commands=retval
 
 # Disable specific warning flags for C++.
 


### PR DESCRIPTION
The warnings in question: `../auto_tests/../toxcore/crypto_core.h:89:4: error: unknown command tag name [-Werror,-Wdocumentation-unknown-command]    * @retval 0 if both mem locations of length are equal `

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2019)
<!-- Reviewable:end -->
