### PR TITLE
refactor: Store time in Mono_Time in milliseconds.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-b2996d73cab7c7453dc10ccf7ad733622558de3b1ad0db824a379cf96f500379  /usr/local/bin/tox-bootstrapd
+b18557c5c89ac6a06137a692418270ab08adc0544ed631545b862fca21502743  /usr/local/bin/tox-bootstrapd

--- a/toxcore/mono_time.h
+++ b/toxcore/mono_time.h
@@ -61,8 +61,16 @@ void mono_time_free(const Memory *mem, Mono_Time *mono_time);
 non_null()
 void mono_time_update(Mono_Time *mono_time);
 
-/**
- * Return unix time since epoch in seconds.
+/** @brief Return current monotonic time in milliseconds (ms).
+ *
+ * The starting point is UNIX epoch as measured by `time()` in `mono_time_new()`.
+ */
+non_null()
+uint64_t mono_time_get_ms(const Mono_Time *mono_time);
+
+/** @brief Return a monotonically increasing time in seconds.
+ *
+ * The starting point is UNIX epoch as measured by `time()` in `mono_time_new()`.
  */
 non_null()
 uint64_t mono_time_get(const Mono_Time *mono_time);
@@ -73,9 +81,10 @@ uint64_t mono_time_get(const Mono_Time *mono_time);
 non_null()
 bool mono_time_is_timeout(const Mono_Time *mono_time, uint64_t timestamp, uint64_t timeout);
 
-/**
- * Return current monotonic time in milliseconds (ms). The starting point is
- * unspecified.
+/** @brief Return current monotonic time in milliseconds (ms).
+ *
+ * The starting point is unspecified and in particular is likely not comparable
+ * to the return value of `mono_time_get_ms()`.
  */
 non_null()
 uint64_t current_time_monotonic(Mono_Time *mono_time);


### PR DESCRIPTION
Conversion to seconds happens in `mono_time_get`, and a new function
`mono_time_get_ms` allows code to retrieve monotonic time in
milliseconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2203)
<!-- Reviewable:end -->
