### PR TITLE
cleanup: Remove more boolean conversions (and a bugfix).

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -166,7 +166,7 @@ static void test_basic(void)
     ck_assert_msg(packet_resp_plain[0] == TCP_PACKET_ROUTING_RESPONSE, "Server sent the wrong packet id: %u",
                   packet_resp_plain[0]);
     ck_assert_msg(packet_resp_plain[1] == 0, "Server did not refuse the connection.");
-    ck_assert_msg(public_key_cmp(packet_resp_plain + 2, f_public_key) == 0, "Server sent the wrong public key.");
+    ck_assert_msg(pk_equal(packet_resp_plain + 2, f_public_key), "Server sent the wrong public key.");
 
     // Closing connections.
     kill_sock(sock);
@@ -315,14 +315,14 @@ static void test_some(void)
     ck_assert_msg(len == 1 + 1 + CRYPTO_PUBLIC_KEY_SIZE, "Wrong response packet length of %d.", len);
     ck_assert_msg(data[0] == TCP_PACKET_ROUTING_RESPONSE, "Wrong response packet id of %d.", data[0]);
     ck_assert_msg(data[1] == 16, "Server didn't refuse connection using wrong public key.");
-    ck_assert_msg(public_key_cmp(data + 2, con3->public_key) == 0, "Key in response packet wrong.");
+    ck_assert_msg(pk_equal(data + 2, con3->public_key), "Key in response packet wrong.");
 
     // Connection 3
     len = read_packet_sec_TCP(logger, con3, data, 2 + 1 + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == 1 + 1 + CRYPTO_PUBLIC_KEY_SIZE, "Wrong response packet length of %d.", len);
     ck_assert_msg(data[0] == TCP_PACKET_ROUTING_RESPONSE, "Wrong response packet id of %d.", data[0]);
     ck_assert_msg(data[1] == 16, "Server didn't refuse connection using wrong public key.");
-    ck_assert_msg(public_key_cmp(data + 2, con1->public_key) == 0, "Key in response packet wrong.");
+    ck_assert_msg(pk_equal(data + 2, con1->public_key), "Key in response packet wrong.");
 
     uint8_t test_packet[512] = {16, 17, 16, 86, 99, 127, 255, 189, 78}; // What is this packet????
 
@@ -458,7 +458,7 @@ static int oob_data_callback(void *object, const uint8_t *public_key, const uint
         return 1;
     }
 
