### PR TITLE
test: Add fuzzer support functions for internal toxcore objects.

### DIFF
--- a/testing/fuzzing/BUILD.bazel
+++ b/testing/fuzzing/BUILD.bazel
@@ -15,6 +15,13 @@ cc_library(
     visibility = ["//c-toxcore:__subpackages__"],
 )
 
+cc_library(
+    name = "fuzz_tox",
+    hdrs = ["fuzz_tox.h"],
+    visibility = ["//c-toxcore:__subpackages__"],
+    deps = [":fuzz_support"],
+)
+
 cc_fuzz_test(
     name = "bootstrap_fuzz_test",
     srcs = ["bootstrap_harness.cc"],

--- a/testing/fuzzing/fuzz_support.cc
+++ b/testing/fuzzing/fuzz_support.cc
@@ -1,1 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2021-2022 The TokTok team.
+ */
+
 #include "fuzz_support.h"

--- a/testing/fuzzing/fuzz_tox.h
+++ b/testing/fuzzing/fuzz_tox.h
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022 The TokTok team.
+ */
+
+#ifndef C_TOXCORE_TESTING_FUZZING_FUZZ_TOX_H
+#define C_TOXCORE_TESTING_FUZZING_FUZZ_TOX_H
+
+#include <cassert>
+#include <memory>
+
+#include "../../toxcore/DHT.h"
+#include "../../toxcore/logger.h"
+#include "../../toxcore/network.h"
+#include "fuzz_support.h"
+
+constexpr uint16_t SIZE_IP_PORT = SIZE_IP6 + sizeof(uint16_t);
+
+template <typename T>
+using Ptr = std::unique_ptr<T, void (*)(T *)>;
+
+/** @brief Construct any Tox resource using fuzzer input data.
+ *
+ * Constructs (or fails by returning) a valid object of type T and passes it to
+ * a function specified on the rhs of `>>`. Takes care of cleaning up the
+ * resource after the specified function returns.
+ *
+ * Some `with` instances require additional inputs such as the `Fuzz_Data`
+ * reference or a logger.
+ */
+template <typename T>
+struct with;
+
+/** @brief Construct a Logger without logging callback.
+ */
+template <>
+struct with<Logger> {
+    template <typename F>
+    void operator>>(F &&f)
+    {
+        Ptr<Logger> logger(logger_new(), logger_kill);
+        assert(logger != nullptr);
+        f(std::move(logger));
+    }
+};
+
+/** @brief Construct an IP_Port by unpacking fuzzer input with `unpack_ip_port`.
+ */
+template <>
+struct with<IP_Port> {
+    Fuzz_Data &input_;
+
+    template <typename F>
+    void operator>>(F &&f)
+    {
+        CONSUME_OR_RETURN(const uint8_t *ipp_packed, input_, SIZE_IP_PORT);
+        IP_Port ipp;
+        unpack_ip_port(&ipp, ipp_packed, SIZE_IP6, true);
+
+        f(ipp);
+    }
+};
+
+/** @brief Construct a Networking_Core object using the Network vtable passed.
+ *
+ * Use `with<Logger>{} >> with<Networking_Core>{input, ns} >> ...` to construct
+ * a logger and pass it to the Networking_Core constructor function.
+ */
+template <>
+struct with<Networking_Core> {
+    Fuzz_Data &input_;
+    const Network *ns_;
+    Ptr<Logger> logger_{nullptr, logger_kill};
+
+    friend with operator>>(with<Logger> f, with self)
+    {
+        f >> [&self](Ptr<Logger> logger) { self.logger_ = std::move(logger); };
+        return self;
+    }
+
+    template <typename F>
+    void operator>>(F &&f)
+    {
+        with<IP_Port>{input_} >> [&f, this](const IP_Port &ipp) {
+            Ptr<Networking_Core> net(
+                new_networking_ex(logger_.get(), ns_, &ipp.ip, ipp.port, ipp.port + 100, nullptr),
+                kill_networking);
+            if (net == nullptr) {
+                return;
+            }
+            f(std::move(net));
+        };
+    }
+};
+
+#endif  // C_TOXCORE_TESTING_FUZZING_FUZZ_TOX_H

--- a/toxcore/DHT_fuzz_test.cc
+++ b/toxcore/DHT_fuzz_test.cc
@@ -7,7 +7,7 @@
 
 namespace {
 
-void TestHandleRequest(Fuzz_Data input)
+void TestHandleRequest(Fuzz_Data &input)
 {
     CONSUME_OR_RETURN(const uint8_t *self_public_key, input, CRYPTO_PUBLIC_KEY_SIZE);
     CONSUME_OR_RETURN(const uint8_t *self_secret_key, input, CRYPTO_SECRET_KEY_SIZE);
@@ -19,7 +19,7 @@ void TestHandleRequest(Fuzz_Data input)
         self_public_key, self_secret_key, public_key, request, &request_id, input.data, input.size);
 }
 
-void TestUnpackNodes(Fuzz_Data input)
+void TestUnpackNodes(Fuzz_Data &input)
 {
     CONSUME1_OR_RETURN(const bool tcp_enabled, input);
 

--- a/toxcore/group_moderation_fuzz_test.cc
+++ b/toxcore/group_moderation_fuzz_test.cc
@@ -4,7 +4,7 @@
 
 namespace {
 
-void TestModListUnpack(Fuzz_Data input)
+void TestModListUnpack(Fuzz_Data &input)
 {
     CONSUME1_OR_RETURN(const uint16_t num_mods, input);
     Moderation mods{};
@@ -12,7 +12,7 @@ void TestModListUnpack(Fuzz_Data input)
     mod_list_cleanup(&mods);
 }
 
-void TestSanctionsListUnpack(Fuzz_Data input)
+void TestSanctionsListUnpack(Fuzz_Data &input)
 {
     Mod_Sanction sanctions[10];
     Mod_Sanction_Creds creds;
@@ -20,7 +20,7 @@ void TestSanctionsListUnpack(Fuzz_Data input)
     sanctions_list_unpack(sanctions, &creds, 10, input.data, input.size, &processed_data_len);
 }
 
-void TestSanctionCredsUnpack(Fuzz_Data input)
+void TestSanctionCredsUnpack(Fuzz_Data &input)
 {
     CONSUME_OR_RETURN(const uint8_t *data, input, MOD_SANCTIONS_CREDS_SIZE);
     Mod_Sanction_Creds creds;


### PR DESCRIPTION
These help creating fuzzer fixtures with non-trivially constructed
objects and takes care of cleaning them up afterwards so the fuzzer code
can focus on the system under test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2232)
<!-- Reviewable:end -->
