### PR TITLE
fix: Fix return type of functions returning uint64_t.

### DIFF
--- a/toxcore/events/file_recv.c
+++ b/toxcore/events/file_recv.c
@@ -90,7 +90,7 @@ static void tox_event_file_recv_set_file_size(Tox_Event_File_Recv *file_recv,
     assert(file_recv != nullptr);
     file_recv->file_size = file_size;
 }
-uint32_t tox_event_file_recv_get_file_size(const Tox_Event_File_Recv *file_recv)
+uint64_t tox_event_file_recv_get_file_size(const Tox_Event_File_Recv *file_recv)
 {
     assert(file_recv != nullptr);
     return file_recv->file_size;

--- a/toxcore/events/file_recv_chunk.c
+++ b/toxcore/events/file_recv_chunk.c
@@ -76,7 +76,7 @@ static void tox_event_file_recv_chunk_set_position(Tox_Event_File_Recv_Chunk *fi
     assert(file_recv_chunk != nullptr);
     file_recv_chunk->position = position;
 }
-uint32_t tox_event_file_recv_chunk_get_position(const Tox_Event_File_Recv_Chunk *file_recv_chunk)
+uint64_t tox_event_file_recv_chunk_get_position(const Tox_Event_File_Recv_Chunk *file_recv_chunk)
 {
     assert(file_recv_chunk != nullptr);
     return file_recv_chunk->position;

--- a/toxcore/tox_events.h
+++ b/toxcore/tox_events.h
@@ -78,7 +78,7 @@ size_t tox_event_file_recv_get_filename_length(
     const Tox_Event_File_Recv *file_recv);
 uint32_t tox_event_file_recv_get_file_number(
     const Tox_Event_File_Recv *file_recv);
-uint32_t tox_event_file_recv_get_file_size(
+uint64_t tox_event_file_recv_get_file_size(
     const Tox_Event_File_Recv *file_recv);
 uint32_t tox_event_file_recv_get_friend_number(
     const Tox_Event_File_Recv *file_recv);
@@ -94,7 +94,7 @@ uint32_t tox_event_file_recv_chunk_get_file_number(
     const Tox_Event_File_Recv_Chunk *file_recv_chunk);
 uint32_t tox_event_file_recv_chunk_get_friend_number(
     const Tox_Event_File_Recv_Chunk *file_recv_chunk);
-uint32_t tox_event_file_recv_chunk_get_position(
+uint64_t tox_event_file_recv_chunk_get_position(
     const Tox_Event_File_Recv_Chunk *file_recv_chunk);
 
 typedef struct Tox_Event_File_Recv_Control Tox_Event_File_Recv_Control;


### PR DESCRIPTION
They were losing precision by going through uint32_t.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2052)
<!-- Reviewable:end -->
