### PR TITLE
docs: Add information regarding git submodules, cmp to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,6 +39,7 @@ This repository, although called `toxcore`, in fact contains several libraries b
 | `toxencryptsave` | Library    | libtoxcore, libnacl or libsodium              | Cross-platform | Provides encryption of Tox profiles (savedata), as well as arbitrary data. |
 | `DHT_bootstrap`  | Executable | libtoxcore                                    | Cross-platform | A simple DHT bootstrap node.                                               |
 | `tox-bootstrapd` | Executable | libtoxcore, libconfig                         | Unix-like      | Highly configurable DHT bootstrap node daemon (systemd, SysVinit, Docker). |
+| `cmp`            | Library    |                                               | Cross-platform | C implementation of the MessagePack serialization format. [https://github.com/camgunz/cmp](https://github.com/camgunz/cmp) |
 
 #### Secondary
 
@@ -80,6 +81,9 @@ Useful for generating Tox profiles from the output of the vanity key generators,
 #### Library dependencies
 
 Library dependencies are listed in the [components](#components) table. The dependencies need to be satisfied for the components to be built. Note that if you don't have a dependency for some component, e.g. you don't have `libopus` installed required for building `toxav` component, building of that component is silently disabled.
+
+
+Be advised that due to the addition of `cmp` as a submodule, you now also need to initialize the git submodules required by toxcore. This can be done by cloning the repo with the addition of `--recurse-submodules` or by running `git submodules update --init` in the root directory of the repo. 
 
 #### Compiler requirements
 


### PR DESCRIPTION
Add missing information regarding submodules, crucial to building c-toxcore.