### PR TITLE
cleanup: Make `*_free` and `kill_*` functions nullable.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-ffa04330027fd3d29e395f4609107e685d4cc7ca58caa2d24ebdb9569c0c855a  /usr/local/bin/tox-bootstrapd
+eba633bbca47d051b4b23e5ae14537a6d872a50aa0da8b7635214ee6908b87db  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2655,6 +2655,10 @@ void do_dht(DHT *dht)
 
 void kill_dht(DHT *dht)
 {
+    if (dht == nullptr) {
+        return;
+    }
+
     networking_registerhandler(dht->net, NET_PACKET_GET_NODES, nullptr, nullptr);
     networking_registerhandler(dht->net, NET_PACKET_SEND_NODES_IPV6, nullptr, nullptr);
     networking_registerhandler(dht->net, NET_PACKET_CRYPTO, nullptr, nullptr);

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -473,7 +473,7 @@ non_null()
 DHT *new_dht(const Logger *log, const Random *rng, const Network *ns, Mono_Time *mono_time, Networking_Core *net,
              bool hole_punching_enabled, bool lan_discovery_enabled);
 
-non_null()
+nullable(1)
 void kill_dht(DHT *dht);
 
 /**

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -761,7 +761,7 @@ Messenger *new_messenger(Mono_Time *mono_time, const Random *rng, const Network 
  *
  * Free all datastructures.
  */
-non_null()
+nullable(1)
 void kill_messenger(Messenger *m);
 
 /** @brief The main loop that needs to be run at least 20 times per second. */

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -1580,6 +1580,10 @@ void do_tcp_connections(const Logger *logger, TCP_Connections *tcp_c, void *user
 
 void kill_tcp_connections(TCP_Connections *tcp_c)
 {
+    if (tcp_c == nullptr) {
+        return;
+    }
+
     for (uint32_t i = 0; i < tcp_c->tcp_connections_length; ++i) {
         kill_TCP_connection(tcp_c->tcp_connections[i].connection);
     }

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -260,7 +260,8 @@ int kill_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connections_number
 
 non_null(1, 2) nullable(3)
 void do_tcp_connections(const Logger *logger, TCP_Connections *tcp_c, void *userdata);
-non_null()
+
+nullable(1)
 void kill_tcp_connections(TCP_Connections *tcp_c);
 
 #endif

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -1277,6 +1277,10 @@ void do_TCP_server(TCP_Server *tcp_server, const Mono_Time *mono_time)
 
 void kill_TCP_server(TCP_Server *tcp_server)
 {
+    if (tcp_server == nullptr) {
+        return;
+    }
+
     for (uint32_t i = 0; i < tcp_server->num_listening_socks; ++i) {
         kill_sock(tcp_server->ns, tcp_server->socks_listening[i]);
     }

--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -43,7 +43,7 @@ non_null()
 void do_TCP_server(TCP_Server *tcp_server, const Mono_Time *mono_time);
 
 /** Kill the TCP server */
-non_null()
+nullable(1)
 void kill_TCP_server(TCP_Server *tcp_server);
 
 

--- a/toxcore/bin_pack.h
+++ b/toxcore/bin_pack.h
@@ -70,7 +70,7 @@ Bin_Pack *bin_pack_new(uint8_t *buf, uint32_t buf_size);
  *
  * Does not deallocate the buffer inside.
  */
-non_null()
+nullable(1)
 void bin_pack_free(Bin_Pack *bp);
 
 /** @brief Start packing a MessagePack array.

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -164,7 +164,7 @@ non_null()
 void do_friend_connections(Friend_Connections *fr_c, void *userdata);
 
 /** Free everything related with friend_connections. */
-non_null()
+nullable(1)
 void kill_friend_connections(Friend_Connections *fr_c);
 
 typedef struct Friend_Conn Friend_Conn;

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -47,6 +47,8 @@ non_null()
 void friendreq_init(Friend_Requests *fr, Friend_Connections *fr_c);
 
 Friend_Requests *friendreq_new(void);
-non_null() void friendreq_kill(Friend_Requests *fr);
+
+nullable(1)
+void friendreq_kill(Friend_Requests *fr);
 
 #endif

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -3800,6 +3800,10 @@ void do_groupchats(Group_Chats *g_c, void *userdata)
 /** Free everything related with group chats. */
 void kill_groupchats(Group_Chats *g_c)
 {
+    if (g_c == nullptr) {
+        return;
+    }
+
     for (uint16_t i = 0; i < g_c->num_chats; ++i) {
         del_groupchat(g_c, i, false);
     }

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -392,7 +392,7 @@ non_null(1) nullable(2)
 void do_groupchats(Group_Chats *g_c, void *userdata);
 
 /** Free everything related with group chats. */
-non_null()
+nullable(1)
 void kill_groupchats(Group_Chats *g_c);
 
 #endif

--- a/toxcore/list.c
+++ b/toxcore/list.c
@@ -156,6 +156,10 @@ int bs_list_init(BS_List *list, uint32_t element_size, uint32_t initial_capacity
 
 void bs_list_free(BS_List *list)
 {
+    if (list == nullptr) {
+        return;
+    }
+
     // free both arrays
     free(list->data);
     list->data = nullptr;

--- a/toxcore/list.h
+++ b/toxcore/list.h
@@ -40,7 +40,7 @@ non_null()
 int bs_list_init(BS_List *list, uint32_t element_size, uint32_t initial_capacity);
 
 /** Free a list initiated with list_init */
-non_null()
+nullable(1)
 void bs_list_free(BS_List *list);
 
 /** @brief Retrieve the id of an element in the list

--- a/toxcore/logger.h
+++ b/toxcore/logger.h
@@ -43,7 +43,7 @@ Logger *logger_new(void);
 /**
  * Frees all resources associated with the logger.
  */
-non_null()
+nullable(1)
 void logger_kill(Logger *log);
 
 /**

--- a/toxcore/mono_time.c
+++ b/toxcore/mono_time.c
@@ -172,6 +172,9 @@ Mono_Time *mono_time_new(void)
 
 void mono_time_free(Mono_Time *mono_time)
 {
+    if (mono_time == nullptr) {
+        return;
+    }
 #ifdef OS_WIN32
     pthread_mutex_destroy(&mono_time->last_clock_lock);
 #endif

--- a/toxcore/mono_time.h
+++ b/toxcore/mono_time.h
@@ -46,7 +46,9 @@ extern "C" {
 typedef struct Mono_Time Mono_Time;
 
 Mono_Time *mono_time_new(void);
-non_null() void mono_time_free(Mono_Time *mono_time);
+
+nullable(1)
+void mono_time_free(Mono_Time *mono_time);
 
 /**
  * Update mono_time; subsequent calls to mono_time_get or mono_time_is_timeout

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -3172,6 +3172,10 @@ void do_net_crypto(Net_Crypto *c, void *userdata)
 
 void kill_net_crypto(Net_Crypto *c)
 {
+    if (c == nullptr) {
+        return;
+    }
+
     for (uint32_t i = 0; i < c->crypto_connections_length; ++i) {
         crypto_kill(c, i);
     }

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -386,6 +386,7 @@ uint32_t crypto_run_interval(const Net_Crypto *c);
 non_null(1) nullable(2)
 void do_net_crypto(Net_Crypto *c, void *userdata);
 
-non_null() void kill_net_crypto(Net_Crypto *c);
+nullable(1)
+void kill_net_crypto(Net_Crypto *c);
 
 #endif

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -579,7 +579,7 @@ non_null()
 Networking_Core *new_networking_no_udp(const Logger *log, const Network *ns);
 
 /** Function to cleanup networking stuff (doesn't do much right now). */
-non_null()
+nullable(1)
 void kill_networking(Networking_Core *net);
 
 #ifdef __cplusplus

--- a/toxcore/onion.h
+++ b/toxcore/onion.h
@@ -148,7 +148,7 @@ void set_callback_handle_recv_1(Onion *onion, onion_recv_1_cb *function, void *o
 non_null()
 Onion *new_onion(const Logger *log, const Mono_Time *mono_time, const Random *rng, DHT *dht);
 
-non_null()
+nullable(1)
 void kill_onion(Onion *onion);
 
 

--- a/toxcore/onion_announce.h
+++ b/toxcore/onion_announce.h
@@ -131,7 +131,7 @@ void onion_announce_extra_data_callback(Onion_Announce *onion_a, uint16_t extra_
 non_null()
 Onion_Announce *new_onion_announce(const Logger *log, const Random *rng, const Mono_Time *mono_time, DHT *dht);
 
-non_null()
+nullable(1)
 void kill_onion_announce(Onion_Announce *onion_a);
 
 #endif

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -199,7 +199,7 @@ void do_onion_client(Onion_Client *onion_c);
 non_null()
 Onion_Client *new_onion_client(const Logger *logger, const Random *rng, const Mono_Time *mono_time, Net_Crypto *c);
 
-non_null()
+nullable(1)
 void kill_onion_client(Onion_Client *onion_c);
 
 

--- a/toxcore/ping.h
+++ b/toxcore/ping.h
@@ -20,7 +20,7 @@ typedef struct Ping Ping;
 non_null()
 Ping *ping_new(const Mono_Time *mono_time, const Random *rng, DHT *dht);
 
-non_null()
+nullable(1)
 void ping_kill(Ping *ping);
 
 /** @brief Add nodes to the to_ping list.

--- a/toxcore/ping_array.h
+++ b/toxcore/ping_array.h
@@ -34,7 +34,7 @@ struct Ping_Array *ping_array_new(uint32_t size, uint32_t timeout);
 /**
  * @brief Free all the allocated memory in a @ref Ping_Array.
  */
-non_null()
+nullable(1)
 void ping_array_kill(Ping_Array *array);
 
 /**


### PR DESCRIPTION
These should be no-ops when passed a null pointer.

See https://github.com/TokTok/hs-tokstyle/pull/190 for the tokstyle check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2238)
<!-- Reviewable:end -->
