### PR TITLE
feat: Add support for overriding network functions.

### DIFF
--- a/auto_tests/auto_test_support.c
+++ b/auto_tests/auto_test_support.c
@@ -208,8 +208,9 @@ static void initialise_autotox(struct Tox_Options *options, AutoTox *autotox, ui
                                const Run_Auto_Options *autotest_opts)
 {
     autotox->index = index;
-    autotox->tox = tox_new_log(options, nullptr, &autotox->index);
-    ck_assert_msg(autotox->tox != nullptr, "failed to create tox instance #%u", index);
+    Tox_Err_New err;
+    autotox->tox = tox_new_log(options, &err, &autotox->index);
+    ck_assert_msg(autotox->tox != nullptr, "failed to create tox instance #%u (error = %d)", index, err);
 
     set_mono_time_callback(autotox);
 

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -182,7 +182,8 @@ static void send_onion_packet(const Networking_Core *net, const Onion_Path *path
  */
 static Networking_Core *new_networking(const Logger *log, const IP *ip, uint16_t port)
 {
-    return new_networking_ex(log, ip, port, port + (TOX_PORTRANGE_TO - TOX_PORTRANGE_FROM), nullptr);
+    const Network *ns = system_network();
+    return new_networking_ex(log, ns, ip, port, port + (TOX_PORTRANGE_TO - TOX_PORTRANGE_FROM), nullptr);
 }
 
 static void test_basic(void)
@@ -426,7 +427,8 @@ static Onions *new_onions(uint16_t port, uint32_t *index)
     }
 
     TCP_Proxy_Info inf = {{{{0}}}};
-    on->onion_c = new_onion_client(on->log, on->mono_time, new_net_crypto(on->log, on->mono_time, dht, &inf));
+    const Network *ns = system_network();
+    on->onion_c = new_onion_client(on->log, on->mono_time, new_net_crypto(on->log, on->mono_time, ns, dht, &inf));
 
     if (!on->onion_c) {
         kill_onion_announce(on->onion_a);

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -145,7 +145,8 @@ int main(int argc, char *argv[])
     Mono_Time *mono_time = mono_time_new();
     const uint16_t start_port = PORT;
     const uint16_t end_port = start_port + (TOX_PORTRANGE_TO - TOX_PORTRANGE_FROM);
-    DHT *dht = new_dht(logger, mono_time, new_networking_ex(logger, &ip, start_port, end_port, nullptr), true, true);
+    const Network *ns = system_network();
+    DHT *dht = new_dht(logger, mono_time, new_networking_ex(logger, ns, &ip, start_port, end_port, nullptr), true, true);
     Onion *onion = new_onion(logger, mono_time, dht);
     const Onion_Announce *onion_a = new_onion_announce(logger, mono_time, dht);
 
@@ -166,7 +167,7 @@ int main(int argc, char *argv[])
 #ifdef TCP_RELAY_ENABLED
 #define NUM_PORTS 3
     uint16_t ports[NUM_PORTS] = {443, 3389, PORT};
-    TCP_Server *tcp_s = new_TCP_server(logger, ipv6enabled, NUM_PORTS, ports, dht_get_self_secret_key(dht), onion);
+    TCP_Server *tcp_s = new_TCP_server(logger, ns, ipv6enabled, NUM_PORTS, ports, dht_get_self_secret_key(dht), onion);
 
     if (tcp_s == nullptr) {
         printf("TCP server failed to initialize.\n");
@@ -220,7 +221,7 @@ int main(int argc, char *argv[])
     int is_waiting_for_dht_connection = 1;
 
     uint64_t last_LANdiscovery = 0;
-    const Broadcast_Info *broadcast = lan_discovery_init();
+    const Broadcast_Info *broadcast = lan_discovery_init(ns);
 
     while (1) {
         mono_time_update(mono_time);

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-4453168947518175a5500c9d8d08cd83b0e054486da7297b2a9e0e146aadc743  /usr/local/bin/tox-bootstrapd
+8216f2b48b15db02c373766c9e8f898a0cf8ebb26310635b146a118d0bcf1f71  /usr/local/bin/tox-bootstrapd

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -278,14 +278,15 @@ int main(int argc, char *argv[])
     }
 
     const uint16_t end_port = start_port + (TOX_PORTRANGE_TO - TOX_PORTRANGE_FROM);
-    Networking_Core *net = new_networking_ex(logger, &ip, start_port, end_port, nullptr);
+    const Network *ns = system_network();
+    Networking_Core *net = new_networking_ex(logger, ns, &ip, start_port, end_port, nullptr);
 
     if (net == nullptr) {
         if (enable_ipv6 && enable_ipv4_fallback) {
             log_write(LOG_LEVEL_WARNING, "Couldn't initialize IPv6 networking. Falling back to using IPv4.\n");
             enable_ipv6 = 0;
             ip_init(&ip, enable_ipv6);
-            net = new_networking_ex(logger, &ip, start_port, end_port, nullptr);
+            net = new_networking_ex(logger, ns, &ip, start_port, end_port, nullptr);
 
             if (net == nullptr) {
                 log_write(LOG_LEVEL_ERROR, "Couldn't fallback to IPv4. Exiting.\n");
@@ -411,8 +412,8 @@ int main(int argc, char *argv[])
             return 1;
         }
 
-        tcp_server = new_TCP_server(logger, enable_ipv6, tcp_relay_port_count, tcp_relay_ports, dht_get_self_secret_key(dht),
-                                    onion);
+        tcp_server = new_TCP_server(logger, ns, enable_ipv6, tcp_relay_port_count, tcp_relay_ports,
+                                    dht_get_self_secret_key(dht), onion);
 
         free(tcp_relay_ports);
 
@@ -478,7 +479,7 @@ int main(int argc, char *argv[])
     Broadcast_Info *broadcast = nullptr;
 
     if (enable_lan_discovery) {
-        broadcast = lan_discovery_init();
+        broadcast = lan_discovery_init(ns);
         log_write(LOG_LEVEL_INFO, "Initialized LAN discovery successfully.\n");
     }
 

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
     Messenger_Options options = {0};
     options.ipv6enabled = ipv6enabled;
     Messenger_Error err;
-    m = new_messenger(mono_time, &options, &err);
+    m = new_messenger(mono_time, system_network(), &options, &err);
 
     if (!m) {
         fprintf(stderr, "Failed to allocate messenger datastructure: %d\n", err);

--- a/toxcore/LAN_discovery.h
+++ b/toxcore/LAN_discovery.h
@@ -29,7 +29,8 @@ bool lan_discovery_send(const Networking_Core *net, const Broadcast_Info *broadc
 /**
  * Discovers broadcast devices and IP addresses.
  */
-Broadcast_Info *lan_discovery_init(void);
+non_null()
+Broadcast_Info *lan_discovery_init(const Network *ns);
 
 /**
  * Free all resources associated with the broadcast info.

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -234,6 +234,7 @@ typedef struct Friend {
 struct Messenger {
     Logger *log;
     Mono_Time *mono_time;
+    const Network *ns;
 
     Networking_Core *net;
     Net_Crypto *net_crypto;
@@ -753,7 +754,7 @@ typedef enum Messenger_Error {
  * if error is not NULL it will be set to one of the values in the enum above.
  */
 non_null()
-Messenger *new_messenger(Mono_Time *mono_time, Messenger_Options *options, Messenger_Error *error);
+Messenger *new_messenger(Mono_Time *mono_time, const Network *ns, Messenger_Options *options, Messenger_Error *error);
 
 /** @brief Run this before closing shop.
  *

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -148,7 +148,7 @@ static int proxy_http_read_connection_response(const Logger *logger, const TCP_C
     char success[] = "200";
     uint8_t data[16]; // draining works the best if the length is a power of 2
 
-    const int ret = read_TCP_packet(logger, tcp_conn->con.sock, data, sizeof(data) - 1, &tcp_conn->con.ip_port);
+    const int ret = read_TCP_packet(logger, tcp_conn->con.ns, tcp_conn->con.sock, data, sizeof(data) - 1, &tcp_conn->con.ip_port);
 
     if (ret == -1) {
         return 0;
@@ -158,11 +158,11 @@ static int proxy_http_read_connection_response(const Logger *logger, const TCP_C
 
     if (strstr((const char *)data, success) != nullptr) {
         // drain all data
-        const uint16_t data_left = net_socket_data_recv_buffer(tcp_conn->con.sock);
+        const uint16_t data_left = net_socket_data_recv_buffer(tcp_conn->con.ns, tcp_conn->con.sock);
 
         if (data_left > 0) {
             VLA(uint8_t, temp_data, data_left);
-            if (read_TCP_packet(logger, tcp_conn->con.sock, temp_data, data_left, &tcp_conn->con.ip_port) == -1) {
+            if (read_TCP_packet(logger, tcp_conn->con.ns, tcp_conn->con.sock, temp_data, data_left, &tcp_conn->con.ip_port) == -1) {
                 LOGGER_ERROR(logger, "failed to drain TCP data (but ignoring failure)");
                 return 1;
             }
@@ -203,7 +203,7 @@ non_null()
 static int socks5_read_handshake_response(const Logger *logger, const TCP_Client_Connection *tcp_conn)
 {
     uint8_t data[2];
-    const int ret = read_TCP_packet(logger, tcp_conn->con.sock, data, sizeof(data), &tcp_conn->con.ip_port);
+    const int ret = read_TCP_packet(logger, tcp_conn->con.ns, tcp_conn->con.sock, data, sizeof(data), &tcp_conn->con.ip_port);
 
     if (ret == -1) {
         return 0;
@@ -253,7 +253,7 @@ static int proxy_socks5_read_connection_response(const Logger *logger, const TCP
 {
     if (net_family_is_ipv4(tcp_conn->ip_port.ip.family)) {
         uint8_t data[4 + sizeof(IP4) + sizeof(uint16_t)];
-        const int ret = read_TCP_packet(logger, tcp_conn->con.sock, data, sizeof(data), &tcp_conn->con.ip_port);
+        const int ret = read_TCP_packet(logger, tcp_conn->con.ns, tcp_conn->con.sock, data, sizeof(data), &tcp_conn->con.ip_port);
 
         if (ret == -1) {
             return 0;
@@ -264,7 +264,7 @@ static int proxy_socks5_read_connection_response(const Logger *logger, const TCP
         }
     } else {
         uint8_t data[4 + sizeof(IP6) + sizeof(uint16_t)];
-        int ret = read_TCP_packet(logger, tcp_conn->con.sock, data, sizeof(data), &tcp_conn->con.ip_port);
+        int ret = read_TCP_packet(logger, tcp_conn->con.ns, tcp_conn->con.sock, data, sizeof(data), &tcp_conn->con.ip_port);
 
         if (ret == -1) {
             return 0;
@@ -528,7 +528,8 @@ void onion_response_handler(TCP_Client_Connection *con, tcp_onion_response_cb *o
 }
 
 /** Create new TCP connection to ip_port/public_key */
-TCP_Client_Connection *new_TCP_connection(const Logger *logger, const Mono_Time *mono_time, const IP_Port *ip_port,
+TCP_Client_Connection *new_TCP_connection(
+        const Logger *logger, const Mono_Time *mono_time, const Network *ns, const IP_Port *ip_port,
         const uint8_t *public_key, const uint8_t *self_public_key, const uint8_t *self_secret_key,
         const TCP_Proxy_Info *proxy_info)
 {
@@ -552,29 +553,30 @@ TCP_Client_Connection *new_TCP_connection(const Logger *logger, const Mono_Time 
         family = proxy_info->ip_port.ip.family;
     }
 
-    const Socket sock = net_socket(family, TOX_SOCK_STREAM, TOX_PROTO_TCP);
+    const Socket sock = net_socket(ns, family, TOX_SOCK_STREAM, TOX_PROTO_TCP);
 
     if (!sock_valid(sock)) {
         return nullptr;
     }
 
-    if (!set_socket_nosigpipe(sock)) {
-        kill_sock(sock);
+    if (!set_socket_nosigpipe(ns, sock)) {
+        kill_sock(ns, sock);
         return nullptr;
     }
 
-    if (!(set_socket_nonblock(sock) && connect_sock_to(logger, sock, ip_port, proxy_info))) {
-        kill_sock(sock);
+    if (!(set_socket_nonblock(ns, sock) && connect_sock_to(logger, sock, ip_port, proxy_info))) {
+        kill_sock(ns, sock);
         return nullptr;
     }
 
     TCP_Client_Connection *temp = (TCP_Client_Connection *)calloc(1, sizeof(TCP_Client_Connection));
 
     if (temp == nullptr) {
-        kill_sock(sock);
+        kill_sock(ns, sock);
         return nullptr;
     }
 
+    temp->con.ns = ns;
     temp->con.sock = sock;
     temp->con.ip_port = *ip_port;
     memcpy(temp->public_key, public_key, CRYPTO_PUBLIC_KEY_SIZE);
@@ -600,7 +602,7 @@ TCP_Client_Connection *new_TCP_connection(const Logger *logger, const Mono_Time 
             temp->status = TCP_CLIENT_CONNECTING;
 
             if (generate_handshake(temp) == -1) {
-                kill_sock(sock);
+                kill_sock(ns, sock);
                 free(temp);
                 return nullptr;
             }
@@ -807,8 +809,7 @@ non_null(1, 2) nullable(3)
 static bool tcp_process_packet(const Logger *logger, TCP_Client_Connection *conn, void *userdata)
 {
     uint8_t packet[MAX_PACKET_SIZE];
-    const int len = read_packet_TCP_secure_connection(logger, conn->con.sock, &conn->next_packet_length,
-                    conn->con.shared_key, conn->recv_nonce, packet, sizeof(packet), &conn->ip_port);
+    const int len = read_packet_TCP_secure_connection(logger, conn->con.ns, conn->con.sock, &conn->next_packet_length, conn->con.shared_key, conn->recv_nonce, packet, sizeof(packet), &conn->ip_port);
 
     if (len == 0) {
         return false;
@@ -925,7 +926,7 @@ void do_TCP_connection(const Logger *logger, const Mono_Time *mono_time,
 
     if (tcp_connection->status == TCP_CLIENT_UNCONFIRMED) {
         uint8_t data[TCP_SERVER_HANDSHAKE_SIZE];
-        const int len = read_TCP_packet(logger, tcp_connection->con.sock, data, sizeof(data), &tcp_connection->con.ip_port);
+        const int len = read_TCP_packet(logger, tcp_connection->con.ns, tcp_connection->con.sock, data, sizeof(data), &tcp_connection->con.ip_port);
 
         if (sizeof(data) == len) {
             if (handle_handshake(tcp_connection, data) == 0) {
@@ -955,7 +956,7 @@ void kill_TCP_connection(TCP_Client_Connection *tcp_connection)
     }
 
     wipe_priority_list(tcp_connection->con.priority_queue_start);
-    kill_sock(tcp_connection->con.sock);
+    kill_sock(tcp_connection->con.ns, tcp_connection->con.sock);
     crypto_memzero(tcp_connection, sizeof(TCP_Client_Connection));
     free(tcp_connection);
 }

--- a/toxcore/TCP_client.h
+++ b/toxcore/TCP_client.h
@@ -55,8 +55,9 @@ non_null()
 void tcp_con_set_custom_uint(TCP_Client_Connection *con, uint32_t value);
 
 /** Create new TCP connection to ip_port/public_key */
-non_null(1, 2, 3, 4, 5, 6) nullable(7)
-TCP_Client_Connection *new_TCP_connection(const Logger *logger, const Mono_Time *mono_time, const IP_Port *ip_port,
+non_null(1, 2, 3, 4, 5, 6, 7) nullable(8)
+TCP_Client_Connection *new_TCP_connection(
+        const Logger *logger, const Mono_Time *mono_time, const Network *ns, const IP_Port *ip_port,
         const uint8_t *public_key, const uint8_t *self_public_key, const uint8_t *self_secret_key,
         const TCP_Proxy_Info *proxy_info);
 

--- a/toxcore/TCP_common.h
+++ b/toxcore/TCP_common.h
@@ -46,6 +46,7 @@ void wipe_priority_list(TCP_Priority_List *p);
 #define MAX_PACKET_SIZE 2048
 
 typedef struct TCP_Connection {
+    const Network *ns;
     Socket sock;
     IP_Port ip_port;  // for debugging.
     uint8_t sent_nonce[CRYPTO_NONCE_SIZE]; /* Nonce of sent packets. */
@@ -78,8 +79,9 @@ int send_pending_data(const Logger *logger, TCP_Connection *con);
  * @retval -1 on failure (connection must be killed).
  */
 non_null()
-int write_packet_TCP_secure_connection(const Logger *logger, TCP_Connection *con, const uint8_t *data, uint16_t length,
-                                       bool priority);
+int write_packet_TCP_secure_connection(
+        const Logger *logger, TCP_Connection *con, const uint8_t *data, uint16_t length,
+        bool priority);
 
 /** @brief Read length bytes from socket.
  *
@@ -87,7 +89,8 @@ int write_packet_TCP_secure_connection(const Logger *logger, TCP_Connection *con
  * return -1 on failure/no data in buffer.
  */
 non_null()
-int read_TCP_packet(const Logger *logger, Socket sock, uint8_t *data, uint16_t length, const IP_Port *ip_port);
+int read_TCP_packet(
+        const Logger *logger, const Network *ns, Socket sock, uint8_t *data, uint16_t length, const IP_Port *ip_port);
 
 /**
  * @return length of received packet on success.
@@ -95,8 +98,9 @@ int read_TCP_packet(const Logger *logger, Socket sock, uint8_t *data, uint16_t l
  * @retval -1 on failure (connection must be killed).
  */
 non_null()
-int read_packet_TCP_secure_connection(const Logger *logger, Socket sock, uint16_t *next_packet_length,
-                                      const uint8_t *shared_key, uint8_t *recv_nonce, uint8_t *data,
-                                      uint16_t max_len, const IP_Port *ip_port);
+int read_packet_TCP_secure_connection(
+        const Logger *logger, const Network *ns, Socket sock, uint16_t *next_packet_length,
+        const uint8_t *shared_key, uint8_t *recv_nonce, uint8_t *data,
+        uint16_t max_len, const IP_Port *ip_port);
 
 #endif

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -251,8 +251,8 @@ uint32_t tcp_copy_connected_relays_index(const TCP_Connections *tcp_c, Node_form
  * Returns NULL on failure.
  */
 non_null()
-TCP_Connections *new_tcp_connections(const Logger *logger, Mono_Time *mono_time, const uint8_t *secret_key,
-                                     const TCP_Proxy_Info *proxy_info);
+TCP_Connections *new_tcp_connections(const Logger *logger, Mono_Time *mono_time, const Network *ns,
+                                     const uint8_t *secret_key, const TCP_Proxy_Info *proxy_info);
 
 non_null()
 int kill_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connections_number);

--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -33,9 +33,9 @@ non_null()
 size_t tcp_server_listen_count(const TCP_Server *tcp_server);
 
 /** Create new TCP server instance. */
-non_null(1, 4, 5) nullable(6)
-TCP_Server *new_TCP_server(const Logger *logger, bool ipv6_enabled, uint16_t num_sockets, const uint16_t *ports,
-                           const uint8_t *secret_key, Onion *onion);
+non_null(1, 2, 5, 6) nullable(7)
+TCP_Server *new_TCP_server(const Logger *logger, const Network *ns, bool ipv6_enabled, uint16_t num_sockets,
+                           const uint16_t *ports, const uint8_t *secret_key, Onion *onion);
 
 /** Run the TCP_server */
 non_null()

--- a/toxcore/attributes.h
+++ b/toxcore/attributes.h
@@ -18,7 +18,7 @@
 #define GNU_PRINTF(f, a)
 #endif
 
-#if defined(__GNUC__) && defined(_DEBUG)
+#if defined(__GNUC__) && defined(_DEBUG) && !defined(__OPTIMIZE__)
 #define non_null(...) __attribute__((__nonnull__(__VA_ARGS__)))
 #else
 #define non_null(...)

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -896,8 +896,9 @@ int send_friend_request_packet(Friend_Connections *fr_c, int friendcon_id, uint3
 }
 
 /** Create new friend_connections instance. */
-Friend_Connections *new_friend_connections(const Logger *logger, const Mono_Time *mono_time, Onion_Client *onion_c,
-        bool local_discovery_enabled)
+Friend_Connections *new_friend_connections(
+        const Logger *logger, const Mono_Time *mono_time, const Network *ns,
+        Onion_Client *onion_c, bool local_discovery_enabled)
 {
     if (onion_c == nullptr) {
         return nullptr;
@@ -921,7 +922,7 @@ Friend_Connections *new_friend_connections(const Logger *logger, const Mono_Time
     new_connection_handler(temp->net_crypto, &handle_new_connections, temp);
 
     if (temp->local_discovery_enabled) {
-        temp->broadcast = lan_discovery_init();
+        temp->broadcast = lan_discovery_init(ns);
 
         if (temp->broadcast == nullptr) {
             LOGGER_ERROR(logger, "could not initialise LAN discovery");

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -156,7 +156,8 @@ void set_friend_request_callback(Friend_Connections *fr_c, fr_request_cb *fr_req
 /** Create new friend_connections instance. */
 non_null()
 Friend_Connections *new_friend_connections(
-    const Logger *logger, const Mono_Time *mono_time, Onion_Client *onion_c, bool local_discovery_enabled);
+        const Logger *logger, const Mono_Time *mono_time, const Network *ns,
+        Onion_Client *onion_c, bool local_discovery_enabled);
 
 /** main friend_connections loop. */
 non_null()

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -128,6 +128,7 @@ static const Crypto_Connection empty_crypto_connection = {{0}};
 struct Net_Crypto {
     const Logger *log;
     Mono_Time *mono_time;
+    const Network *ns;
 
     DHT *dht;
     TCP_Connections *tcp_c;
@@ -3073,7 +3074,7 @@ void load_secret_key(Net_Crypto *c, const uint8_t *sk)
 /** @brief Create new instance of Net_Crypto.
  * Sets all the global connection variables to their default values.
  */
-Net_Crypto *new_net_crypto(const Logger *log, Mono_Time *mono_time, DHT *dht, const TCP_Proxy_Info *proxy_info)
+Net_Crypto *new_net_crypto(const Logger *log, Mono_Time *mono_time, const Network *ns, DHT *dht, const TCP_Proxy_Info *proxy_info)
 {
     if (dht == nullptr) {
         return nullptr;
@@ -3087,8 +3088,9 @@ Net_Crypto *new_net_crypto(const Logger *log, Mono_Time *mono_time, DHT *dht, co
 
     temp->log = log;
     temp->mono_time = mono_time;
+    temp->ns = ns;
 
-    temp->tcp_c = new_tcp_connections(log, mono_time, dht_get_self_secret_key(dht), proxy_info);
+    temp->tcp_c = new_tcp_connections(log, mono_time, ns, dht_get_self_secret_key(dht), proxy_info);
 
     if (temp->tcp_c == nullptr) {
         free(temp);

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -376,7 +376,7 @@ void load_secret_key(Net_Crypto *c, const uint8_t *sk);
  * Sets all the global connection variables to their default values.
  */
 non_null()
-Net_Crypto *new_net_crypto(const Logger *log, Mono_Time *mono_time, DHT *dht, const TCP_Proxy_Info *proxy_info);
+Net_Crypto *new_net_crypto(const Logger *log, Mono_Time *mono_time, const Network *ns, DHT *dht, const TCP_Proxy_Info *proxy_info);
 
 /** return the optimal interval in ms for running do_net_crypto. */
 non_null()

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -564,6 +564,7 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
     }
 
     tox->mono_time = mono_time_new();
+    tox_set_network(tox, nullptr);
 
     if (tox->mono_time == nullptr) {
         SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);
@@ -595,7 +596,7 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
     lock(tox);
 
     Messenger_Error m_error;
-    tox->m = new_messenger(tox->mono_time, &m_options, &m_error);
+    tox->m = new_messenger(tox->mono_time, &tox->ns, &m_options, &m_error);
 
     if (tox->m == nullptr) {
         if (m_error == MESSENGER_ERROR_PORT) {
@@ -2678,4 +2679,14 @@ bool tox_dht_get_nodes(const Tox *tox, const uint8_t *public_key, const char *ip
     SET_ERROR_PARAMETER(error, TOX_ERR_DHT_GET_NODES_OK);
 
     return true;
+}
+
+void tox_set_network(Tox *tox, const Network *ns)
+{
+    assert(tox != nullptr);
+    if (ns != nullptr) {
+        tox->ns = *ns;
+    } else {
+        tox->ns = *system_network();
+    }
 }

--- a/toxcore/tox_private.h
+++ b/toxcore/tox_private.h
@@ -11,6 +11,8 @@
 #include <stdint.h>
 
 #include "DHT.h"
+#include "network.h"
+#include "tox.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -131,6 +133,8 @@ typedef enum Tox_Err_Dht_Get_Nodes {
  */
 bool tox_dht_get_nodes(const Tox *tox, const uint8_t *public_key, const char *ip, uint16_t port,
                        const uint8_t *target_public_key, Tox_Err_Dht_Get_Nodes *error);
+
+void tox_set_network(Tox *tox, const Network *ns);
 
 #ifdef __cplusplus
 }

--- a/toxcore/tox_struct.h
+++ b/toxcore/tox_struct.h
@@ -17,6 +17,7 @@ extern "C" {
 struct Tox {
     Messenger *m;
     Mono_Time *mono_time;
+    Network ns;
     pthread_mutex_t *mutex;
 
     tox_log_cb *log_callback;


### PR DESCRIPTION
The idea here is to have a `Network` object that contains functions for
network operations and an optional userdata object that can manage those
network operations. This allows e.g. a fuzzer to replace the network
functions with no-ops or fuzzer inputs, reducing the need for `#ifdef`s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2177)
<!-- Reviewable:end -->
