### PR TITLE
fix: Don't crash if RNG init failed.

### DIFF
--- a/other/analysis/run-gcc
+++ b/other/analysis/run-gcc
@@ -16,7 +16,6 @@ run() {
     -Wall \
     -Wextra \
     -Werror \
-    -Wno-error=null-dereference \
     -Wno-error=type-limits \
     -Wno-aggressive-loop-optimizations \
     -Wno-float-conversion \

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-e1464fd52269f481bd529805f0e81f717c8586b0df93a0767507a6b2b8f3678b  /usr/local/bin/tox-bootstrapd
+ccc903803f118d6d069f65bb0a1ef95979ab8b374d207e8f13716771d6da9dd8  /usr/local/bin/tox-bootstrapd

--- a/toxencryptsave/toxencryptsave.h
+++ b/toxencryptsave/toxencryptsave.h
@@ -238,7 +238,7 @@ typedef struct Tox_Pass_Key Tox_Pass_Key;
  * Deallocate a Tox_Pass_Key. This function behaves like `free()`, so NULL is an
  * acceptable argument value.
  */
-void tox_pass_key_free(struct Tox_Pass_Key *key);
+void tox_pass_key_free(Tox_Pass_Key *key);
 
 /**
  * Generates a secret symmetric key from the given passphrase.
@@ -253,9 +253,9 @@ void tox_pass_key_free(struct Tox_Pass_Key *key);
  * @param passphrase The user-provided password. Can be empty.
  * @param passphrase_len The length of the password.
  *
- * @return true on success.
+ * @return new symmetric key on success, NULL on failure.
  */
-struct Tox_Pass_Key *tox_pass_key_derive(const uint8_t *passphrase, size_t passphrase_len,
+Tox_Pass_Key *tox_pass_key_derive(const uint8_t *passphrase, size_t passphrase_len,
         Tox_Err_Key_Derivation *error);
 
 /**
@@ -265,9 +265,9 @@ struct Tox_Pass_Key *tox_pass_key_derive(const uint8_t *passphrase, size_t passp
  * @param passphrase_len The length of the password.
  * @param salt An array of at least TOX_PASS_SALT_LENGTH bytes.
  *
- * @return true on success.
+ * @return new symmetric key on success, NULL on failure.
  */
-struct Tox_Pass_Key *tox_pass_key_derive_with_salt(const uint8_t *passphrase, size_t passphrase_len,
+Tox_Pass_Key *tox_pass_key_derive_with_salt(const uint8_t *passphrase, size_t passphrase_len,
         const uint8_t *salt, Tox_Err_Key_Derivation *error);
 
 /**
@@ -282,7 +282,7 @@ struct Tox_Pass_Key *tox_pass_key_derive_with_salt(const uint8_t *passphrase, si
  *
  * @return true on success.
  */
-bool tox_pass_key_encrypt(const struct Tox_Pass_Key *key, const uint8_t *plaintext, size_t plaintext_len,
+bool tox_pass_key_encrypt(const Tox_Pass_Key *key, const uint8_t *plaintext, size_t plaintext_len,
                           uint8_t *ciphertext, Tox_Err_Encryption *error);
 
 /**
@@ -295,7 +295,7 @@ bool tox_pass_key_encrypt(const struct Tox_Pass_Key *key, const uint8_t *plainte
  *
  * @return true on success.
  */
-bool tox_pass_key_decrypt(const struct Tox_Pass_Key *key, const uint8_t *ciphertext, size_t ciphertext_len,
+bool tox_pass_key_decrypt(const Tox_Pass_Key *key, const uint8_t *ciphertext, size_t ciphertext_len,
                           uint8_t *plaintext, Tox_Err_Decryption *error);
 
 typedef enum Tox_Err_Get_Salt {


### PR DESCRIPTION
`system_random()` can fail and return NULL, which should be handled by
toxencryptsave functions.

Also synced function comments between .h and .c file for toxencryptsave.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2246)
<!-- Reviewable:end -->
