### PR TITLE
chore: Enable a bunch more warnings in GCC builds.

### DIFF
--- a/.github/scripts/flags-gcc.sh
+++ b/.github/scripts/flags-gcc.sh
@@ -6,6 +6,43 @@
 add_flag -Wall
 add_flag -Wextra
 
+# Some additional warning flags not enabled by any of the above.
+add_flag -Wbool-compare
+add_flag -Wcast-align
+add_flag -Wcast-qual
+add_flag -Wchar-subscripts
+add_flag -Wdouble-promotion
+add_flag -Wduplicated-cond
+add_flag -Wempty-body
+add_flag -Wenum-compare
+add_flag -Wfloat-equal
+add_flag -Wformat=2
+add_flag -Wframe-address
+add_flag -Wframe-larger-than=12400
+add_flag -Wignored-attributes
+add_flag -Wignored-qualifiers
+add_flag -Winit-self
+add_flag -Winline
+add_flag -Wlarger-than=530000
+add_flag -Wmaybe-uninitialized
+add_flag -Wmemset-transposed-args
+add_flag -Wmisleading-indentation
+add_flag -Wmissing-declarations
+add_flag -Wnonnull
+add_flag -Wnull-dereference
+add_flag -Wodr
+add_flag -Wredundant-decls
+add_flag -Wreturn-type
+add_flag -Wshadow
+add_flag -Wsuggest-attribute=format
+add_flag -Wundef
+add_flag -Wunsafe-loop-optimizations
+add_flag -Wunused-but-set-parameter
+add_flag -Wunused-but-set-variable
+add_flag -Wunused-label
+add_flag -Wunused-local-typedefs
+add_flag -Wunused-value
+
 # Disable specific warning flags for both C and C++.
 
 # struct Foo foo = {0}; is a common idiom.

--- a/toxcore/ccompat.h
+++ b/toxcore/ccompat.h
@@ -67,10 +67,12 @@
 #if !defined(__cplusplus) || __cplusplus < 201103L
 #define nullptr NULL
 #ifndef static_assert
+#define STATIC_ASSERT_(cond, msg, line) typedef int static_assert_##line[(cond) ? 1 : -1]
+#define STATIC_ASSERT(cond, msg, line) STATIC_ASSERT_(cond, msg, line)
 #ifdef __GNUC__
-#define static_assert(cond, msg) extern __attribute__((__unused__)) const int unused_for_static_assert
+#define static_assert(cond, msg) __attribute__((__unused__)) STATIC_ASSERT(cond, msg, __LINE__)
 #else // !__GNUC__
-#define static_assert(cond, msg) extern const int unused_for_static_assert
+#define static_assert(cond, msg) STATIC_ASSERT(cond, msg, __LINE__)
 #endif // !__GNUC__
 #endif // !static_assert
 #endif // !__cplusplus


### PR DESCRIPTION
g++ doesn't emit these warnings properly, so the `run-gcc` tool, which
compiles code as C++, doesn't work for all of these. There are a few
builds that do use GCC, e.g. the sonar-scan build, so these flags will
be passed at some point in CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2122)
<!-- Reviewable:end -->
