### PR TITLE
refactor: Rename bin_pack/unpack functions the same as cmp funcs.

### DIFF
--- a/toxcore/bin_pack.c
+++ b/toxcore/bin_pack.c
@@ -122,12 +122,12 @@ bool bin_pack_u64(Bin_Pack *bp, uint64_t val)
     return cmp_write_uinteger(&bp->ctx, val);
 }
 
-bool bin_pack_bytes(Bin_Pack *bp, const uint8_t *data, uint32_t length)
+bool bin_pack_bin(Bin_Pack *bp, const uint8_t *data, uint32_t length)
 {
     return cmp_write_bin(&bp->ctx, data, length);
 }
 
-bool bin_pack_bin(Bin_Pack *bp, uint32_t size)
+bool bin_pack_bin_marker(Bin_Pack *bp, uint32_t size)
 {
     return cmp_write_bin_marker(&bp->ctx, size);
 }
@@ -155,7 +155,7 @@ bool bin_pack_u64_b(Bin_Pack *bp, uint64_t val)
            && bin_pack_u32_b(bp, val & 0xffffffff);
 }
 
-bool bin_pack_bytes_b(Bin_Pack *bp, const uint8_t *data, uint32_t length)
+bool bin_pack_bin_b(Bin_Pack *bp, const uint8_t *data, uint32_t length)
 {
     return bp->ctx.write(&bp->ctx, data, length) == length;
 }

--- a/toxcore/bin_pack.h
+++ b/toxcore/bin_pack.h
@@ -91,13 +91,13 @@ non_null() bool bin_pack_u32(Bin_Pack *bp, uint32_t val);
 /** @brief Pack a `uint64_t` as MessagePack positive integer. */
 non_null() bool bin_pack_u64(Bin_Pack *bp, uint64_t val);
 /** @brief Pack a byte array as MessagePack bin. */
-non_null() bool bin_pack_bytes(Bin_Pack *bp, const uint8_t *data, uint32_t length);
+non_null() bool bin_pack_bin(Bin_Pack *bp, const uint8_t *data, uint32_t length);
 
 /** @brief Start packing a custom binary representation.
  *
  * A call to this function must be followed by exactly `size` bytes packed by functions below.
  */
-non_null() bool bin_pack_bin(Bin_Pack *bp, uint32_t size);
+non_null() bool bin_pack_bin_marker(Bin_Pack *bp, uint32_t size);
 
 /** @brief Write a `uint8_t` directly to the packer in 1 byte. */
 non_null() bool bin_pack_u08_b(Bin_Pack *bp, uint8_t val);
@@ -113,7 +113,7 @@ non_null() bool bin_pack_u64_b(Bin_Pack *bp, uint64_t val);
  * Note that unless you prepend the array length manually, there is no record of it in the resulting
  * serialised representation.
  */
-non_null() bool bin_pack_bytes_b(Bin_Pack *bp, const uint8_t *data, uint32_t length);
+non_null() bool bin_pack_bin_b(Bin_Pack *bp, const uint8_t *data, uint32_t length);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/toxcore/bin_pack_test.cc
+++ b/toxcore/bin_pack_test.cc
@@ -85,4 +85,41 @@ TEST(BinPack, LargeMsgPackedUint32CannotBeUnpackedAsUint8)
     EXPECT_FALSE(bin_unpack_u08(bu.get(), &val));
 }
 
