### PR TITLE
chore: Disable non-null attributes by default.

### DIFF
--- a/.circleci/cmake-ubsan
+++ b/.circleci/cmake-ubsan
@@ -11,6 +11,10 @@ add_flag -fno-omit-frame-pointer
 add_flag -fno-sanitize-recover=all
 add_flag -fsanitize=undefined,nullability,local-bounds,float-divide-by-zero,integer
 add_flag -fno-sanitize=implicit-conversion,unsigned-integer-overflow
+# Enable extra checks. We only do this on ubsan because it shows useful error
+# messages for the kind of bugs this catches (mostly incorrect nullability
+# annotations). Other builds will segfault, ubsan will show a stack trace.
+add_flag -D_DEBUG
 cmake -B_build -H. -GNinja \
   -DCMAKE_C_FLAGS="$C_FLAGS" \
   -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \

--- a/toxcore/attributes.h
+++ b/toxcore/attributes.h
@@ -18,7 +18,7 @@
 #define GNU_PRINTF(f, a)
 #endif
 
-#if defined(__GNUC__) && !defined(NDEBUG)
+#if defined(__GNUC__) && defined(_DEBUG)
 #define non_null(...) __attribute__((__nonnull__(__VA_ARGS__)))
 #else
 #define non_null(...)


### PR DESCRIPTION
We enable them on CI, but a default build will compile without them so a
default build doesn't end up with lots of warnings (which we also
disable on CI).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2021)
<!-- Reviewable:end -->