-    if (public_key_cmp(public_key, oob_pubkey) != 0) {
+    if (!pk_equal(public_key, oob_pubkey)) {
         return 1;
     }
 
@@ -563,7 +563,7 @@ static void test_client(void)
     // All callback methods save data should have run during the above network prodding.
     ck_assert_msg(oob_data_callback_good == 1, "OOB callback not called");
     ck_assert_msg(response_callback_good == 1, "Response callback not called.");
-    ck_assert_msg(public_key_cmp(response_callback_public_key, f2_public_key) == 0, "Wrong public key.");
+    ck_assert_msg(pk_equal(response_callback_public_key, f2_public_key), "Wrong public key.");
     ck_assert_msg(status_callback_good == 1, "Status callback not called.");
     ck_assert_msg(status_callback_status == 2, "Wrong status callback status.");
     ck_assert_msg(status_callback_connection_id == response_callback_connection_id,
@@ -680,17 +680,17 @@ static void test_tcp_connection(void)
     uint8_t self_secret_key[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(self_public_key, self_secret_key);
     TCP_Server *tcp_s = new_TCP_server(logger, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr);
-    ck_assert_msg(public_key_cmp(tcp_server_public_key(tcp_s), self_public_key) == 0, "Wrong public key");
+    ck_assert_msg(pk_equal(tcp_server_public_key(tcp_s), self_public_key), "Wrong public key");
 
     TCP_Proxy_Info proxy_info;
     proxy_info.proxy_type = TCP_PROXY_NONE;
     crypto_new_keypair(self_public_key, self_secret_key);
     TCP_Connections *tc_1 = new_tcp_connections(logger, mono_time, self_secret_key, &proxy_info);
-    ck_assert_msg(public_key_cmp(tcp_connections_public_key(tc_1), self_public_key) == 0, "Wrong public key");
+    ck_assert_msg(pk_equal(tcp_connections_public_key(tc_1), self_public_key), "Wrong public key");
 
     crypto_new_keypair(self_public_key, self_secret_key);
     TCP_Connections *tc_2 = new_tcp_connections(logger, mono_time, self_secret_key, &proxy_info);
-    ck_assert_msg(public_key_cmp(tcp_connections_public_key(tc_2), self_public_key) == 0, "Wrong public key");
+    ck_assert_msg(pk_equal(tcp_connections_public_key(tc_2), self_public_key), "Wrong public key");
 
     IP_Port ip_port_tcp_s;
 
@@ -788,17 +788,17 @@ static void test_tcp_connection2(void)
     uint8_t self_secret_key[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(self_public_key, self_secret_key);
     TCP_Server *tcp_s = new_TCP_server(logger, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr);
-    ck_assert_msg(public_key_cmp(tcp_server_public_key(tcp_s), self_public_key) == 0, "Wrong public key");
+    ck_assert_msg(pk_equal(tcp_server_public_key(tcp_s), self_public_key), "Wrong public key");
 
     TCP_Proxy_Info proxy_info;
     proxy_info.proxy_type = TCP_PROXY_NONE;
     crypto_new_keypair(self_public_key, self_secret_key);
     TCP_Connections *tc_1 = new_tcp_connections(logger, mono_time, self_secret_key, &proxy_info);
-    ck_assert_msg(public_key_cmp(tcp_connections_public_key(tc_1), self_public_key) == 0, "Wrong public key");
+    ck_assert_msg(pk_equal(tcp_connections_public_key(tc_1), self_public_key), "Wrong public key");
 
     crypto_new_keypair(self_public_key, self_secret_key);
     TCP_Connections *tc_2 = new_tcp_connections(logger, mono_time, self_secret_key, &proxy_info);
-    ck_assert_msg(public_key_cmp(tcp_connections_public_key(tc_2), self_public_key) == 0, "Wrong public key");
+    ck_assert_msg(pk_equal(tcp_connections_public_key(tc_2), self_public_key), "Wrong public key");
 
     IP_Port ip_port_tcp_s;
 

--- a/auto_tests/dht_test.c
+++ b/auto_tests/dht_test.c
@@ -72,7 +72,7 @@ static int client_in_list(Client_data *list, uint32_t length, const uint8_t *pub
     uint32_t i;
 
     for (i = 0; i < length; ++i) {
-        if (id_equal(public_key, list[i].public_key)) {
+        if (pk_equal(public_key, list[i].public_key)) {
             return i;
         }
     }
@@ -106,7 +106,7 @@ static void test_addto_lists_update(DHT            *dht,
     // check ip_port update for existing id
     test = random_u32() % length;
     test_ipp.port = random_u32() % TOX_PORT_DEFAULT;
-    id_copy(test_id, list[test].public_key);
+    pk_copy(test_id, list[test].public_key);
 
     used = addto_lists(dht, &test_ipp, test_id);
     ck_assert_msg(used >= 1, "Wrong number of added clients");
@@ -120,7 +120,7 @@ static void test_addto_lists_update(DHT            *dht,
     test2 = random_u32() % (length / 2) + length / 2;
 
     ipport_copy(&test_ipp, ipv6 ? &list[test1].assoc6.ip_port : &list[test1].assoc4.ip_port);
-    id_copy(test_id, list[test2].public_key);
+    pk_copy(test_id, list[test2].public_key);
 
     if (ipv6) {
         list[test2].assoc6.ip_port.port = -1;
@@ -139,7 +139,7 @@ static void test_addto_lists_update(DHT            *dht,
     test2 = random_u32() % (length / 2) + length / 2;
 
     ipport_copy(&test_ipp, ipv6 ? &list[test2].assoc6.ip_port : &list[test2].assoc4.ip_port);
-    id_copy(test_id, list[test1].public_key);
+    pk_copy(test_id, list[test1].public_key);
 
     if (ipv6) {
         list[test1].assoc6.ip_port.port = -1;
@@ -173,9 +173,9 @@ static void test_addto_lists_bad(DHT            *dht,
     test3 = random_u32() % (length / 3) + 2 * length / 3;
     ck_assert_msg(!(test1 == test2 || test1 == test3 || test2 == test3), "Wrong test indices are chosen");
 
-    id_copy((uint8_t *)&test_id1, list[test1].public_key);
-    id_copy((uint8_t *)&test_id2, list[test2].public_key);
-    id_copy((uint8_t *)&test_id3, list[test3].public_key);
+    pk_copy((uint8_t *)&test_id1, list[test1].public_key);
+    pk_copy((uint8_t *)&test_id2, list[test2].public_key);
+    pk_copy((uint8_t *)&test_id3, list[test3].public_key);
 
     // mark nodes as "bad"
     if (ipv6) {

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-aea24cfae8db82511a298e2dbedb6634145732190ebcad361690cb6ca6560d7c  /usr/local/bin/tox-bootstrapd
+a80ea98f55b82eb5d60baa5d7fc32913ff964b04b931a17b74233148a27786f5  /usr/local/bin/tox-bootstrapd

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -13,6 +13,7 @@ sh_test(
     size = "small",
     srcs = ["//hs-tokstyle/tools:check-cimple"],
     args = ["$(locations %s)" % f for f in CIMPLE_FILES] + [
+        "-Wno-boolean-return",
         "-Wno-callback-names",
         "-Wno-enum-names",
         "-Wno-memcpy-structs",

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -391,7 +391,7 @@ static int msg_parse_in(const Logger *log, MSIMessage *dest, const uint8_t *data
     const uint8_t *it = data;
     int size_constraint = length;
 
-    while (*it) {/* until end byte is hit */
+    while (*it != 0) {/* until end byte is hit */
         switch (*it) {
             case ID_REQUEST: {
                 if (!check_size(log, it, &size_constraint, 1) ||
@@ -435,7 +435,7 @@ static int msg_parse_in(const Logger *log, MSIMessage *dest, const uint8_t *data
         }
     }
 
-    if (dest->request.exists == false) {
+    if (!dest->request.exists) {
         LOGGER_ERROR(log, "Invalid request field!");
         return -1;
     }

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -421,7 +421,7 @@ bool toxav_answer(ToxAV *av, uint32_t friend_number, uint32_t audio_bit_rate, ui
     Toxav_Err_Answer rc = TOXAV_ERR_ANSWER_OK;
     ToxAVCall *call;
 
-    if (m_friend_exists(av->m, friend_number) == 0) {
+    if (!m_friend_exists(av->m, friend_number)) {
         rc = TOXAV_ERR_ANSWER_FRIEND_NOT_FOUND;
         goto RETURN;
     }
@@ -612,7 +612,7 @@ static Toxav_Err_Call_Control call_control_handle(ToxAVCall *call, Toxav_Call_Co
 }
 static Toxav_Err_Call_Control call_control(ToxAV *av, uint32_t friend_number, Toxav_Call_Control control)
 {
-    if (m_friend_exists(av->m, friend_number) == 0) {
+    if (!m_friend_exists(av->m, friend_number)) {
         return TOXAV_ERR_CALL_CONTROL_FRIEND_NOT_FOUND;
     }
 
@@ -644,7 +644,7 @@ bool toxav_audio_set_bit_rate(ToxAV *av, uint32_t friend_number, uint32_t bit_ra
     Toxav_Err_Bit_Rate_Set rc = TOXAV_ERR_BIT_RATE_SET_OK;
     ToxAVCall *call;
 
-    if (m_friend_exists(av->m, friend_number) == 0) {
+    if (!m_friend_exists(av->m, friend_number)) {
         rc = TOXAV_ERR_BIT_RATE_SET_FRIEND_NOT_FOUND;
         goto RETURN;
     }
@@ -716,7 +716,7 @@ bool toxav_video_set_bit_rate(ToxAV *av, uint32_t friend_number, uint32_t bit_ra
     Toxav_Err_Bit_Rate_Set rc = TOXAV_ERR_BIT_RATE_SET_OK;
     ToxAVCall *call;
 
-    if (m_friend_exists(av->m, friend_number) == 0) {
+    if (!m_friend_exists(av->m, friend_number)) {
         rc = TOXAV_ERR_BIT_RATE_SET_FRIEND_NOT_FOUND;
         goto RETURN;
     }
@@ -802,7 +802,7 @@ bool toxav_audio_send_frame(ToxAV *av, uint32_t friend_number, const int16_t *pc
     Toxav_Err_Send_Frame rc = TOXAV_ERR_SEND_FRAME_OK;
     ToxAVCall *call;
 
-    if (m_friend_exists(av->m, friend_number) == 0) {
+    if (!m_friend_exists(av->m, friend_number)) {
         rc = TOXAV_ERR_SEND_FRAME_FRIEND_NOT_FOUND;
         goto RETURN;
     }
@@ -929,7 +929,7 @@ bool toxav_video_send_frame(ToxAV *av, uint32_t friend_number, uint16_t width, u
 
     int vpx_encode_flags = 0;
 
-    if (m_friend_exists(av->m, friend_number) == 0) {
+    if (!m_friend_exists(av->m, friend_number)) {
         rc = TOXAV_ERR_SEND_FRAME_FRIEND_NOT_FOUND;
         goto RETURN;
     }
@@ -1238,7 +1238,7 @@ static ToxAVCall *call_new(ToxAV *av, uint32_t friend_number, Toxav_Err_Call *er
     Toxav_Err_Call rc = TOXAV_ERR_CALL_OK;
     ToxAVCall *call = nullptr;
 
-    if (m_friend_exists(av->m, friend_number) == 0) {
+    if (!m_friend_exists(av->m, friend_number)) {
         rc = TOXAV_ERR_CALL_FRIEND_NOT_FOUND;
         goto RETURN;
     }

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -359,7 +359,7 @@ bool lan_discovery_send(Networking_Core *net, const Broadcast_Info *broadcast, c
 
     uint8_t data[CRYPTO_PUBLIC_KEY_SIZE + 1];
     data[0] = NET_PACKET_LAN_DISCOVERY;
-    id_copy(data + 1, dht_pk);
+    pk_copy(data + 1, dht_pk);
 
     send_broadcasts(net, broadcast, port, data, 1 + CRYPTO_PUBLIC_KEY_SIZE);
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -207,15 +207,15 @@ typedef struct Friend {
     uint8_t info[MAX_FRIEND_REQUEST_DATA_SIZE]; // the data that is sent during the friend requests we do.
     uint8_t name[MAX_NAME_LENGTH];
     uint16_t name_length;
-    uint8_t name_sent; // 0 if we didn't send our name to this friend 1 if we have.
+    bool name_sent; // false if we didn't send our name to this friend, true if we have.
     uint8_t statusmessage[MAX_STATUSMESSAGE_LENGTH];
     uint16_t statusmessage_length;
-    uint8_t statusmessage_sent;
+    bool statusmessage_sent;
     Userstatus userstatus;
-    uint8_t userstatus_sent;
-    uint8_t user_istyping;
-    uint8_t user_istyping_sent;
-    uint8_t is_typing;
+    bool userstatus_sent;
+    bool user_istyping;
+    bool user_istyping_sent;
+    bool is_typing;
     uint16_t info_size; // Length of the info.
     uint32_t message_id; // a semi-unique id used in read receipts.
     uint32_t friendrequest_nospam; // The nospam number used in the friend request.
@@ -378,13 +378,16 @@ int m_delfriend(Messenger *m, int32_t friendnumber);
 non_null()
 int m_get_friend_connectionstatus(const Messenger *m, int32_t friendnumber);
 
-/** Checks if there exists a friend with given friendnumber.
+/**
+ * Checks if there exists a friend with given friendnumber.
  *
- *  return 1 if friend exists.
- *  return 0 if friend doesn't exist.
+ * @param friendnumber The index in the friend list.
+ *
+ * @retval true if friend exists.
+ * @retval false if friend doesn't exist.
  */
 non_null()
-int m_friend_exists(const Messenger *m, int32_t friendnumber);
+bool m_friend_exists(const Messenger *m, int32_t friendnumber);
 
 /** Send a message of type to an online friend.
  *
@@ -499,10 +502,11 @@ non_null() uint64_t m_get_last_online(const Messenger *m, int32_t friendnumber);
  * returns -1 on failure.
  */
 non_null()
-int m_set_usertyping(Messenger *m, int32_t friendnumber, uint8_t is_typing);
+int m_set_usertyping(Messenger *m, int32_t friendnumber, bool is_typing);
 
 /** Get the typing status of a friend.
  *
+ * returns -1 if friend number is invalid.
  * returns 0 if friend is not typing.
  * returns 1 if friend is typing.
  */
@@ -575,11 +579,11 @@ void m_callback_conference_invite(Messenger *m, m_conference_invite_cb *function
 
 /** Send a conference invite packet.
  *
- *  return 1 on success
- *  return 0 on failure
+ *  return true on success
+ *  return false on failure
  */
 non_null()
-int send_conference_invite_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length);
+bool send_conference_invite_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length);
 
 /*** FILE SENDING */
 

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -92,11 +92,11 @@ void tcp_con_set_custom_uint(TCP_Client_Connection *con, uint32_t value)
     con->custom_uint = value;
 }
 
-/** return 1 on success
- * return 0 on failure
+/** return true on success
+ * return false on failure
  */
 non_null()
-static int connect_sock_to(const Logger *logger, Socket sock, const IP_Port *ip_port, const TCP_Proxy_Info *proxy_info)
+static bool connect_sock_to(const Logger *logger, Socket sock, const IP_Port *ip_port, const TCP_Proxy_Info *proxy_info)
 {
     IP_Port ipp_copy = *ip_port;
 
@@ -107,7 +107,7 @@ static int connect_sock_to(const Logger *logger, Socket sock, const IP_Port *ip_
     /* nonblocking socket, connect will never return success */
     net_connect(logger, sock, &ipp_copy);
 
-    return 1;
+    return true;
 }
 
 /** return 1 on success.
@@ -329,7 +329,7 @@ int send_routing_request(const Logger *logger, TCP_Client_Connection *con, const
     uint8_t packet[1 + CRYPTO_PUBLIC_KEY_SIZE];
     packet[0] = TCP_PACKET_ROUTING_REQUEST;
     memcpy(packet + 1, public_key, CRYPTO_PUBLIC_KEY_SIZE);
-    return write_packet_TCP_secure_connection(logger, &con->con, packet, sizeof(packet), 1);
+    return write_packet_TCP_secure_connection(logger, &con->con, packet, sizeof(packet), true);
 }
 
 void routing_response_handler(TCP_Client_Connection *con, tcp_routing_response_cb *response_callback, void *object)
@@ -368,7 +368,7 @@ int send_data(const Logger *logger, TCP_Client_Connection *con, uint8_t con_id, 
     VLA(uint8_t, packet, 1 + length);
     packet[0] = con_id + NUM_RESERVED_PORTS;
     memcpy(packet + 1, data, length);
-    return write_packet_TCP_secure_connection(logger, &con->con, packet, SIZEOF_VLA(packet), 0);
+    return write_packet_TCP_secure_connection(logger, &con->con, packet, SIZEOF_VLA(packet), false);
 }
 
 /** return 1 on success.
@@ -386,7 +386,7 @@ int send_oob_packet(const Logger *logger, TCP_Client_Connection *con, const uint
     packet[0] = TCP_PACKET_OOB_SEND;
     memcpy(packet + 1, public_key, CRYPTO_PUBLIC_KEY_SIZE);
     memcpy(packet + 1 + CRYPTO_PUBLIC_KEY_SIZE, data, length);
-    return write_packet_TCP_secure_connection(logger, &con->con, packet, SIZEOF_VLA(packet), 0);
+    return write_packet_TCP_secure_connection(logger, &con->con, packet, SIZEOF_VLA(packet), false);
 }
 
 
@@ -433,7 +433,7 @@ static int client_send_disconnect_notification(const Logger *logger, TCP_Client_
     uint8_t packet[1 + 1];
     packet[0] = TCP_PACKET_DISCONNECT_NOTIFICATION;
     packet[1] = id;
-    return write_packet_TCP_secure_connection(logger, &con->con, packet, sizeof(packet), 1);
+    return write_packet_TCP_secure_connection(logger, &con->con, packet, sizeof(packet), true);
 }
 
 /** return 1 on success.
@@ -449,7 +449,7 @@ static int tcp_send_ping_request(const Logger *logger, TCP_Client_Connection *co
     uint8_t packet[1 + sizeof(uint64_t)];
     packet[0] = TCP_PACKET_PING;
     memcpy(packet + 1, &con->ping_request_id, sizeof(uint64_t));
-    const int ret = write_packet_TCP_secure_connection(logger, &con->con, packet, sizeof(packet), 1);
+    const int ret = write_packet_TCP_secure_connection(logger, &con->con, packet, sizeof(packet), true);
 
     if (ret == 1) {
         con->ping_request_id = 0;
@@ -471,7 +471,7 @@ static int tcp_send_ping_response(const Logger *logger, TCP_Client_Connection *c
     uint8_t packet[1 + sizeof(uint64_t)];
     packet[0] = TCP_PACKET_PONG;
     memcpy(packet + 1, &con->ping_response_id, sizeof(uint64_t));
-    const int ret = write_packet_TCP_secure_connection(logger, &con->con, packet, sizeof(packet), 1);
+    const int ret = write_packet_TCP_secure_connection(logger, &con->con, packet, sizeof(packet), true);
 
     if (ret == 1) {
         con->ping_response_id = 0;
@@ -504,7 +504,7 @@ int send_onion_request(const Logger *logger, TCP_Client_Connection *con, const u
     VLA(uint8_t, packet, 1 + length);
     packet[0] = TCP_PACKET_ONION_REQUEST;
     memcpy(packet + 1, data, length);
-    return write_packet_TCP_secure_connection(logger, &con->con, packet, SIZEOF_VLA(packet), 0);
+    return write_packet_TCP_secure_connection(logger, &con->con, packet, SIZEOF_VLA(packet), false);
 }
 
 void onion_response_handler(TCP_Client_Connection *con, tcp_onion_response_cb *onion_callback, void *object)

--- a/toxcore/TCP_common.c
+++ b/toxcore/TCP_common.c
@@ -84,10 +84,11 @@ int send_pending_data(const Logger *logger, TCP_Connection *con)
     return -1;
 }
 
-/** return 0 on failure (only if calloc fails)
- * return 1 on success
+/** return false on failure (only if calloc fails)
+ * return true on success
  */
-bool add_priority(TCP_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
+non_null()
+static bool add_priority(TCP_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
 {
     TCP_Priority_List *p = con->priority_queue_end;
     TCP_Priority_List *new_list = (TCP_Priority_List *)calloc(1, sizeof(TCP_Priority_List));
@@ -129,11 +130,11 @@ int write_packet_TCP_secure_connection(const Logger *logger, TCP_Connection *con
         return -1;
     }
 
-    bool sendpriority = 1;
+    bool sendpriority = true;
 
     if (send_pending_data(logger, con) == -1) {
         if (priority) {
-            sendpriority = 0;
+            sendpriority = false;
         } else {
             return 0;
         }
@@ -162,7 +163,7 @@ int write_packet_TCP_secure_connection(const Logger *logger, TCP_Connection *con
             return 1;
         }
 
-        return add_priority(con, packet, SIZEOF_VLA(packet), len);
+        return add_priority(con, packet, SIZEOF_VLA(packet), len) ? 1 : 0;
     }
 
     len = net_send(logger, con->sock, packet, SIZEOF_VLA(packet), &con->ip_port);

--- a/toxcore/TCP_common.h
+++ b/toxcore/TCP_common.h
@@ -70,12 +70,6 @@ int send_pending_data_nonpriority(const Logger *logger, TCP_Connection *con);
 non_null()
 int send_pending_data(const Logger *logger, TCP_Connection *con);
 
-/** return 0 on failure (only if calloc fails)
- * return 1 on success
- */
-non_null()
-bool add_priority(TCP_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent);
-
 /** return 1 on success.
  * return 0 if could not send packet.
  * return -1 on failure (connection must be killed).

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -305,7 +305,7 @@ int send_packet_tcp_connection(const TCP_Connections *tcp_c, int connections_num
     // TODO(irungentoo): thread safety?
     int ret = -1;
 
-    bool limit_reached = 0;
+    bool limit_reached = false;
 
     for (unsigned int i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
         uint32_t tcp_con_num = con_to->connections[i].tcp_connection;
@@ -323,7 +323,7 @@ int send_packet_tcp_connection(const TCP_Connections *tcp_c, int connections_num
             ret = send_data(tcp_c->logger, tcp_con->connection, connection_id, packet, length);
 
             if (ret == 0) {
-                limit_reached = 1;
+                limit_reached = true;
             }
 
             if (ret == 1) {
@@ -498,7 +498,7 @@ static int find_tcp_connection_to(const TCP_Connections *tcp_c, const uint8_t *p
         const TCP_Connection_to *con_to = get_connection(tcp_c, i);
 
         if (con_to != nullptr) {
-            if (public_key_cmp(con_to->public_key, public_key) == 0) {
+            if (pk_equal(con_to->public_key, public_key)) {
                 return i;
             }
         }
@@ -519,11 +519,11 @@ static int find_tcp_connection_relay(const TCP_Connections *tcp_c, const uint8_t
 
         if (tcp_con != nullptr) {
             if (tcp_con->status == TCP_CONN_SLEEPING) {
-                if (public_key_cmp(tcp_con->relay_pk, relay_pk) == 0) {
+                if (pk_equal(tcp_con->relay_pk, relay_pk)) {
                     return i;
                 }
             } else {
-                if (public_key_cmp(tcp_con_public_key(tcp_con->connection), relay_pk) == 0) {
+                if (pk_equal(tcp_con_public_key(tcp_con->connection), relay_pk)) {
                     return i;
                 }
             }

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -86,20 +86,20 @@ void crypto_sha512(uint8_t *hash, const uint8_t *data, size_t length);
  * @brief Compare 2 public keys of length @ref CRYPTO_PUBLIC_KEY_SIZE, not vulnerable to
  * timing attacks.
  *
- * @retval 0 if both mem locations of length are equal
- * @retval -1 if they are not
+ * @retval true if both mem locations of length are equal
+ * @retval false if they are not
  */
 non_null()
-int32_t public_key_cmp(const uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE], const uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE]);
+bool public_key_eq(const uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE], const uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE]);
 
 /**
  * @brief Compare 2 SHA512 checksums of length CRYPTO_SHA512_SIZE, not vulnerable to
  * timing attacks.
  *
- * @return 0 if both mem locations of length are equal, -1 if they are not.
+ * @return true if both mem locations of length are equal, false if they are not.
  */
 non_null()
-int32_t crypto_sha512_cmp(const uint8_t *cksum1, const uint8_t *cksum2);
+bool crypto_sha512_eq(const uint8_t *cksum1, const uint8_t *cksum2);
 
 /**
  * @brief Return a random 8 bit integer.

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -202,7 +202,7 @@ int getfriend_conn_id_pk(const Friend_Connections *fr_c, const uint8_t *real_pk)
         const Friend_Conn *friend_con = get_conn(fr_c, i);
 
         if (friend_con != nullptr) {
-            if (public_key_cmp(friend_con->real_public_key, real_pk) == 0) {
+            if (pk_equal(friend_con->real_public_key, real_pk)) {
                 return i;
             }
         }
@@ -229,7 +229,7 @@ static int friend_add_tcp_relay(Friend_Connections *fr_c, int friendcon_id, cons
     }
 
     /* Local ip and same pk means that they are hosting a TCP relay. */
-    if (ip_is_local(&ipp_copy.ip) && public_key_cmp(friend_con->dht_temp_pk, public_key) == 0) {
+    if (ip_is_local(&ipp_copy.ip) && pk_equal(friend_con->dht_temp_pk, public_key)) {
         if (!net_family_is_unspec(friend_con->dht_ip_port.ip.family)) {
             ipp_copy.ip = friend_con->dht_ip_port.ip;
         } else {
@@ -241,7 +241,7 @@ static int friend_add_tcp_relay(Friend_Connections *fr_c, int friendcon_id, cons
 
     for (unsigned i = 0; i < FRIEND_MAX_STORED_TCP_RELAYS; ++i) {
         if (!net_family_is_unspec(friend_con->tcp_relays[i].ip_port.ip.family)
-                && public_key_cmp(friend_con->tcp_relays[i].public_key, public_key) == 0) {
+                && pk_equal(friend_con->tcp_relays[i].public_key, public_key)) {
             memset(&friend_con->tcp_relays[i], 0, sizeof(Node_format));
         }
     }
@@ -351,7 +351,7 @@ static void dht_ip_callback(void *object, int32_t number, const IP_Port *ip_port
         friend_new_connection(fr_c, number);
     }
 
-    set_direct_ip_port(fr_c->net_crypto, friend_con->crypt_connection_id, ip_port, 1);
+    set_direct_ip_port(fr_c->net_crypto, friend_con->crypt_connection_id, ip_port, true);
     friend_con->dht_ip_port = *ip_port;
     friend_con->dht_ip_port_lastrecv = mono_time_get(fr_c->mono_time);
 
@@ -443,7 +443,7 @@ static void dht_pk_callback(void *object, int32_t number, const uint8_t *dht_pub
         return;
     }
 
-    if (public_key_cmp(friend_con->dht_temp_pk, dht_public_key) == 0) {
+    if (pk_equal(friend_con->dht_temp_pk, dht_public_key)) {
         return;
     }
 
@@ -577,13 +577,13 @@ static int handle_new_connections(void *object, const New_Connection *n_c)
     friend_con->crypt_connection_id = id;
 
     if (!net_family_is_ipv4(n_c->source.ip.family) && !net_family_is_ipv6(n_c->source.ip.family)) {
-        set_direct_ip_port(fr_c->net_crypto, friend_con->crypt_connection_id, &friend_con->dht_ip_port, 0);
+        set_direct_ip_port(fr_c->net_crypto, friend_con->crypt_connection_id, &friend_con->dht_ip_port, false);
     } else {
         friend_con->dht_ip_port = n_c->source;
         friend_con->dht_ip_port_lastrecv = mono_time_get(fr_c->mono_time);
     }
 
-    if (public_key_cmp(friend_con->dht_temp_pk, n_c->dht_public_key) != 0) {
+    if (!pk_equal(friend_con->dht_temp_pk, n_c->dht_public_key)) {
         change_dht_pk(fr_c, friendcon_id, n_c->dht_public_key);
     }
 
@@ -973,7 +973,7 @@ void do_friend_connections(Friend_Connections *fr_c, void *userdata)
 
                 if (friend_con->dht_lock > 0) {
                     if (friend_new_connection(fr_c, i) == 0) {
-                        set_direct_ip_port(fr_c->net_crypto, friend_con->crypt_connection_id, &friend_con->dht_ip_port, 0);
+                        set_direct_ip_port(fr_c->net_crypto, friend_con->crypt_connection_id, &friend_con->dht_ip_port, false);
                         connect_to_saved_tcp_relays(fr_c, i, MAX_FRIEND_TCP_CONNECTIONS / 2); /* Only fill it half up. */
                     }
                 }

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -73,7 +73,7 @@ static void addto_receivedlist(Friend_Requests *fr, const uint8_t *real_pk)
         fr->received.requests_index = 0;
     }
 
-    id_copy(fr->received.requests[fr->received.requests_index], real_pk);
+    pk_copy(fr->received.requests[fr->received.requests_index], real_pk);
     ++fr->received.requests_index;
 }
 
@@ -86,7 +86,7 @@ non_null()
 static bool request_received(const Friend_Requests *fr, const uint8_t *real_pk)
 {
     for (uint32_t i = 0; i < MAX_RECEIVED_STORED; ++i) {
-        if (id_equal(fr->received.requests[i], real_pk)) {
+        if (pk_equal(fr->received.requests[i], real_pk)) {
             return true;
         }
     }
@@ -102,7 +102,7 @@ static bool request_received(const Friend_Requests *fr, const uint8_t *real_pk)
 int remove_request_received(Friend_Requests *fr, const uint8_t *real_pk)
 {
     for (uint32_t i = 0; i < MAX_RECEIVED_STORED; ++i) {
-        if (id_equal(fr->received.requests[i], real_pk)) {
+        if (pk_equal(fr->received.requests[i], real_pk)) {
             crypto_memzero(fr->received.requests[i], CRYPTO_PUBLIC_KEY_SIZE);
             return 0;
         }

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -60,7 +60,19 @@ static_assert(GROUP_ID_LENGTH == CRYPTO_PUBLIC_KEY_SIZE,
 non_null()
 static bool group_id_eq(const uint8_t *a, const uint8_t *b)
 {
-    return public_key_cmp(a, b) == 0;
+    return pk_equal(a, b);
+}
+
+non_null()
+static bool g_title_eq(Group_c *g, const uint8_t *title, uint8_t title_len)
+{
+    return memeq(g->title, g->title_len, title, title_len);
+}
+
+non_null()
+static bool g_peer_nick_eq(Group_Peer *peer, const uint8_t *nick, uint8_t nick_len)
+{
+    return memeq(peer->nick, peer->nick_len, nick, nick_len);
 }
 
 /** return false if the groupnumber is not valid.
@@ -190,7 +202,7 @@ non_null()
 static int peer_in_group(const Group_c *g, const uint8_t *real_pk)
 {
     for (uint32_t i = 0; i < g->numpeers; ++i) {
-        if (id_equal(g->group[i].real_pk, real_pk)) {
+        if (pk_equal(g->group[i].real_pk, real_pk)) {
             return i;
         }
     }
@@ -202,7 +214,7 @@ non_null()
 static int frozen_in_group(const Group_c *g, const uint8_t *real_pk)
 {
     for (uint32_t i = 0; i < g->numfrozen; ++i) {
-        if (id_equal(g->frozen[i].real_pk, real_pk)) {
+        if (pk_equal(g->frozen[i].real_pk, real_pk)) {
             return i;
         }
     }
@@ -285,14 +297,14 @@ typedef enum Groupchat_Closest_Change {
 non_null()
 static bool add_to_closest(Group_c *g, const uint8_t *real_pk, const uint8_t *temp_pk)
 {
-    if (public_key_cmp(g->real_pk, real_pk) == 0) {
+    if (pk_equal(g->real_pk, real_pk)) {
         return false;
     }
 
     unsigned int index = DESIRED_CLOSEST;
 
     for (unsigned int i = 0; i < DESIRED_CLOSEST; ++i) {
-        if (g->closest_peers[i].active && public_key_cmp(real_pk, g->closest_peers[i].real_pk) == 0) {
+        if (g->closest_peers[i].active && pk_equal(real_pk, g->closest_peers[i].real_pk)) {
             return true;
         }
     }
@@ -366,7 +378,7 @@ static bool pk_in_closest_peers(const Group_c *g, const uint8_t *real_pk)
             continue;
         }
 
-        if (public_key_cmp(g->closest_peers[i].real_pk, real_pk) == 0) {
+        if (pk_equal(g->closest_peers[i].real_pk, real_pk)) {
             return true;
         }
     }
@@ -641,12 +653,12 @@ static int addpeer(Group_Chats *g_c, uint32_t groupnumber, const uint8_t *real_p
                            get_peer_index(g, peer_number);
 
     if (peer_index != -1) {
-        if (!id_equal(g->group[peer_index].real_pk, real_pk)) {
+        if (!pk_equal(g->group[peer_index].real_pk, real_pk)) {
             return -1;
         }
 
         if (fresh || !g->group[peer_index].temp_pk_updated) {
-            id_copy(g->group[peer_index].temp_pk, temp_pk);
+            pk_copy(g->group[peer_index].temp_pk, temp_pk);
             g->group[peer_index].temp_pk_updated = true;
         }
 
@@ -657,11 +669,11 @@ static int addpeer(Group_Chats *g_c, uint32_t groupnumber, const uint8_t *real_p
         const int frozen_index = get_frozen_index(g, peer_number);
 
         if (frozen_index != -1) {
-            if (!id_equal(g->frozen[frozen_index].real_pk, real_pk)) {
+            if (!pk_equal(g->frozen[frozen_index].real_pk, real_pk)) {
                 return -1;
             }
 
-            id_copy(g->frozen[frozen_index].temp_pk, temp_pk);
+            pk_copy(g->frozen[frozen_index].temp_pk, temp_pk);
 
             return -1;
         }
@@ -680,8 +692,8 @@ static int addpeer(Group_Chats *g_c, uint32_t groupnumber, const uint8_t *real_p
 
     const uint32_t new_index = g->numpeers;
 
-    id_copy(g->group[new_index].real_pk, real_pk);
-    id_copy(g->group[new_index].temp_pk, temp_pk);
+    pk_copy(g->group[new_index].real_pk, real_pk);
+    pk_copy(g->group[new_index].temp_pk, temp_pk);
     g->group[new_index].temp_pk_updated = true;
     g->group[new_index].peer_number = peer_number;
     g->group[new_index].last_active = mono_time_get(g_c->mono_time);
@@ -717,7 +729,7 @@ static void remove_from_closest(Group_c *g, int peer_index)
 {
     for (uint32_t i = 0; i < DESIRED_CLOSEST; ++i) {
         if (g->closest_peers[i].active
-                && id_equal(g->closest_peers[i].real_pk, g->group[peer_index].real_pk)) {
+                && pk_equal(g->closest_peers[i].real_pk, g->group[peer_index].real_pk)) {
             g->closest_peers[i].active = false;
             g->changed = GROUPCHAT_CLOSEST_CHANGE_REMOVED;
             break;
@@ -789,7 +801,7 @@ static bool delpeer(Group_Chats *g_c, uint32_t groupnumber, int peer_index, void
 
 static int cmp_u64(uint64_t a, uint64_t b)
 {
-    return (a > b) - (a < b);
+    return (a > b ? 1 : 0) - (a < b ? 1 : 0);
 }
 
 /** Order peers with friends first and with more recently active earlier */
@@ -899,13 +911,12 @@ static bool setnick(Group_Chats *g_c, uint32_t groupnumber, int peer_index, cons
 
     g->group[peer_index].nick_updated = true;
 
-    if (g->group[peer_index].nick_len == nick_len
-            && (nick_len == 0 || !memcmp(g->group[peer_index].nick, nick, nick_len))) {
+    if (g_peer_nick_eq(&g->group[peer_index], nick, nick_len)) {
         /* same name as already stored */
         return true;
     }
 
-    if (nick_len != 0) {
+    if (nick_len > 0) {
         memcpy(g->group[peer_index].nick, nick, nick_len);
     }
 
@@ -936,7 +947,7 @@ static bool settitle(Group_Chats *g_c, uint32_t groupnumber, int peer_index, con
         return false;
     }
 
-    if (g->title_len == title_len && !memcmp(g->title, title, title_len)) {
+    if (g_title_eq(g, title, title_len)) {
         /* same title as already set */
         return true;
     }
@@ -970,7 +981,7 @@ static void check_disconnected(Group_Chats *g_c, uint32_t groupnumber, void *use
     }
 
     for (uint32_t i = 0; i < g->numpeers; ++i) {
-        while (i < g->numpeers && !id_equal(g->group[i].real_pk, g->real_pk)) {
+        while (i < g->numpeers && !pk_equal(g->group[i].real_pk, g->real_pk)) {
             freeze_peer(g_c, groupnumber, i, userdata);
         }
     }
@@ -1027,7 +1038,7 @@ static void rejoin_frozen_friend(Group_Chats *g_c, int friendcon_id)
         }
 
         for (uint32_t j = 0; j < g->numfrozen; ++j) {
-            if (id_equal(g->frozen[j].real_pk, real_pk)) {
+            if (pk_equal(g->frozen[j].real_pk, real_pk)) {
                 try_send_rejoin(g_c, g, real_pk);
                 break;
             }
@@ -1108,7 +1119,7 @@ static int add_conn_to_groupchat(Group_Chats *g_c, int friendcon_id, Group_c *g,
         ind = empty;
     }
 
-    if (!(g->connections[ind].reasons & reason)) {
+    if ((g->connections[ind].reasons & reason) == 0) {
         g->connections[ind].reasons |= reason;
 
         if (reason == GROUPCHAT_CONNECTION_REASON_INTRODUCER) {
@@ -1128,7 +1139,7 @@ static unsigned int send_peer_introduced(const Group_Chats *g_c, int friendcon_i
  */
 static void remove_connection_reason(Group_Chats *g_c, Group_c *g, uint16_t i, uint8_t reason)
 {
-    if (!(g->connections[i].reasons & reason)) {
+    if ((g->connections[i].reasons & reason) == 0) {
         return;
     }
 
@@ -1856,7 +1867,7 @@ int group_title_send(const Group_Chats *g_c, uint32_t groupnumber, const uint8_t
     }
 
     /* same as already set? */
-    if (g->title_len == title_len && !memcmp(g->title, title, title_len)) {
+    if (g_title_eq(g, title, title_len)) {
         return 0;
     }
 
@@ -2310,7 +2321,7 @@ static int handle_send_peers(Group_Chats *g_c, uint32_t groupnumber, const uint8
         d += sizeof(uint16_t);
 
         if (g->status == GROUPCHAT_STATUS_VALID
-                && public_key_cmp(d, nc_get_self_public_key(g_c->m->net_crypto)) == 0) {
+                && pk_equal(d, nc_get_self_public_key(g_c->m->net_crypto))) {
             g->peer_number = peer_num;
             g->status = GROUPCHAT_STATUS_CONNECTED;
 
@@ -2647,7 +2658,7 @@ static bool check_message_info(uint32_t message_number, uint8_t message_id, Grou
         ++peer->num_last_message_infos;
     }
 
-    memmove(i + 1, i, ((peer->last_message_infos + peer->num_last_message_infos - 1) - i) * sizeof(Message_Info));
+    memmove(i + 1, i, (&peer->last_message_infos[peer->num_last_message_infos - 1] - i) * sizeof(Message_Info));
 
     i->message_number = message_number;
     i->message_id = message_id;
@@ -2713,7 +2724,7 @@ static void handle_message_packet_group(Group_Chats *g_c, uint32_t groupnumber, 
             uint8_t real_pk[CRYPTO_PUBLIC_KEY_SIZE];
             get_friendcon_public_keys(real_pk, nullptr, g_c->fr_c, g->connections[i].number);
 
-            if (id_equal(g->group[index].real_pk, real_pk)) {
+            if (pk_equal(g->group[index].real_pk, real_pk)) {
                 /* Received message from peer relayed via another peer, so
                  * the introduction was successful */
                 remove_connection_reason(g_c, g, i, GROUPCHAT_CONNECTION_REASON_INTRODUCER);
@@ -2727,7 +2738,7 @@ static void handle_message_packet_group(Group_Chats *g_c, uint32_t groupnumber, 
 
     uint8_t real_pk[CRYPTO_PUBLIC_KEY_SIZE];
     get_friendcon_public_keys(real_pk, nullptr, g_c->fr_c, g->connections[connection_index].number);
-    const bool direct_from_sender = id_equal(g->group[index].real_pk, real_pk);
+    const bool direct_from_sender = pk_equal(g->group[index].real_pk, real_pk);
 
     switch (message_id) {
         case GROUP_MESSAGE_PING_ID: {
@@ -3251,6 +3262,7 @@ static uint8_t *save_peer(const Group_Peer *peer, uint8_t *data)
     host_to_lendian_bytes64(data, peer->last_active);
     data += sizeof(uint64_t);
 
+    // TODO(iphydf): This looks broken: nick_len can be > 255.
     *data = peer->nick_len;
     ++data;
 
@@ -3271,7 +3283,7 @@ static uint32_t saved_conf_size(const Group_c *g)
     for (uint32_t j = 0; j < g->numpeers + g->numfrozen; ++j) {
         const Group_Peer *peer = (j < g->numpeers) ? &g->group[j] : &g->frozen[j - g->numpeers];
 
-        if (id_equal(peer->real_pk, g->real_pk)) {
+        if (pk_equal(peer->real_pk, g->real_pk)) {
             continue;
         }
 
@@ -3318,7 +3330,7 @@ static uint8_t *save_conf(const Group_c *g, uint8_t *data)
     for (uint32_t j = 0; j < g->numpeers + g->numfrozen; ++j) {
         const Group_Peer *peer = (j < g->numpeers) ? &g->group[j] : &g->frozen[j - g->numpeers];
 
-        if (id_equal(peer->real_pk, g->real_pk)) {
+        if (pk_equal(peer->real_pk, g->real_pk)) {
             continue;
         }
 
@@ -3444,9 +3456,9 @@ static uint32_t load_group(Group_c *g, const Group_Chats *g_c, const uint8_t *da
         Group_Peer *peer = &g->frozen[j];
         memset(peer, 0, sizeof(Group_Peer));
 
-        id_copy(peer->real_pk, data);
+        pk_copy(peer->real_pk, data);
         data += CRYPTO_PUBLIC_KEY_SIZE;
-        id_copy(peer->temp_pk, data);
+        pk_copy(peer->temp_pk, data);
         data += CRYPTO_PUBLIC_KEY_SIZE;
 
         lendian_bytes_to_host16(&peer->peer_number, data);
@@ -3481,7 +3493,7 @@ static uint32_t load_group(Group_c *g, const Group_Chats *g_c, const uint8_t *da
 
     g->status = GROUPCHAT_STATUS_CONNECTED;
 
-    id_copy(g->real_pk, nc_get_self_public_key(g_c->m->net_crypto));
+    pk_copy(g->real_pk, nc_get_self_public_key(g_c->m->net_crypto));
 
     assert((data - init_data) < UINT32_MAX);
 
@@ -3515,7 +3527,7 @@ static State_Load_Status load_conferences_helper(Group_Chats *g_c, const uint8_t
             // HACK: suppress unused variable warning
             if (!ret) {
                 // wipe_group_chat(...) must be able to wipe partially allocated groups
-                assert(ret == true);
+                assert(ret);
             }
 
             return STATE_LOAD_STATUS_ERROR;

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -415,7 +415,7 @@ static int tcp_oob_handle_cookie_request(const Net_Crypto *c, unsigned int tcp_c
         return -1;
     }
 
-    if (public_key_cmp(dht_public_key, dht_public_key_temp) != 0) {
+    if (!pk_equal(dht_public_key, dht_public_key_temp)) {
         return -1;
     }
 
@@ -514,25 +514,25 @@ static int create_crypto_handshake(const Net_Crypto *c, uint8_t *packet, const u
  * peer_real_pk must be at least CRYPTO_PUBLIC_KEY_SIZE
  * cookie must be at least COOKIE_LENGTH
  *
- * return -1 on failure.
- * return 0 on success.
+ * return false on failure.
+ * return true on success.
  */
 non_null(1, 2, 3, 4, 5, 6, 7) nullable(9)
-static int handle_crypto_handshake(const Net_Crypto *c, uint8_t *nonce, uint8_t *session_pk, uint8_t *peer_real_pk,
-                                   uint8_t *dht_public_key, uint8_t *cookie, const uint8_t *packet, uint16_t length, const uint8_t *expected_real_pk)
+static bool handle_crypto_handshake(const Net_Crypto *c, uint8_t *nonce, uint8_t *session_pk, uint8_t *peer_real_pk,
+                                    uint8_t *dht_public_key, uint8_t *cookie, const uint8_t *packet, uint16_t length, const uint8_t *expected_real_pk)
 {
     if (length != HANDSHAKE_PACKET_LENGTH) {
-        return -1;
+        return false;
     }
 
     uint8_t cookie_plain[COOKIE_DATA_LENGTH];
 
     if (open_cookie(c->mono_time, cookie_plain, packet + 1, c->secret_symmetric_key) != 0) {
-        return -1;
+        return false;
     }
 
-    if (expected_real_pk != nullptr && public_key_cmp(cookie_plain, expected_real_pk) != 0) {
-        return -1;
+    if (expected_real_pk != nullptr && !pk_equal(cookie_plain, expected_real_pk)) {
+        return false;
     }
 
     uint8_t cookie_hash[CRYPTO_SHA512_SIZE];
@@ -544,11 +544,11 @@ static int handle_crypto_handshake(const Net_Crypto *c, uint8_t *nonce, uint8_t 
                            HANDSHAKE_PACKET_LENGTH - (1 + COOKIE_LENGTH + CRYPTO_NONCE_SIZE), plain);
 
     if (len != sizeof(plain)) {
-        return -1;
+        return false;
     }
 
-    if (crypto_sha512_cmp(cookie_hash, plain + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE) != 0) {
-        return -1;
+    if (!crypto_sha512_eq(cookie_hash, plain + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE)) {
+        return false;
     }
 
     memcpy(nonce, plain, CRYPTO_NONCE_SIZE);
@@ -556,7 +556,7 @@ static int handle_crypto_handshake(const Net_Crypto *c, uint8_t *nonce, uint8_t 
     memcpy(cookie, plain + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_SHA512_SIZE, COOKIE_LENGTH);
     memcpy(peer_real_pk, cookie_plain, CRYPTO_PUBLIC_KEY_SIZE);
     memcpy(dht_public_key, cookie_plain + CRYPTO_PUBLIC_KEY_SIZE, CRYPTO_PUBLIC_KEY_SIZE);
-    return 0;
+    return true;
 }
 
 
@@ -627,15 +627,15 @@ static IP_Port return_ip_port_connection(const Net_Crypto *c, int crypt_connecti
     }
 
     const uint64_t current_time = mono_time_get(c->mono_time);
-    bool v6 = 0;
-    bool v4 = 0;
+    bool v6 = false;
+    bool v4 = false;
 
     if ((UDP_DIRECT_TIMEOUT + conn->direct_lastrecv_timev4) > current_time) {
-        v4 = 1;
+        v4 = true;
     }
 
     if ((UDP_DIRECT_TIMEOUT + conn->direct_lastrecv_timev6) > current_time) {
-        v6 = 1;
+        v6 = true;
     }
 
     /* Prefer IP_Ports which haven't timed out to those which have.
@@ -1728,12 +1728,12 @@ static int handle_packet_crypto_hs(Net_Crypto *c, int crypt_connection_id, const
     uint8_t dht_public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t cookie[COOKIE_LENGTH];
 
-    if (handle_crypto_handshake(c, conn->recv_nonce, conn->peersessionpublic_key, peer_real_pk, dht_public_key, cookie,
-                                packet, length, conn->public_key) != 0) {
+    if (!handle_crypto_handshake(c, conn->recv_nonce, conn->peersessionpublic_key, peer_real_pk, dht_public_key, cookie,
+                                 packet, length, conn->public_key)) {
         return -1;
     }
 
-    if (public_key_cmp(dht_public_key, conn->dht_public_key) == 0) {
+    if (pk_equal(dht_public_key, conn->dht_public_key)) {
         encrypt_precompute(conn->peersessionpublic_key, conn->sessionsecret_key, conn->shared_key);
 
         if (conn->status == CRYPTO_CONN_COOKIE_REQUESTING) {
@@ -1941,7 +1941,7 @@ static int getcryptconnection_id(const Net_Crypto *c, const uint8_t *public_key)
             continue;
         }
 
-        if (public_key_cmp(public_key, c->crypto_connections[i].public_key) == 0) {
+        if (pk_equal(public_key, c->crypto_connections[i].public_key)) {
             return i;
         }
     }
@@ -2021,8 +2021,8 @@ static int handle_new_connection_handshake(Net_Crypto *c, const IP_Port *source,
     n_c.source = *source;
     n_c.cookie_length = COOKIE_LENGTH;
 
-    if (handle_crypto_handshake(c, n_c.recv_nonce, n_c.peersessionpublic_key, n_c.public_key, n_c.dht_public_key,
-                                n_c.cookie, data, length, nullptr) != 0) {
+    if (!handle_crypto_handshake(c, n_c.recv_nonce, n_c.peersessionpublic_key, n_c.public_key, n_c.dht_public_key,
+                                 n_c.cookie, data, length, nullptr)) {
         free(n_c.cookie);
         return -1;
     }
@@ -2036,7 +2036,7 @@ static int handle_new_connection_handshake(Net_Crypto *c, const IP_Port *source,
             return -1;
         }
 
-        if (public_key_cmp(n_c.dht_public_key, conn->dht_public_key) != 0) {
+        if (!pk_equal(n_c.dht_public_key, conn->dht_public_key)) {
             connection_kill(c, crypt_connection_id, userdata);
         } else {
             if (conn->status != CRYPTO_CONN_COOKIE_REQUESTING && conn->status != CRYPTO_CONN_HANDSHAKE_SENT) {
@@ -2673,7 +2673,7 @@ static void send_crypto_packets(Net_Crypto *c)
                 conn->last_sendqueue_counter = (conn->last_sendqueue_counter + 1) %
                                                (CONGESTION_QUEUE_ARRAY_SIZE * CONGESTION_LAST_SENT_ARRAY_SIZE);
 
-                bool direct_connected = 0;
+                bool direct_connected = false;
                 /* return value can be ignored since the `if` above ensures the connection is established */
                 crypto_connection_status(c, i, &direct_connected, nullptr);
 
@@ -3020,14 +3020,14 @@ bool crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, bool
     }
 
     if (direct_connected != nullptr) {
-        *direct_connected = 0;
+        *direct_connected = false;
 
         const uint64_t current_time = mono_time_get(c->mono_time);
 
         if ((UDP_DIRECT_TIMEOUT + conn->direct_lastrecv_timev4) > current_time) {
-            *direct_connected = 1;
+            *direct_connected = true;
         } else if ((UDP_DIRECT_TIMEOUT + conn->direct_lastrecv_timev6) > current_time) {
-            *direct_connected = 1;
+            *direct_connected = true;
         }
     }
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1023,7 +1023,7 @@ Networking_Core *new_networking_ex(const Logger *log, const IP *ip, uint16_t por
         int res = bind(temp->sock.socket, (struct sockaddr *)&addr, addrsize);
 #endif
 
-        if (!res) {
+        if (res == 0) {
             temp->port = *portptr;
 
             char ip_str[IP_NTOA_LEN];
@@ -1361,7 +1361,7 @@ int addr_resolve(const char *address, IP *to, IP *extra)
                     get_ip4(&to->ip.v4, &addr->sin_addr);
                     result = TOX_ADDR_RESOLVE_INET;
                     done = true;
-                } else if (!(result & TOX_ADDR_RESOLVE_INET)) { /* AF_UNSPEC requested, store away */
+                } else if ((result & TOX_ADDR_RESOLVE_INET) == 0) { /* AF_UNSPEC requested, store away */
                     const struct sockaddr_in *addr = (const struct sockaddr_in *)(void *)walker->ai_addr;
                     get_ip4(&ip4.ip.v4, &addr->sin_addr);
                     result |= TOX_ADDR_RESOLVE_INET;
@@ -1378,7 +1378,7 @@ int addr_resolve(const char *address, IP *to, IP *extra)
                         result = TOX_ADDR_RESOLVE_INET6;
                         done = true;
                     }
-                } else if (!(result & TOX_ADDR_RESOLVE_INET6)) { /* AF_UNSPEC requested, store away */
+                } else if ((result & TOX_ADDR_RESOLVE_INET6) == 0) { /* AF_UNSPEC requested, store away */
                     if (walker->ai_addrlen == sizeof(struct sockaddr_in6)) {
                         const struct sockaddr_in6 *addr = (const struct sockaddr_in6 *)(void *)walker->ai_addr;
                         get_ip6(&ip6.ip.v6, &addr->sin6_addr);
@@ -1392,13 +1392,13 @@ int addr_resolve(const char *address, IP *to, IP *extra)
     }
 
     if (family == AF_UNSPEC) {
-        if (result & TOX_ADDR_RESOLVE_INET6) {
+        if ((result & TOX_ADDR_RESOLVE_INET6) != 0) {
             ip_copy(to, &ip6);
 
-            if ((result & TOX_ADDR_RESOLVE_INET) && (extra != nullptr)) {
+            if ((result & TOX_ADDR_RESOLVE_INET) != 0 && (extra != nullptr)) {
                 ip_copy(extra, &ip4);
             }
-        } else if (result & TOX_ADDR_RESOLVE_INET) {
+        } else if ((result & TOX_ADDR_RESOLVE_INET) != 0) {
             ip_copy(to, &ip4);
         } else {
             result = 0;
@@ -1412,7 +1412,7 @@ int addr_resolve(const char *address, IP *to, IP *extra)
 
 bool addr_resolve_or_parse_ip(const char *address, IP *to, IP *extra)
 {
-    if (!addr_resolve(address, to, extra)) {
+    if (addr_resolve(address, to, extra) == 0) {
         if (!addr_parse_ip(address, to)) {
             return false;
         }

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -48,7 +48,7 @@ struct Onion_Announce {
 non_null()
 static bool onion_ping_id_eq(const uint8_t *a, const uint8_t *b)
 {
-    return public_key_cmp(a, b) == 0;
+    return pk_equal(a, b);
 }
 
 uint8_t *onion_announce_entry_public_key(Onion_Announce *onion_a, uint32_t entry)
@@ -253,7 +253,7 @@ static int in_entries(const Onion_Announce *onion_a, const uint8_t *public_key)
 {
     for (unsigned int i = 0; i < ONION_ANNOUNCE_MAX_ENTRIES; ++i) {
         if (!mono_time_is_timeout(onion_a->mono_time, onion_a->entries[i].time, ONION_ANNOUNCE_TIMEOUT)
-                && public_key_cmp(onion_a->entries[i].public_key, public_key) == 0) {
+                && pk_equal(onion_a->entries[i].public_key, public_key)) {
             return i;
         }
     }
@@ -428,8 +428,8 @@ static int handle_announce_request(void *object, const IP_Port *source, const ui
         pl[0] = 0;
         memcpy(pl + 1, ping_id2, ONION_PING_ID_SIZE);
     } else {
-        if (public_key_cmp(onion_a->entries[index].public_key, packet_public_key) == 0) {
-            if (public_key_cmp(onion_a->entries[index].data_public_key, data_public_key) != 0) {
+        if (pk_equal(onion_a->entries[index].public_key, packet_public_key)) {
+            if (!pk_equal(onion_a->entries[index].data_public_key, data_public_key)) {
                 pl[0] = 0;
                 memcpy(pl + 1, ping_id2, ONION_PING_ID_SIZE);
             } else {

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -47,7 +47,7 @@ void ping_send_request(Ping *ping, const IP_Port *ipp, const uint8_t *public_key
     int       rc;
     uint64_t  ping_id;
 
-    if (id_equal(public_key, dht_get_self_public_key(ping->dht))) {
+    if (pk_equal(public_key, dht_get_self_public_key(ping->dht))) {
         return;
     }
 
@@ -57,7 +57,7 @@ void ping_send_request(Ping *ping, const IP_Port *ipp, const uint8_t *public_key
     dht_get_shared_key_sent(ping->dht, shared_key, public_key);
     // Generate random ping_id.
     uint8_t data[PING_DATA_SIZE];
-    id_copy(data, public_key);
+    pk_copy(data, public_key);
     memcpy(data + CRYPTO_PUBLIC_KEY_SIZE, ipp, sizeof(IP_Port));
     ping_id = ping_array_add(ping->ping_array, ping->mono_time, data, sizeof(data));
 
@@ -71,7 +71,7 @@ void ping_send_request(Ping *ping, const IP_Port *ipp, const uint8_t *public_key
     memcpy(ping_plain + 1, &ping_id, sizeof(ping_id));
 
     pk[0] = NET_PACKET_PING_REQUEST;
-    id_copy(pk + 1, dht_get_self_public_key(ping->dht));     // Our pubkey
+    pk_copy(pk + 1, dht_get_self_public_key(ping->dht));     // Our pubkey
     random_nonce(pk + 1 + CRYPTO_PUBLIC_KEY_SIZE); // Generate new nonce
 
 
@@ -96,7 +96,7 @@ static int ping_send_response(const Ping *ping, const IP_Port *ipp, const uint8_
 {
     uint8_t pk[DHT_PING_SIZE];
 
-    if (id_equal(public_key, dht_get_self_public_key(ping->dht))) {
+    if (pk_equal(public_key, dht_get_self_public_key(ping->dht))) {
         return 1;
     }
 
@@ -105,7 +105,7 @@ static int ping_send_response(const Ping *ping, const IP_Port *ipp, const uint8_
     memcpy(ping_plain + 1, &ping_id, sizeof(ping_id));
 
     pk[0] = NET_PACKET_PING_RESPONSE;
-    id_copy(pk + 1, dht_get_self_public_key(ping->dht));     // Our pubkey
+    pk_copy(pk + 1, dht_get_self_public_key(ping->dht));     // Our pubkey
     random_nonce(pk + 1 + CRYPTO_PUBLIC_KEY_SIZE); // Generate new nonce
 
     // Encrypt ping_id using recipient privkey
@@ -133,7 +133,7 @@ static int handle_ping_request(void *object, const IP_Port *source, const uint8_
 
     Ping *ping = dht_get_ping(dht);
 
-    if (id_equal(packet + 1, dht_get_self_public_key(ping->dht))) {
+    if (pk_equal(packet + 1, dht_get_self_public_key(ping->dht))) {
         return 1;
     }
 
@@ -182,7 +182,7 @@ static int handle_ping_response(void *object, const IP_Port *source, const uint8
 
     Ping *ping = dht_get_ping(dht);
 
-    if (id_equal(packet + 1, dht_get_self_public_key(ping->dht))) {
+    if (pk_equal(packet + 1, dht_get_self_public_key(ping->dht))) {
         return 1;
     }
 
@@ -217,7 +217,7 @@ static int handle_ping_response(void *object, const IP_Port *source, const uint8
         return 1;
     }
 
-    if (!id_equal(packet + 1, data)) {
+    if (!pk_equal(packet + 1, data)) {
         return 1;
     }
 
@@ -242,7 +242,7 @@ static int in_list(const Client_data *list, uint16_t length, const Mono_Time *mo
                    const IP_Port *ip_port)
 {
     for (unsigned int i = 0; i < length; ++i) {
-        if (id_equal(list[i].public_key, public_key)) {
+        if (pk_equal(list[i].public_key, public_key)) {
             const IPPTsPng *ipptp;
 
             if (net_family_is_ipv4(ip_port->ip.family)) {
@@ -299,7 +299,7 @@ int32_t ping_add(Ping *ping, const uint8_t *public_key, const IP_Port *ip_port)
             return 0;
         }
 
-        if (public_key_cmp(ping->to_ping[i].public_key, public_key) == 0) {
+        if (pk_equal(ping->to_ping[i].public_key, public_key)) {
             return -1;
         }
     }

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1428,7 +1428,7 @@ bool tox_friend_get_typing(const Tox *tox, uint32_t friend_number, Tox_Err_Frien
     }
 
     SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_QUERY_OK);
-    return !!ret;
+    return ret != 0;
 }
 
 void tox_callback_friend_typing(Tox *tox, tox_friend_typing_cb *callback)

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -21,12 +21,12 @@
 
 
 /** id functions */
-bool id_equal(const uint8_t *dest, const uint8_t *src)
+bool pk_equal(const uint8_t *dest, const uint8_t *src)
 {
-    return public_key_cmp(dest, src) == 0;
+    return public_key_eq(dest, src);
 }
 
-uint32_t id_copy(uint8_t *dest, const uint8_t *src)
+uint32_t pk_copy(uint8_t *dest, const uint8_t *src)
 {
     memcpy(dest, src, CRYPTO_PUBLIC_KEY_SIZE);
     return CRYPTO_PUBLIC_KEY_SIZE;
@@ -54,6 +54,11 @@ int create_recursive_mutex(pthread_mutex_t *mutex)
     pthread_mutexattr_destroy(&attr);
 
     return 0;
+}
+
+bool memeq(const uint8_t *a, size_t a_size, const uint8_t *b, size_t b_size)
+{
+    return a_size == b_size && memcmp(a, b, a_size) == 0;
 }
 
 int16_t max_s16(int16_t a, int16_t b)

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -20,12 +20,26 @@
 extern "C" {
 #endif
 
-/** id functions */
-non_null() bool id_equal(const uint8_t *dest, const uint8_t *src);
-non_null() uint32_t id_copy(uint8_t *dest, const uint8_t *src); /* return value is CLIENT_ID_SIZE */
+/** Equality function for public keys. */
+non_null() bool pk_equal(const uint8_t *dest, const uint8_t *src);
+/**
+ * @brief Copy a public key from `src` to `dest`.
+ * @retval CLIENT_ID_SIZE
+ */
+non_null() uint32_t pk_copy(uint8_t *dest, const uint8_t *src);
 
 /** Returns -1 if failed or 0 if success */
 non_null() int create_recursive_mutex(pthread_mutex_t *mutex);
+
+/**
+ * @brief Checks whether two buffers are the same length and contents.
+ *
+ * Calls `memcmp` after checking the sizes are equal.
+ *
+ * @retval true if sizes and contents are equal.
+ * @retval false otherwise.
+ */
+non_null() bool memeq(const uint8_t *a, size_t a_size, const uint8_t *b, size_t b_size);
 
 // Safe min/max functions with specific types. This forces the conversion to the
 // desired type before the comparison expression, giving the choice of

--- a/toxcore/util_test.cc
+++ b/toxcore/util_test.cc
@@ -16,7 +16,7 @@ TEST(Util, TwoRandomIdsAreNotEqual)
     crypto_new_keypair(pk1, sk1);
     crypto_new_keypair(pk2, sk2);
 
-    EXPECT_FALSE(id_equal(pk1, pk2));
+    EXPECT_FALSE(pk_equal(pk1, pk2));
 }
 
 TEST(Util, IdCopyMakesKeysEqual)
@@ -26,9 +26,9 @@ TEST(Util, IdCopyMakesKeysEqual)
     uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE] = {0};
 
     crypto_new_keypair(pk1, sk1);
-    id_copy(pk2, pk1);
+    pk_copy(pk2, pk1);
 
-    EXPECT_TRUE(id_equal(pk1, pk2));
+    EXPECT_TRUE(pk_equal(pk1, pk2));
 }
 
 }  // namespace


### PR DESCRIPTION
These were found by the new stronger type check in cimple. The one
bugfix is in `crypto_sha512_cmp`, which used to think `crypto_verify_32`
returns bool while actually it's -1/0/1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2116)
<!-- Reviewable:end -->
