### PR TITLE
cleanup: Make addr_resolve a private function.

### DIFF
--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -25,11 +25,11 @@ static void test_addr_resolv_localhost(void)
     IP ip;
     ip_init(&ip, 0); // ipv6enabled = 0
 
-    int res = addr_resolve(localhost, &ip, nullptr);
+    bool res = addr_resolve_or_parse_ip(localhost, &ip, nullptr);
 
     int error = net_error();
     char *strerror = net_new_strerror(error);
-    ck_assert_msg(res > 0, "Resolver failed: %d, %s", error, strerror);
+    ck_assert_msg(res, "Resolver failed: %d, %s", error, strerror);
     net_kill_strerror(strerror);
 
     char ip_str[IP_NTOA_LEN];
@@ -39,20 +39,20 @@ static void test_addr_resolv_localhost(void)
                   ip_ntoa(&ip, ip_str, sizeof(ip_str)));
 
     ip_init(&ip, 1); // ipv6enabled = 1
-    res = addr_resolve(localhost, &ip, nullptr);
+    res = addr_resolve_or_parse_ip(localhost, &ip, nullptr);
 
 #if USE_IPV6
 
     int localhost_split = 0;
 
-    if (!(res & TOX_ADDR_RESOLVE_INET6)) {
-        res = addr_resolve("ip6-localhost", &ip, nullptr);
+    if (!net_family_is_ipv6(ip.family)) {
+        res = addr_resolve_or_parse_ip("ip6-localhost", &ip, nullptr);
         localhost_split = 1;
     }
 
     error = net_error();
     strerror = net_new_strerror(error);
-    ck_assert_msg(res > 0, "Resolver failed: %d, %s", error, strerror);
+    ck_assert_msg(res, "Resolver failed: %d, %s", error, strerror);
     net_kill_strerror(strerror);
 
     ck_assert_msg(net_family_is_ipv6(ip.family), "Expected family TOX_AF_INET6 (%d), got %u.", TOX_AF_INET6,
@@ -72,10 +72,10 @@ static void test_addr_resolv_localhost(void)
     ip.family = net_family_unspec;
     IP extra;
     ip_reset(&extra);
-    res = addr_resolve(localhost, &ip, &extra);
+    res = addr_resolve_or_parse_ip(localhost, &ip, &extra);
     error = net_error();
     strerror = net_new_strerror(error);
-    ck_assert_msg(res > 0, "Resolver failed: %d, %s", error, strerror);
+    ck_assert_msg(res, "Resolver failed: %d, %s", error, strerror);
     net_kill_strerror(strerror);
 
 #if USE_IPV6

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-0bec5d4230562fff1e3b0d5902e95d168eab233ca0232d3fd62705c91c91f580  /usr/local/bin/tox-bootstrapd
+3db2672c5fb3593c5582c8004cd2e14ea775510e5ca5a088e6b1c4fff7b8c373  /usr/local/bin/tox-bootstrapd

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1329,7 +1329,31 @@ bool addr_parse_ip(const char *address, IP *to)
     return false;
 }
 
-int addr_resolve(const char *address, IP *to, IP *extra)
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+/** addr_resolve return values */
+#define TOX_ADDR_RESOLVE_INET  1
+#define TOX_ADDR_RESOLVE_INET6 2
+#endif
+
+/**
+ * Uses getaddrinfo to resolve an address into an IP address.
+ *
+ * Uses the first IPv4/IPv6 addresses returned by getaddrinfo.
+ *
+ * @param address a hostname (or something parseable to an IP address)
+ * @param to to.family MUST be initialized, either set to a specific IP version
+ *   (TOX_AF_INET/TOX_AF_INET6) or to the unspecified TOX_AF_UNSPEC (0), if both
+ *   IP versions are acceptable
+ * @param extra can be NULL and is only set in special circumstances, see returns
+ *
+ * Returns in `*to` a valid IPAny (v4/v6),
+ * prefers v6 if `ip.family` was TOX_AF_UNSPEC and both available
+ * Returns in `*extra` an IPv4 address, if family was TOX_AF_UNSPEC and `*to` is TOX_AF_INET6
+ *
+ * @return 0 on failure, `TOX_ADDR_RESOLVE_*` on success.
+ */
+non_null(1, 2) nullable(3)
+static int addr_resolve(const char *address, IP *to, IP *extra)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     return 0;

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -257,10 +257,6 @@ bool ipv6_ipv4_in_v6(const IP6 *a);
 
 #define TOX_ENABLE_IPV6_DEFAULT true
 
-/** addr_resolve return values */
-#define TOX_ADDR_RESOLVE_INET  1
-#define TOX_ADDR_RESOLVE_INET6 2
-
 #define TOX_INET6_ADDRSTRLEN 66
 #define TOX_INET_ADDRSTRLEN 22
 
@@ -346,26 +342,6 @@ void ip_copy(IP *target, const IP *source);
 /** copies an ip_port structure (careful about direction) */
 non_null()
 void ipport_copy(IP_Port *target, const IP_Port *source);
-
-/**
- * Uses getaddrinfo to resolve an address into an IP address.
- *
- * Uses the first IPv4/IPv6 addresses returned by getaddrinfo.
- *
- * @param address a hostname (or something parseable to an IP address)
- * @param to to.family MUST be initialized, either set to a specific IP version
- *   (TOX_AF_INET/TOX_AF_INET6) or to the unspecified TOX_AF_UNSPEC (0), if both
- *   IP versions are acceptable
- * @param extra can be NULL and is only set in special circumstances, see returns
- *
- * Returns in `*to` a valid IPAny (v4/v6),
- * prefers v6 if `ip.family` was TOX_AF_UNSPEC and both available
- * Returns in `*extra` an IPv4 address, if family was TOX_AF_UNSPEC and `*to` is TOX_AF_INET6
- *
- * @return 0 on failure, `TOX_ADDR_RESOLVE_*` on success.
- */
-non_null(1, 2) nullable(3)
-int addr_resolve(const char *address, IP *to, IP *extra);
 
 /**
  * Resolves string into an IP address


### PR DESCRIPTION
This isn't used anywhere except in network_test. That test now checks
behaviour of the function actually used elsewhere in tox code, instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2188)
<!-- Reviewable:end -->
