### PR TITLE
chore: Update the Appveyor build to VS2019 to work around conan issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,11 @@
 ---
+image: Visual Studio 2019
+
 cache:
   - '%USERPROFILE%\.conan -> conanfile.py'
 
 install:
-  - set PATH=C:\Python38-x64\Scripts;%PATH%
+  - set PATH=C:\Python310-x64\Scripts;%PATH%
   - py -3 -m pip install conan
 
 before_build:


### PR DESCRIPTION
Apparently the libvpx recipe doesn't really work on VS2015 anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2159)
<!-- Reviewable:end -->
