### PR TITLE
cleanup: Expose `struct Tox` to internal code.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -761,7 +761,7 @@ static bool tcp_oobdata_callback_called;
 static int tcp_oobdata_callback(void *object, const uint8_t *public_key, unsigned int id, const uint8_t *data,
                                 uint16_t length, void *userdata)
 {
-    TCP_Connections *tcp_c = (TCP_Connections *)object;
+    const TCP_Connections *tcp_c = (const TCP_Connections *)object;
 
     if (length != 6) {
         return -1;

--- a/auto_tests/auto_test_support.c
+++ b/auto_tests/auto_test_support.c
@@ -5,6 +5,7 @@
 #include "../testing/misc_tools.h"
 #include "../toxcore/Messenger.h"
 #include "../toxcore/mono_time.h"
+#include "../toxcore/tox_struct.h"
 
 #include "auto_test_support.h"
 
@@ -87,7 +88,7 @@ void bootstrap_tox_live_network(Tox *tox, bool enable_tcp)
     }
 }
 
-bool all_connected(AutoTox *autotoxes, uint32_t tox_count)
+bool all_connected(const AutoTox *autotoxes, uint32_t tox_count)
 {
     if (tox_count) {
         ck_assert(autotoxes != nullptr);
@@ -102,7 +103,7 @@ bool all_connected(AutoTox *autotoxes, uint32_t tox_count)
     return true;
 }
 
-bool all_friends_connected(AutoTox *autotoxes, uint32_t tox_count)
+bool all_friends_connected(const AutoTox *autotoxes, uint32_t tox_count)
 {
     if (tox_count) {
         ck_assert(autotoxes != nullptr);
@@ -148,8 +149,7 @@ void set_mono_time_callback(AutoTox *autotox)
 {
     ck_assert(autotox != nullptr);
 
-    // TODO(iphydf): Don't rely on toxcore internals.
-    Mono_Time *mono_time = ((Messenger *)autotox->tox)->mono_time;
+    Mono_Time *mono_time = autotox->tox->mono_time;
 
     autotox->clock = current_time_monotonic(mono_time);
     mono_time_set_current_time_callback(mono_time, nullptr, nullptr);  // set to default first

--- a/auto_tests/auto_test_support.h
+++ b/auto_tests/auto_test_support.h
@@ -21,9 +21,9 @@ typedef struct AutoTox {
     void *state;
 } AutoTox;
 
-bool all_connected(AutoTox *autotoxes, uint32_t tox_count);
+bool all_connected(const AutoTox *autotoxes, uint32_t tox_count);
 
-bool all_friends_connected(AutoTox *autotoxes, uint32_t tox_count);
+bool all_friends_connected(const AutoTox *autotoxes, uint32_t tox_count);
 
 void iterate_all_wait(AutoTox *autotoxes, uint32_t tox_count, uint32_t wait);
 

--- a/auto_tests/lan_discovery_test.c
+++ b/auto_tests/lan_discovery_test.c
@@ -3,6 +3,7 @@
 
 #include "../testing/misc_tools.h"
 #include "../toxcore/ccompat.h"
+#include "../toxcore/tox_struct.h"
 #include "auto_test_support.h"
 
 static uint64_t get_state_clock_callback(Mono_Time *mono_time, void *user_data)
@@ -20,16 +21,13 @@ int main(void)
     ck_assert(tox1 != nullptr);
     ck_assert(tox2 != nullptr);
 
-    // TODO(iphydf): Don't rely on toxcore internals.
-    uint64_t clock = current_time_monotonic(((Messenger *)tox1)->mono_time);
+    uint64_t clock = current_time_monotonic(tox1->mono_time);
     Mono_Time *mono_time;
 
-    // TODO(iphydf): Don't rely on toxcore internals.
-    mono_time = ((Messenger *)tox1)->mono_time;
+    mono_time = tox1->mono_time;
     mono_time_set_current_time_callback(mono_time, get_state_clock_callback, &clock);
 
-    // TODO(iphydf): Don't rely on toxcore internals.
-    mono_time = ((Messenger *)tox2)->mono_time;
+    mono_time = tox2->mono_time;
     mono_time_set_current_time_callback(mono_time, get_state_clock_callback, &clock);
 
     printf("Waiting for LAN discovery. This loop will attempt to run until successful.");

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-c93318d8f05a4e9c9bd74bfb6f01b776c7dcb7450745dfe5f31dac592353cd74  /usr/local/bin/tox-bootstrapd
+41b304348d45a0389807fa9bf45fec05b1c34e47905656923fb3cbc172c2c9ff  /usr/local/bin/tox-bootstrapd

--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -154,6 +154,7 @@ cc_library(
         "//c-toxcore/toxcore:ccompat",
         "//c-toxcore/toxcore:logger",
         "//c-toxcore/toxcore:mono_time",
+        "//c-toxcore/toxcore:tox",
         "//c-toxcore/toxcore:util",
     ],
 )

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -17,6 +17,7 @@
 #include "../toxcore/ccompat.h"
 #include "../toxcore/logger.h"
 #include "../toxcore/mono_time.h"
+#include "../toxcore/tox_struct.h"
 #include "../toxcore/util.h"
 
 // TODO(zoff99): don't hardcode this, let the application choose it
@@ -157,9 +158,7 @@ ToxAV *toxav_new(Tox *tox, Toxav_Err_New *error)
 
     // TODO(iphydf): Don't rely on toxcore internals.
     Messenger *m;
-    //!TOKSTYLE-
-    m = *(Messenger **)tox;
-    //!TOKSTYLE+
+    m = tox->m;
 
     if (m->msi_packet != nullptr) {
         rc = TOXAV_ERR_NEW_MULTIPLE;

--- a/toxav/toxav_old.c
+++ b/toxav/toxav_old.c
@@ -8,16 +8,12 @@
  */
 #include "toxav.h"
 
+#include "../toxcore/tox_struct.h"
 #include "groupav.h"
 
 int toxav_add_av_groupchat(Tox *tox, audio_data_cb *audio_callback, void *userdata)
 {
-    // TODO(iphydf): Don't rely on toxcore internals.
-    const Messenger *m;
-    //!TOKSTYLE-
-    m = *(const Messenger **)tox;
-    //!TOKSTYLE+
-    return add_av_groupchat(m->log, tox, m->conferences_object, audio_callback, userdata);
+    return add_av_groupchat(tox->m->log, tox, tox->m->conferences_object, audio_callback, userdata);
 }
 
 /** @brief Join a AV group (you need to have been invited first).
@@ -30,12 +26,7 @@ int toxav_add_av_groupchat(Tox *tox, audio_data_cb *audio_callback, void *userda
 int toxav_join_av_groupchat(Tox *tox, uint32_t friendnumber, const uint8_t *data, uint16_t length,
                             audio_data_cb *audio_callback, void *userdata)
 {
-    // TODO(iphydf): Don't rely on toxcore internals.
-    const Messenger *m;
-    //!TOKSTYLE-
-    m = *(const Messenger **)tox;
-    //!TOKSTYLE+
-    return join_av_groupchat(m->log, tox, m->conferences_object, friendnumber, data, length, audio_callback, userdata);
+    return join_av_groupchat(tox->m->log, tox, tox->m->conferences_object, friendnumber, data, length, audio_callback, userdata);
 }
 
 /** @brief Send audio to the group chat.
@@ -55,12 +46,7 @@ int toxav_join_av_groupchat(Tox *tox, uint32_t friendnumber, const uint8_t *data
 int toxav_group_send_audio(Tox *tox, uint32_t groupnumber, const int16_t *pcm, unsigned int samples, uint8_t channels,
                            uint32_t sample_rate)
 {
-    // TODO(iphydf): Don't rely on toxcore internals.
-    const Messenger *m;
-    //!TOKSTYLE-
-    m = *(const Messenger **)tox;
-    //!TOKSTYLE+
-    return group_send_audio(m->conferences_object, groupnumber, pcm, samples, channels, sample_rate);
+    return group_send_audio(tox->m->conferences_object, groupnumber, pcm, samples, channels, sample_rate);
 }
 
 /** @brief Enable A/V in a groupchat.
@@ -80,12 +66,7 @@ int toxav_group_send_audio(Tox *tox, uint32_t groupnumber, const int16_t *pcm, u
  */
 int toxav_groupchat_enable_av(Tox *tox, uint32_t groupnumber, audio_data_cb *audio_callback, void *userdata)
 {
-    // TODO(iphydf): Don't rely on toxcore internals.
-    const Messenger *m;
-    //!TOKSTYLE-
-    m = *(const Messenger **)tox;
-    //!TOKSTYLE+
-    return groupchat_enable_av(m->log, tox, m->conferences_object, groupnumber, audio_callback, userdata);
+    return groupchat_enable_av(tox->m->log, tox, tox->m->conferences_object, groupnumber, audio_callback, userdata);
 }
 
 /** @brief Disable A/V in a groupchat.
@@ -95,21 +76,11 @@ int toxav_groupchat_enable_av(Tox *tox, uint32_t groupnumber, audio_data_cb *aud
  */
 int toxav_groupchat_disable_av(Tox *tox, uint32_t groupnumber)
 {
-    // TODO(iphydf): Don't rely on toxcore internals.
-    const Messenger *m;
-    //!TOKSTYLE-
-    m = *(const Messenger **)tox;
-    //!TOKSTYLE+
-    return groupchat_disable_av(m->conferences_object, groupnumber);
+    return groupchat_disable_av(tox->m->conferences_object, groupnumber);
 }
 
 /** @brief Return whether A/V is enabled in the groupchat. */
 bool toxav_groupchat_av_enabled(Tox *tox, uint32_t groupnumber)
 {
-    // TODO(iphydf): Don't rely on toxcore internals.
-    const Messenger *m;
-    //!TOKSTYLE-
-    m = *(const Messenger **)tox;
-    //!TOKSTYLE+
-    return groupchat_av_enabled(m->conferences_object, groupnumber);
+    return groupchat_av_enabled(tox->m->conferences_object, groupnumber);
 }

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -516,6 +516,7 @@ cc_library(
     hdrs = [
         "tox.h",
         "tox_private.h",
+        "tox_struct.h",
     ],
     visibility = ["//c-toxcore:__subpackages__"],
     deps = [

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -68,6 +68,7 @@ libtoxcore_la_SOURCES = ../toxcore/attributes.h \
                         ../toxcore/tox_unpack.h \
                         ../toxcore/tox_unpack.c \
                         ../toxcore/tox_private.h \
+                        ../toxcore/tox_struct.h \
                         ../toxcore/tox_api.c \
                         ../toxcore/util.h \
                         ../toxcore/util.c \

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1082,13 +1082,9 @@ int file_get_id(const Messenger *m, int32_t friendnumber, uint32_t filenumber, u
 
     file_number = temp_filenum;
 
-    struct File_Transfers *ft;
-
-    if (inbound) {
-        ft = &m->friendlist[friendnumber].file_receiving[file_number];
-    } else {
-        ft = &m->friendlist[friendnumber].file_sending[file_number];
-    }
+    const struct File_Transfers *const ft = inbound
+        ? &m->friendlist[friendnumber].file_receiving[file_number]
+        : &m->friendlist[friendnumber].file_sending[file_number];
 
     if (ft->status == FILESTATUS_NONE) {
         return -2;

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -679,7 +679,7 @@ non_null()
 static int receivepacket(const Logger *log, Socket sock, IP_Port *ip_port, uint8_t *data, uint32_t *length)
 {
     memset(ip_port, 0, sizeof(IP_Port));
-    struct sockaddr_storage addr;
+    struct sockaddr_storage addr = {0};
 #ifdef OS_WIN32
     int addrlen = sizeof(addr);
 #else

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -23,6 +23,7 @@
 #include "mono_time.h"
 #include "network.h"
 #include "tox_private.h"
+#include "tox_struct.h"
 
 #include "../toxencryptsave/defines.h"
 
@@ -53,40 +54,6 @@ static_assert(TOX_MAX_NAME_LENGTH == MAX_NAME_LENGTH,
               "TOX_MAX_NAME_LENGTH is assumed to be equal to MAX_NAME_LENGTH");
 static_assert(TOX_MAX_STATUS_MESSAGE_LENGTH == MAX_STATUSMESSAGE_LENGTH,
               "TOX_MAX_STATUS_MESSAGE_LENGTH is assumed to be equal to MAX_STATUSMESSAGE_LENGTH");
-
-struct Tox {
-    // XXX: Messenger *must* be the first member, because toxav casts its
-    // `Tox *` to `Messenger **`.
-    Messenger *m;
-    Mono_Time *mono_time;
-    pthread_mutex_t *mutex;
-
-    tox_log_cb *log_callback;
-    tox_self_connection_status_cb *self_connection_status_callback;
-    tox_friend_name_cb *friend_name_callback;
-    tox_friend_status_message_cb *friend_status_message_callback;
-    tox_friend_status_cb *friend_status_callback;
-    tox_friend_connection_status_cb *friend_connection_status_callback;
-    tox_friend_typing_cb *friend_typing_callback;
-    tox_friend_read_receipt_cb *friend_read_receipt_callback;
-    tox_friend_request_cb *friend_request_callback;
-    tox_friend_message_cb *friend_message_callback;
-    tox_file_recv_control_cb *file_recv_control_callback;
-    tox_file_chunk_request_cb *file_chunk_request_callback;
-    tox_file_recv_cb *file_recv_callback;
-    tox_file_recv_chunk_cb *file_recv_chunk_callback;
-    tox_conference_invite_cb *conference_invite_callback;
-    tox_conference_connected_cb *conference_connected_callback;
-    tox_conference_message_cb *conference_message_callback;
-    tox_conference_title_cb *conference_title_callback;
-    tox_conference_peer_name_cb *conference_peer_name_callback;
-    tox_conference_peer_list_changed_cb *conference_peer_list_changed_callback;
-    tox_dht_get_nodes_response_cb *dht_get_nodes_response_callback;
-    tox_friend_lossy_packet_cb *friend_lossy_packet_callback_per_pktid[UINT8_MAX + 1];
-    tox_friend_lossless_packet_cb *friend_lossless_packet_callback_per_pktid[UINT8_MAX + 1];
-
-    void *toxav_object; // workaround to store a ToxAV object (setter and getter functions are available)
-};
 
 non_null()
 static void lock(const Tox *tox)

--- a/toxcore/tox_struct.h
+++ b/toxcore/tox_struct.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2016-2022 The TokTok team.
+ * Copyright © 2013 Tox project.
+ */
+
+#ifndef C_TOXCORE_TOXCORE_TOX_STRUCT_H
+#define C_TOXCORE_TOXCORE_TOX_STRUCT_H
+
+#include "Messenger.h"
+#include "tox.h"
+#include "tox_private.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct Tox {
+    Messenger *m;
+    Mono_Time *mono_time;
+    pthread_mutex_t *mutex;
+
+    tox_log_cb *log_callback;
+    tox_self_connection_status_cb *self_connection_status_callback;
+    tox_friend_name_cb *friend_name_callback;
+    tox_friend_status_message_cb *friend_status_message_callback;
+    tox_friend_status_cb *friend_status_callback;
+    tox_friend_connection_status_cb *friend_connection_status_callback;
+    tox_friend_typing_cb *friend_typing_callback;
+    tox_friend_read_receipt_cb *friend_read_receipt_callback;
+    tox_friend_request_cb *friend_request_callback;
+    tox_friend_message_cb *friend_message_callback;
+    tox_file_recv_control_cb *file_recv_control_callback;
+    tox_file_chunk_request_cb *file_chunk_request_callback;
+    tox_file_recv_cb *file_recv_callback;
+    tox_file_recv_chunk_cb *file_recv_chunk_callback;
+    tox_conference_invite_cb *conference_invite_callback;
+    tox_conference_connected_cb *conference_connected_callback;
+    tox_conference_message_cb *conference_message_callback;
+    tox_conference_title_cb *conference_title_callback;
+    tox_conference_peer_name_cb *conference_peer_name_callback;
+    tox_conference_peer_list_changed_cb *conference_peer_list_changed_callback;
+    tox_dht_get_nodes_response_cb *dht_get_nodes_response_callback;
+    tox_friend_lossy_packet_cb *friend_lossy_packet_callback_per_pktid[UINT8_MAX + 1];
+    tox_friend_lossless_packet_cb *friend_lossless_packet_callback_per_pktid[UINT8_MAX + 1];
+
+    void *toxav_object; // workaround to store a ToxAV object (setter and getter functions are available)
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // C_TOXCORE_TOXCORE_TOX_STRUCT_H


### PR DESCRIPTION
To avoid unsafe casts that tokstyle doesn't allow and that can cause
random breakages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2158)
<!-- Reviewable:end -->
