### PR TITLE
cleanup: Remove all boolean-int conversions.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-a80ea98f55b82eb5d60baa5d7fc32913ff964b04b931a17b74233148a27786f5  /usr/local/bin/tox-bootstrapd
+6b4d6b18a788c6a400b05f78de42717a4c6c588c920ed967527def7fc2b03740  /usr/local/bin/tox-bootstrapd

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -382,7 +382,7 @@ bool lan_discovery_send(Networking_Core *net, const Broadcast_Info *broadcast, c
     ip_port.ip = broadcast_ip(net_family(net), net_family_ipv4);
 
     if (ip_isset(&ip_port.ip)) {
-        if (sendpacket(net, &ip_port, data, 1 + CRYPTO_PUBLIC_KEY_SIZE)) {
+        if (sendpacket(net, &ip_port, data, 1 + CRYPTO_PUBLIC_KEY_SIZE) > 0) {
             res = true;
         }
     }

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -680,11 +680,11 @@ void m_callback_msi_packet(Messenger *m, m_msi_packet_cb *function, void *userda
 
 /** Send an msi packet.
  *
- *  return 1 on success
- *  return 0 on failure
+ *  return true on success
+ *  return false on failure
  */
 non_null()
-int m_msi_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length);
+bool m_msi_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length);
 
 /** Set handlers for lossy rtp packets.
  *

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -1161,7 +1161,7 @@ static bool tcp_epoll_process(TCP_Server *tcp_server, const Mono_Time *mono_time
         switch (status) {
             case TCP_SOCKET_LISTENING: {
                 // socket is from socks_listening, accept connection
-                while (1) {
+                while (true) {
                     const Socket sock_new = net_accept(sock);
 
                     if (!sock_valid(sock_new)) {

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -489,7 +489,7 @@ static int handle_packet(void *object, int number, const uint8_t *data, uint16_t
 
     if (data[0] == PACKET_ID_SHARE_RELAYS) {
         Node_format nodes[MAX_SHARED_RELAYS];
-        const int n = unpack_nodes(nodes, MAX_SHARED_RELAYS, nullptr, data + 1, length - 1, 1);
+        const int n = unpack_nodes(nodes, MAX_SHARED_RELAYS, nullptr, data + 1, length - 1, true);
 
         if (n == -1) {
             return -1;
@@ -876,7 +876,7 @@ int send_friend_request_packet(Friend_Connections *fr_c, int friendcon_id, uint3
 
     if (friend_con->status == FRIENDCONN_STATUS_CONNECTED) {
         packet[0] = PACKET_ID_FRIEND_REQUESTS;
-        return write_cryptpacket(fr_c->net_crypto, friend_con->crypt_connection_id, packet, SIZEOF_VLA(packet), false) != -1;
+        return write_cryptpacket(fr_c->net_crypto, friend_con->crypt_connection_id, packet, SIZEOF_VLA(packet), false) != -1 ? 1 : 0;
     }
 
     packet[0] = CRYPTO_PACKET_FRIEND_REQ;

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -241,11 +241,11 @@ int add_groupchat(Group_Chats *g_c, uint8_t type);
 /** Delete a groupchat from the chats array, informing the group first as
  * appropriate.
  *
- * return 0 on success.
- * return -1 if groupnumber is invalid.
+ * return true on success.
+ * return false if groupnumber is invalid.
  */
 non_null()
-int del_groupchat(Group_Chats *g_c, uint32_t groupnumber, bool leave_permanently);
+bool del_groupchat(Group_Chats *g_c, uint32_t groupnumber, bool leave_permanently);
 
 /** Copy the public key of (frozen, if frozen is true) peernumber who is in
  * groupnumber to pk. pk must be CRYPTO_PUBLIC_KEY_SIZE long.

--- a/toxcore/list.c
+++ b/toxcore/list.c
@@ -58,7 +58,7 @@ static int find(const BS_List *list, const uint8_t *data)
     int d = -1; // used to determine if closest match is found
     // closest match is found if we move back to where we have already been
 
-    while (1) {
+    while (true) {
         const int r = memcmp(data, list->data + list->element_size * i, list->element_size);
 
         if (r == 0) {
@@ -176,7 +176,7 @@ int bs_list_find(const BS_List *list, const uint8_t *data)
     return list->ids[r];
 }
 
-int bs_list_add(BS_List *list, const uint8_t *data, int id)
+bool bs_list_add(BS_List *list, const uint8_t *data, int id)
 {
     // find where the new element should be inserted
     // see: return value of find()
@@ -184,7 +184,7 @@ int bs_list_add(BS_List *list, const uint8_t *data, int id)
 
     if (i >= 0) {
         // already in list
-        return 0;
+        return false;
     }
 
     i = ~i;
@@ -195,7 +195,7 @@ int bs_list_add(BS_List *list, const uint8_t *data, int id)
         const uint32_t new_capacity = list->n + list->n / 2 + 1;
 
         if (!resize(list, new_capacity)) {
-            return 0;
+            return false;
         }
 
         list->capacity = new_capacity;
@@ -213,20 +213,20 @@ int bs_list_add(BS_List *list, const uint8_t *data, int id)
     // increase n
     ++list->n;
 
-    return 1;
+    return true;
 }
 
-int bs_list_remove(BS_List *list, const uint8_t *data, int id)
+bool bs_list_remove(BS_List *list, const uint8_t *data, int id)
 {
     const int i = find(list, data);
 
     if (i < 0) {
-        return 0;
+        return false;
     }
 
     if (list->ids[i] != id) {
         // this should never happen
-        return 0;
+        return false;
     }
 
     // decrease the size of the arrays if needed
@@ -244,5 +244,5 @@ int bs_list_remove(BS_List *list, const uint8_t *data, int id)
             (list->n - i) * list->element_size);
     memmove(&list->ids[i], &list->ids[i + 1], (list->n - i) * sizeof(int));
 
-    return 1;
+    return true;
 }

--- a/toxcore/list.h
+++ b/toxcore/list.h
@@ -11,6 +11,7 @@
 #ifndef C_TOXCORE_TOXCORE_LIST_H
 #define C_TOXCORE_TOXCORE_LIST_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "attributes.h"
@@ -53,20 +54,20 @@ int bs_list_find(const BS_List *list, const uint8_t *data);
 /** Add an element with associated id to the list
  *
  * return value:
- *  1 : success
- *  0 : failure (data already in list)
+ *  true  : success
+ *  false : failure (data already in list)
  */
 non_null()
-int bs_list_add(BS_List *list, const uint8_t *data, int id);
+bool bs_list_add(BS_List *list, const uint8_t *data, int id);
 
 /** Remove element from the list
  *
  * return value:
- *  1 : success
- *  0 : failure (element not found or id does not match)
+ *  true  : success
+ *  false : failure (element not found or id does not match)
  */
 non_null()
-int bs_list_remove(BS_List *list, const uint8_t *data, int id);
+bool bs_list_remove(BS_List *list, const uint8_t *data, int id);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -1514,7 +1514,7 @@ static void connection_kill(Net_Crypto *c, int crypt_connection_id, void *userda
                 false, userdata);
     }
 
