### PR TITLE
cleanup: Split tox_unpack into two smaller libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,8 @@ set(toxcore_SOURCES ${toxcore_SOURCES}
   toxcore/events/events_alloc.c
   toxcore/events/events_alloc.h
   toxcore/events/self_connection_status.c
+  toxcore/bin_unpack.c
+  toxcore/bin_unpack.h
   toxcore/tox_events.c
   toxcore/tox_events.h
   toxcore/tox_unpack.c

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -15,6 +15,17 @@ cc_library(
 )
 
 cc_library(
+    name = "bin_unpack",
+    srcs = ["bin_unpack.c"],
+    hdrs = ["bin_unpack.h"],
+    visibility = ["//c-toxcore:__subpackages__"],
+    deps = [
+        ":ccompat",
+        "@msgpack-c",
+    ],
+)
+
+cc_library(
     name = "ccompat",
     srcs = ["ccompat.c"],
     hdrs = ["ccompat.h"],
@@ -475,6 +486,7 @@ cc_library(
     hdrs = ["tox_unpack.h"],
     visibility = ["//c-toxcore:__subpackages__"],
     deps = [
+        ":bin_unpack",
         ":ccompat",
         ":toxcore",
         "@msgpack-c",
@@ -490,6 +502,7 @@ cc_library(
     hdrs = ["tox_events.h"],
     visibility = ["//c-toxcore:__subpackages__"],
     deps = [
+        ":bin_unpack",
         ":ccompat",
         ":tox_unpack",
         ":toxcore",

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -6,6 +6,8 @@ libtoxcore_la_include_HEADERS = \
 libtoxcore_la_includedir = $(includedir)/tox
 
 libtoxcore_la_SOURCES = ../toxcore/attributes.h \
+                        ../toxcore/bin_unpack.c \
+                        ../toxcore/bin_unpack.h \
                         ../toxcore/ccompat.c \
                         ../toxcore/ccompat.h \
                         ../toxcore/events/conference_connected.c \

--- a/toxcore/bin_unpack.c
+++ b/toxcore/bin_unpack.c
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022 The TokTok team.
+ */
+
+#include "bin_unpack.h"
+
+#include <msgpack.h>
+
+#include "ccompat.h"
+
+bool bin_unpack_bool(bool *val, const msgpack_object *obj)
+{
+    if (obj->type != MSGPACK_OBJECT_BOOLEAN) {
+        return false;
+    }
+
+    *val = obj->via.boolean;
+    return true;
+}
+
+bool bin_unpack_u16(uint16_t *val, const msgpack_object *obj)
+{
+    if (obj->type != MSGPACK_OBJECT_POSITIVE_INTEGER || obj->via.u64 > UINT16_MAX) {
+        return false;
+    }
+
+    *val = (uint16_t)obj->via.u64;
+    return true;
+}
+
+bool bin_unpack_u32(uint32_t *val, const msgpack_object *obj)
+{
+    if (obj->type != MSGPACK_OBJECT_POSITIVE_INTEGER || obj->via.u64 > UINT32_MAX) {
+        return false;
+    }
+
+    *val = (uint32_t)obj->via.u64;
+    return true;
+}
+
+bool bin_unpack_u64(uint64_t *val, const msgpack_object *obj)
+{
+    if (obj->type != MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        return false;
+    }
+
+    *val = obj->via.u64;
+    return true;
+}
+
+bool bin_unpack_bytes(uint8_t **data_ptr, size_t *data_length_ptr, const msgpack_object *obj)
+{
+    if (obj->type != MSGPACK_OBJECT_BIN) {
+        return false;
+    }
+
+    const uint32_t data_length = obj->via.bin.size;
+    uint8_t *const data = (uint8_t *)malloc(data_length);
+
+    if (data == nullptr) {
+        return false;
+    }
+
+    memcpy(data, obj->via.bin.ptr, data_length);
+
+    *data_ptr = data;
+    *data_length_ptr = data_length;
+    return true;
+}
+
+bool bin_unpack_bytes_fixed(uint8_t *data, uint32_t data_length, const msgpack_object *obj)
+{
+    if (obj->type != MSGPACK_OBJECT_BIN || obj->via.bin.size != data_length) {
+        return false;
+    }
+
+    memcpy(data, obj->via.bin.ptr, data_length);
+
+    return true;
+}

--- a/toxcore/bin_unpack.h
+++ b/toxcore/bin_unpack.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022 The TokTok team.
+ */
+
+#ifndef C_TOXCORE_TOXCORE_BIN_UNPACK_H
+#define C_TOXCORE_TOXCORE_BIN_UNPACK_H
+
+#include <msgpack.h>
+#include <stdint.h>
+
+#include "attributes.h"
+
+non_null() bool bin_unpack_bool(bool *val, const msgpack_object *obj);
+non_null() bool bin_unpack_u16(uint16_t *val, const msgpack_object *obj);
+non_null() bool bin_unpack_u32(uint32_t *val, const msgpack_object *obj);
+non_null() bool bin_unpack_u64(uint64_t *val, const msgpack_object *obj);
+non_null() bool bin_unpack_bytes(uint8_t **data, size_t *data_length, const msgpack_object *obj);
+non_null() bool bin_unpack_bytes_fixed(uint8_t *data, uint32_t data_length, const msgpack_object *obj);
+
+#endif  // C_TOXCORE_TOXCORE_BIN_UNPACK_H

--- a/toxcore/events/conference_connected.c
+++ b/toxcore/events/conference_connected.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -71,7 +71,7 @@ static bool tox_event_conference_connected_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->conference_number, &obj->via.array.ptr[0]);
+    return bin_unpack_u32(&event->conference_number, &obj->via.array.ptr[0]);
 }
 
 

--- a/toxcore/events/conference_invite.c
+++ b/toxcore/events/conference_invite.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
@@ -122,9 +123,9 @@ static bool tox_event_conference_invite_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
            && tox_unpack_conference_type(&event->type, &obj->via.array.ptr[1])
-           && tox_unpack_bin(&event->cookie, &event->cookie_length, &obj->via.array.ptr[2]);
+           && bin_unpack_bytes(&event->cookie, &event->cookie_length, &obj->via.array.ptr[2]);
 }
 
 

--- a/toxcore/events/conference_message.c
+++ b/toxcore/events/conference_message.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
@@ -137,10 +138,10 @@ static bool tox_event_conference_message_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->conference_number, &obj->via.array.ptr[0])
-           && tox_unpack_u32(&event->peer_number, &obj->via.array.ptr[1])
+    return bin_unpack_u32(&event->conference_number, &obj->via.array.ptr[0])
+           && bin_unpack_u32(&event->peer_number, &obj->via.array.ptr[1])
            && tox_unpack_message_type(&event->type, &obj->via.array.ptr[2])
-           && tox_unpack_bin(&event->message, &event->message_length, &obj->via.array.ptr[3]);
+           && bin_unpack_bytes(&event->message, &event->message_length, &obj->via.array.ptr[3]);
 }
 
 

--- a/toxcore/events/conference_peer_list_changed.c
+++ b/toxcore/events/conference_peer_list_changed.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -73,7 +73,7 @@ static bool tox_event_conference_peer_list_changed_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->conference_number, &obj->via.array.ptr[0]);
+    return bin_unpack_u32(&event->conference_number, &obj->via.array.ptr[0]);
 }
 
 

