### PR TITLE
chore: Support producing shared libraries on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ project(toxcore)
 
 list(APPEND CMAKE_MODULE_PATH ${toxcore_SOURCE_DIR}/cmake)
 
+option(FLAT_OUTPUT_STRUCTURE "Whether to produce output artifacts in ${CMAKE_BINARY_DIR}/{bin,lib}" OFF)
+if(FLAT_OUTPUT_STRUCTURE)
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+endif()
+
 set_source_files_properties(
   toxcore/mono_time.c
   toxcore/network.c

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,19 +4,29 @@ image: Visual Studio 2019
 cache:
   - '%USERPROFILE%\.conan -> conanfile.py'
 
+environment:
+  matrix:
+    - job_name: static
+    - job_name: shared
+
 install:
   - set PATH=C:\Python310-x64\Scripts;%PATH%
   - py -3 -m pip install conan
-
-before_build:
   - git submodule update --init --recursive
-  - conan install -if _build .
+
+for:
+  - matrix:
+      only:
+        - job_name: static
+    before_build:
+      - conan install -if _build -o with_tests=True .
+  - matrix:
+      only:
+        - job_name: shared
+    before_build:
+      - conan install -if _build -o with_tests=True -o shared=True .
 
 build_script:
-  - conan build -bf _build -if _build .
-
-test_script:
   - set CONAN_CPU_COUNT=50
   - set CTEST_OUTPUT_ON_FAILURE=1
-  - conan install -if _build -o with_tests=True .
   - conan build -bf _build -if _build .

--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -25,10 +25,10 @@ static IP get_loopback(void)
 {
     IP ip;
 #if USE_IPV6
-    ip.family = net_family_ipv6;
+    ip.family = net_family_ipv6();
     ip.ip.v6 = get_ip6_loopback();
 #else
-    ip.family = net_family_ipv4;
+    ip.family = net_family_ipv4();
     ip.ip.v4 = get_ip4_loopback();
 #endif
     return ip;
@@ -68,7 +68,7 @@ static void test_basic(void)
 
     // Check all opened ports for connectivity.
     for (uint8_t i = 0; i < NUM_PORTS; i++) {
-        sock = net_socket(ns, net_family_ipv6, TOX_SOCK_STREAM, TOX_PROTO_TCP);
+        sock = net_socket(ns, net_family_ipv6(), TOX_SOCK_STREAM, TOX_PROTO_TCP);
         localhost.port = net_htons(ports[i]);
         bool ret = net_connect(logger, sock, &localhost);
         ck_assert_msg(ret, "Failed to connect to created TCP relay server on port %d (%d).", ports[i], errno);
@@ -201,7 +201,7 @@ static struct sec_TCP_con *new_TCP_con(const Logger *logger, const Random *rng, 
     struct sec_TCP_con *sec_c = (struct sec_TCP_con *)malloc(sizeof(struct sec_TCP_con));
     ck_assert(sec_c != nullptr);
     sec_c->ns = ns;
-    Socket sock = net_socket(ns, net_family_ipv6, TOX_SOCK_STREAM, TOX_PROTO_TCP);
+    Socket sock = net_socket(ns, net_family_ipv6(), TOX_SOCK_STREAM, TOX_PROTO_TCP);
 
     IP_Port localhost;
     localhost.ip = get_loopback();

--- a/auto_tests/auto_test_support.c
+++ b/auto_tests/auto_test_support.c
@@ -13,7 +13,12 @@
 #define ABORT_ON_LOG_ERROR true
 #endif
 
-const Run_Auto_Options default_run_auto_options = { GRAPH_COMPLETE, nullptr };
+Run_Auto_Options default_run_auto_options() {
+    return (Run_Auto_Options) {
+        .graph = GRAPH_COMPLETE,
+        .init_autotox = nullptr,
+    };
+}
 
 // List of live bootstrap nodes. These nodes should have TCP server enabled.
 static const struct BootstrapNodes {

--- a/auto_tests/auto_test_support.h
+++ b/auto_tests/auto_test_support.h
@@ -43,7 +43,7 @@ typedef struct Run_Auto_Options {
     void (*init_autotox)(AutoTox *autotox, uint32_t n);
 } Run_Auto_Options;
 
-extern const Run_Auto_Options default_run_auto_options;
+Run_Auto_Options default_run_auto_options(void);
 
 void run_auto_test(struct Tox_Options *options, uint32_t tox_count, void test(AutoTox *autotoxes),
                    uint32_t state_size, const Run_Auto_Options *autotest_opts);

--- a/auto_tests/conference_av_test.c
+++ b/auto_tests/conference_av_test.c
@@ -455,7 +455,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
 
     run_auto_test(nullptr, NUM_AV_GROUP_TOX, test_groupav, sizeof(State), &options);

--- a/auto_tests/conference_double_invite_test.c
+++ b/auto_tests/conference_double_invite_test.c
@@ -81,7 +81,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
 
     run_auto_test(nullptr, 2, conference_double_invite_test, sizeof(State), &options);

--- a/auto_tests/conference_invite_merge_test.c
+++ b/auto_tests/conference_invite_merge_test.c
@@ -170,7 +170,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
 
     run_auto_test(nullptr, NUM_INVITE_MERGE_TOX, conference_invite_merge_test, sizeof(State), &options);

--- a/auto_tests/conference_peer_nick_test.c
+++ b/auto_tests/conference_peer_nick_test.c
@@ -129,7 +129,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
     run_auto_test(nullptr, 2, conference_peer_nick_test, sizeof(State), &options);
 

--- a/auto_tests/conference_test.c
+++ b/auto_tests/conference_test.c
@@ -433,7 +433,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
 
     run_auto_test(nullptr, NUM_GROUP_TOX, test_many_group, sizeof(State), &options);

--- a/auto_tests/dht_getnodes_api_test.c
+++ b/auto_tests/dht_getnodes_api_test.c
@@ -141,7 +141,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
 
     run_auto_test(nullptr, NUM_TOXES, test_dht_getnodes, sizeof(State), &options);

--- a/auto_tests/forwarding_test.c
+++ b/auto_tests/forwarding_test.c
@@ -20,10 +20,10 @@ static inline IP get_loopback(void)
 {
     IP ip;
 #if USE_IPV6
-    ip.family = net_family_ipv6;
+    ip.family = net_family_ipv6();
     ip.ip.v6 = get_ip6_loopback();
 #else
-    ip.family = net_family_ipv4;
+    ip.family = net_family_ipv4();
     ip.ip.v4 = get_ip4_loopback();
 #endif
     return ip;
@@ -309,7 +309,7 @@ static void test_forwarding(void)
         ck_assert(NUM_FORWARDER - NUM_FORWARDER_TCP > 1);
 
         for (uint32_t i = NUM_FORWARDER_TCP; i < NUM_FORWARDER; ++i) {
-            ck_assert_msg(get_close_nodes(subtoxes[i]->dht, dht_get_self_public_key(subtoxes[i]->dht), nodes, net_family_unspec, true,
+            ck_assert_msg(get_close_nodes(subtoxes[i]->dht, dht_get_self_public_key(subtoxes[i]->dht), nodes, net_family_unspec(), true,
                                           true) > 0,
                           "node %u has no nodes marked as announce nodes", i);
         }

--- a/auto_tests/friend_connection_test.c
+++ b/auto_tests/friend_connection_test.c
@@ -18,7 +18,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
     run_auto_test(nullptr, 2, friend_connection_test, 0, &options);
 

--- a/auto_tests/friend_request_spam_test.c
+++ b/auto_tests/friend_request_spam_test.c
@@ -63,7 +63,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
     run_auto_test(nullptr, FR_TOX_COUNT, test_friend_request, sizeof(State), &options);
 

--- a/auto_tests/lossless_packet_test.c
+++ b/auto_tests/lossless_packet_test.c
@@ -58,7 +58,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
 
     run_auto_test(nullptr, 2, test_lossless_packet, sizeof(State), &options);

--- a/auto_tests/lossy_packet_test.c
+++ b/auto_tests/lossy_packet_test.c
@@ -58,7 +58,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
 
     run_auto_test(nullptr, 2, test_lossy_packet, sizeof(State), &options);

--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -72,7 +72,7 @@ static void test_addr_resolv_localhost(void)
 #endif
 
     ip_init(&ip, 1); // ipv6enabled = 1
-    ip.family = net_family_unspec;
+    ip.family = net_family_unspec();
     IP extra;
     ip_reset(&extra);
     res = addr_resolve_or_parse_ip(ns, localhost, &ip, &extra);
@@ -115,14 +115,14 @@ static void test_ip_equal(void)
     res = ip_equal(nullptr, &ip1);
     ck_assert_msg(res == 0, "ip_equal(NULL, PTR): expected result 0, got %d.", res);
 
-    ip1.family = net_family_ipv4;
+    ip1.family = net_family_ipv4();
     ip1.ip.v4.uint32 = net_htonl(0x7F000001);
 
     res = ip_equal(&ip1, &ip2);
     ck_assert_msg(res == 0, "ip_equal( {TOX_AF_INET, 127.0.0.1}, {TOX_AF_UNSPEC, 0} ): "
                   "expected result 0, got %d.", res);
 
-    ip2.family = net_family_ipv4;
+    ip2.family = net_family_ipv4();
     ip2.ip.v4.uint32 = net_htonl(0x7F000001);
 
     res = ip_equal(&ip1, &ip2);
@@ -135,7 +135,7 @@ static void test_ip_equal(void)
     ck_assert_msg(res == 0, "ip_equal( {TOX_AF_INET, 127.0.0.1}, {TOX_AF_INET, 127.0.0.2} ): "
                   "expected result 0, got %d.", res);
 
-    ip2.family = net_family_ipv6;
+    ip2.family = net_family_ipv6();
     ip2.ip.v6.uint32[0] = 0;
     ip2.ip.v6.uint32[1] = 0;
     ip2.ip.v6.uint32[2] = net_htonl(0xFFFF);

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -18,10 +18,10 @@ static inline IP get_loopback(void)
 {
     IP ip;
 #if USE_IPV6
-    ip.family = net_family_ipv6;
+    ip.family = net_family_ipv6();
     ip.ip.v6 = get_ip6_loopback();
 #else
-    ip.family = net_family_ipv4;
+    ip.family = net_family_ipv4();
     ip.ip.v4 = get_ip4_loopback();
 #endif
     return ip;

--- a/auto_tests/overflow_recvq_test.c
+++ b/auto_tests/overflow_recvq_test.c
@@ -56,7 +56,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
     run_auto_test(nullptr, 3, net_crypto_overflow_test, sizeof(State), &options);
 

--- a/auto_tests/overflow_sendq_test.c
+++ b/auto_tests/overflow_sendq_test.c
@@ -38,7 +38,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
     run_auto_test(nullptr, 2, net_crypto_overflow_test, 0, &options);
 

--- a/auto_tests/reconnect_test.c
+++ b/auto_tests/reconnect_test.c
@@ -94,7 +94,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
     run_auto_test(nullptr, TOX_COUNT, test_reconnect, 0, &options);
 

--- a/auto_tests/send_message_test.c
+++ b/auto_tests/send_message_test.c
@@ -65,7 +65,7 @@ int main(void)
     struct Tox_Options *tox_options = tox_options_new(nullptr);
     ck_assert(tox_options != nullptr);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
     tox_options_set_ipv6_enabled(tox_options, true);
     run_auto_test(tox_options, 2, send_message_test, sizeof(State), &options);

--- a/auto_tests/typing_test.c
+++ b/auto_tests/typing_test.c
@@ -55,7 +55,7 @@ int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    Run_Auto_Options options = default_run_auto_options;
+    Run_Auto_Options options = default_run_auto_options();
     options.graph = GRAPH_LINEAR;
     run_auto_test(nullptr, 2, test_typing, sizeof(State), &options);
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,8 +18,14 @@ class ToxConan(ConanFile):
     generators = "cmake_find_package"
     scm = {"type": "git", "url": "auto", "revision": "auto"}
 
-    options = {"with_tests": [True, False]}
-    default_options = {"with_tests": False}
+    options = {
+        "shared": [True, False],
+        "with_tests": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "with_tests": False,
+    }
 
     _cmake = None
 
@@ -30,11 +36,16 @@ class ToxConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["AUTOTEST"] = self.options.with_tests
         self._cmake.definitions["BUILD_MISC_TESTS"] = self.options.with_tests
-        self._cmake.definitions["ENABLE_SHARED"] = False
-        self._cmake.definitions["ENABLE_STATIC"] = True
+
+        self._cmake.definitions[
+            "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = self.options.shared
+        self._cmake.definitions["ENABLE_SHARED"] = self.options.shared
+        self._cmake.definitions["ENABLE_STATIC"] = not self.options.shared
         self._cmake.definitions["MUST_BUILD_TOXAV"] = True
         if self.settings.compiler == "Visual Studio":
             self._cmake.definitions["MSVC_STATIC_SODIUM"] = True
+            self._cmake.definitions[
+                "FLAT_OUTPUT_STRUCTURE"] = self.options.shared
 
         self._cmake.configure()
         return self._cmake

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-ccc903803f118d6d069f65bb0a1ef95979ab8b374d207e8f13716771d6da9dd8  /usr/local/bin/tox-bootstrapd
+cfa2c61f92df59419af678ef9d6fcd4f5609a505235d77a54c1a4ec66f1c10af  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -193,7 +193,7 @@ static IP_Port ip_port_normalize(const IP_Port *ip_port)
     IP_Port res = *ip_port;
 
     if (net_family_is_ipv6(res.ip.family) && ipv6_ipv4_in_v6(&res.ip.ip.v6)) {
-        res.ip.family = net_family_ipv4;
+        res.ip.family = net_family_ipv4();
         res.ip.ip.v4.uint32 = res.ip.ip.v6.uint32[3];
     }
 
@@ -571,24 +571,24 @@ int unpack_ip_port(IP_Port *ip_port, const uint8_t *data, uint16_t length, bool 
 
     if (data[0] == TOX_AF_INET) {
         is_ipv4 = true;
-        host_family = net_family_ipv4;
+        host_family = net_family_ipv4();
     } else if (data[0] == TOX_TCP_INET) {
         if (!tcp_enabled) {
             return -1;
         }
 
         is_ipv4 = true;
-        host_family = net_family_tcp_ipv4;
+        host_family = net_family_tcp_ipv4();
     } else if (data[0] == TOX_AF_INET6) {
         is_ipv4 = false;
-        host_family = net_family_ipv6;
+        host_family = net_family_ipv6();
     } else if (data[0] == TOX_TCP_INET6) {
         if (!tcp_enabled) {
             return -1;
         }
 
         is_ipv4 = false;
-        host_family = net_family_tcp_ipv6;
+        host_family = net_family_tcp_ipv6();
     } else {
         return -1;
     }
@@ -1549,7 +1549,7 @@ static int sendnodes_ipv6(const DHT *dht, const IP_Port *ip_port, const uint8_t 
 
     Node_format nodes_list[MAX_SENT_NODES];
     const uint32_t num_nodes =
-        get_close_nodes(dht, client_id, nodes_list, net_family_unspec, ip_is_lan(&ip_port->ip), false);
+        get_close_nodes(dht, client_id, nodes_list, net_family_unspec(), ip_is_lan(&ip_port->ip), false);
 
     VLA(uint8_t, plain, 1 + node_format_size * MAX_SENT_NODES + length);
 
@@ -1792,7 +1792,7 @@ int dht_addfriend(DHT *dht, const uint8_t *public_key, dht_ip_cb *ip_callback,
 
     dht_friend_lock(dht_friend, ip_callback, data, number, lock_count);
 
-    dht_friend->num_to_bootstrap = get_close_nodes(dht, dht_friend->public_key, dht_friend->to_bootstrap, net_family_unspec,
+    dht_friend->num_to_bootstrap = get_close_nodes(dht, dht_friend->public_key, dht_friend->to_bootstrap, net_family_unspec(),
                                    true, false);
 
     return 0;
@@ -2038,7 +2038,7 @@ int dht_bootstrap_from_address(DHT *dht, const char *address, bool ipv6enabled,
 
     if (ipv6enabled) {
         /* setup for getting BOTH: an IPv6 AND an IPv4 address */
-        ip_port_v64.ip.family = net_family_unspec;
+        ip_port_v64.ip.family = net_family_unspec();
         ip_reset(&ip_port_v4.ip);
         ip_extra = &ip_port_v4.ip;
     }
@@ -2847,7 +2847,7 @@ uint32_t dht_size(const DHT *dht)
     const uint32_t size32 = sizeof(uint32_t);
     const uint32_t sizesubhead = size32 * 2;
 
-    return size32 + sizesubhead + packed_node_size(net_family_ipv4) * numv4 + packed_node_size(net_family_ipv6) * numv6;
+    return size32 + sizesubhead + packed_node_size(net_family_ipv4()) * numv4 + packed_node_size(net_family_ipv6()) * numv6;
 }
 
 /** Save the DHT in data where data is an array of size `dht_size()`. */

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2380,7 +2380,7 @@ void do_messenger(Messenger *m, void *userdata)
             /* Add self tcp server. */
             IP_Port local_ip_port;
             local_ip_port.port = m->options.tcp_server_port;
-            local_ip_port.ip.family = net_family_ipv4;
+            local_ip_port.ip.family = net_family_ipv4();
             local_ip_port.ip.ip.v4 = get_ip4_loopback();
             add_tcp_relay(m->net_crypto, &local_ip_port, tcp_server_public_key(m->tcp_server));
         }
@@ -2964,7 +2964,7 @@ static State_Load_Status load_status(Messenger *m, const uint8_t *data, uint32_t
 non_null()
 static uint32_t tcp_relay_size(const Messenger *m)
 {
-    return NUM_SAVED_TCP_RELAYS * packed_node_size(net_family_tcp_ipv6);
+    return NUM_SAVED_TCP_RELAYS * packed_node_size(net_family_tcp_ipv6());
 }
 
 non_null()
@@ -2981,7 +2981,7 @@ static uint8_t *save_tcp_relays(const Messenger *m, uint8_t *data)
     uint32_t num = m->num_loaded_relays;
     num += copy_connected_tcp_relays(m->net_crypto, relays + num, NUM_SAVED_TCP_RELAYS - num);
 
-    const int l = pack_nodes(m->log, data, NUM_SAVED_TCP_RELAYS * packed_node_size(net_family_tcp_ipv6), relays, num);
+    const int l = pack_nodes(m->log, data, NUM_SAVED_TCP_RELAYS * packed_node_size(net_family_tcp_ipv6()), relays, num);
 
     if (l > 0) {
         const uint32_t len = l;
@@ -3014,7 +3014,7 @@ static State_Load_Status load_tcp_relays(Messenger *m, const uint8_t *data, uint
 non_null()
 static uint32_t path_node_size(const Messenger *m)
 {
-    return NUM_SAVED_PATH_NODES * packed_node_size(net_family_tcp_ipv6);
+    return NUM_SAVED_PATH_NODES * packed_node_size(net_family_tcp_ipv6());
 }
 
 non_null()
@@ -3025,7 +3025,7 @@ static uint8_t *save_path_nodes(const Messenger *m, uint8_t *data)
     data = state_write_section_header(data, STATE_COOKIE_TYPE, 0, STATE_TYPE_PATH_NODE);
     memset(nodes, 0, sizeof(nodes));
     const unsigned int num = onion_backup_nodes(m->onion_c, nodes, NUM_SAVED_PATH_NODES);
-    const int l = pack_nodes(m->log, data, NUM_SAVED_PATH_NODES * packed_node_size(net_family_tcp_ipv6), nodes, num);
+    const int l = pack_nodes(m->log, data, NUM_SAVED_PATH_NODES * packed_node_size(net_family_tcp_ipv6()), nodes, num);
 
     if (l > 0) {
         const uint32_t len = l;

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -572,7 +572,7 @@ void set_forwarding_packet_tcp_connection_callback(TCP_Connections *tcp_c,
 IP_Port tcp_connections_number_to_ip_port(unsigned int tcp_connections_number)
 {
     IP_Port ip_port = {{{0}}};
-    ip_port.ip.family = net_family_tcp_server;
+    ip_port.ip.family = net_family_tcp_server();
     ip_port.ip.ip.v6.uint32[0] = tcp_connections_number;
     return ip_port;
 }
@@ -1282,9 +1282,9 @@ static int add_tcp_relay_instance(TCP_Connections *tcp_c, const IP_Port *ip_port
     IP_Port ipp_copy = *ip_port;
 
     if (net_family_is_tcp_ipv4(ipp_copy.ip.family)) {
-        ipp_copy.ip.family = net_family_ipv4;
+        ipp_copy.ip.family = net_family_ipv4();
     } else if (net_family_is_tcp_ipv6(ipp_copy.ip.family)) {
-        ipp_copy.ip.family = net_family_ipv6;
+        ipp_copy.ip.family = net_family_ipv6();
     }
 
     if (!net_family_is_ipv4(ipp_copy.ip.family) && !net_family_is_ipv6(ipp_copy.ip.family)) {
@@ -1451,9 +1451,9 @@ static bool copy_tcp_relay_conn(const TCP_Connections *tcp_c, Node_format *tcp_r
     Family *const family = &tcp_relay->ip_port.ip.family;
 
     if (net_family_is_ipv4(*family)) {
-        *family = net_family_tcp_ipv4;
+        *family = net_family_tcp_ipv4();
     } else if (net_family_is_ipv6(*family)) {
-        *family = net_family_tcp_ipv6;
+        *family = net_family_tcp_ipv6();
     }
 
     return true;

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -574,7 +574,7 @@ static int rm_connection_index(TCP_Server *tcp_server, TCP_Secure_Connection *co
 static IP_Port con_id_to_ip_port(uint32_t con_id, uint64_t identifier)
 {
     IP_Port ip_port = {{{0}}};
-    ip_port.ip.family = net_family_tcp_client;
+    ip_port.ip.family = net_family_tcp_client();
     ip_port.ip.ip.v6.uint32[0] = con_id;
     ip_port.ip.ip.v6.uint64[1] = identifier;
     return ip_port;
@@ -980,7 +980,7 @@ TCP_Server *new_TCP_server(const Logger *logger, const Random *rng, const Networ
 
 #endif
 
-    const Family family = ipv6_enabled ? net_family_ipv6 : net_family_ipv4;
+    const Family family = ipv6_enabled ? net_family_ipv6() : net_family_ipv4();
 
     for (uint32_t i = 0; i < num_sockets; ++i) {
         const Socket sock = new_listening_TCP_socket(logger, ns, family, ports[i]);

--- a/toxcore/announce.c
+++ b/toxcore/announce.c
@@ -344,7 +344,7 @@ static int create_reply_plain_data_search_request(Announcements *announce,
 
     Node_format nodes_list[MAX_SENT_NODES];
     const int num_nodes = get_close_nodes(announce->dht, data_public_key, nodes_list,
-                                          net_family_unspec, ip_is_lan(&source->ip), true);
+                                          net_family_unspec(), ip_is_lan(&source->ip), true);
 
     if (num_nodes < 0 || num_nodes > MAX_SENT_NODES) {
         return -1;

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -975,7 +975,7 @@ void do_friend_connections(Friend_Connections *fr_c, void *userdata)
                 }
 
                 if (friend_con->dht_ip_port_lastrecv + FRIEND_DHT_TIMEOUT < temp_time) {
-                    friend_con->dht_ip_port.ip.family = net_family_unspec;
+                    friend_con->dht_ip_port.ip.family = net_family_unspec();
                 }
 
                 if (friend_con->dht_lock > 0) {

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -293,17 +293,27 @@ static int make_family(Family tox_family)
     }
 }
 
+static const Family family_unspec = {TOX_AF_UNSPEC};
+static const Family family_ipv4 = {TOX_AF_INET};
+static const Family family_ipv6 = {TOX_AF_INET6};
+static const Family family_tcp_server = {TCP_SERVER_FAMILY};
+static const Family family_tcp_client = {TCP_CLIENT_FAMILY};
+static const Family family_tcp_ipv4 = {TCP_INET};
+static const Family family_tcp_ipv6 = {TCP_INET6};
+static const Family family_tox_tcp_ipv4 = {TOX_TCP_INET};
+static const Family family_tox_tcp_ipv6 = {TOX_TCP_INET6};
+
 static const Family *make_tox_family(int family)
 {
     switch (family) {
         case AF_INET:
-            return &net_family_ipv4;
+            return &family_ipv4;
 
         case AF_INET6:
-            return &net_family_ipv6;
+            return &family_ipv6;
 
         case AF_UNSPEC:
-            return &net_family_unspec;
+            return &family_unspec;
 
         default:
             return nullptr;
@@ -370,59 +380,94 @@ IP6 get_ip6_loopback(void)
 
 const Socket net_invalid_socket = { (int)INVALID_SOCKET };
 
-const Family net_family_unspec = {TOX_AF_UNSPEC};
-const Family net_family_ipv4 = {TOX_AF_INET};
-const Family net_family_ipv6 = {TOX_AF_INET6};
-const Family net_family_tcp_server = {TCP_SERVER_FAMILY};
-const Family net_family_tcp_client = {TCP_CLIENT_FAMILY};
-const Family net_family_tcp_ipv4 = {TCP_INET};
-const Family net_family_tcp_ipv6 = {TCP_INET6};
-const Family net_family_tox_tcp_ipv4 = {TOX_TCP_INET};
-const Family net_family_tox_tcp_ipv6 = {TOX_TCP_INET6};
+Family net_family_unspec()
+{
+    return family_unspec;
+}
+
+Family net_family_ipv4()
+{
+    return family_ipv4;
+}
+
+Family net_family_ipv6()
+{
+    return family_ipv6;
+}
+
+Family net_family_tcp_server()
+{
+    return family_tcp_server;
+}
+
+Family net_family_tcp_client()
+{
+    return family_tcp_client;
+}
+
+Family net_family_tcp_ipv4()
+{
+    return family_tcp_ipv4;
+}
+
+Family net_family_tcp_ipv6()
+{
+    return family_tcp_ipv6;
+}
+
+Family net_family_tox_tcp_ipv4()
+{
+    return family_tox_tcp_ipv4;
+}
+
+Family net_family_tox_tcp_ipv6()
+{
+    return family_tox_tcp_ipv6;
+}
 
 bool net_family_is_unspec(Family family)
 {
-    return family.value == net_family_unspec.value;
+    return family.value == family_unspec.value;
 }
 
 bool net_family_is_ipv4(Family family)
 {
-    return family.value == net_family_ipv4.value;
+    return family.value == family_ipv4.value;
 }
 
 bool net_family_is_ipv6(Family family)
 {
-    return family.value == net_family_ipv6.value;
+    return family.value == family_ipv6.value;
 }
 
 bool net_family_is_tcp_server(Family family)
 {
-    return family.value == net_family_tcp_server.value;
+    return family.value == family_tcp_server.value;
 }
 
 bool net_family_is_tcp_client(Family family)
 {
-    return family.value == net_family_tcp_client.value;
+    return family.value == family_tcp_client.value;
 }
 
 bool net_family_is_tcp_ipv4(Family family)
 {
-    return family.value == net_family_tcp_ipv4.value;
+    return family.value == family_tcp_ipv4.value;
 }
 
 bool net_family_is_tcp_ipv6(Family family)
 {
-    return family.value == net_family_tcp_ipv6.value;
+    return family.value == family_tcp_ipv6.value;
 }
 
 bool net_family_is_tox_tcp_ipv4(Family family)
 {
-    return family.value == net_family_tox_tcp_ipv4.value;
+    return family.value == family_tox_tcp_ipv4.value;
 }
 
 bool net_family_is_tox_tcp_ipv6(Family family)
 {
-    return family.value == net_family_tox_tcp_ipv6.value;
+    return family.value == family_tox_tcp_ipv6.value;
 }
 
 bool sock_valid(Socket sock)
@@ -849,7 +894,7 @@ int send_packet(const Networking_Core *net, const IP_Port *ip_port, Packet packe
         ip6.uint32[2] = net_htonl(0xFFFF);
         ip6.uint32[3] = ipp_copy.ip.ip.v4.uint32;
 
-        ipp_copy.ip.family = net_family_ipv6;
+        ipp_copy.ip.family = net_family_ipv6();
         ipp_copy.ip.ip.v6 = ip6;
     }
 
@@ -951,7 +996,7 @@ static int receivepacket(const Network *ns, const Logger *log, Socket sock, IP_P
         ip_port->port = addr_in6->sin6_port;
 
         if (ipv6_ipv4_in_v6(&ip_port->ip.ip.v6)) {
-            ip_port->ip.family = net_family_ipv4;
+            ip_port->ip.family = net_family_ipv4();
             ip_port->ip.ip.v4.uint32 = ip_port->ip.ip.v6.uint32[3];
         }
     } else {
@@ -1354,7 +1399,7 @@ void ip_init(IP *ip, bool ipv6enabled)
     }
 
     *ip = empty_ip;
-    ip->family = ipv6enabled ? net_family_ipv6 : net_family_ipv4;
+    ip->family = ipv6enabled ? net_family_ipv6() : net_family_ipv4();
 }
 
 /** checks if ip is valid */
@@ -1460,7 +1505,7 @@ bool addr_parse_ip(const char *address, IP *to)
     struct in_addr addr4;
 
     if (inet_pton4(address, &addr4) == 1) {
-        to->family = net_family_ipv4;
+        to->family = net_family_ipv4();
         get_ip4(&to->ip.v4, &addr4);
         return true;
     }
@@ -1468,7 +1513,7 @@ bool addr_parse_ip(const char *address, IP *to)
     struct in6_addr addr6;
 
     if (inet_pton6(address, &addr6) == 1) {
-        to->family = net_family_ipv6;
+        to->family = net_family_ipv6();
         get_ip6(&to->ip.v6, &addr6);
         return true;
     }

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -84,15 +84,15 @@ bool net_family_is_tcp_ipv6(Family family);
 bool net_family_is_tox_tcp_ipv4(Family family);
 bool net_family_is_tox_tcp_ipv6(Family family);
 
-extern const Family net_family_unspec;
-extern const Family net_family_ipv4;
-extern const Family net_family_ipv6;
-extern const Family net_family_tcp_server;
-extern const Family net_family_tcp_client;
-extern const Family net_family_tcp_ipv4;
-extern const Family net_family_tcp_ipv6;
-extern const Family net_family_tox_tcp_ipv4;
-extern const Family net_family_tox_tcp_ipv6;
+Family net_family_unspec(void);
+Family net_family_ipv4(void);
+Family net_family_ipv6(void);
+Family net_family_tcp_server(void);
+Family net_family_tcp_client(void);
+Family net_family_tcp_ipv4(void);
+Family net_family_tcp_ipv6(void);
+Family net_family_tox_tcp_ipv4(void);
+Family net_family_tox_tcp_ipv6(void);
 
 #define MAX_UDP_PACKET_SIZE 2048
 

--- a/toxcore/network_test.cc
+++ b/toxcore/network_test.cc
@@ -8,7 +8,7 @@ TEST(IpNtoa, DoesntWriteOutOfBounds)
 {
     Ip_Ntoa ip_str;
     IP ip;
-    ip.family = net_family_ipv6;
+    ip.family = net_family_ipv6();
     ip.ip.v6.uint64[0] = -1;
     ip.ip.v6.uint64[1] = -1;
 
@@ -22,7 +22,7 @@ TEST(IpNtoa, ReportsInvalidIpFamily)
 {
     Ip_Ntoa ip_str;
     IP ip;
-    ip.family.value = 255 - net_family_ipv6.value;
+    ip.family.value = 255 - net_family_ipv6().value;
     ip.ip.v4.uint32 = 0;
 
     net_ip_ntoa(&ip, &ip_str);
@@ -34,7 +34,7 @@ TEST(IpNtoa, FormatsIPv4)
 {
     Ip_Ntoa ip_str;
     IP ip;
-    ip.family = net_family_ipv4;
+    ip.family = net_family_ipv4();
     ip.ip.v4.uint8[0] = 192;
     ip.ip.v4.uint8[1] = 168;
     ip.ip.v4.uint8[2] = 0;
@@ -49,7 +49,7 @@ TEST(IpParseAddr, FormatsIPv4)
 {
     char ip_str[IP_NTOA_LEN];
     IP ip;
-    ip.family = net_family_ipv4;
+    ip.family = net_family_ipv4();
     ip.ip.v4.uint8[0] = 192;
     ip.ip.v4.uint8[1] = 168;
     ip.ip.v4.uint8[2] = 0;
@@ -64,7 +64,7 @@ TEST(IpParseAddr, FormatsIPv6)
 {
     char ip_str[IP_NTOA_LEN];
     IP ip;
-    ip.family = net_family_ipv6;
+    ip.family = net_family_ipv6();
     ip.ip.v6.uint64[0] = -1;
     ip.ip.v6.uint64[1] = -1;
 

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -465,7 +465,7 @@ static int handle_announce_request_common(
     /* Respond with a announce response packet */
     Node_format nodes_list[MAX_SENT_NODES];
     const unsigned int num_nodes =
-        get_close_nodes(onion_a->dht, plain + ONION_PING_ID_SIZE, nodes_list, net_family_unspec, ip_is_lan(&source->ip), false);
+        get_close_nodes(onion_a->dht, plain + ONION_PING_ID_SIZE, nodes_list, net_family_unspec(), ip_is_lan(&source->ip), false);
 
     assert(num_nodes <= UINT8_MAX);
 

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -1042,7 +1042,7 @@ static int handle_tcp_onion(void *object, const uint8_t *data, uint16_t length, 
     }
 
     IP_Port ip_port = {{{0}}};
-    ip_port.ip.family = net_family_tcp_server;
+    ip_port.ip.family = net_family_tcp_server();
 
     if (data[0] == NET_PACKET_ANNOUNCE_RESPONSE_OLD) {
         return handle_announce_response(object, &ip_port, data, length, userdata);

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -533,7 +533,7 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
         ip_init(&m_options.proxy_info.ip_port.ip, m_options.ipv6enabled);
 
         if (m_options.ipv6enabled) {
-            m_options.proxy_info.ip_port.ip.family = net_family_unspec;
+            m_options.proxy_info.ip_port.ip.family = net_family_unspec();
         }
 
         const char *const proxy_host = tox_options_get_proxy_host(opts);


### PR DESCRIPTION
The FLAT_OUTPUT_STRUCTURE CMake option was added to allow the tests to
find the .dlls.

The global data symbols were converted to functions to allow
WINDOWS_EXPORT_ALL_SYMBOLS handle them.

See: https://cmake.org/cmake/help/v3.23/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2204)
<!-- Reviewable:end -->

Resolves #2012 