+TEST(BinPack, BinCanHoldPackedInts)
+{
+    std::array<uint8_t, 12> buf;
+    Bin_Pack_Ptr bp(bin_pack_new(buf.data(), buf.size()));
+    ASSERT_NE(bp, nullptr);
+    ASSERT_TRUE(bin_pack_bin_marker(bp.get(), 8));
+    ASSERT_TRUE(bin_pack_u64_b(bp.get(), 1234567812345678LL));
+    ASSERT_TRUE(bin_pack_u16_b(bp.get(), 54321));
+
+    Bin_Unpack_Ptr bu(bin_unpack_new(buf.data(), buf.size()));
+    ASSERT_NE(bu, nullptr);
+    uint32_t size;
+    EXPECT_TRUE(bin_unpack_bin_size(bu.get(), &size));
+    EXPECT_EQ(size, 8);
+    uint64_t val1;
+    EXPECT_TRUE(bin_unpack_u64_b(bu.get(), &val1));
+    EXPECT_EQ(val1, 1234567812345678LL);
+    uint16_t val2;
+    EXPECT_TRUE(bin_unpack_u16_b(bu.get(), &val2));
+    EXPECT_EQ(val2, 54321);
+}
+
+TEST(BinPack, BinCanHoldArbitraryData)
+{
+    std::array<uint8_t, 7> buf;
+    Bin_Pack_Ptr bp(bin_pack_new(buf.data(), buf.size()));
+    ASSERT_NE(bp, nullptr);
+    ASSERT_TRUE(bin_pack_bin_marker(bp.get(), 5));
+    ASSERT_TRUE(bin_pack_bin_b(bp.get(), reinterpret_cast<const uint8_t *>("hello"), 5));
+
+    Bin_Unpack_Ptr bu(bin_unpack_new(buf.data(), buf.size()));
+    ASSERT_NE(bu, nullptr);
+    std::array<uint8_t, 5> str;
+    EXPECT_TRUE(bin_unpack_bin_fixed(bu.get(), str.data(), str.size()));
+    EXPECT_EQ(str, (std::array<uint8_t, 5>{'h', 'e', 'l', 'l', 'o'}));
+}
+
 }  // namespace

--- a/toxcore/bin_unpack.c
+++ b/toxcore/bin_unpack.c
@@ -104,15 +104,16 @@ bool bin_unpack_u64(Bin_Unpack *bu, uint64_t *val)
     return cmp_read_ulong(&bu->ctx, val);
 }
 
