### PR TITLE
cleanup: Reduce scope of array-typed variables where possible.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-94517a4a344a150051515fb29b3b75fc9ea3ac2fcb4d13c7241ec61c3a494223  /usr/local/bin/tox-bootstrapd
+591106a972c27f19e72bd8927964e1ecc57976f4f4ff538699eaf3eb6236f9ea  /usr/local/bin/tox-bootstrapd

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -19,6 +19,7 @@ sh_test(
         "-Wno-type-check",
         "+RTS",
         "-N3",
+        "-RTS",
     ],
     data = CIMPLE_FILES,
     tags = ["haskell"],

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -3060,9 +3060,8 @@ static uint8_t *save_path_nodes(const Messenger *m, uint8_t *data)
 non_null()
 static State_Load_Status load_path_nodes(Messenger *m, const uint8_t *data, uint32_t length)
 {
-    Node_format nodes[NUM_SAVED_PATH_NODES];
-
     if (length > 0) {
+        Node_format nodes[NUM_SAVED_PATH_NODES];
         const int num = unpack_nodes(nodes, NUM_SAVED_PATH_NODES, nullptr, data, length, false);
 
         if (num == -1) {

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -522,9 +522,8 @@ non_null()
 static void loglogdata(const Logger *log, const char *message, const uint8_t *buffer,
                        uint16_t buflen, const IP_Port *ip_port, long res)
 {
-    char ip_str[IP_NTOA_LEN];
-
     if (res < 0) { /* Windows doesn't necessarily know `%zu` */
+        char ip_str[IP_NTOA_LEN];
         const int error = net_error();
         char *strerror = net_new_strerror(error);
         LOGGER_TRACE(log, "[%2u] %s %3u%c %s:%u (%u: %s) | %08x%08x...%02x",
@@ -533,11 +532,13 @@ static void loglogdata(const Logger *log, const char *message, const uint8_t *bu
                      strerror, data_0(buflen, buffer), data_1(buflen, buffer), buffer[buflen - 1]);
         net_kill_strerror(strerror);
     } else if ((res > 0) && ((size_t)res <= buflen)) {
+        char ip_str[IP_NTOA_LEN];
         LOGGER_TRACE(log, "[%2u] %s %3u%c %s:%u (%u: %s) | %08x%08x...%02x",
                      buffer[0], message, min_u16(res, 999), (size_t)res < buflen ? '<' : '=',
                      ip_ntoa(&ip_port->ip, ip_str, sizeof(ip_str)), net_ntohs(ip_port->port), 0, "OK",
                      data_0(buflen, buffer), data_1(buflen, buffer), buffer[buflen - 1]);
     } else { /* empty or overwrite */
+        char ip_str[IP_NTOA_LEN];
         LOGGER_TRACE(log, "[%2u] %s %lu%c%u %s:%u (%u: %s) | %08x%08x...%02x",
                      buffer[0], message, res, res == 0 ? '!' : '>', buflen,
                      ip_ntoa(&ip_port->ip, ip_str, sizeof(ip_str)), net_ntohs(ip_port->port), 0, "OK",


### PR DESCRIPTION
Cimple cannot actually find these without also causing false positives,
but I found them with cimple before removing the code causing false
positives again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2167)
<!-- Reviewable:end -->
