### PR TITLE
cleanup: Disable LAN discovery in TCP-only mode.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-1621d73bde74b114060d4a4b5721a1f33219312a3b92cfda448ebeb28140e8d6  /usr/local/bin/tox-bootstrapd
+2e5b749cd2a911c127e197d3791527a9b13f5b7a5a5f6cbdea80cc199707156d  /usr/local/bin/tox-bootstrapd

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -536,6 +536,10 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
     m_options.hole_punching_enabled = tox_options_get_hole_punching_enabled(opts);
     m_options.local_discovery_enabled = tox_options_get_local_discovery_enabled(opts);
 
+    if (m_options.udp_disabled) {
+        m_options.local_discovery_enabled = false;
+    }
+
     tox->log_callback = tox_options_get_log_callback(opts);
     m_options.log_callback = tox_log_handler;
     m_options.log_context = tox;


### PR DESCRIPTION
It causes warnings in the logs.

Also added the IP/Port to TCP connect logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2141)
<!-- Reviewable:end -->
