### PR TITLE
cleanup: Move all the group.h structs into group.c.

### DIFF
--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -263,7 +263,7 @@ static void group_av_peer_new(void *object, uint32_t groupnumber, uint32_t frien
         return;
     }
 
-    peer_av->mono_time = group_av->g_c->mono_time;
+    peer_av->mono_time = g_mono_time(group_av->g_c);
     peer_av->buffer = create_queue(GROUP_JBUF_SIZE);
 
     if (group_peer_set_object(group_av->g_c, groupnumber, friendgroupnumber, peer_av) == -1) {


### PR DESCRIPTION
Almost nothing used these. The one thing that did only does it to get a
`Mono_Time` object. We should probably get that from elsewhere, but for
now the refactoring is just this simple move.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2150)
<!-- Reviewable:end -->
