### PR TITLE
cleanup: Avoid creating invalid enum values.

### DIFF
--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1380,7 +1380,7 @@ Tox_User_Status tox_friend_get_status(const Tox *tox, uint32_t friend_number, To
 
     if (ret == USERSTATUS_INVALID) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_QUERY_FRIEND_NOT_FOUND);
-        return (Tox_User_Status)(TOX_USER_STATUS_BUSY + 1);
+        return TOX_USER_STATUS_NONE;
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_QUERY_OK);


### PR DESCRIPTION
Enums should be fairly strong type guarantees about the possible value
range. The API says the return value is unspecified, so this is not a
breaking change.

Fixes https://github.com/TokTok/c-toxcore/issues/169

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2114)
<!-- Reviewable:end -->
