### PR TITLE
cleanup: Remove any disallowed casts.

### DIFF
--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -27,7 +27,7 @@ sh_test(
     name = "cimplefmt_test",
     size = "small",
     srcs = ["//hs-cimple/tools:cimplefmt"],
-    args = ["$(locations %s)" % f for f in CIMPLE_FILES],
+    args = ["--reparse"] + ["$(locations %s)" % f for f in CIMPLE_FILES],
     data = CIMPLE_FILES,
     tags = ["haskell"],
 )

--- a/toxav/video.c
+++ b/toxav/video.c
@@ -332,7 +332,7 @@ void vc_iterate(VCSession *vc)
             dest = vpx_codec_get_frame(vc->decoder, &iter)) {
         if (vc->vcb != nullptr) {
             vc->vcb(vc->av, vc->friend_number, dest->d_w, dest->d_h,
-                    (const uint8_t *)dest->planes[0], (const uint8_t *)dest->planes[1], (const uint8_t *)dest->planes[2],
+                    dest->planes[0], dest->planes[1], dest->planes[2],
                     dest->stride[0], dest->stride[1], dest->stride[2], vc->vcb_user_data);
         }
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1273,15 +1273,19 @@ bool ip_parse_addr(const IP *ip, char *address, size_t length)
     }
 
     if (net_family_is_ipv4(ip->family)) {
-        const struct in_addr *addr = (const struct in_addr *)&ip->ip.v4;
+        struct in_addr addr;
+        addr.s_addr = ip->ip.v4.uint32;
         assert(make_family(ip->family) == AF_INET);
-        return inet_ntop4(addr, address, length) != nullptr;
+        return inet_ntop4(&addr, address, length) != nullptr;
     }
 
     if (net_family_is_ipv6(ip->family)) {
-        const struct in6_addr *addr = (const struct in6_addr *)&ip->ip.v6;
+        struct in6_addr addr;
+        static_assert(sizeof(addr.s6_addr) == sizeof(ip->ip.v6.uint8),
+                "assumption does not hold: s6_addr should be 16 bytes");
+        memcpy(addr.s6_addr, ip->ip.v6.uint8, sizeof(ip->ip.v6.uint8));
         assert(make_family(ip->family) == AF_INET6);
-        return inet_ntop6(addr, address, length) != nullptr;
+        return inet_ntop6(&addr, address, length) != nullptr;
     }
 
     return false;


### PR DESCRIPTION
The ones in toxav weren't needed. The ones in network.c are
non-trivially correct. Now, the code is more easily verifiable.