### PR TITLE
cleanup: Reduce name shadowing; remove ptr-to-bool conversions.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-30dec481315934168e3b8abf54fe4ed5814161230bd499e0f935a4df1922dd33  /usr/local/bin/tox-bootstrapd
+d69f99a7aa2e9290024b1dea3443fbfe9bfbaba444db5ccace5df2d88f15300a  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -340,7 +340,7 @@ int create_request(const uint8_t *send_public_key, const uint8_t *send_secret_ke
     memcpy(temp + 1, data, length);
     temp[0] = request_id;
     const int len = encrypt_data(recv_public_key, send_secret_key, nonce, temp, length + 1,
-                                 CRYPTO_SIZE + packet);
+                                 packet + CRYPTO_SIZE);
 
     if (len == -1) {
         crypto_memzero(temp, MAX_CRYPTO_REQUEST_SIZE);
@@ -942,13 +942,13 @@ static int dht_cmp_entry(const void *a, const void *b)
         return 1;
     }
 
-    const int close = id_closest(cmp_public_key, entry1.public_key, entry2.public_key);
+    const int closest = id_closest(cmp_public_key, entry1.public_key, entry2.public_key);
 
-    if (close == 1) {
+    if (closest == 1) {
         return 1;
     }
 
-    if (close == 2) {
+    if (closest == 2) {
         return -1;
     }
 

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -82,7 +82,7 @@ static Broadcast_Info *fetch_broadcast_info(uint16_t port)
     if (ret == NO_ERROR) {
         IP_ADAPTER_INFO *pAdapter = pAdapterInfo;
 
-        while (pAdapter) {
+        while (pAdapter != nullptr) {
             IP gateway = {0};
             IP subnet_mask = {0};
 
@@ -108,7 +108,7 @@ static Broadcast_Info *fetch_broadcast_info(uint16_t port)
         }
     }
 
-    if (pAdapterInfo) {
+    if (pAdapterInfo != nullptr) {
         free(pAdapterInfo);
     }
 

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -317,7 +317,7 @@ static int clear_receipts(Messenger *m, int32_t friendnumber)
 
     struct Receipts *receipts = m->friendlist[friendnumber].receipts_start;
 
-    while (receipts) {
+    while (receipts != nullptr) {
         struct Receipts *temp_r = receipts->next;
         free(receipts);
         receipts = temp_r;
@@ -378,7 +378,7 @@ static int do_receipts(Messenger *m, int32_t friendnumber, void *userdata)
 
     struct Receipts *receipts = m->friendlist[friendnumber].receipts_start;
 
-    while (receipts) {
+    while (receipts != nullptr) {
         if (friend_received_packet(m, friendnumber, receipts->packet_num) == -1) {
             break;
         }
@@ -1422,8 +1422,8 @@ static int64_t send_file_data_packet(const Messenger *m, int32_t friendnumber, u
  *  return -6 if packet queue full.
  *  return -7 if wrong position.
  */
-int file_data(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uint64_t position, const uint8_t *data,
-              uint16_t length)
+int send_file_data(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uint64_t position,
+                   const uint8_t *data, uint16_t length)
 {
     assert(length == 0 || data != nullptr);
 
@@ -1542,7 +1542,7 @@ static bool do_all_filetransfers(Messenger *m, int32_t friendnumber, void *userd
         } else if (ft->status == FILESTATUS_TRANSFERRING && ft->paused == FILE_PAUSE_NOT) {
             if (ft->size == 0) {
                 /* Send 0 data to friend if file is 0 length. */
-                file_data(m, friendnumber, i, 0, nullptr, 0);
+                send_file_data(m, friendnumber, i, 0, nullptr, 0);
                 continue;
             }
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -665,8 +665,7 @@ int file_seek(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uin
  *  return -7 if wrong position.
  */
 non_null(1) nullable(5)
-int file_data(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uint64_t position, const uint8_t *data,
-              uint16_t length);
+int send_file_data(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uint64_t position, const uint8_t *data, uint16_t length);
 
 /*** A/V related */
 

--- a/toxcore/TCP_common.c
+++ b/toxcore/TCP_common.c
@@ -56,7 +56,7 @@ int send_pending_data(const Logger *logger, TCP_Connection *con)
 
     TCP_Priority_List *p = con->priority_queue_start;
 
-    while (p) {
+    while (p != nullptr) {
         const uint16_t left = p->size - p->sent;
         const int len = net_send(logger, con->sock, p->data + p->sent, left, &con->ip_port);
 

--- a/toxcore/logger.c
+++ b/toxcore/logger.c
@@ -105,7 +105,7 @@ void logger_write(const Logger *log, Logger_Level level, const char *file, int l
     // On Windows, the path separator *may* be a backslash, so we look for that
     // one too.
     const char *windows_filename = strrchr(file, '\\');
-    file = windows_filename ? windows_filename + 1 : file;
+    file = windows_filename != nullptr ? windows_filename + 1 : file;
 #endif
 
     // Format message

--- a/toxcore/onion_announce.h
+++ b/toxcore/onion_announce.h
@@ -34,7 +34,7 @@ typedef struct Onion_Announce Onion_Announce;
 non_null()
 uint8_t *onion_announce_entry_public_key(Onion_Announce *onion_a, uint32_t entry);
 non_null()
-void onion_announce_entry_set_time(Onion_Announce *onion_a, uint32_t entry, uint64_t time);
+void onion_announce_entry_set_time(Onion_Announce *onion_a, uint32_t entry, uint64_t cur_time);
 
 /** Create an onion announce request packet in packet of max_packet_length (recommended size ONION_ANNOUNCE_REQUEST_SIZE).
  *

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -641,13 +641,13 @@ static int onion_client_cmp_entry(const void *a, const void *b)
         return 1;
     }
 
-    const int close = id_closest(cmp_public_key, entry1.public_key, entry2.public_key);
+    const int closest = id_closest(cmp_public_key, entry1.public_key, entry2.public_key);
 
-    if (close == 1) {
+    if (closest == 1) {
         return 1;
     }
 
-    if (close == 2) {
+    if (closest == 2) {
         return -1;
     }
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1744,7 +1744,7 @@ bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number,
 {
     assert(tox != nullptr);
     lock(tox);
-    const int ret = file_data(tox->m, friend_number, file_number, position, data, length);
+    const int ret = send_file_data(tox->m, friend_number, file_number, position, data, length);
     unlock(tox);
 
     if (ret == 0) {


### PR DESCRIPTION
Missed a few of those in check-c. check-cimple now catches these with a
stronger type check.

Other changes:
* `ptr + int` must always have the `ptr` first, so `int + ptr` is not
  allowed anymore.
* `close` and `time` were shadowing libc functions. `file_data` was
  shadowed in a function (and is not a good function name anyway), so
  renamed to `send_file_data` which is more descriptive.
* Within a function, all local variables of the same name must have the
  same type.
* The `strerror_r` change wasn't necessary, but I kept it because it
  seems a bit clearer to me now. `#ifdef`s inside functions are a bit
  confusing sometimes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2099)
<!-- Reviewable:end -->
