### PR TITLE
cleanup: Remove all uses of `TOX_*_MAX_SIZE` macros.

### DIFF
--- a/auto_tests/file_saving_test.c
+++ b/auto_tests/file_saving_test.c
@@ -95,16 +95,17 @@ static void load_data_decrypted(void)
 
     ck_assert_msg(t != nullptr, "tox_new returned the error value %d", err);
 
-    uint8_t readname[TOX_MAX_NAME_LENGTH];
+    uint8_t *readname = (uint8_t *)malloc(tox_self_get_name_size(t));
+    ck_assert(readname != nullptr);
     tox_self_get_name(t, readname);
-    readname[tox_self_get_name_size(t)] = '\0';
 
-    ck_assert_msg(strcmp((const char *)readname, name) == 0,
+    ck_assert_msg(memcmp(readname, name, tox_self_get_name_size(t)) == 0,
                   "name returned by tox_self_get_name does not match expected result");
 
     tox_kill(t);
     free(clear);
     free(cipher);
+    free(readname);
     fclose(f);
 }
 

--- a/auto_tests/lossless_packet_test.c
+++ b/auto_tests/lossless_packet_test.c
@@ -7,8 +7,6 @@
 #include <time.h>
 
 #include "../testing/misc_tools.h"
-#include "../toxcore/ccompat.h"
-#include "../toxcore/tox.h"
 #include "../toxcore/util.h"
 #include "check_compat.h"
 
