### PR TITLE
cleanup: Remove redundant `()` around `return` expression.

### DIFF
--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -2948,7 +2948,7 @@ static int lossy_packet_not_received(const Group_c *g, int peer_index, uint16_t 
 /** Does this group type make use of lossy packets? */
 static bool type_uses_lossy(uint8_t type)
 {
-    return (type == GROUPCHAT_TYPE_AV);
+    return type == GROUPCHAT_TYPE_AV;
 }
 
 static int handle_lossy(void *object, int friendcon_id, const uint8_t *data, uint16_t length, void *userdata)

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -233,7 +233,7 @@ static int create_cookie_request(const Net_Crypto *c, uint8_t *packet, const uin
         return -1;
     }
 
-    return (1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE + len);
+    return 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE + len;
 }
 
 /** Create cookie of length COOKIE_LENGTH from bytes of length COOKIE_DATA_LENGTH using encryption_key

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -346,18 +346,18 @@ static bool path_timed_out(const Mono_Time *mono_time, const Onion_Client_Paths 
     const bool is_new = onion_paths->last_path_success[pathnum] == onion_paths->path_creation_time[pathnum];
     const uint64_t timeout = is_new ? ONION_PATH_FIRST_TIMEOUT : ONION_PATH_TIMEOUT;
 
-    return ((onion_paths->last_path_used_times[pathnum] >= ONION_PATH_MAX_NO_RESPONSE_USES
+    return (onion_paths->last_path_used_times[pathnum] >= ONION_PATH_MAX_NO_RESPONSE_USES
              && mono_time_is_timeout(mono_time, onion_paths->last_path_used[pathnum], timeout))
-            || mono_time_is_timeout(mono_time, onion_paths->path_creation_time[pathnum], ONION_PATH_MAX_LIFETIME));
+            || mono_time_is_timeout(mono_time, onion_paths->path_creation_time[pathnum], ONION_PATH_MAX_LIFETIME);
 }
 
 /** should node be considered to have timed out */
 non_null()
 static bool onion_node_timed_out(const Onion_Node *node, const Mono_Time *mono_time)
 {
-    return (node->timestamp == 0
+    return node->timestamp == 0
             || (node->pings_since_last_response >= ONION_NODE_MAX_PINGS
-                && mono_time_is_timeout(mono_time, node->last_pinged, ONION_NODE_TIMEOUT)));
+                && mono_time_is_timeout(mono_time, node->last_pinged, ONION_NODE_TIMEOUT));
 }
 
 /** Create a new path or use an old suitable one (if pathnum is valid)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2130)
<!-- Reviewable:end -->
