### PR TITLE
cleanup: Use `_Static_assert` in gcc/clang.

### DIFF
--- a/.github/scripts/cmake-osx
+++ b/.github/scripts/cmake-osx
@@ -20,6 +20,11 @@ add_ld_flag -undefined error
 # Make compilation error on a warning
 add_flag -Werror
 
+# Allow _Static_assert. Supported C11 extensions are fine, since we have several
+# C99-only compilers we test against anyway. Anything that passes all the
+# compilers we use is fine.
+add_c_flag -Wno-c11-extensions
+
 cmake -B_build -H. \
   -DCMAKE_C_FLAGS="$C_FLAGS" \
   -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \

--- a/toxcore/ccompat.h
+++ b/toxcore/ccompat.h
@@ -67,11 +67,12 @@
 #if !defined(__cplusplus) || __cplusplus < 201103L
 #define nullptr NULL
 #ifndef static_assert
+#ifdef __GNUC__
+// We'll just assume gcc and clang support C11 _Static_assert.
+#define static_assert _Static_assert
+#else // !__GNUC__
 #define STATIC_ASSERT_(cond, msg, line) typedef int static_assert_##line[(cond) ? 1 : -1]
 #define STATIC_ASSERT(cond, msg, line) STATIC_ASSERT_(cond, msg, line)
-#ifdef __GNUC__
-#define static_assert(cond, msg) __attribute__((__unused__)) STATIC_ASSERT(cond, msg, __LINE__)
-#else // !__GNUC__
 #define static_assert(cond, msg) STATIC_ASSERT(cond, msg, __LINE__)
 #endif // !__GNUC__
 #endif // !static_assert


### PR DESCRIPTION
Hopefully they don't throw warnings at us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2186)
<!-- Reviewable:end -->