--- a/toxcore/events/conference_peer_name.c
+++ b/toxcore/events/conference_peer_name.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -123,9 +123,9 @@ static bool tox_event_conference_peer_name_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->conference_number, &obj->via.array.ptr[0])
-           && tox_unpack_u32(&event->peer_number, &obj->via.array.ptr[1])
-           && tox_unpack_bin(&event->name, &event->name_length, &obj->via.array.ptr[2]);
+    return bin_unpack_u32(&event->conference_number, &obj->via.array.ptr[0])
+           && bin_unpack_u32(&event->peer_number, &obj->via.array.ptr[1])
+           && bin_unpack_bytes(&event->name, &event->name_length, &obj->via.array.ptr[2]);
 }
 
 

--- a/toxcore/events/conference_title.c
+++ b/toxcore/events/conference_title.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -122,9 +122,9 @@ static bool tox_event_conference_title_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->conference_number, &obj->via.array.ptr[0])
-           && tox_unpack_u32(&event->peer_number, &obj->via.array.ptr[1])
-           && tox_unpack_bin(&event->title, &event->title_length, &obj->via.array.ptr[2]);
+    return bin_unpack_u32(&event->conference_number, &obj->via.array.ptr[0])
+           && bin_unpack_u32(&event->peer_number, &obj->via.array.ptr[1])
+           && bin_unpack_bytes(&event->title, &event->title_length, &obj->via.array.ptr[2]);
 }
 
 

