### PR TITLE
chore: Remove valgrind build.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,33 +96,6 @@ bazel-tsan_task:
         -//c-toxcore/auto_tests:tcp_relay_test
         -//c-toxcore/auto_tests:tox_many_test
 
-# TODO(iphydf): Fix timeouts so we can run more of the tests disabled below.
-bazel-valgrind_task:
-  container:
-    image: toxchat/toktok-stack:latest-release
-    cpu: 2
-    memory: 4G
-  configure_script:
-    - git submodule update --init --recursive
-    - /src/workspace/tools/inject-repo c-toxcore
-  test_all_script:
-    - cd /src/workspace && bazel test -k
-        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
-        --build_tag_filters=-haskell,-fuzz-test
-        --test_tag_filters=-haskell,-fuzz-test
-        --remote_download_minimal
-        --config=valgrind
-        --
-        //c-toxcore/...
-        -//c-toxcore/auto_tests:conference_av_test
-        -//c-toxcore/auto_tests:conference_test
-        -//c-toxcore/auto_tests:encryptsave_test
-        -//c-toxcore/auto_tests:file_transfer_test
-        -//c-toxcore/auto_tests:onion_test
-        -//c-toxcore/auto_tests:tcp_relay_test
-        -//c-toxcore/auto_tests:tox_many_tcp_test
-        -//c-toxcore/auto_tests:tox_many_test
-
 cimple_task:
   container:
     image: toxchat/toktok-stack:latest-release

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,7 +16,6 @@ branches:
           - "bazel-dbg"
           - "bazel-opt"
           - "bazel-tsan"
-          - "bazel-valgrind"
           - "build-compcert"
           - "build-macos"
           - "build-nacl"


### PR DESCRIPTION
This is very slow, around 20 minutes, which seriously slows down
velocity for little gain. MSAN runs on unit tests and 1 auto test, so
we'll catch increasingly many valgrind-ish bugs that way in one of the
1-5-minute builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2208)
<!-- Reviewable:end -->
