### PR TITLE
cleanup: Don't reference local variables in macro bodies.

### DIFF
--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -143,21 +143,6 @@ void ac_iterate(ACSession *ac)
             const int fs = (ac->lp_sampling_rate * ac->lp_frame_duration) / 1000;
             rc = opus_decode(ac->decoder, nullptr, 0, temp_audio_buffer, fs, 1);
         } else {
-            /* Get values from packet and decode. */
-            /* NOTE: This didn't work very well */
-#if 0
-            rc = convert_bw_to_sampling_rate(opus_packet_get_bandwidth(msg->data));
-
-            if (rc != -1) {
-                cs->last_packet_sampling_rate = rc;
-            } else {
-                LOGGER_WARNING(ac->log, "Failed to load packet values!");
-                free(msg);
-                pthread_mutex_lock(ac->queue_mutex);
-                continue;
-            }
-
-#endif
             assert(msg->len > 4);
 
             /* Pick up sampling rate from packet */

--- a/toxav/toxav_old.c
+++ b/toxav/toxav_old.c
@@ -20,8 +20,9 @@
 int toxav_add_av_groupchat(Tox *tox, audio_data_cb *audio_callback, void *userdata)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    Messenger *m;
     //!TOKSTYLE-
-    Messenger *m = *(Messenger **)tox;
+    m = *(Messenger **)tox;
     //!TOKSTYLE+
     return add_av_groupchat(m->log, tox, m->conferences_object, audio_callback, userdata);
 }
@@ -37,8 +38,9 @@ int toxav_join_av_groupchat(Tox *tox, uint32_t friendnumber, const uint8_t *data
                             audio_data_cb *audio_callback, void *userdata)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    Messenger *m;
     //!TOKSTYLE-
-    Messenger *m = *(Messenger **)tox;
+    m = *(Messenger **)tox;
     //!TOKSTYLE+
     return join_av_groupchat(m->log, tox, m->conferences_object, friendnumber, data, length, audio_callback, userdata);
 }
@@ -60,8 +62,9 @@ int toxav_group_send_audio(Tox *tox, uint32_t groupnumber, const int16_t *pcm, u
                            uint32_t sample_rate)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    Messenger *m;
     //!TOKSTYLE-
-    Messenger *m = *(Messenger **)tox;
+    m = *(Messenger **)tox;
     //!TOKSTYLE+
     return group_send_audio(m->conferences_object, groupnumber, pcm, samples, channels, sample_rate);
 }
@@ -84,8 +87,9 @@ int toxav_group_send_audio(Tox *tox, uint32_t groupnumber, const int16_t *pcm, u
 int toxav_groupchat_enable_av(Tox *tox, uint32_t groupnumber, audio_data_cb *audio_callback, void *userdata)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    Messenger *m;
     //!TOKSTYLE-
-    Messenger *m = *(Messenger **)tox;
+    m = *(Messenger **)tox;
     //!TOKSTYLE+
     return groupchat_enable_av(m->log, tox, m->conferences_object, groupnumber, audio_callback, userdata);
 }
@@ -98,8 +102,9 @@ int toxav_groupchat_enable_av(Tox *tox, uint32_t groupnumber, audio_data_cb *aud
 int toxav_groupchat_disable_av(Tox *tox, uint32_t groupnumber)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    Messenger *m;
     //!TOKSTYLE-
-    Messenger *m = *(Messenger **)tox;
+    m = *(Messenger **)tox;
     //!TOKSTYLE+
     return groupchat_disable_av(m->conferences_object, groupnumber);
 }
@@ -109,8 +114,9 @@ int toxav_groupchat_disable_av(Tox *tox, uint32_t groupnumber)
 bool toxav_groupchat_av_enabled(Tox *tox, uint32_t groupnumber)
 {
     // TODO(iphydf): Don't rely on toxcore internals.
+    Messenger *m;
     //!TOKSTYLE-
-    Messenger *m = *(Messenger **)tox;
+    m = *(Messenger **)tox;
     //!TOKSTYLE+
     return groupchat_av_enabled(m->conferences_object, groupnumber);
 }

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2543,30 +2543,30 @@ static uint32_t friend_size(void)
     uint32_t data = 0;
     const struct Saved_Friend *const temp = nullptr;
 