-bool bin_unpack_bytes(Bin_Unpack *bu, uint8_t **data_ptr, uint32_t *data_length_ptr)
+bool bin_unpack_bin(Bin_Unpack *bu, uint8_t **data_ptr, uint32_t *data_length_ptr)
 {
     uint32_t bin_size;
-    if (!cmp_read_bin_size(&bu->ctx, &bin_size) || bin_size > bu->bytes_size) {
+    if (!bin_unpack_bin_size(bu, &bin_size) || bin_size > bu->bytes_size) {
+        // There aren't as many bytes as this bin claims to want to allocate.
         return false;
     }
     uint8_t *const data = (uint8_t *)malloc(bin_size);
 
-    if (!bu->ctx.read(&bu->ctx, data, bin_size)) {
+    if (!bin_unpack_bin_b(bu, data, bin_size)) {
         free(data);
         return false;
     }
@@ -122,24 +123,24 @@ bool bin_unpack_bytes(Bin_Unpack *bu, uint8_t **data_ptr, uint32_t *data_length_
     return true;
 }
 
-bool bin_unpack_bytes_fixed(Bin_Unpack *bu, uint8_t *data, uint32_t data_length)
+bool bin_unpack_bin_fixed(Bin_Unpack *bu, uint8_t *data, uint32_t data_length)
 {
     uint32_t bin_size;
-    if (!cmp_read_bin_size(&bu->ctx, &bin_size) || bin_size != data_length) {
+    if (!bin_unpack_bin_size(bu, &bin_size) || bin_size != data_length) {
         return false;
     }
 
-    return bu->ctx.read(&bu->ctx, data, bin_size);
+    return bin_unpack_bin_b(bu, data, bin_size);
 }
 
-bool bin_unpack_bin(Bin_Unpack *bu, uint32_t *size)
+bool bin_unpack_bin_size(Bin_Unpack *bu, uint32_t *size)
 {
     return cmp_read_bin_size(&bu->ctx, size);
 }
 
 bool bin_unpack_u08_b(Bin_Unpack *bu, uint8_t *val)
 {
-    return bu->ctx.read(&bu->ctx, val, 1);
+    return bin_unpack_bin_b(bu, val, 1);
 }
 
 bool bin_unpack_u16_b(Bin_Unpack *bu, uint16_t *val)
@@ -178,7 +179,7 @@ bool bin_unpack_u64_b(Bin_Unpack *bu, uint64_t *val)
     return true;
 }
 
-bool bin_unpack_bytes_b(Bin_Unpack *bu, uint8_t *data, uint32_t length)
+bool bin_unpack_bin_b(Bin_Unpack *bu, uint8_t *data, uint32_t length)
 {
     return bu->ctx.read(&bu->ctx, data, length);
 }

--- a/toxcore/bin_unpack.h
+++ b/toxcore/bin_unpack.h
@@ -67,19 +67,19 @@ non_null() bool bin_unpack_u64(Bin_Unpack *bu, uint64_t *val);
  * remaining to be unpacked as the bin claims to need, so it's not possible to cause an arbitrarily
  * large allocation unless the input array was already that large.
  */
-non_null() bool bin_unpack_bytes(Bin_Unpack *bu, uint8_t **data_ptr, uint32_t *data_length_ptr);
+non_null() bool bin_unpack_bin(Bin_Unpack *bu, uint8_t **data_ptr, uint32_t *data_length_ptr);
 /** @brief Unpack a MessagePack bin of a fixed length into a pre-allocated byte array.
  *
  * Unlike the function above, this function does not allocate any memory, but requires the size to
  * be known up front.
  */
-non_null() bool bin_unpack_bytes_fixed(Bin_Unpack *bu, uint8_t *data, uint32_t data_length);
+non_null() bool bin_unpack_bin_fixed(Bin_Unpack *bu, uint8_t *data, uint32_t data_length);
 
 /** @brief Start unpacking a custom binary representation.
  *
  * A call to this function must be followed by exactly `size` bytes packed by functions below.
  */
-non_null() bool bin_unpack_bin(Bin_Unpack *bu, uint32_t *size);
+non_null() bool bin_unpack_bin_size(Bin_Unpack *bu, uint32_t *size);
 
 /** @brief Read a `uint8_t` directly from the unpacker, consuming 1 byte. */
 non_null() bool bin_unpack_u08_b(Bin_Unpack *bu, uint8_t *val);
@@ -91,7 +91,7 @@ non_null() bool bin_unpack_u32_b(Bin_Unpack *bu, uint32_t *val);
 non_null() bool bin_unpack_u64_b(Bin_Unpack *bu, uint64_t *val);
 
 /** @brief Read a byte array directly from the packer, consuming `length` bytes. */
-non_null() bool bin_unpack_bytes_b(Bin_Unpack *bu, uint8_t *data, uint32_t length);
+non_null() bool bin_unpack_bin_b(Bin_Unpack *bu, uint8_t *data, uint32_t length);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/toxcore/events/conference_invite.c
+++ b/toxcore/events/conference_invite.c
@@ -112,7 +112,7 @@ static bool tox_event_conference_invite_pack(
            && bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->type)
-           && bin_pack_bytes(bp, event->cookie, event->cookie_length);
+           && bin_pack_bin(bp, event->cookie, event->cookie_length);
 }
 
 non_null()
@@ -126,7 +126,7 @@ static bool tox_event_conference_invite_unpack(
 
     return bin_unpack_u32(bu, &event->friend_number)
            && tox_unpack_conference_type(bu, &event->type)
-           && bin_unpack_bytes(bu, &event->cookie, &event->cookie_length);
+           && bin_unpack_bin(bu, &event->cookie, &event->cookie_length);
 }
 
 

--- a/toxcore/events/conference_message.c
+++ b/toxcore/events/conference_message.c
@@ -127,7 +127,7 @@ static bool tox_event_conference_message_pack(
            && bin_pack_u32(bp, event->conference_number)
            && bin_pack_u32(bp, event->peer_number)
            && bin_pack_u32(bp, event->type)
-           && bin_pack_bytes(bp, event->message, event->message_length);
+           && bin_pack_bin(bp, event->message, event->message_length);
 }
 
 non_null()
@@ -142,7 +142,7 @@ static bool tox_event_conference_message_unpack(
     return bin_unpack_u32(bu, &event->conference_number)
            && bin_unpack_u32(bu, &event->peer_number)
            && tox_unpack_message_type(bu, &event->type)
-           && bin_unpack_bytes(bu, &event->message, &event->message_length);
+           && bin_unpack_bin(bu, &event->message, &event->message_length);
 }
 
 

--- a/toxcore/events/conference_peer_name.c
+++ b/toxcore/events/conference_peer_name.c
@@ -112,7 +112,7 @@ static bool tox_event_conference_peer_name_pack(
            && bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->conference_number)
            && bin_pack_u32(bp, event->peer_number)
-           && bin_pack_bytes(bp, event->name, event->name_length);
+           && bin_pack_bin(bp, event->name, event->name_length);
 }
 
 non_null()
@@ -126,7 +126,7 @@ static bool tox_event_conference_peer_name_unpack(
 
     return bin_unpack_u32(bu, &event->conference_number)
            && bin_unpack_u32(bu, &event->peer_number)
-           && bin_unpack_bytes(bu, &event->name, &event->name_length);
+           && bin_unpack_bin(bu, &event->name, &event->name_length);
 }
 
 

--- a/toxcore/events/conference_title.c
+++ b/toxcore/events/conference_title.c
@@ -111,7 +111,7 @@ static bool tox_event_conference_title_pack(
            && bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->conference_number)
            && bin_pack_u32(bp, event->peer_number)
-           && bin_pack_bytes(bp, event->title, event->title_length);
+           && bin_pack_bin(bp, event->title, event->title_length);
 }
 
 non_null()