-    while (1) { /* TODO(irungentoo): is this really the best way to do this? */
+    while (true) { /* TODO(irungentoo): is this really the best way to do this? */
         pthread_mutex_lock(&c->connections_mutex);
 
         if (c->connection_use_counter == 0) {
@@ -1629,7 +1629,7 @@ static int handle_data_packet_core(Net_Crypto *c, int crypt_connection_id, const
             return -1;
         }
 
-        while (1) {
+        while (true) {
             pthread_mutex_lock(conn->mutex);
             const int ret = read_data_beg_buffer(&conn->recv_array, &dt);
             pthread_mutex_unlock(conn->mutex);
@@ -1831,7 +1831,7 @@ static int realloc_cryptoconnection(Net_Crypto *c, uint32_t num)
 non_null()
 static int create_crypto_connection(Net_Crypto *c)
 {
-    while (1) { /* TODO(irungentoo): is this really the best way to do this? */
+    while (true) { /* TODO(irungentoo): is this really the best way to do this? */
         pthread_mutex_lock(&c->connections_mutex);
 
         if (c->connection_use_counter == 0) {
@@ -2238,7 +2238,7 @@ static int tcp_data_callback(void *object, int crypt_connection_id, const uint8_
     // This unlocks the mutex that at this point is locked by do_tcp before
     // calling do_tcp_connections.
     pthread_mutex_unlock(&c->tcp_mutex);
-    const int ret = handle_packet_connection(c, crypt_connection_id, data, length, 0, userdata);
+    const int ret = handle_packet_connection(c, crypt_connection_id, data, length, false, userdata);
     pthread_mutex_lock(&c->tcp_mutex);
 
     if (ret != 0) {
@@ -2546,7 +2546,7 @@ static int udp_handle_packet(void *object, const IP_Port *source, const uint8_t 
         return 0;
     }
 
-    if (handle_packet_connection(c, crypt_connection_id, packet, length, 1, userdata) != 0) {
+    if (handle_packet_connection(c, crypt_connection_id, packet, length, true, userdata) != 0) {
         return 1;
     }
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1317,7 +1317,7 @@ bool addr_parse_ip(const char *address, IP *to)
 int addr_resolve(const char *address, IP *to, IP *extra)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    return false;
+    return 0;
 #else
 
     if (address == nullptr || to == nullptr) {

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -359,7 +359,7 @@ int onion_send_1(const Onion *onion, const uint8_t *plain, uint16_t len, const I
 
     IP_Port send_to;
 
-    if (ipport_unpack(&send_to, plain, len, 0) == -1) {
+    if (ipport_unpack(&send_to, plain, len, false) == -1) {
         return 1;
     }
 
@@ -417,7 +417,7 @@ static int handle_send_1(void *object, const IP_Port *source, const uint8_t *pac
 
     IP_Port send_to;
 
-    if (ipport_unpack(&send_to, plain, len, 0) == -1) {
+    if (ipport_unpack(&send_to, plain, len, false) == -1) {
         return 1;
     }
 
@@ -485,7 +485,7 @@ static int handle_send_2(void *object, const IP_Port *source, const uint8_t *pac
 
     IP_Port send_to;
 
-    if (ipport_unpack(&send_to, plain, len, 0) == -1) {
+    if (ipport_unpack(&send_to, plain, len, false) == -1) {
         return 1;
     }
 
@@ -545,7 +545,7 @@ static int handle_recv_3(void *object, const IP_Port *source, const uint8_t *pac
 
     IP_Port send_to;
 
-    if (ipport_unpack(&send_to, plain, len, 0) == -1) {
+    if (ipport_unpack(&send_to, plain, len, false) == -1) {
         return 1;
     }
 
@@ -593,7 +593,7 @@ static int handle_recv_2(void *object, const IP_Port *source, const uint8_t *pac
 
     IP_Port send_to;
 
-    if (ipport_unpack(&send_to, plain, len, 0) == -1) {
+    if (ipport_unpack(&send_to, plain, len, false) == -1) {
         return 1;
     }
 
@@ -641,7 +641,7 @@ static int handle_recv_1(void *object, const IP_Port *source, const uint8_t *pac
 
     IP_Port send_to;
 
-    if (ipport_unpack(&send_to, plain, len, 1) == -1) {
+    if (ipport_unpack(&send_to, plain, len, true) == -1) {
         return 1;
     }
 

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -897,7 +897,7 @@ static int handle_announce_response(void *object, const IP_Port *source, const u
 
     if (len_nodes != 0) {
         Node_format nodes[MAX_SENT_NODES];
-        const int num_nodes = unpack_nodes(nodes, MAX_SENT_NODES, nullptr, plain + 1 + ONION_PING_ID_SIZE, len_nodes, 0);
+        const int num_nodes = unpack_nodes(nodes, MAX_SENT_NODES, nullptr, plain + 1 + ONION_PING_ID_SIZE, len_nodes, false);
 
         if (num_nodes <= 0) {
             return 1;
@@ -999,7 +999,7 @@ static int handle_dhtpk_announce(void *object, const uint8_t *source_pubkey, con
     if (len_nodes != 0) {
         Node_format nodes[MAX_SENT_NODES];
         const int num_nodes = unpack_nodes(nodes, MAX_SENT_NODES, nullptr, data + 1 + sizeof(uint64_t) + CRYPTO_PUBLIC_KEY_SIZE,
-                                     len_nodes, 1);
+                                     len_nodes, true);
 
         if (num_nodes <= 0) {
             return 1;
@@ -1767,21 +1767,21 @@ static void do_announce(Onion_Client *onion_c)
     }
 }
 
-/**  return 0 if we are not connected to the network.
- *  return 1 if we are.
+/**  return false if we are not connected to the network.
+ *  return true if we are.
  */
 non_null()
-static int onion_isconnected(const Onion_Client *onion_c)
+static bool onion_isconnected(const Onion_Client *onion_c)
 {
     unsigned int num = 0;
     unsigned int announced = 0;
 
     if (mono_time_is_timeout(onion_c->mono_time, onion_c->last_packet_recv, ONION_OFFLINE_TIMEOUT)) {
-        return 0;
+        return false;
     }
 
     if (onion_c->path_nodes_index == 0) {
-        return 0;
+        return false;
     }
 
     for (unsigned int i = 0; i < MAX_ONION_CLIENTS_ANNOUNCE; ++i) {
@@ -1804,11 +1804,11 @@ static int onion_isconnected(const Onion_Client *onion_c)
      * we are connected to */
     if (num != 0 && announced != 0) {
         if ((num / 2) <= announced && (pnodes / 2) <= num) {
-            return 1;
+            return true;
         }
     }
 
-    return 0;
+    return false;
 }
 
 non_null()

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -234,12 +234,12 @@ static int handle_ping_response(void *object, const IP_Port *source, const uint8
 
 /** Check if public_key with ip_port is in the list.
  *
- * return 1 if it is.
- * return 0 if it isn't.
+ * return true if it is.
+ * return false if it isn't.
  */
 non_null()
-static int in_list(const Client_data *list, uint16_t length, const Mono_Time *mono_time, const uint8_t *public_key,
-                   const IP_Port *ip_port)
+static bool in_list(const Client_data *list, uint16_t length, const Mono_Time *mono_time, const uint8_t *public_key,
+                    const IP_Port *ip_port)
 {
     for (unsigned int i = 0; i < length; ++i) {
         if (pk_equal(list[i].public_key, public_key)) {
@@ -253,12 +253,12 @@ static int in_list(const Client_data *list, uint16_t length, const Mono_Time *mo
 
             if (!mono_time_is_timeout(mono_time, ipptp->timestamp, BAD_NODE_TIMEOUT)
                     && ipport_equal(&ipptp->ip_port, ip_port)) {
-                return 1;
+                return true;
             }
         }
     }
 
-    return 0;
+    return false;
 }
 
 /** Add nodes to the to_ping list.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1879,10 +1879,10 @@ bool tox_conference_delete(Tox *tox, uint32_t conference_number, Tox_Err_Confere
 {
     assert(tox != nullptr);
     lock(tox);
-    const int ret = del_groupchat(tox->m->conferences_object, conference_number, true);
+    const bool ret = del_groupchat(tox->m->conferences_object, conference_number, true);
     unlock(tox);
 
-    if (ret == -1) {
+    if (!ret) {
         SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_DELETE_CONFERENCE_NOT_FOUND);
         return false;
     }


### PR DESCRIPTION
These were found by the new cimple type check which is completely
unforgiving to implicit boolean conversions. After this PR, there should
be no more implicit int-to-bool or bool-to-int conversions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2120)
<!-- Reviewable:end -->
