### PR TITLE
perf: Reduce minimal encoding size of packed events.

### DIFF
--- a/auto_tests/BUILD.bazel
+++ b/auto_tests/BUILD.bazel
@@ -16,9 +16,9 @@ cc_library(
     deps = [
         ":check_compat",
         "//c-toxcore/testing:misc_tools",
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:Messenger",
         "//c-toxcore/toxcore:mono_time",
+        "//c-toxcore/toxcore:tox",
     ],
 )
 
@@ -44,7 +44,6 @@ flaky_tests = {
         ":check_compat",
         "//c-toxcore/testing:misc_tools",
         "//c-toxcore/toxav",
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:DHT_srcs",
         "//c-toxcore/toxcore:Messenger",
         "//c-toxcore/toxcore:TCP_client",
@@ -61,6 +60,7 @@ flaky_tests = {
         "//c-toxcore/toxcore:onion",
         "//c-toxcore/toxcore:onion_announce",
         "//c-toxcore/toxcore:onion_client",
+        "//c-toxcore/toxcore:tox",
         "//c-toxcore/toxcore:tox_dispatch",
         "//c-toxcore/toxcore:tox_events",
         "//c-toxcore/toxencryptsave",

--- a/auto_tests/tox_dispatch_test.c
+++ b/auto_tests/tox_dispatch_test.c
@@ -46,7 +46,7 @@ static void print_events(Tox_Events *events)
 {
     const uint32_t size = tox_events_bytes_size(events);
 
-    if (size > 24) {
+    if (size > 1) {
         tox_events_print(events);
     }
 
@@ -76,9 +76,9 @@ static bool await_message(Tox **toxes, const Tox_Dispatch *dispatch)
 {
     for (uint32_t i = 0; i < 100; ++i) {
         // Ignore events on tox 1.
-        print_events(tox_events_iterate(toxes[0], nullptr));
+        print_events(tox_events_iterate(toxes[0], false, nullptr));
         // Check if tox 2 got the message from tox 1.
-        Tox_Events *events = tox_events_iterate(toxes[1], nullptr);
+        Tox_Events *events = tox_events_iterate(toxes[1], false, nullptr);
 
         dump_events("/tmp/test.mp", events);
 
@@ -131,8 +131,8 @@ static void test_tox_events(void)
     while (tox_self_get_connection_status(toxes[0]) == TOX_CONNECTION_NONE ||
             tox_self_get_connection_status(toxes[1]) == TOX_CONNECTION_NONE) {
         // Ignore connection events for now.
-        print_events(tox_events_iterate(toxes[0], nullptr));
-        print_events(tox_events_iterate(toxes[1], nullptr));
+        print_events(tox_events_iterate(toxes[0], false, nullptr));
+        print_events(tox_events_iterate(toxes[1], false, nullptr));
 
         c_sleep(tox_iteration_interval(toxes[0]));
     }
@@ -142,8 +142,8 @@ static void test_tox_events(void)
     while (tox_friend_get_connection_status(toxes[0], 0, nullptr) == TOX_CONNECTION_NONE ||
             tox_friend_get_connection_status(toxes[1], 0, nullptr) == TOX_CONNECTION_NONE) {
         // Ignore connection events for now.
-        print_events(tox_events_iterate(toxes[0], nullptr));
-        print_events(tox_events_iterate(toxes[1], nullptr));
+        print_events(tox_events_iterate(toxes[0], false, nullptr));
+        print_events(tox_events_iterate(toxes[1], false, nullptr));
 
         c_sleep(tox_iteration_interval(toxes[0]));
     }

--- a/auto_tests/tox_events_test.c
+++ b/auto_tests/tox_events_test.c
@@ -15,9 +15,9 @@ static bool await_message(Tox **toxes)
 {
     for (uint32_t i = 0; i < 100; ++i) {
         // Ignore events on tox 1.
-        tox_events_free(tox_events_iterate(toxes[0], nullptr));
+        tox_events_free(tox_events_iterate(toxes[0], false, nullptr));
         // Check if tox 2 got the message from tox 1.
-        Tox_Events *events = tox_events_iterate(toxes[1], nullptr);
+        Tox_Events *events = tox_events_iterate(toxes[1], false, nullptr);
 
         if (events != nullptr) {
             ck_assert(tox_events_get_friend_message_size(events) == 1);
@@ -66,8 +66,8 @@ static void test_tox_events(void)
     while (tox_self_get_connection_status(toxes[0]) == TOX_CONNECTION_NONE ||
             tox_self_get_connection_status(toxes[1]) == TOX_CONNECTION_NONE) {
         // Ignore connection events for now.
-        tox_events_free(tox_events_iterate(toxes[0], nullptr));
-        tox_events_free(tox_events_iterate(toxes[1], nullptr));
+        tox_events_free(tox_events_iterate(toxes[0], false, nullptr));
+        tox_events_free(tox_events_iterate(toxes[1], false, nullptr));
 
         c_sleep(tox_iteration_interval(toxes[0]));
     }
@@ -77,8 +77,8 @@ static void test_tox_events(void)
     while (tox_friend_get_connection_status(toxes[0], 0, nullptr) == TOX_CONNECTION_NONE ||
             tox_friend_get_connection_status(toxes[1], 0, nullptr) == TOX_CONNECTION_NONE) {
         // Ignore connection events for now.
-        tox_events_free(tox_events_iterate(toxes[0], nullptr));
-        tox_events_free(tox_events_iterate(toxes[1], nullptr));
+        tox_events_free(tox_events_iterate(toxes[0], false, nullptr));
+        tox_events_free(tox_events_iterate(toxes[1], false, nullptr));
 
         c_sleep(tox_iteration_interval(toxes[0]));
     }

--- a/other/BUILD.bazel
+++ b/other/BUILD.bazel
@@ -17,12 +17,12 @@ cc_binary(
     srcs = ["DHT_bootstrap.c"],
     deps = [
         "//c-toxcore/testing:misc_tools",
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:DHT",
         "//c-toxcore/toxcore:TCP_server",
         "//c-toxcore/toxcore:friend_requests",
         "//c-toxcore/toxcore:logger",
         "//c-toxcore/toxcore:mono_time",
         "//c-toxcore/toxcore:network",
+        "//c-toxcore/toxcore:tox",
     ],
 )

--- a/other/bootstrap_daemon/BUILD.bazel
+++ b/other/bootstrap_daemon/BUILD.bazel
@@ -10,7 +10,6 @@ cc_binary(
     ]),
     deps = [
         "//c-toxcore/other:bootstrap_node_packets",
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:DHT",
         "//c-toxcore/toxcore:TCP_server",
         "//c-toxcore/toxcore:ccompat",
@@ -18,6 +17,7 @@ cc_binary(
         "//c-toxcore/toxcore:mono_time",
         "//c-toxcore/toxcore:network",
         "//c-toxcore/toxcore:onion_announce",
+        "//c-toxcore/toxcore:tox",
         "@libconfig",
     ],
 )

--- a/other/fun/BUILD.bazel
+++ b/other/fun/BUILD.bazel
@@ -46,8 +46,8 @@ cc_binary(
         "create_savedata.c",
     ],
     deps = [
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:ccompat",
+        "//c-toxcore/toxcore:tox",
         "@libsodium",
     ],
 )
@@ -83,8 +83,8 @@ cc_binary(
     srcs = ["strkey.c"],
     copts = ["-w"],
     deps = [
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:ccompat",
+        "//c-toxcore/toxcore:tox",
         "@libsodium",
     ],
 )
@@ -95,7 +95,7 @@ cc_binary(
     srcs = ["save-generator.c"],
     deps = [
         "//c-toxcore/testing:misc_tools",
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:ccompat",
+        "//c-toxcore/toxcore:tox",
     ],
 )

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -40,8 +40,8 @@ cc_library(
     hdrs = ["misc_tools.h"],
     visibility = ["//c-toxcore:__subpackages__"],
     deps = [
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:ccompat",
+        "//c-toxcore/toxcore:tox",
         "@libsodium",
     ],
 )
@@ -84,6 +84,6 @@ cc_binary(
     srcs = ["random_testing.cc"],
     deps = [
         ":misc_tools",
-        "//c-toxcore/toxcore",
+        "//c-toxcore/toxcore:tox",
     ],
 )

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -470,7 +470,7 @@ cc_library(
 )
 
 cc_library(
-    name = "toxcore",
+    name = "tox",
     srcs = [
         "tox.c",
         "tox_api.c",
@@ -499,7 +499,7 @@ cc_library(
     deps = [
         ":bin_unpack",
         ":ccompat",
-        ":toxcore",
+        ":tox",
         "@msgpack-c",
     ],
 )
@@ -516,8 +516,8 @@ cc_library(
         ":bin_pack",
         ":bin_unpack",
         ":ccompat",
+        ":tox",
         ":tox_unpack",
-        ":toxcore",
         "@msgpack-c",
     ],
 )
@@ -531,6 +531,12 @@ cc_library(
         ":ccompat",
         ":tox_events",
     ],
+)
+
+alias(
+    name = "toxcore",
+    actual = ":tox_dispatch",
+    visibility = ["//c-toxcore:__subpackages__"],
 )
 
 sh_library(

--- a/toxcore/events/conference_invite.c
+++ b/toxcore/events/conference_invite.c
@@ -107,6 +107,8 @@ static void tox_event_conference_invite_pack(
     const Tox_Event_Conference_Invite *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_CONFERENCE_INVITE);
     bin_pack_array(mp, 3);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_u32(mp, event->type);
@@ -198,8 +200,6 @@ void tox_events_pack_conference_invite(const Tox_Events *events, msgpack_packer 
 {
     const uint32_t size = tox_events_get_conference_invite_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_conference_invite_pack(tox_events_get_conference_invite(events, i), mp);
     }
@@ -207,23 +207,13 @@ void tox_events_pack_conference_invite(const Tox_Events *events, msgpack_packer 
 
 bool tox_events_unpack_conference_invite(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Conference_Invite *event = tox_events_add_conference_invite(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Conference_Invite *event = tox_events_add_conference_invite(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_conference_invite_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_conference_invite_unpack(event, obj);
 }
 
 

--- a/toxcore/events/conference_message.c
+++ b/toxcore/events/conference_message.c
@@ -121,6 +121,8 @@ static void tox_event_conference_message_pack(
     const Tox_Event_Conference_Message *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_CONFERENCE_MESSAGE);
     bin_pack_array(mp, 4);
     bin_pack_u32(mp, event->conference_number);
     bin_pack_u32(mp, event->peer_number);
@@ -214,8 +216,6 @@ void tox_events_pack_conference_message(const Tox_Events *events, msgpack_packer
 {
     const uint32_t size = tox_events_get_conference_message_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_conference_message_pack(tox_events_get_conference_message(events, i), mp);
     }
@@ -223,23 +223,13 @@ void tox_events_pack_conference_message(const Tox_Events *events, msgpack_packer
 
 bool tox_events_unpack_conference_message(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Conference_Message *event = tox_events_add_conference_message(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Conference_Message *event = tox_events_add_conference_message(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_conference_message_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_conference_message_unpack(event, obj);
 }
 
 

--- a/toxcore/events/conference_peer_list_changed.c
+++ b/toxcore/events/conference_peer_list_changed.c
@@ -60,7 +60,8 @@ static void tox_event_conference_peer_list_changed_pack(
     const Tox_Event_Conference_Peer_List_Changed *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
-    bin_pack_array(mp, 1);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_CONFERENCE_PEER_LIST_CHANGED);
     bin_pack_u32(mp, event->conference_number);
 }
 
@@ -69,12 +70,7 @@ static bool tox_event_conference_peer_list_changed_unpack(
     Tox_Event_Conference_Peer_List_Changed *event, const msgpack_object *obj)
 {
     assert(event != nullptr);
-
-    if (obj->type != MSGPACK_OBJECT_ARRAY || obj->via.array.size < 1) {
-        return false;
-    }
-
-    return bin_unpack_u32(&event->conference_number, &obj->via.array.ptr[0]);
+    return bin_unpack_u32(&event->conference_number, obj);
 }
 
 
@@ -151,8 +147,6 @@ void tox_events_pack_conference_peer_list_changed(const Tox_Events *events, msgp
 {
     const uint32_t size = tox_events_get_conference_peer_list_changed_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_conference_peer_list_changed_pack(tox_events_get_conference_peer_list_changed(events, i), mp);
     }
@@ -160,23 +154,13 @@ void tox_events_pack_conference_peer_list_changed(const Tox_Events *events, msgp
 
 bool tox_events_unpack_conference_peer_list_changed(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Conference_Peer_List_Changed *event = tox_events_add_conference_peer_list_changed(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Conference_Peer_List_Changed *event = tox_events_add_conference_peer_list_changed(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_conference_peer_list_changed_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_conference_peer_list_changed_unpack(event, obj);
 }
 
 

--- a/toxcore/events/conference_peer_name.c
+++ b/toxcore/events/conference_peer_name.c
@@ -107,6 +107,8 @@ static void tox_event_conference_peer_name_pack(
     const Tox_Event_Conference_Peer_Name *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_CONFERENCE_PEER_NAME);
     bin_pack_array(mp, 3);
     bin_pack_u32(mp, event->conference_number);
     bin_pack_u32(mp, event->peer_number);
@@ -199,8 +201,6 @@ void tox_events_pack_conference_peer_name(const Tox_Events *events, msgpack_pack
 {
     const uint32_t size = tox_events_get_conference_peer_name_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_conference_peer_name_pack(tox_events_get_conference_peer_name(events, i), mp);
     }
@@ -208,23 +208,13 @@ void tox_events_pack_conference_peer_name(const Tox_Events *events, msgpack_pack
 
 bool tox_events_unpack_conference_peer_name(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Conference_Peer_Name *event = tox_events_add_conference_peer_name(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Conference_Peer_Name *event = tox_events_add_conference_peer_name(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_conference_peer_name_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_conference_peer_name_unpack(event, obj);
 }
 
 

--- a/toxcore/events/conference_title.c
+++ b/toxcore/events/conference_title.c
@@ -106,6 +106,8 @@ static void tox_event_conference_title_pack(
     const Tox_Event_Conference_Title *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_CONFERENCE_TITLE);
     bin_pack_array(mp, 3);
     bin_pack_u32(mp, event->conference_number);
     bin_pack_u32(mp, event->peer_number);
@@ -197,8 +199,6 @@ void tox_events_pack_conference_title(const Tox_Events *events, msgpack_packer *
 {
     const uint32_t size = tox_events_get_conference_title_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_conference_title_pack(tox_events_get_conference_title(events, i), mp);
     }
@@ -206,23 +206,13 @@ void tox_events_pack_conference_title(const Tox_Events *events, msgpack_packer *
 
 bool tox_events_unpack_conference_title(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Conference_Title *event = tox_events_add_conference_title(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Conference_Title *event = tox_events_add_conference_title(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_conference_title_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_conference_title_unpack(event, obj);
 }
 
 

--- a/toxcore/events/file_chunk_request.c
+++ b/toxcore/events/file_chunk_request.c
@@ -98,6 +98,8 @@ static void tox_event_file_chunk_request_pack(
     const Tox_Event_File_Chunk_Request *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FILE_CHUNK_REQUEST);
     bin_pack_array(mp, 4);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_u32(mp, event->file_number);
@@ -191,8 +193,6 @@ void tox_events_pack_file_chunk_request(const Tox_Events *events, msgpack_packer
 {
     const uint32_t size = tox_events_get_file_chunk_request_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_file_chunk_request_pack(tox_events_get_file_chunk_request(events, i), mp);
     }
@@ -200,23 +200,13 @@ void tox_events_pack_file_chunk_request(const Tox_Events *events, msgpack_packer
 
 bool tox_events_unpack_file_chunk_request(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_File_Chunk_Request *event = tox_events_add_file_chunk_request(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_File_Chunk_Request *event = tox_events_add_file_chunk_request(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_file_chunk_request_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_file_chunk_request_unpack(event, obj);
 }
 
 

--- a/toxcore/events/file_recv.c
+++ b/toxcore/events/file_recv.c
@@ -134,6 +134,8 @@ static void tox_event_file_recv_pack(
     const Tox_Event_File_Recv *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FILE_RECV);
     bin_pack_array(mp, 5);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_u32(mp, event->file_number);
@@ -229,8 +231,6 @@ void tox_events_pack_file_recv(const Tox_Events *events, msgpack_packer *mp)
 {
     const uint32_t size = tox_events_get_file_recv_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_file_recv_pack(tox_events_get_file_recv(events, i), mp);
     }
@@ -238,23 +238,13 @@ void tox_events_pack_file_recv(const Tox_Events *events, msgpack_packer *mp)
 
 bool tox_events_unpack_file_recv(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_File_Recv *event = tox_events_add_file_recv(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_File_Recv *event = tox_events_add_file_recv(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_file_recv_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_file_recv_unpack(event, obj);
 }
 
 

--- a/toxcore/events/file_recv_chunk.c
+++ b/toxcore/events/file_recv_chunk.c
@@ -120,6 +120,8 @@ static void tox_event_file_recv_chunk_pack(
     const Tox_Event_File_Recv_Chunk *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FILE_RECV_CHUNK);
     bin_pack_array(mp, 4);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_u32(mp, event->file_number);
@@ -213,8 +215,6 @@ void tox_events_pack_file_recv_chunk(const Tox_Events *events, msgpack_packer *m
 {
     const uint32_t size = tox_events_get_file_recv_chunk_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_file_recv_chunk_pack(tox_events_get_file_recv_chunk(events, i), mp);
     }
@@ -222,23 +222,13 @@ void tox_events_pack_file_recv_chunk(const Tox_Events *events, msgpack_packer *m
 
 bool tox_events_unpack_file_recv_chunk(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_File_Recv_Chunk *event = tox_events_add_file_recv_chunk(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_File_Recv_Chunk *event = tox_events_add_file_recv_chunk(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_file_recv_chunk_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_file_recv_chunk_unpack(event, obj);
 }
 
 

--- a/toxcore/events/file_recv_control.c
+++ b/toxcore/events/file_recv_control.c
@@ -86,6 +86,8 @@ static void tox_event_file_recv_control_pack(
     const Tox_Event_File_Recv_Control *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FILE_RECV_CONTROL);
     bin_pack_array(mp, 3);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_u32(mp, event->file_number);
@@ -177,8 +179,6 @@ void tox_events_pack_file_recv_control(const Tox_Events *events, msgpack_packer 
 {
     const uint32_t size = tox_events_get_file_recv_control_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_file_recv_control_pack(tox_events_get_file_recv_control(events, i), mp);
     }
@@ -186,23 +186,13 @@ void tox_events_pack_file_recv_control(const Tox_Events *events, msgpack_packer 
 
 bool tox_events_unpack_file_recv_control(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_File_Recv_Control *event = tox_events_add_file_recv_control(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_File_Recv_Control *event = tox_events_add_file_recv_control(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_file_recv_control_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_file_recv_control_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_connection_status.c
+++ b/toxcore/events/friend_connection_status.c
@@ -75,6 +75,8 @@ static void tox_event_friend_connection_status_pack(
 {
     assert(event != nullptr);
     bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_CONNECTION_STATUS);
+    bin_pack_array(mp, 2);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_u32(mp, event->connection_status);
 }
@@ -165,8 +167,6 @@ void tox_events_pack_friend_connection_status(const Tox_Events *events, msgpack_
 {
     const uint32_t size = tox_events_get_friend_connection_status_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_connection_status_pack(tox_events_get_friend_connection_status(events, i), mp);
     }
@@ -174,23 +174,13 @@ void tox_events_pack_friend_connection_status(const Tox_Events *events, msgpack_
 
 bool tox_events_unpack_friend_connection_status(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Connection_Status *event = tox_events_add_friend_connection_status(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Connection_Status *event = tox_events_add_friend_connection_status(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_connection_status_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_connection_status_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_lossless_packet.c
+++ b/toxcore/events/friend_lossless_packet.c
@@ -94,6 +94,8 @@ static void tox_event_friend_lossless_packet_pack(
 {
     assert(event != nullptr);
     bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_LOSSLESS_PACKET);
+    bin_pack_array(mp, 2);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_bytes(mp, event->data, event->data_length);
 }
@@ -183,8 +185,6 @@ void tox_events_pack_friend_lossless_packet(const Tox_Events *events, msgpack_pa
 {
     const uint32_t size = tox_events_get_friend_lossless_packet_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_lossless_packet_pack(tox_events_get_friend_lossless_packet(events, i), mp);
     }
@@ -192,23 +192,13 @@ void tox_events_pack_friend_lossless_packet(const Tox_Events *events, msgpack_pa
 
 bool tox_events_unpack_friend_lossless_packet(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Lossless_Packet *event = tox_events_add_friend_lossless_packet(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Lossless_Packet *event = tox_events_add_friend_lossless_packet(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_lossless_packet_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_lossless_packet_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_lossy_packet.c
+++ b/toxcore/events/friend_lossy_packet.c
@@ -93,6 +93,8 @@ static void tox_event_friend_lossy_packet_pack(
 {
     assert(event != nullptr);
     bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_LOSSY_PACKET);
+    bin_pack_array(mp, 2);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_bytes(mp, event->data, event->data_length);
 }
@@ -182,8 +184,6 @@ void tox_events_pack_friend_lossy_packet(const Tox_Events *events, msgpack_packe
 {
     const uint32_t size = tox_events_get_friend_lossy_packet_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_lossy_packet_pack(tox_events_get_friend_lossy_packet(events, i), mp);
     }
@@ -191,23 +191,13 @@ void tox_events_pack_friend_lossy_packet(const Tox_Events *events, msgpack_packe
 
 bool tox_events_unpack_friend_lossy_packet(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Lossy_Packet *event = tox_events_add_friend_lossy_packet(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Lossy_Packet *event = tox_events_add_friend_lossy_packet(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_lossy_packet_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_lossy_packet_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_message.c
+++ b/toxcore/events/friend_message.c
@@ -106,6 +106,8 @@ static void tox_event_friend_message_pack(
     const Tox_Event_Friend_Message *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_MESSAGE);
     bin_pack_array(mp, 3);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_u32(mp, event->type);
@@ -197,8 +199,6 @@ void tox_events_pack_friend_message(const Tox_Events *events, msgpack_packer *mp
 {
     const uint32_t size = tox_events_get_friend_message_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_message_pack(tox_events_get_friend_message(events, i), mp);
     }
@@ -206,23 +206,13 @@ void tox_events_pack_friend_message(const Tox_Events *events, msgpack_packer *mp
 
 bool tox_events_unpack_friend_message(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Message *event = tox_events_add_friend_message(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Message *event = tox_events_add_friend_message(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_message_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_message_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_name.c
+++ b/toxcore/events/friend_name.c
@@ -93,6 +93,8 @@ static void tox_event_friend_name_pack(
 {
     assert(event != nullptr);
     bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_NAME);
+    bin_pack_array(mp, 2);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_bytes(mp, event->name, event->name_length);
 }
@@ -181,8 +183,6 @@ void tox_events_pack_friend_name(const Tox_Events *events, msgpack_packer *mp)
 {
     const uint32_t size = tox_events_get_friend_name_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_name_pack(tox_events_get_friend_name(events, i), mp);
     }
@@ -190,23 +190,13 @@ void tox_events_pack_friend_name(const Tox_Events *events, msgpack_packer *mp)
 
 bool tox_events_unpack_friend_name(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Name *event = tox_events_add_friend_name(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Name *event = tox_events_add_friend_name(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_name_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_name_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_read_receipt.c
+++ b/toxcore/events/friend_read_receipt.c
@@ -72,6 +72,8 @@ static void tox_event_friend_read_receipt_pack(
 {
     assert(event != nullptr);
     bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_READ_RECEIPT);
+    bin_pack_array(mp, 2);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_u32(mp, event->message_id);
 }
@@ -161,8 +163,6 @@ void tox_events_pack_friend_read_receipt(const Tox_Events *events, msgpack_packe
 {
     const uint32_t size = tox_events_get_friend_read_receipt_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_read_receipt_pack(tox_events_get_friend_read_receipt(events, i), mp);
     }
@@ -170,23 +170,13 @@ void tox_events_pack_friend_read_receipt(const Tox_Events *events, msgpack_packe
 
 bool tox_events_unpack_friend_read_receipt(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Read_Receipt *event = tox_events_add_friend_read_receipt(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Read_Receipt *event = tox_events_add_friend_read_receipt(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_read_receipt_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_read_receipt_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_request.c
+++ b/toxcore/events/friend_request.c
@@ -94,6 +94,8 @@ static void tox_event_friend_request_pack(
 {
     assert(event != nullptr);
     bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_REQUEST);
+    bin_pack_array(mp, 2);
     bin_pack_bytes(mp, event->public_key, TOX_PUBLIC_KEY_SIZE);
     bin_pack_bytes(mp, event->message, event->message_length);
 }
@@ -182,8 +184,6 @@ void tox_events_pack_friend_request(const Tox_Events *events, msgpack_packer *mp
 {
     const uint32_t size = tox_events_get_friend_request_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_request_pack(tox_events_get_friend_request(events, i), mp);
     }
@@ -191,23 +191,13 @@ void tox_events_pack_friend_request(const Tox_Events *events, msgpack_packer *mp
 
 bool tox_events_unpack_friend_request(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Request *event = tox_events_add_friend_request(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Request *event = tox_events_add_friend_request(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_request_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_request_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_status.c
+++ b/toxcore/events/friend_status.c
@@ -73,6 +73,8 @@ static void tox_event_friend_status_pack(
 {
     assert(event != nullptr);
     bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_STATUS);
+    bin_pack_array(mp, 2);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_u32(mp, event->connection_status);
 }
@@ -161,8 +163,6 @@ void tox_events_pack_friend_status(const Tox_Events *events, msgpack_packer *mp)
 {
     const uint32_t size = tox_events_get_friend_status_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_status_pack(tox_events_get_friend_status(events, i), mp);
     }
@@ -170,23 +170,13 @@ void tox_events_pack_friend_status(const Tox_Events *events, msgpack_packer *mp)
 
 bool tox_events_unpack_friend_status(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Status *event = tox_events_add_friend_status(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Status *event = tox_events_add_friend_status(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_status_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_status_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_status_message.c
+++ b/toxcore/events/friend_status_message.c
@@ -95,6 +95,8 @@ static void tox_event_friend_status_message_pack(
 {
     assert(event != nullptr);
     bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_STATUS_MESSAGE);
+    bin_pack_array(mp, 2);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_bytes(mp, event->status_message, event->status_message_length);
 }
@@ -184,8 +186,6 @@ void tox_events_pack_friend_status_message(const Tox_Events *events, msgpack_pac
 {
     const uint32_t size = tox_events_get_friend_status_message_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_status_message_pack(tox_events_get_friend_status_message(events, i), mp);
     }
@@ -193,23 +193,13 @@ void tox_events_pack_friend_status_message(const Tox_Events *events, msgpack_pac
 
 bool tox_events_unpack_friend_status_message(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Status_Message *event = tox_events_add_friend_status_message(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Status_Message *event = tox_events_add_friend_status_message(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_status_message_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_status_message_unpack(event, obj);
 }
 
 

--- a/toxcore/events/friend_typing.c
+++ b/toxcore/events/friend_typing.c
@@ -71,6 +71,8 @@ static void tox_event_friend_typing_pack(
 {
     assert(event != nullptr);
     bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_FRIEND_TYPING);
+    bin_pack_array(mp, 2);
     bin_pack_u32(mp, event->friend_number);
     bin_pack_bool(mp, event->typing);
 }
@@ -159,8 +161,6 @@ void tox_events_pack_friend_typing(const Tox_Events *events, msgpack_packer *mp)
 {
     const uint32_t size = tox_events_get_friend_typing_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_friend_typing_pack(tox_events_get_friend_typing(events, i), mp);
     }
@@ -168,23 +168,13 @@ void tox_events_pack_friend_typing(const Tox_Events *events, msgpack_packer *mp)
 
 bool tox_events_unpack_friend_typing(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Friend_Typing *event = tox_events_add_friend_typing(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Friend_Typing *event = tox_events_add_friend_typing(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_friend_typing_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_friend_typing_unpack(event, obj);
 }
 
 

--- a/toxcore/events/self_connection_status.c
+++ b/toxcore/events/self_connection_status.c
@@ -59,7 +59,8 @@ static void tox_event_self_connection_status_pack(
     const Tox_Event_Self_Connection_Status *event, msgpack_packer *mp)
 {
     assert(event != nullptr);
-    bin_pack_array(mp, 1);
+    bin_pack_array(mp, 2);
+    bin_pack_u32(mp, TOX_EVENT_SELF_CONNECTION_STATUS);
     bin_pack_u32(mp, event->connection_status);
 }
 
@@ -68,12 +69,7 @@ static bool tox_event_self_connection_status_unpack(
     Tox_Event_Self_Connection_Status *event, const msgpack_object *obj)
 {
     assert(event != nullptr);
-
-    if (obj->type != MSGPACK_OBJECT_ARRAY || obj->via.array.size < 1) {
-        return false;
-    }
-
-    return tox_unpack_connection(&event->connection_status, &obj->via.array.ptr[0]);
+    return tox_unpack_connection(&event->connection_status, obj);
 }
 
 
@@ -147,8 +143,6 @@ void tox_events_pack_self_connection_status(const Tox_Events *events, msgpack_pa
 {
     const uint32_t size = tox_events_get_self_connection_status_size(events);
 
-    bin_pack_array(mp, size);
-
     for (uint32_t i = 0; i < size; ++i) {
         tox_event_self_connection_status_pack(tox_events_get_self_connection_status(events, i), mp);
     }
@@ -156,23 +150,13 @@ void tox_events_pack_self_connection_status(const Tox_Events *events, msgpack_pa
 
 bool tox_events_unpack_self_connection_status(Tox_Events *events, const msgpack_object *obj)
 {
-    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+    Tox_Event_Self_Connection_Status *event = tox_events_add_self_connection_status(events);
+
+    if (event == nullptr) {
         return false;
     }
 
-    for (uint32_t i = 0; i < obj->via.array.size; ++i) {
-        Tox_Event_Self_Connection_Status *event = tox_events_add_self_connection_status(events);
-
-        if (event == nullptr) {
-            return false;
-        }
-
-        if (!tox_event_self_connection_status_unpack(event, &obj->via.array.ptr[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return tox_event_self_connection_status_unpack(event, obj);
 }
 
 

--- a/toxcore/tox_events.h
+++ b/toxcore/tox_events.h
@@ -184,6 +184,36 @@ Tox_Connection tox_event_self_connection_status_get_connection_status(
     const Tox_Event_Self_Connection_Status *self_connection_status);
 
 
+typedef enum Tox_Event {
+    TOX_EVENT_SELF_CONNECTION_STATUS        = 0,
+
+    TOX_EVENT_FRIEND_REQUEST                = 1,
+    TOX_EVENT_FRIEND_CONNECTION_STATUS      = 2,
+    TOX_EVENT_FRIEND_LOSSY_PACKET           = 3,
+    TOX_EVENT_FRIEND_LOSSLESS_PACKET        = 4,
+
+    TOX_EVENT_FRIEND_NAME                   = 5,
+    TOX_EVENT_FRIEND_STATUS                 = 6,
+    TOX_EVENT_FRIEND_STATUS_MESSAGE         = 7,
+
+    TOX_EVENT_FRIEND_MESSAGE                = 8,
+    TOX_EVENT_FRIEND_READ_RECEIPT           = 9,
+    TOX_EVENT_FRIEND_TYPING                 = 10,
+
+    TOX_EVENT_FILE_CHUNK_REQUEST            = 11,
+    TOX_EVENT_FILE_RECV                     = 12,
+    TOX_EVENT_FILE_RECV_CHUNK               = 13,
+    TOX_EVENT_FILE_RECV_CONTROL             = 14,
+
+    TOX_EVENT_CONFERENCE_INVITE             = 15,
+    TOX_EVENT_CONFERENCE_CONNECTED          = 16,
+    TOX_EVENT_CONFERENCE_PEER_LIST_CHANGED  = 17,
+    TOX_EVENT_CONFERENCE_PEER_NAME          = 18,
+    TOX_EVENT_CONFERENCE_TITLE              = 19,
+
+    TOX_EVENT_CONFERENCE_MESSAGE            = 20,
+} Tox_Event;
+
 /**
  * Container object for all Tox core events.
  *
@@ -289,14 +319,18 @@ typedef enum Tox_Err_Events_Iterate {
  * Otherwise it returns an object with the recorded events in it. If an
  * allocation fails while recording events, some events may be dropped.
  *
+ * If @p fail_hard is `true`, any failure will result in NULL, so all recorded
+ * events will be dropped.
+ *
  * The result must be freed using `tox_events_free`.
  *
  * @param tox The Tox instance to iterate on.
+ * @param fail_hard Drop all events when any allocation fails.
  * @param error An error code. Will be set to OK on success.
  *
  * @returns the recorded events structure.
  */
-Tox_Events *tox_events_iterate(Tox *tox, Tox_Err_Events_Iterate *error);
+Tox_Events *tox_events_iterate(Tox *tox, bool fail_hard, Tox_Err_Events_Iterate *error);
 
 /**
  * Frees all memory associated with the events structure.


### PR DESCRIPTION
We're using a union-like encoding now with an enum telling which union
member to set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2024)
<!-- Reviewable:end -->
