### PR TITLE
fix: remove bogus asserts in fuzzer harness

### DIFF
--- a/testing/fuzzing/toxsave_harness.cc
+++ b/testing/fuzzing/toxsave_harness.cc
@@ -14,11 +14,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   tox_options_set_savedata_data(tox_options, data, size);
   tox_options_set_savedata_type(tox_options, TOX_SAVEDATA_TYPE_TOX_SAVE);
 
-  Tox_Err_New error_new;
-  Tox *tox = tox_new(tox_options, &error_new);
-
-  assert(tox != nullptr);
-  assert(error_new == TOX_ERR_NEW_OK);
+  Tox *tox = tox_new(tox_options, nullptr);
 
   tox_options_free(tox_options);
 


### PR DESCRIPTION
We can not assert that loading succeeds while feeding corrupted data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2031)
<!-- Reviewable:end -->
