### PR TITLE
chore: Fix path to fuzzer binaries in clusterfuzz build.

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -21,5 +21,5 @@ for TARGET in $FUZZ_TARGETS; do
   cmake --build ./ --target "$TARGET"
 
   # copy to output files
-  cp "$WORK"/"$TARGET" "$OUT"/
+  cp "$WORK/testing/fuzzing/$TARGET" "$OUT"/
 done


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2228)
<!-- Reviewable:end -->
