### PR TITLE
cleanup: Avoid casting function pointers.

### DIFF
--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -266,6 +266,7 @@ struct Messenger {
     uint16_t num_loaded_relays;
     Node_format loaded_relays[NUM_SAVED_TCP_RELAYS]; // Relays loaded from config
 
+    m_friend_request_cb *friend_request;
     m_friend_message_cb *friend_message;
     m_friend_name_cb *friend_namechange;
     m_friend_status_message_cb *friend_statusmessagechange;


### PR DESCRIPTION
Also added declarations using the `_cb` type for each of the callback
handlers in tox.h. This forces cppcheck to check whether the parameter
names in the definitions agree with the `_cb` parameter names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2091)
<!-- Reviewable:end -->
