### PR TITLE
cleanup: Add assertion for decrypted data length.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-9a0865f65e2d370ff8f4784b729ae0ef269563929acffa9cf06b1319d2f07fc3  /usr/local/bin/tox-bootstrapd
+1621d73bde74b114060d4a4b5721a1f33219312a3b92cfda448ebeb28140e8d6  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -411,15 +411,15 @@ int handle_request(const uint8_t *self_public_key, const uint8_t *self_secret_ke
     memcpy(public_key, packet + 1 + CRYPTO_PUBLIC_KEY_SIZE, CRYPTO_PUBLIC_KEY_SIZE);
     const uint8_t *const nonce = packet + 1 + CRYPTO_PUBLIC_KEY_SIZE * 2;
     uint8_t temp[MAX_CRYPTO_REQUEST_SIZE];
-    int len1 = decrypt_data(public_key, self_secret_key, nonce,
-                            packet + CRYPTO_SIZE, packet_length - CRYPTO_SIZE, temp);
+    int32_t len1 = decrypt_data(public_key, self_secret_key, nonce,
+                                packet + CRYPTO_SIZE, packet_length - CRYPTO_SIZE, temp);
 
     if (len1 == -1 || len1 == 0) {
         crypto_memzero(temp, MAX_CRYPTO_REQUEST_SIZE);
         return -1;
     }
 
-    assert(len1 > 0);
+    assert(len1 == packet_length - CRYPTO_SIZE - CRYPTO_MAC_SIZE);
     request_id[0] = temp[0];
     --len1;
     memcpy(data, temp + 1, len1);

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -162,7 +162,10 @@ static int proxy_http_read_connection_response(const Logger *logger, const TCP_C
 
         if (data_left > 0) {
             VLA(uint8_t, temp_data, data_left);
-            read_TCP_packet(logger, tcp_conn->con.sock, temp_data, data_left, &tcp_conn->con.ip_port);
+            if (read_TCP_packet(logger, tcp_conn->con.sock, temp_data, data_left, &tcp_conn->con.ip_port) == -1) {
+                LOGGER_ERROR(logger, "failed to drain TCP data (but ignoring failure)");
+                return 1;
+            }
         }
 
         return 1;


### PR DESCRIPTION
Hopefully this will make it clear enough to coverity that we're not
overrunning any buffers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2140)
<!-- Reviewable:end -->
