### PR TITLE
test: Add a profiling script and Dockerfile.

### DIFF
--- a/other/docker/perf/Dockerfile
+++ b/other/docker/perf/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.14.0
+
+RUN ["apk", "add", "--no-cache", \
+ "bash", \
+ "gcc", \
+ "linux-headers", \
+ "msgpack-c-dev", \
+ "musl-dev", \
+ "libsodium-dev", \
+ "libvpx-dev", \
+ "opus-dev", \
+ "perf"]
+
+WORKDIR /work
+COPY other/docker/perf/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/other/docker/perf/entrypoint.sh
+++ b/other/docker/perf/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eux
+
+TEST=${1:-conference_test}
+OUTPUT="/work/c-toxcore/test.perf"
+
+readarray -t FLAGS <<<"$(pkg-config --cflags --libs libsodium msgpack opus vpx | sed -e 's/ /\n/g')"
+readarray -t SRCS <<<"$(find /work/c-toxcore/tox* -name "*.c")"
+
+gcc -pthread -g \
+  -o "/work/$TEST" -O3 -fno-omit-frame-pointer \
+  "${SRCS[@]}" \
+  /work/c-toxcore/auto_tests/auto_test_support.c \
+  /work/c-toxcore/testing/misc_tools.c \
+  "/work/c-toxcore/auto_tests/$TEST.c" \
+  -DMIN_LOGGER_LEVEL=LOGGER_LEVEL_TRACE \
+  "${FLAGS[@]}"
+
+time perf record -g --call-graph dwarf --freq=max "/work/$TEST" /work/c-toxcore/auto_tests/
+perf report | head -n50
+perf script -F +pid >"$OUTPUT"
+chown 1000:100 "$OUTPUT"

--- a/other/docker/perf/run
+++ b/other/docker/perf/run
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eux
+
+docker build -t toxchat/c-toxcore:perf -f other/docker/perf/Dockerfile .
+docker run --privileged --rm -it \
+  -v "$PWD:/work/c-toxcore" \
+  toxchat/c-toxcore:perf \
+  "$@"


### PR DESCRIPTION
This works on my kernel. If your kernel is older/newer, you may need a
different alpine base image that matches your kernel more closely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2066)
<!-- Reviewable:end -->
