### PR TITLE
chore: Fix implicit declaration warning in fuzz build

### DIFF
--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -34,6 +34,7 @@
 
 //!TOKSTYLE-
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#include <assert.h>
 #include "../testing/fuzzing/fuzz_adapter.h"
 #endif
 //!TOKSTYLE+


### PR DESCRIPTION
```
Building C object CMakeFiles/toxcore_static.dir/toxcore/crypto_core.c.o
c-toxcore/toxcore/crypto_core.c:251:5: warning: implicit declaration of function 'assert' is invalid in C99 [-Wimplicit-function-declaration]
    assert(length >= crypto_box_MACBYTES);
    ^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2026)
<!-- Reviewable:end -->
