### PR TITLE
chore: Pin Conan to fix Appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ cache:
 
 install:
   - set PATH=C:\Python38-x64\Scripts;%PATH%
-  - py -3 -m pip install conan
+  - py -3 -m pip install conan==1.45.0
 
 before_build:
   - conan install -if _build .


### PR DESCRIPTION
Conan is confused about the libvpx library in 1.46.0.

`https://github.com/conan-io/conan/pull/10755` looks possibly related,
but I haven't verified that. It's listed as a bug fix for autotools
(which is what libvpx uses) and messes with MD(d)/MT(d) (which is what
fails.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2152)
<!-- Reviewable:end -->