@@ -20,31 +18,36 @@ typedef struct State {
 
 #define LOSSLESS_PACKET_FILLER 160
 
-static void handle_lossless_packet(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
-                                   void *user_data)
+static void handle_lossless_packet(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length, void *user_data)
 {
-    const AutoTox *autotox = (AutoTox *)user_data;
-    State *state = (State *)autotox->state;
+    uint8_t *cmp_packet = (uint8_t *)malloc(tox_max_custom_packet_size());
+    ck_assert(cmp_packet != nullptr);
+    memset(cmp_packet, LOSSLESS_PACKET_FILLER, tox_max_custom_packet_size());
 
-    uint8_t cmp_packet[TOX_MAX_CUSTOM_PACKET_SIZE];
-    memset(cmp_packet, LOSSLESS_PACKET_FILLER, sizeof(cmp_packet));
-
-    if (length == TOX_MAX_CUSTOM_PACKET_SIZE && memcmp(data, cmp_packet, sizeof(cmp_packet)) == 0) {
+    if (length == tox_max_custom_packet_size() && memcmp(data, cmp_packet, tox_max_custom_packet_size()) == 0) {
+        const AutoTox *autotox = (AutoTox *)user_data;
+        State *state = (State *)autotox->state;
         state->custom_packet_received = true;
     }
+
+    free(cmp_packet);
 }
 
 static void test_lossless_packet(AutoTox *autotoxes)
 {
     tox_callback_friend_lossless_packet(autotoxes[1].tox, &handle_lossless_packet);
-    uint8_t packet[TOX_MAX_CUSTOM_PACKET_SIZE + 1];
-    memset(packet, LOSSLESS_PACKET_FILLER, sizeof(packet));
+    const size_t packet_size = tox_max_custom_packet_size() + 1;
+    uint8_t *packet = (uint8_t *)malloc(packet_size);
+    ck_assert(packet != nullptr);
+    memset(packet, LOSSLESS_PACKET_FILLER, packet_size);
 
-    bool ret = tox_friend_send_lossless_packet(autotoxes[0].tox, 0, packet, sizeof(packet), nullptr);
+    bool ret = tox_friend_send_lossless_packet(autotoxes[0].tox, 0, packet, packet_size, nullptr);
     ck_assert_msg(ret == false, "should not be able to send custom packets this big %i", ret);
 
-    ret = tox_friend_send_lossless_packet(autotoxes[0].tox, 0, packet, TOX_MAX_CUSTOM_PACKET_SIZE, nullptr);
+    ret = tox_friend_send_lossless_packet(autotoxes[0].tox, 0, packet, tox_max_custom_packet_size(), nullptr);
     ck_assert_msg(ret == true, "tox_friend_send_lossless_packet fail %i", ret);
+
+    free(packet);
 
     do {
         iterate_all_wait(autotoxes, 2, ITERATION_INTERVAL);

--- a/auto_tests/save_compatibility_test.c
+++ b/auto_tests/save_compatibility_test.c
@@ -92,7 +92,8 @@ static void test_save_compatibility(const char *save_path)
     ck_assert_msg(name_size == EXPECTED_NAME_SIZE, "name sizes do not match expected %zu got %zu", EXPECTED_NAME_SIZE,
                   name_size);
 
-    uint8_t name[TOX_MAX_NAME_LENGTH];
+    uint8_t *name = (uint8_t *)malloc(tox_self_get_name_size(tox));
+    ck_assert(name != nullptr);
     tox_self_get_name(tox, name);
     ck_assert_msg(strncmp((const char *)name, EXPECTED_NAME, name_size) == 0,
                   "names do not match, expected %s got %s", EXPECTED_NAME, name);
@@ -101,7 +102,8 @@ static void test_save_compatibility(const char *save_path)
     ck_assert_msg(status_message_size == EXPECTED_STATUS_MESSAGE_SIZE,
                   "status message sizes do not match, expected %zu got %zu", EXPECTED_STATUS_MESSAGE_SIZE, status_message_size);
 
-    uint8_t status_message[TOX_MAX_STATUS_MESSAGE_LENGTH];
+    uint8_t *status_message = (uint8_t *)malloc(tox_self_get_status_message_size(tox));
+    ck_assert(status_message != nullptr);
     tox_self_get_status_message(tox, status_message);
     ck_assert_msg(strncmp((const char *)status_message, EXPECTED_STATUS_MESSAGE, status_message_size) == 0,
                   "status messages do not match, expected %s got %s",
@@ -128,6 +130,8 @@ static void test_save_compatibility(const char *save_path)
     /* Giving the tox a chance to error on iterate due to corrupted loaded structures */
     tox_iterate(tox, nullptr);
 
+    free(status_message);
+    free(name);
     tox_kill(tox);
 }
 

--- a/auto_tests/save_friend_test.c
+++ b/auto_tests/save_friend_test.c
@@ -13,8 +13,8 @@
 #include "check_compat.h"
 
 struct test_data {
-    uint8_t name[TOX_MAX_NAME_LENGTH];
-    uint8_t status_message[TOX_MAX_STATUS_MESSAGE_LENGTH];
+    uint8_t *name;
+    uint8_t *status_message;
     bool received_name;
     bool received_status_message;
 };
@@ -31,10 +31,23 @@ static void set_random(Tox *m, bool (*setter)(Tox *, const uint8_t *, size_t, To
     setter(m, text, SIZEOF_VLA(text), nullptr);
 }
 
+static void alloc_string(uint8_t **to, size_t length)
+{
+    free(*to);
+    *to = (uint8_t *)malloc(length);
+    ck_assert(*to != nullptr);
+}
+
+static void set_string(uint8_t **to, const uint8_t *from, size_t length)
+{
+    alloc_string(to, length);
+    memcpy(*to, from, length);
+}
+
 static void namechange_callback(Tox *tox, uint32_t friend_number, const uint8_t *name, size_t length, void *user_data)
 {
     struct test_data *to_compare = (struct test_data *)user_data;
-    memcpy(to_compare->name, name, length);
+    set_string(&to_compare->name, name, length);
     to_compare->received_name = true;
 }
 
@@ -42,7 +55,7 @@ static void statuschange_callback(Tox *tox, uint32_t friend_number, const uint8_
                                   void *user_data)
 {
     struct test_data *to_compare = (struct test_data *)user_data;
-    memcpy(to_compare->status_message, message, length);
+    set_string(&to_compare->status_message, message, length);
     to_compare->received_status_message = true;
 }
 
@@ -60,7 +73,7 @@ int main(void)
 
     tox_bootstrap(tox2, "localhost", dht_port, dht_key, nullptr);
 
-    struct test_data to_compare = {{0}};
+    struct test_data to_compare = {nullptr};
 
     uint8_t public_key[TOX_PUBLIC_KEY_SIZE];
     tox_self_get_public_key(tox1, public_key);
@@ -68,13 +81,15 @@ int main(void)
     tox_self_get_public_key(tox2, public_key);
     tox_friend_add_norequest(tox1, public_key, nullptr);
 
-    uint8_t reference_name[TOX_MAX_NAME_LENGTH] = { 0 };
-    uint8_t reference_status[TOX_MAX_STATUS_MESSAGE_LENGTH] = { 0 };
+    uint8_t *reference_name = (uint8_t *)malloc(tox_max_name_length());
+    uint8_t *reference_status = (uint8_t *)malloc(tox_max_status_message_length());
+    ck_assert(reference_name != nullptr);
+    ck_assert(reference_status != nullptr);
 
-    set_random(tox1, tox_self_set_name, TOX_MAX_NAME_LENGTH);
-    set_random(tox2, tox_self_set_name, TOX_MAX_NAME_LENGTH);
-    set_random(tox1, tox_self_set_status_message, TOX_MAX_STATUS_MESSAGE_LENGTH);
-    set_random(tox2, tox_self_set_status_message, TOX_MAX_STATUS_MESSAGE_LENGTH);
+    set_random(tox1, tox_self_set_name, tox_max_name_length());
+    set_random(tox2, tox_self_set_name, tox_max_name_length());
+    set_random(tox1, tox_self_set_status_message, tox_max_status_message_length());
+    set_random(tox2, tox_self_set_status_message, tox_max_status_message_length());
 
     tox_self_get_name(tox2, reference_name);
     tox_self_get_status_message(tox2, reference_status);
@@ -118,12 +133,14 @@ int main(void)
 
     Tox *const tox_to_compare = tox_new_log(options, nullptr, nullptr);
 
+    alloc_string(&to_compare.name, tox_friend_get_name_size(tox_to_compare, 0, nullptr));
     tox_friend_get_name(tox_to_compare, 0, to_compare.name, nullptr);
+    alloc_string(&to_compare.status_message, tox_friend_get_status_message_size(tox_to_compare, 0, nullptr));
     tox_friend_get_status_message(tox_to_compare, 0, to_compare.status_message, nullptr);
 
-    ck_assert_msg(memcmp(reference_name, to_compare.name, TOX_MAX_NAME_LENGTH) == 0,
+    ck_assert_msg(memcmp(reference_name, to_compare.name, tox_max_name_length()) == 0,
                   "incorrect name: should be all zeroes");
-    ck_assert_msg(memcmp(reference_status, to_compare.status_message, TOX_MAX_STATUS_MESSAGE_LENGTH) == 0,
+    ck_assert_msg(memcmp(reference_status, to_compare.status_message, tox_max_status_message_length()) == 0,
                   "incorrect status message: should be all zeroes");
 
     tox_options_free(options);
@@ -131,6 +148,10 @@ int main(void)
     tox_kill(tox2);
     tox_kill(tox_to_compare);
     free(savedata);
+    free(to_compare.name);
+    free(to_compare.status_message);
+    free(reference_status);
+    free(reference_name);
 
     return 0;
 }

--- a/auto_tests/send_message_test.c
+++ b/auto_tests/send_message_test.c
@@ -24,27 +24,34 @@ static void message_callback(
         ck_abort_msg("Bad type");
     }
 
-    uint8_t cmp_msg[TOX_MAX_MESSAGE_LENGTH];
-    memset(cmp_msg, MESSAGE_FILLER, sizeof(cmp_msg));
+    const size_t cmp_msg_len = tox_max_message_length();
+    uint8_t *cmp_msg = (uint8_t *)malloc(cmp_msg_len);
+    ck_assert(cmp_msg != nullptr);
+    memset(cmp_msg, MESSAGE_FILLER, cmp_msg_len);
 
-    if (length == TOX_MAX_MESSAGE_LENGTH && memcmp(string, cmp_msg, sizeof(cmp_msg)) == 0) {
+    if (length == tox_max_message_length() && memcmp(string, cmp_msg, cmp_msg_len) == 0) {
         state->message_received = true;
     }
+
+    free(cmp_msg);
 }
 
 static void send_message_test(AutoTox *autotoxes)
 {
     tox_callback_friend_message(autotoxes[1].tox, &message_callback);
 
-    uint8_t msgs[TOX_MAX_MESSAGE_LENGTH + 1];
-    memset(msgs, MESSAGE_FILLER, sizeof(msgs));
+    const size_t msgs_len = tox_max_message_length() + 1;
+    uint8_t *msgs = (uint8_t *)malloc(msgs_len);
+    memset(msgs, MESSAGE_FILLER, msgs_len);
 
     Tox_Err_Friend_Send_Message errm;
-    tox_friend_send_message(autotoxes[0].tox, 0, TOX_MESSAGE_TYPE_NORMAL, msgs, TOX_MAX_MESSAGE_LENGTH + 1, &errm);
-    ck_assert_msg(errm == TOX_ERR_FRIEND_SEND_MESSAGE_TOO_LONG, "TOX_MAX_MESSAGE_LENGTH is too small? error=%d", errm);
+    tox_friend_send_message(autotoxes[0].tox, 0, TOX_MESSAGE_TYPE_NORMAL, msgs, msgs_len, &errm);
+    ck_assert_msg(errm == TOX_ERR_FRIEND_SEND_MESSAGE_TOO_LONG, "tox_max_message_length() is too small? error=%d", errm);
 
-    tox_friend_send_message(autotoxes[0].tox, 0, TOX_MESSAGE_TYPE_NORMAL, msgs, TOX_MAX_MESSAGE_LENGTH, &errm);
-    ck_assert_msg(errm == TOX_ERR_FRIEND_SEND_MESSAGE_OK, "TOX_MAX_MESSAGE_LENGTH is too big? error=%d", errm);
+    tox_friend_send_message(autotoxes[0].tox, 0, TOX_MESSAGE_TYPE_NORMAL, msgs, tox_max_message_length(), &errm);
+    ck_assert_msg(errm == TOX_ERR_FRIEND_SEND_MESSAGE_OK, "tox_max_message_length() is too big? error=%d", errm);
+
+    free(msgs);
 
     do {
         iterate_all_wait(autotoxes, 2, ITERATION_INTERVAL);

--- a/other/fun/save-generator.c
+++ b/other/fun/save-generator.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -72,8 +73,10 @@ static void print_information(Tox *tox)
     int length = snprintf(nospam_str, sizeof(nospam_str), "%08X", nospam);
     nospam_str[length] = '\0';
 
-    uint8_t name[TOX_MAX_NAME_LENGTH];
+    uint8_t *name = (uint8_t *)malloc(tox_self_get_name_size(tox) + 1);
+    assert(name != nullptr);
     tox_self_get_name(tox, name);
+    name[tox_self_get_name_size(tox)] = '\0';
 
     printf("INFORMATION\n");
     printf("----------------------------------\n");


### PR DESCRIPTION
We should use the functions for these instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2214)
<!-- Reviewable:end -->
