### PR TITLE
feat: Improve how we share TCP relays with friends

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-e76672b3b101846848d17ea141c541975db2b9edaad26d193073bbef4c07f310  /usr/local/bin/tox-bootstrapd
+e73d3dce83fd0dd2bc5f5517692e84fb64b856201e22fcbfc59dc84fc22e3ee6  /usr/local/bin/tox-bootstrapd

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -231,6 +231,15 @@ int add_tcp_relay_global(TCP_Connections *tcp_c, const IP_Port *ip_port, const u
 non_null()
 uint32_t tcp_copy_connected_relays(const TCP_Connections *tcp_c, Node_format *tcp_relays, uint16_t max_num);
 
+/** Copy a maximum of `max_num` TCP relays we are connected to starting at the index in the TCP relay array
+ * for `tcp_c` designated by `idx`. If idx is greater than the array length a modulo operation is performed.
+ *
+ * Returns the number of relays successfully copied.
+ */
+non_null()
+uint32_t tcp_copy_connected_relays_index(const TCP_Connections *tcp_c, Node_format *tcp_relays, uint16_t max_num,
+        uint32_t idx);
+
 /** Returns a new TCP_Connections object associated with the secret_key.
  *
  * In order for others to connect to this instance new_tcp_connection_to() must be called with the

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -48,6 +48,7 @@ struct Friend_Conn {
 
     Node_format tcp_relays[FRIEND_MAX_STORED_TCP_RELAYS];
     uint16_t tcp_relay_counter;
+    uint32_t tcp_relay_share_index;
 
     bool hosting_tcp_relay;
 };
@@ -286,9 +287,12 @@ static unsigned int send_relays(Friend_Connections *fr_c, int friendcon_id)
     Node_format nodes[MAX_SHARED_RELAYS] = {{{0}}};
     uint8_t data[1024];
 
-    const int n = copy_connected_tcp_relays(fr_c->net_crypto, nodes, MAX_SHARED_RELAYS);
+    const uint32_t n = copy_connected_tcp_relays_index(fr_c->net_crypto, nodes, MAX_SHARED_RELAYS,
+                       friend_con->tcp_relay_share_index);
 
-    for (int i = 0; i < n; ++i) {
+    friend_con->tcp_relay_share_index += MAX_SHARED_RELAYS;
+
+    for (uint32_t i = 0; i < n; ++i) {
         /* Associated the relays being sent with this connection.
          * On receiving the peer will do the same which will establish the connection. */
         friend_add_tcp_relay(fr_c, friendcon_id, &nodes[i].ip_port, nodes[i].public_key);

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -36,8 +36,8 @@
 /** Max number of tcp relays sent to friends */
 #define MAX_SHARED_RELAYS RECOMMENDED_FRIEND_TCP_CONNECTIONS
 
-/** Interval between the sending of tcp relay information */
-#define SHARE_RELAYS_INTERVAL (5 * 60)
+/** How often we share our TCP relays with each friend connection */
+#define SHARE_RELAYS_INTERVAL (60 * 2)
 
 
 typedef enum Friendconn_Status {

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2344,7 +2344,7 @@ int send_tcp_onion_request(Net_Crypto *c, unsigned int tcp_connections_number, c
     return ret;
 }
 
-/** Copy a maximum of num TCP relays we are connected to to tcp_relays.
+/** Copy a maximum of num random TCP relays we are connected to to tcp_relays.
  * NOTE that the family of the copied ip ports will be set to TCP_INET or TCP_INET6.
  *
  * return number of relays copied to tcp_relays on success.
@@ -2358,6 +2358,19 @@ unsigned int copy_connected_tcp_relays(Net_Crypto *c, Node_format *tcp_relays, u
 
     pthread_mutex_lock(&c->tcp_mutex);
     unsigned int ret = tcp_copy_connected_relays(c->tcp_c, tcp_relays, num);
+    pthread_mutex_unlock(&c->tcp_mutex);
+
+    return ret;
+}
+
+uint32_t copy_connected_tcp_relays_index(Net_Crypto *c, Node_format *tcp_relays, uint16_t num, uint32_t idx)
+{
+    if (num == 0) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&c->tcp_mutex);
+    uint32_t ret = tcp_copy_connected_relays_index(c->tcp_c, tcp_relays, num, idx);
     pthread_mutex_unlock(&c->tcp_mutex);
 
     return ret;

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -309,7 +309,7 @@ non_null()
 int send_tcp_onion_request(Net_Crypto *c, unsigned int tcp_connections_number,
                            const uint8_t *data, uint16_t length);
 
-/** Copy a maximum of num TCP relays we are connected to to tcp_relays.
+/** Copy a maximum of num random TCP relays we are connected to to tcp_relays.
  * NOTE that the family of the copied ip ports will be set to TCP_INET or TCP_INET6.
  *
  * return number of relays copied to tcp_relays on success.
@@ -317,6 +317,14 @@ int send_tcp_onion_request(Net_Crypto *c, unsigned int tcp_connections_number,
  */
 non_null()
 unsigned int copy_connected_tcp_relays(Net_Crypto *c, Node_format *tcp_relays, uint16_t num);
+
+/** Copy a maximum of `max_num` TCP relays we are connected to starting at the index in the TCP relay array
+ * for `tcp_c` designated by `idx`. If idx is greater than the array length a modulo operation is performed.
+ *
+ * Returns the number of relays successfully copied.
+ */
+non_null()
+uint32_t copy_connected_tcp_relays_index(Net_Crypto *c, Node_format *tcp_relays, uint16_t num, uint32_t idx);
 
 /** Kill a crypto connection.
  *


### PR DESCRIPTION
Previously we would try to send three random TCP relays that we're
connected to to each friend once every 5 minutes. The problem with
this method is that it could take an extraordinarily long time
to share every relay; some relays might be consistently skipped
while others might be sent repeatedly. Moreover, there's no
guarantee that the nodes you try to send are actually online.
This leads to a prety unreliable and flaky way of sharing.

Now we reduce the timer to two minutes, and cycle through the list
trying 3 nodes each share attempt. This guarantees that every online
node in our list gets shared with every friend after a fixed amount of
time (which depends on how many nodes are in the list)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2047)
<!-- Reviewable:end -->
