### PR TITLE
cleanup: Remove `EAGAIN` from the list of ignored errors.

### DIFF
--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -122,7 +122,7 @@ static bool should_ignore_recv_error(int err)
 
 static bool should_ignore_connect_error(int err)
 {
-    return err == EWOULDBLOCK || err == EINPROGRESS || err == EAGAIN;
+    return err == EWOULDBLOCK || err == EINPROGRESS;
 }
 
 non_null()


### PR DESCRIPTION
It is the same as `EINPROGRESS`, so the check is useless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2127)
<!-- Reviewable:end -->