--- a/toxcore/events/file_chunk_request.c
+++ b/toxcore/events/file_chunk_request.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -114,10 +114,10 @@ static bool tox_event_file_chunk_request_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_u32(&event->file_number, &obj->via.array.ptr[1])
-           && tox_unpack_u64(&event->position, &obj->via.array.ptr[2])
-           && tox_unpack_u16(&event->length, &obj->via.array.ptr[3]);
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_u32(&event->file_number, &obj->via.array.ptr[1])
+           && bin_unpack_u64(&event->position, &obj->via.array.ptr[2])
+           && bin_unpack_u16(&event->length, &obj->via.array.ptr[3]);
 }
 
 

--- a/toxcore/events/file_recv.c
+++ b/toxcore/events/file_recv.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -152,11 +152,11 @@ static bool tox_event_file_recv_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_u32(&event->file_number, &obj->via.array.ptr[1])
-           && tox_unpack_u32(&event->kind, &obj->via.array.ptr[2])
-           && tox_unpack_u64(&event->file_size, &obj->via.array.ptr[3])
-           && tox_unpack_bin(&event->filename, &event->filename_length, &obj->via.array.ptr[4]);
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_u32(&event->file_number, &obj->via.array.ptr[1])
+           && bin_unpack_u32(&event->kind, &obj->via.array.ptr[2])
+           && bin_unpack_u64(&event->file_size, &obj->via.array.ptr[3])
+           && bin_unpack_bytes(&event->filename, &event->filename_length, &obj->via.array.ptr[4]);
 }
 
 

--- a/toxcore/events/file_recv_chunk.c
+++ b/toxcore/events/file_recv_chunk.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -137,10 +137,10 @@ static bool tox_event_file_recv_chunk_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_u32(&event->file_number, &obj->via.array.ptr[1])
-           && tox_unpack_u64(&event->position, &obj->via.array.ptr[2])
-           && tox_unpack_bin(&event->data, &event->data_length, &obj->via.array.ptr[3]);
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_u32(&event->file_number, &obj->via.array.ptr[1])
+           && bin_unpack_u64(&event->position, &obj->via.array.ptr[2])
+           && bin_unpack_bytes(&event->data, &event->data_length, &obj->via.array.ptr[3]);
 }
 
 

--- a/toxcore/events/file_recv_control.c
+++ b/toxcore/events/file_recv_control.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
@@ -100,8 +101,8 @@ static bool tox_event_file_recv_control_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_u32(&event->file_number, &obj->via.array.ptr[1])
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_u32(&event->file_number, &obj->via.array.ptr[1])
            && tox_unpack_file_control(&event->control, &obj->via.array.ptr[2]);
 }
 

--- a/toxcore/events/friend_connection_status.c
+++ b/toxcore/events/friend_connection_status.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
@@ -87,7 +88,7 @@ static bool tox_event_friend_connection_status_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
            && tox_unpack_connection(&event->connection_status, &obj->via.array.ptr[1]);
 }
 

--- a/toxcore/events/friend_lossless_packet.c
+++ b/toxcore/events/friend_lossless_packet.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -108,8 +108,8 @@ static bool tox_event_friend_lossless_packet_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_bin(&event->data, &event->data_length, &obj->via.array.ptr[1]);
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_bytes(&event->data, &event->data_length, &obj->via.array.ptr[1]);
 }
 
 

--- a/toxcore/events/friend_lossy_packet.c
+++ b/toxcore/events/friend_lossy_packet.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -107,8 +107,8 @@ static bool tox_event_friend_lossy_packet_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_bin(&event->data, &event->data_length, &obj->via.array.ptr[1]);
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_bytes(&event->data, &event->data_length, &obj->via.array.ptr[1]);
 }
 
 

--- a/toxcore/events/friend_message.c
+++ b/toxcore/events/friend_message.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
@@ -121,9 +122,9 @@ static bool tox_event_friend_message_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
            && tox_unpack_message_type(&event->type, &obj->via.array.ptr[1])