-#define VALUE_MEMBER(name)          \
-    do {                            \
-        data += sizeof(temp->name); \
+#define VALUE_MEMBER(data, name) \
+    do {                         \
+        data += sizeof(name);    \
     } while (0)
-#define ARRAY_MEMBER(name)          \
-    do {                            \
-        data += sizeof(temp->name); \
+#define ARRAY_MEMBER(data, name) \
+    do {                         \
+        data += sizeof(name);    \
     } while (0)
 
     // Exactly the same in friend_load, friend_save, and friend_size
-    VALUE_MEMBER(status);
-    ARRAY_MEMBER(real_pk);
-    ARRAY_MEMBER(info);
+    VALUE_MEMBER(data, temp->status);
+    ARRAY_MEMBER(data, temp->real_pk);
+    ARRAY_MEMBER(data, temp->info);
     ++data; // padding
-    VALUE_MEMBER(info_size);
-    ARRAY_MEMBER(name);
-    VALUE_MEMBER(name_length);
-    ARRAY_MEMBER(statusmessage);
+    VALUE_MEMBER(data, temp->info_size);
+    ARRAY_MEMBER(data, temp->name);
+    VALUE_MEMBER(data, temp->name_length);
+    ARRAY_MEMBER(data, temp->statusmessage);
     ++data; // padding
-    VALUE_MEMBER(statusmessage_length);
-    VALUE_MEMBER(userstatus);
+    VALUE_MEMBER(data, temp->statusmessage_length);
+    VALUE_MEMBER(data, temp->userstatus);
     data += 3; // padding
-    VALUE_MEMBER(friendrequest_nospam);
-    ARRAY_MEMBER(last_seen_time);
+    VALUE_MEMBER(data, temp->friendrequest_nospam);
+    ARRAY_MEMBER(data, temp->last_seen_time);
 
 #undef VALUE_MEMBER
 #undef ARRAY_MEMBER
@@ -2577,33 +2577,33 @@ static uint32_t friend_size(void)
 non_null()
 static uint8_t *friend_save(const struct Saved_Friend *temp, uint8_t *data)
 {
-#define VALUE_MEMBER(name)                             \
-    do {                                               \
-        memcpy(data, &temp->name, sizeof(temp->name)); \
-        data += sizeof(temp->name);                    \
+#define VALUE_MEMBER(data, name)           \
+    do {                                   \
+        memcpy(data, &name, sizeof(name)); \
+        data += sizeof(name);              \
     } while (0)
 
-#define ARRAY_MEMBER(name)                            \
-    do {                                              \
-        memcpy(data, temp->name, sizeof(temp->name)); \
-        data += sizeof(temp->name);                   \
+#define ARRAY_MEMBER(data, name)          \
+    do {                                  \
+        memcpy(data, name, sizeof(name)); \
+        data += sizeof(name);             \
     } while (0)
 
     // Exactly the same in friend_load, friend_save, and friend_size
-    VALUE_MEMBER(status);
-    ARRAY_MEMBER(real_pk);
-    ARRAY_MEMBER(info);
+    VALUE_MEMBER(data, temp->status);
+    ARRAY_MEMBER(data, temp->real_pk);
+    ARRAY_MEMBER(data, temp->info);
     ++data; // padding
-    VALUE_MEMBER(info_size);
-    ARRAY_MEMBER(name);
-    VALUE_MEMBER(name_length);
-    ARRAY_MEMBER(statusmessage);
+    VALUE_MEMBER(data, temp->info_size);
+    ARRAY_MEMBER(data, temp->name);
+    VALUE_MEMBER(data, temp->name_length);
+    ARRAY_MEMBER(data, temp->statusmessage);
     ++data; // padding
-    VALUE_MEMBER(statusmessage_length);
-    VALUE_MEMBER(userstatus);
+    VALUE_MEMBER(data, temp->statusmessage_length);
+    VALUE_MEMBER(data, temp->userstatus);
     data += 3; // padding
-    VALUE_MEMBER(friendrequest_nospam);
-    ARRAY_MEMBER(last_seen_time);
+    VALUE_MEMBER(data, temp->friendrequest_nospam);
+    ARRAY_MEMBER(data, temp->last_seen_time);
 
 #undef VALUE_MEMBER
 #undef ARRAY_MEMBER
@@ -2615,33 +2615,33 @@ static uint8_t *friend_save(const struct Saved_Friend *temp, uint8_t *data)
 non_null()
 static const uint8_t *friend_load(struct Saved_Friend *temp, const uint8_t *data)
 {
-#define VALUE_MEMBER(name)                             \
-    do {                                               \
-        memcpy(&temp->name, data, sizeof(temp->name)); \
-        data += sizeof(temp->name);                    \
+#define VALUE_MEMBER(data, name)           \
+    do {                                   \
+        memcpy(&name, data, sizeof(name)); \
+        data += sizeof(name);              \
     } while (0)
 
-#define ARRAY_MEMBER(name)                            \
-    do {                                              \
-        memcpy(temp->name, data, sizeof(temp->name)); \
-        data += sizeof(temp->name);                   \
+#define ARRAY_MEMBER(data, name)          \
+    do {                                  \
+        memcpy(name, data, sizeof(name)); \
+        data += sizeof(name);             \
     } while (0)
 
     // Exactly the same in friend_load, friend_save, and friend_size
-    VALUE_MEMBER(status);
-    ARRAY_MEMBER(real_pk);
-    ARRAY_MEMBER(info);
+    VALUE_MEMBER(data, temp->status);
+    ARRAY_MEMBER(data, temp->real_pk);
+    ARRAY_MEMBER(data, temp->info);
     ++data; // padding
-    VALUE_MEMBER(info_size);
-    ARRAY_MEMBER(name);
-    VALUE_MEMBER(name_length);
-    ARRAY_MEMBER(statusmessage);
+    VALUE_MEMBER(data, temp->info_size);
+    ARRAY_MEMBER(data, temp->name);
+    VALUE_MEMBER(data, temp->name_length);
+    ARRAY_MEMBER(data, temp->statusmessage);
     ++data; // padding
-    VALUE_MEMBER(statusmessage_length);
-    VALUE_MEMBER(userstatus);
+    VALUE_MEMBER(data, temp->statusmessage_length);
+    VALUE_MEMBER(data, temp->userstatus);
     data += 3; // padding
-    VALUE_MEMBER(friendrequest_nospam);
-    ARRAY_MEMBER(last_seen_time);
+    VALUE_MEMBER(data, temp->friendrequest_nospam);
+    ARRAY_MEMBER(data, temp->last_seen_time);
 
 #undef VALUE_MEMBER
 #undef ARRAY_MEMBER

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -3138,7 +3138,7 @@ static void kill_timedout(Net_Crypto *c, void *userdata)
 
         if (conn->status == CRYPTO_CONN_ESTABLISHED) {
             // TODO(irungentoo): add a timeout here?
-            do_timeout_here();
+            /* do_timeout_here(); */
         }
 
 #endif


### PR DESCRIPTION
Tokstyle enforces this now: https://github.com/TokTok/hs-tokstyle/pull/156.