### PR TITLE
chore: Clone submodules in clusterfuzzlite Dockerfile.

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -21,5 +21,6 @@ WORKDIR $SRC
 COPY . $SRC/c-toxcore
 # Working directory for build.sh.
 WORKDIR $SRC/c-toxcore
+RUN git submodule update --init --recursive
 # Copy build.sh into $SRC dir.
 COPY ./.clusterfuzzlite/build.sh $SRC/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,28 @@ jobs:
           cache-from: type=registry,ref=toxchat/bootstrap-node:latest-websocket
           cache-to: type=inline
 
+  docker-clusterfuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: "."
+          file: .clusterfuzzlite/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: toxchat/c-toxcore:clusterfuzz
+          cache-from: type=registry,ref=toxchat/c-toxcore:clusterfuzz
+          cache-to: type=inline
+
   docker-fuzzer:
     runs-on: ubuntu-latest
     steps:

--- a/other/docker/tokstyle/Dockerfile
+++ b/other/docker/tokstyle/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
  ca-certificates \
- gcc \
+ clang \
  git \
  libopus-dev \
  libsodium-dev \


### PR DESCRIPTION
Needed for the build afterwards.

Also added the cflite Dockerfile to automatic CI builds so changes to it
are checked in pull requests.

Also fixed the tokstyle docker image. It needs clang instead of gcc now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2210)
<!-- Reviewable:end -->
