### PR TITLE
test: Improve the stability of the save_load test

### DIFF
--- a/auto_tests/save_load_test.c
+++ b/auto_tests/save_load_test.c
@@ -175,6 +175,10 @@ static void test_few_clients(void)
     ck_assert_msg(connected_t1, "Tox1 isn't connected. %u", connected_t1);
     printf("tox clients connected took %lu seconds\n", (unsigned long)(time(nullptr) - con_time));
 
+    // We're done with this callback, so unset it to ensure we don't fail the
+    // test if tox1 goes offline while tox2 and 3 are reloaded.
+    tox_callback_self_connection_status(tox1, nullptr);
+
     reload_tox(&tox2, opts2, &index[1]);
 
     reload_tox(&tox3, opts3, &index[2]);


### PR DESCRIPTION
We were leaving a self_connection_status callback attached to tox1 while
reloading tox2 and 3, the only other toxes in the network. This lead to
tox1 occasionally going offline, triggering the "Tox went offline"
assert and failing the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2160)
<!-- Reviewable:end -->