-           && tox_unpack_bin(&event->message, &event->message_length, &obj->via.array.ptr[2]);
+           && bin_unpack_bytes(&event->message, &event->message_length, &obj->via.array.ptr[2]);
 }
 
 

--- a/toxcore/events/friend_name.c
+++ b/toxcore/events/friend_name.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -107,8 +107,8 @@ static bool tox_event_friend_name_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_bin(&event->name, &event->name_length, &obj->via.array.ptr[1]);
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_bytes(&event->name, &event->name_length, &obj->via.array.ptr[1]);
 }
 
 

--- a/toxcore/events/friend_read_receipt.c
+++ b/toxcore/events/friend_read_receipt.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -85,8 +85,8 @@ static bool tox_event_friend_read_receipt_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_u32(&event->message_id, &obj->via.array.ptr[1]);
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_u32(&event->message_id, &obj->via.array.ptr[1]);
 }
 
 

--- a/toxcore/events/friend_request.c
+++ b/toxcore/events/friend_request.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -109,8 +109,8 @@ static bool tox_event_friend_request_unpack(
         return false;
     }
 
-    return tox_unpack_bin_fixed(event->public_key, TOX_PUBLIC_KEY_SIZE, &obj->via.array.ptr[0])
-           && tox_unpack_bin(&event->message, &event->message_length, &obj->via.array.ptr[1]);
+    return bin_unpack_bytes_fixed(event->public_key, TOX_PUBLIC_KEY_SIZE, &obj->via.array.ptr[0])
+           && bin_unpack_bytes(&event->message, &event->message_length, &obj->via.array.ptr[1]);
 }
 
 

--- a/toxcore/events/friend_status.c
+++ b/toxcore/events/friend_status.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../bin_unpack.h"
 
 #include "../ccompat.h"
 #include "../tox.h"
@@ -85,7 +86,7 @@ static bool tox_event_friend_status_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
            && tox_unpack_user_status(&event->connection_status, &obj->via.array.ptr[1]);
 }
 

--- a/toxcore/events/friend_status_message.c
+++ b/toxcore/events/friend_status_message.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -109,8 +109,8 @@ static bool tox_event_friend_status_message_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_bin(&event->status_message, &event->status_message_length, &obj->via.array.ptr[1]);
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_bytes(&event->status_message, &event->status_message_length, &obj->via.array.ptr[1]);
 }
 
 

