### PR TITLE
cleanup: Remove base_time from mono_time.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-4453168947518175a5500c9d8d08cd83b0e054486da7297b2a9e0e146aadc743  /usr/local/bin/tox-bootstrapd
+b6225d22ccbf9ae3c1cd8378d2607d5687d1f5412cea7569497ba587dd379e46  /usr/local/bin/tox-bootstrapd

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -123,35 +123,6 @@ cc_library(
 )
 
 cc_library(
-    name = "mono_time",
-    srcs = ["mono_time.c"],
-    hdrs = ["mono_time.h"],
-    visibility = [
-        "//c-toxcore/auto_tests:__pkg__",
-        "//c-toxcore/other:__pkg__",
-        "//c-toxcore/other/bootstrap_daemon:__pkg__",
-        "//c-toxcore/testing:__pkg__",
-        "//c-toxcore/toxav:__pkg__",
-    ],
-    deps = [
-        ":ccompat",
-        "//c-toxcore/testing/fuzzing:fuzz_adapter",
-        "@pthread",
-    ],
-)
-
-cc_test(
-    name = "mono_time_test",
-    size = "small",
-    srcs = ["mono_time_test.cc"],
-    deps = [
-        ":mono_time",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_library(
     name = "util",
     srcs = ["util.c"],
     hdrs = ["util.h"],
@@ -165,6 +136,48 @@ cc_library(
         ":attributes",
         ":crypto_core",
         "@pthread",
+    ],
+)
+
+cc_test(
+    name = "util_test",
+    size = "small",
+    srcs = ["util_test.cc"],
+    deps = [
+        ":crypto_core",
+        ":util",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "mono_time",
+    srcs = ["mono_time.c"],
+    hdrs = ["mono_time.h"],
+    visibility = [
+        "//c-toxcore/auto_tests:__pkg__",
+        "//c-toxcore/other:__pkg__",
+        "//c-toxcore/other/bootstrap_daemon:__pkg__",
+        "//c-toxcore/testing:__pkg__",
+        "//c-toxcore/toxav:__pkg__",
+    ],
+    deps = [
+        ":ccompat",
+        ":util",
+        "//c-toxcore/testing/fuzzing:fuzz_adapter",
+        "@pthread",
+    ],
+)
+
+cc_test(
+    name = "mono_time_test",
+    size = "small",
+    srcs = ["mono_time_test.cc"],
+    deps = [
+        ":mono_time",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -197,18 +210,6 @@ cc_test(
     srcs = ["network_test.cc"],
     deps = [
         ":network",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "util_test",
-    size = "small",
-    srcs = ["util_test.cc"],
-    deps = [
-        ":crypto_core",
-        ":util",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/toxcore/mono_time.h
+++ b/toxcore/mono_time.h
@@ -55,8 +55,12 @@ non_null() void mono_time_free(Mono_Time *mono_time);
 non_null()
 void mono_time_update(Mono_Time *mono_time);
 
-/**
- * Return unix time since epoch in seconds.
+/** @brief Return a monotonically increasing time in seconds.
+ *
+ * This time may or may not be close to unix time since epoch. The only
+ * guarantee is that the time will never decrease.
+ *
+ * Always returns a number greater than 0.
  */
 non_null()
 uint64_t mono_time_get(const Mono_Time *mono_time);


### PR DESCRIPTION
The connection to actual unix time is not needed for anything. Mono_Time
is only used for time differences and doesn't care about absolute times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2198)
<!-- Reviewable:end -->
