### PR TITLE
chore: Make coverity scan a nightly job.

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,8 +1,8 @@
 name: coverity-scan
 
 on:
-  push:
-    branches: [master]
+  schedule:
+    - cron: '0 10 * * *'  # Once a day
 
 jobs:
   latest:


### PR DESCRIPTION
Instead of on every push. It only produces results once a day anyway.

Fixes https://github.com/TokTok/c-toxcore/issues/2034

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2074)
<!-- Reviewable:end -->