--- a/toxcore/events/friend_typing.c
+++ b/toxcore/events/friend_typing.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"
-#include "../tox_unpack.h"
 
 
 /*****************************************************
@@ -89,8 +89,8 @@ static bool tox_event_friend_typing_unpack(
         return false;
     }
 
-    return tox_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
-           && tox_unpack_bool(&event->typing, &obj->via.array.ptr[1]);
+    return bin_unpack_u32(&event->friend_number, &obj->via.array.ptr[0])
+           && bin_unpack_bool(&event->typing, &obj->via.array.ptr[1]);
 }
 
 

--- a/toxcore/events/self_connection_status.c
+++ b/toxcore/events/self_connection_status.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../bin_unpack.h"
 #include "../ccompat.h"
 #include "../tox.h"
 #include "../tox_events.h"

--- a/toxcore/tox_unpack.c
+++ b/toxcore/tox_unpack.c
@@ -5,85 +5,16 @@
 #include "tox_unpack.h"
 
 #include <msgpack.h>
+#include <stdint.h>
 
+#include "bin_unpack.h"
 #include "ccompat.h"
-
-bool tox_unpack_bool(bool *val, const msgpack_object *obj)
-{
-    if (obj->type != MSGPACK_OBJECT_BOOLEAN) {
-        return false;
-    }
-
-    *val = obj->via.boolean;
-    return true;
-}
-
-bool tox_unpack_u16(uint16_t *val, const msgpack_object *obj)
-{
-    if (obj->type != MSGPACK_OBJECT_POSITIVE_INTEGER || obj->via.u64 > UINT16_MAX) {
-        return false;
-    }
-
-    *val = (uint16_t)obj->via.u64;
-    return true;
-}
-
-bool tox_unpack_u32(uint32_t *val, const msgpack_object *obj)
-{
-    if (obj->type != MSGPACK_OBJECT_POSITIVE_INTEGER || obj->via.u64 > UINT32_MAX) {
-        return false;
-    }
-
-    *val = (uint32_t)obj->via.u64;
-    return true;
-}
-
-bool tox_unpack_u64(uint64_t *val, const msgpack_object *obj)
-{
-    if (obj->type != MSGPACK_OBJECT_POSITIVE_INTEGER) {
-        return false;
-    }
-
-    *val = obj->via.u64;
-    return true;
-}
-
-bool tox_unpack_bin(uint8_t **data_ptr, size_t *data_length_ptr, const msgpack_object *obj)
-{
-    if (obj->type != MSGPACK_OBJECT_BIN) {
-        return false;
-    }
-
-    const uint32_t data_length = obj->via.bin.size;
-    uint8_t *const data = (uint8_t *)malloc(data_length);
-
-    if (data == nullptr) {
-        return false;
-    }
-
-    memcpy(data, obj->via.bin.ptr, data_length);
-
-    *data_ptr = data;
-    *data_length_ptr = data_length;
-    return true;
-}
-
-bool tox_unpack_bin_fixed(uint8_t *data, uint32_t data_length, const msgpack_object *obj)
-{
-    if (obj->type != MSGPACK_OBJECT_BIN || obj->via.bin.size != data_length) {
-        return false;
-    }
-
-    memcpy(data, obj->via.bin.ptr, data_length);
-
-    return true;
-}
 
 bool tox_unpack_conference_type(Tox_Conference_Type *val, const msgpack_object *obj)
 {
     uint32_t u32;
 
-    if (!tox_unpack_u32(&u32, obj)) {
+    if (!bin_unpack_u32(&u32, obj)) {
         return false;
     }
 
@@ -95,7 +26,7 @@ bool tox_unpack_connection(Tox_Connection *val, const msgpack_object *obj)
 {
     uint32_t u32;
 
-    if (!tox_unpack_u32(&u32, obj)) {
+    if (!bin_unpack_u32(&u32, obj)) {
         return false;
     }
 
@@ -107,7 +38,7 @@ bool tox_unpack_file_control(Tox_File_Control *val, const msgpack_object *obj)
 {
     uint32_t u32;
 
-    if (!tox_unpack_u32(&u32, obj)) {
+    if (!bin_unpack_u32(&u32, obj)) {
         return false;
     }
 
@@ -119,7 +50,7 @@ bool tox_unpack_message_type(Tox_Message_Type *val, const msgpack_object *obj)
 {
     uint32_t u32;
 
-    if (!tox_unpack_u32(&u32, obj)) {
+    if (!bin_unpack_u32(&u32, obj)) {
         return false;
     }
 
@@ -131,7 +62,7 @@ bool tox_unpack_user_status(Tox_User_Status *val, const msgpack_object *obj)
 {
     uint32_t u32;
 
-    if (!tox_unpack_u32(&u32, obj)) {
+    if (!bin_unpack_u32(&u32, obj)) {
         return false;
     }
 

--- a/toxcore/tox_unpack.h
+++ b/toxcore/tox_unpack.h
@@ -6,17 +6,9 @@
 #define C_TOXCORE_TOXCORE_TOX_UNPACK_H
 
 #include <msgpack.h>
-#include <stdint.h>
 
 #include "attributes.h"
 #include "tox.h"
-
-non_null() bool tox_unpack_bool(bool *val, const msgpack_object *obj);
-non_null() bool tox_unpack_u16(uint16_t *val, const msgpack_object *obj);
-non_null() bool tox_unpack_u32(uint32_t *val, const msgpack_object *obj);
-non_null() bool tox_unpack_u64(uint64_t *val, const msgpack_object *obj);
-non_null() bool tox_unpack_bin(uint8_t **data, size_t *data_length, const msgpack_object *obj);
-non_null() bool tox_unpack_bin_fixed(uint8_t *data, uint32_t data_length, const msgpack_object *obj);
 
 non_null() bool tox_unpack_conference_type(Tox_Conference_Type *val, const msgpack_object *obj);
 non_null() bool tox_unpack_connection(Tox_Connection *val, const msgpack_object *obj);


### PR DESCRIPTION
tox_unpack is for unpacking Tox types, and bin_unpack is for unpacking ints and binary data. This prevents us from creating dependency cycles due to tox_unpack depending on tox.h.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2022)
<!-- Reviewable:end -->
