### PR TITLE
perf: Improve how we establish direct connections with friends

### DIFF
--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -62,7 +62,7 @@ typedef struct Crypto_Connection {
     uint64_t temp_packet_sent_time; /* The time at which the last temp_packet was sent in ms. */
     uint32_t temp_packet_num_sent;
 
-    IP_Port ip_portv4; /* The ip and port to contact this guy directly.*/
+    IP_Port ip_portv4; /* The ip and port to contact this peer directly.*/
     IP_Port ip_portv6;
     uint64_t direct_lastrecv_timev4; /* The Time at which we last received a direct packet in ms. */
     uint64_t direct_lastrecv_timev6;
@@ -229,7 +229,7 @@ static int create_cookie_request(const Net_Crypto *c, uint8_t *packet, const uin
     memcpy(packet + 1, dht_get_self_public_key(c->dht), CRYPTO_PUBLIC_KEY_SIZE);
     memcpy(packet + 1 + CRYPTO_PUBLIC_KEY_SIZE, nonce, CRYPTO_NONCE_SIZE);
     const int len = encrypt_data_symmetric(shared_key, nonce, plain, sizeof(plain),
-                                     packet + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE);
+                                           packet + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE);
 
     if (len != COOKIE_REQUEST_PLAIN_LENGTH + CRYPTO_MAC_SIZE) {
         return -1;
@@ -341,8 +341,8 @@ static int handle_cookie_request(const Net_Crypto *c, uint8_t *request_plain, ui
     memcpy(dht_public_key, packet + 1, CRYPTO_PUBLIC_KEY_SIZE);
     dht_get_shared_key_sent(c->dht, shared_key, dht_public_key);
     const int len = decrypt_data_symmetric(shared_key, packet + 1 + CRYPTO_PUBLIC_KEY_SIZE,
-                                     packet + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE, COOKIE_REQUEST_PLAIN_LENGTH + CRYPTO_MAC_SIZE,
-                                     request_plain);
+                                           packet + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE, COOKIE_REQUEST_PLAIN_LENGTH + CRYPTO_MAC_SIZE,
+                                           request_plain);
 
     if (len != COOKIE_REQUEST_PLAIN_LENGTH) {
         return -1;
@@ -486,7 +486,7 @@ static int create_crypto_handshake(const Net_Crypto *c, uint8_t *packet, const u
 
     random_nonce(packet + 1 + COOKIE_LENGTH);
     const int len = encrypt_data(peer_real_pk, c->self_secret_key, packet + 1 + COOKIE_LENGTH, plain, sizeof(plain),
-                           packet + 1 + COOKIE_LENGTH + CRYPTO_NONCE_SIZE);
+                                 packet + 1 + COOKIE_LENGTH + CRYPTO_NONCE_SIZE);
 
     if (len != HANDSHAKE_PACKET_LENGTH - (1 + COOKIE_LENGTH + CRYPTO_NONCE_SIZE)) {
         return -1;
@@ -539,8 +539,8 @@ static bool handle_crypto_handshake(const Net_Crypto *c, uint8_t *nonce, uint8_t
 
     uint8_t plain[CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_SHA512_SIZE + COOKIE_LENGTH];
     const int len = decrypt_data(cookie_plain, c->self_secret_key, packet + 1 + COOKIE_LENGTH,
-                           packet + 1 + COOKIE_LENGTH + CRYPTO_NONCE_SIZE,
-                           HANDSHAKE_PACKET_LENGTH - (1 + COOKIE_LENGTH + CRYPTO_NONCE_SIZE), plain);
+                                 packet + 1 + COOKIE_LENGTH + CRYPTO_NONCE_SIZE,
+                                 HANDSHAKE_PACKET_LENGTH - (1 + COOKIE_LENGTH + CRYPTO_NONCE_SIZE), plain);
 
     if (len != sizeof(plain)) {
         return false;
@@ -1271,7 +1271,7 @@ static int handle_data_packet(const Net_Crypto *c, int crypt_connection_id, uint
     const uint16_t diff = num - num_cur_nonce;
     increment_nonce_number(nonce, diff);
     const int len = decrypt_data_symmetric(conn->shared_key, nonce, packet + 1 + sizeof(uint16_t),
-                                     length - (1 + sizeof(uint16_t)), data);
+                                           length - (1 + sizeof(uint16_t)), data);
 
     if ((unsigned int)len != length - crypto_packet_overhead) {
         return -1;
@@ -1513,7 +1513,7 @@ static void connection_kill(Net_Crypto *c, int crypt_connection_id, void *userda
 
     if (conn->connection_status_callback != nullptr) {
         conn->connection_status_callback(conn->connection_status_callback_object, conn->connection_status_callback_id,
-                false, userdata);
+                                         false, userdata);
     }
 
     while (true) { /* TODO(irungentoo): is this really the best way to do this? */
@@ -1600,7 +1600,7 @@ static int handle_data_packet_core(Net_Crypto *c, int crypt_connection_id, const
 
         if (conn->connection_status_callback != nullptr) {
             conn->connection_status_callback(conn->connection_status_callback_object, conn->connection_status_callback_id,
-                    true, userdata);
+                                             true, userdata);
         }
     }
 
@@ -1614,8 +1614,8 @@ static int handle_data_packet_core(Net_Crypto *c, int crypt_connection_id, const
         }
 
         const int requested = handle_request_packet(c->mono_time, &conn->send_array,
-                                              real_data, real_length,
-                                              &rtt_calc_time, rtt_time);
+                              real_data, real_length,
+                              &rtt_calc_time, rtt_time);
 
         if (requested == -1) {
             return -1;
@@ -2622,7 +2622,7 @@ static void send_crypto_packets(Net_Crypto *c)
                                                      &conn->recv_array) + 1.0) / (conn->packet_recv_rate + 1.0));
 
                 const double request_packet_interval2 = ((CRYPTO_PACKET_MIN_RATE / conn->packet_recv_rate) *
-                                                   (double)CRYPTO_SEND_PACKET_INTERVAL) + (double)PACKET_COUNTER_AVERAGE_INTERVAL;
+                                                        (double)CRYPTO_SEND_PACKET_INTERVAL) + (double)PACKET_COUNTER_AVERAGE_INTERVAL;
 
                 if (request_packet_interval2 < request_packet_interval) {
                     request_packet_interval = request_packet_interval2;
@@ -2715,7 +2715,7 @@ static void send_crypto_packets(Net_Crypto *c)
                                                  PACKET_COUNTER_AVERAGE_INTERVAL));
 
                     const double min_speed_request = 1000.0 * (((double)(total_sent + total_resent)) / (
-                            (double)CONGESTION_QUEUE_ARRAY_SIZE * PACKET_COUNTER_AVERAGE_INTERVAL));
+                                                         (double)CONGESTION_QUEUE_ARRAY_SIZE * PACKET_COUNTER_AVERAGE_INTERVAL));
 
                     if (min_speed < CRYPTO_PACKET_MIN_RATE) {
                         min_speed = CRYPTO_PACKET_MIN_RATE;


### PR DESCRIPTION
We now send our IP_Port to friends in ping packets when we establish
new connections. This forces us to keep trying to establish a UDP
connection if we initially connect via TCP. This addresses an issue
where we often make an initial connection via TCP and have to wait
a long time before a UDP connection gets established.

We make 5 attempts approximately every 3 minute interval.

As a result of these changes we sometimes have connection hickups
when the initial switch from TCP to UDP occurs. I haven't figured out
why yet, but I think it's still better than it was before. Also there still
remains an issue where we sometimes just can't seem to establish
a UDP connection with a friend regardless, but it seems to happen
less frequently now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2137)
<!-- Reviewable:end -->