@@ -125,7 +125,7 @@ static bool tox_event_conference_title_unpack(
 
     return bin_unpack_u32(bu, &event->conference_number)
            && bin_unpack_u32(bu, &event->peer_number)
-           && bin_unpack_bytes(bu, &event->title, &event->title_length);
+           && bin_unpack_bin(bu, &event->title, &event->title_length);
 }
 
 

--- a/toxcore/events/file_recv.c
+++ b/toxcore/events/file_recv.c
@@ -141,7 +141,7 @@ static bool tox_event_file_recv_pack(
            && bin_pack_u32(bp, event->file_number)
            && bin_pack_u32(bp, event->kind)
            && bin_pack_u64(bp, event->file_size)
-           && bin_pack_bytes(bp, event->filename, event->filename_length);
+           && bin_pack_bin(bp, event->filename, event->filename_length);
 }
 
 non_null()
@@ -157,7 +157,7 @@ static bool tox_event_file_recv_unpack(
            && bin_unpack_u32(bu, &event->file_number)
            && bin_unpack_u32(bu, &event->kind)
            && bin_unpack_u64(bu, &event->file_size)
-           && bin_unpack_bytes(bu, &event->filename, &event->filename_length);
+           && bin_unpack_bin(bu, &event->filename, &event->filename_length);
 }
 
 

--- a/toxcore/events/file_recv_chunk.c
+++ b/toxcore/events/file_recv_chunk.c
@@ -126,7 +126,7 @@ static bool tox_event_file_recv_chunk_pack(
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->file_number)
            && bin_pack_u64(bp, event->position)
-           && bin_pack_bytes(bp, event->data, event->data_length);
+           && bin_pack_bin(bp, event->data, event->data_length);
 }
 
 non_null()
@@ -141,7 +141,7 @@ static bool tox_event_file_recv_chunk_unpack(
     return bin_unpack_u32(bu, &event->friend_number)
            && bin_unpack_u32(bu, &event->file_number)
            && bin_unpack_u64(bu, &event->position)
-           && bin_unpack_bytes(bu, &event->data, &event->data_length);
+           && bin_unpack_bin(bu, &event->data, &event->data_length);
 }
 
 

--- a/toxcore/events/friend_lossless_packet.c
+++ b/toxcore/events/friend_lossless_packet.c
@@ -97,7 +97,7 @@ static bool tox_event_friend_lossless_packet_pack(
            && bin_pack_u32(bp, TOX_EVENT_FRIEND_LOSSLESS_PACKET)
            && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
-           && bin_pack_bytes(bp, event->data, event->data_length);
+           && bin_pack_bin(bp, event->data, event->data_length);
 }
 
 non_null()
@@ -110,7 +110,7 @@ static bool tox_event_friend_lossless_packet_unpack(
     }
 
     return bin_unpack_u32(bu, &event->friend_number)
-           && bin_unpack_bytes(bu, &event->data, &event->data_length);
+           && bin_unpack_bin(bu, &event->data, &event->data_length);
 }
 
 

--- a/toxcore/events/friend_lossy_packet.c
+++ b/toxcore/events/friend_lossy_packet.c
@@ -96,7 +96,7 @@ static bool tox_event_friend_lossy_packet_pack(
            && bin_pack_u32(bp, TOX_EVENT_FRIEND_LOSSY_PACKET)
            && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
-           && bin_pack_bytes(bp, event->data, event->data_length);
+           && bin_pack_bin(bp, event->data, event->data_length);
 }
 
 non_null()
