### PR TITLE
fix: Eliminate memory leak in toxav.

### DIFF
--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -710,6 +710,9 @@ void rtp_kill(RTPSession *session)
     LOGGER_DEBUG(session->m->log, "Terminated RTP session V3 work_buffer_list->next_free_entry: %d",
                  (int)session->work_buffer_list->next_free_entry);
 
+    for (int8_t i = 0; i < session->work_buffer_list->next_free_entry; ++i) {
+        free(session->work_buffer_list->work_buffer[i].buf);
+    }
     free(session->work_buffer_list);
     free(session);
 }


### PR DESCRIPTION
This happens when shutting down a toxav session when it still has some
packets in its internal queue. It's not a serious leak and happens very
rarely (1 in 300 runs of the toxav_many_test), but it can happen and
long-running tox instances that start and end calls a lot would
eventually discover this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2155)
<!-- Reviewable:end -->
