### PR TITLE
test: Improve stability of tox_many_tcp_test.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-41b304348d45a0389807fa9bf45fec05b1c34e47905656923fb3cbc172c2c9ff  /usr/local/bin/tox-bootstrapd
+0bec5d4230562fff1e3b0d5902e95d168eab233ca0232d3fd62705c91c91f580  /usr/local/bin/tox-bootstrapd

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -830,8 +830,8 @@ static Socket new_listening_TCP_socket(const Logger *logger, Family family, uint
 
     if (!ok) {
         char *const error = net_new_strerror(net_error());
-        LOGGER_ERROR(logger, "could not bind to TCP port %d (family = %d): %s",
-                     port, family.value, error != nullptr ? error : "(null)");
+        LOGGER_WARNING(logger, "could not bind to TCP port %d (family = %d): %s",
+                       port, family.value, error != nullptr ? error : "(null)");
         net_kill_strerror(error);
         kill_sock(sock);
         return net_invalid_socket;


### PR DESCRIPTION
If the TCP port is in use, try the next TCP port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2182)
<!-- Reviewable:end -->