@@ -109,7 +109,7 @@ static bool tox_event_friend_lossy_packet_unpack(
     }
 
     return bin_unpack_u32(bu, &event->friend_number)
-           && bin_unpack_bytes(bu, &event->data, &event->data_length);
+           && bin_unpack_bin(bu, &event->data, &event->data_length);
 }
 
 

--- a/toxcore/events/friend_message.c
+++ b/toxcore/events/friend_message.c
@@ -111,7 +111,7 @@ static bool tox_event_friend_message_pack(
            && bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->type)
-           && bin_pack_bytes(bp, event->message, event->message_length);
+           && bin_pack_bin(bp, event->message, event->message_length);
 }
 
 non_null()
@@ -125,7 +125,7 @@ static bool tox_event_friend_message_unpack(
 
     return bin_unpack_u32(bu, &event->friend_number)
            && tox_unpack_message_type(bu, &event->type)
-           && bin_unpack_bytes(bu, &event->message, &event->message_length);
+           && bin_unpack_bin(bu, &event->message, &event->message_length);
 }
 
 

--- a/toxcore/events/friend_name.c
+++ b/toxcore/events/friend_name.c
@@ -96,7 +96,7 @@ static bool tox_event_friend_name_pack(
            && bin_pack_u32(bp, TOX_EVENT_FRIEND_NAME)
            && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
-           && bin_pack_bytes(bp, event->name, event->name_length);
+           && bin_pack_bin(bp, event->name, event->name_length);
 }
 
 non_null()
@@ -109,7 +109,7 @@ static bool tox_event_friend_name_unpack(
     }
 
     return bin_unpack_u32(bu, &event->friend_number)
-           && bin_unpack_bytes(bu, &event->name, &event->name_length);
+           && bin_unpack_bin(bu, &event->name, &event->name_length);
 }
 
 

--- a/toxcore/events/friend_request.c
+++ b/toxcore/events/friend_request.c
@@ -96,8 +96,8 @@ static bool tox_event_friend_request_pack(
     return bin_pack_array(bp, 2)
            && bin_pack_u32(bp, TOX_EVENT_FRIEND_REQUEST)
            && bin_pack_array(bp, 2)
-           && bin_pack_bytes(bp, event->public_key, TOX_PUBLIC_KEY_SIZE)
-           && bin_pack_bytes(bp, event->message, event->message_length);
+           && bin_pack_bin(bp, event->public_key, TOX_PUBLIC_KEY_SIZE)
+           && bin_pack_bin(bp, event->message, event->message_length);
 }
 
 non_null()
@@ -109,8 +109,8 @@ static bool tox_event_friend_request_unpack(
         return false;
     }
 
-    return bin_unpack_bytes_fixed(bu, event->public_key, TOX_PUBLIC_KEY_SIZE)
-           && bin_unpack_bytes(bu, &event->message, &event->message_length);
+    return bin_unpack_bin_fixed(bu, event->public_key, TOX_PUBLIC_KEY_SIZE)
+           && bin_unpack_bin(bu, &event->message, &event->message_length);
 }
 
 

--- a/toxcore/events/friend_status_message.c
+++ b/toxcore/events/friend_status_message.c
@@ -98,7 +98,7 @@ static bool tox_event_friend_status_message_pack(
            && bin_pack_u32(bp, TOX_EVENT_FRIEND_STATUS_MESSAGE)
            && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
-           && bin_pack_bytes(bp, event->message, event->message_length);
+           && bin_pack_bin(bp, event->message, event->message_length);
 }
 
 non_null()
@@ -111,7 +111,7 @@ static bool tox_event_friend_status_message_unpack(
     }
 
     return bin_unpack_u32(bu, &event->friend_number)
-           && bin_unpack_bytes(bu, &event->message, &event->message_length);
+           && bin_unpack_bin(bu, &event->message, &event->message_length);
 }
 
 


### PR DESCRIPTION
No real reason to have different names. Also "bin" is shorter than
"bytes" to write.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2219)
<!-- Reviewable:end -->
