### PR TITLE
refactor: Use a struct for the `ip_ntoa` buffer.

### DIFF
--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -35,11 +35,11 @@ static void test_addr_resolv_localhost(void)
     ck_assert_msg(res, "Resolver failed: %d, %s", error, strerror);
     net_kill_strerror(strerror);
 
-    char ip_str[IP_NTOA_LEN];
+    Ip_Ntoa ip_str;
     ck_assert_msg(net_family_is_ipv4(ip.family), "Expected family TOX_AF_INET, got %u.", ip.family.value);
     const uint32_t loopback = get_ip4_loopback().uint32;
     ck_assert_msg(ip.ip.v4.uint32 == loopback, "Expected 127.0.0.1, got %s.",
-                  ip_ntoa(&ip, ip_str, sizeof(ip_str)));
+                  net_ip_ntoa(&ip, &ip_str));
 
     ip_init(&ip, 1); // ipv6enabled = 1
     res = addr_resolve_or_parse_ip(ns, localhost, &ip, nullptr);
@@ -62,7 +62,7 @@ static void test_addr_resolv_localhost(void)
                   ip.family.value);
     IP6 ip6_loopback = get_ip6_loopback();
     ck_assert_msg(!memcmp(&ip.ip.v6, &ip6_loopback, sizeof(IP6)), "Expected ::1, got %s.",
-                  ip_ntoa(&ip, ip_str, sizeof(ip_str)));
+                  net_ip_ntoa(&ip, &ip_str));
 
     if (localhost_split) {
         printf("Localhost seems to be split in two.\n");
@@ -85,17 +85,17 @@ static void test_addr_resolv_localhost(void)
     ck_assert_msg(net_family_is_ipv6(ip.family), "Expected family TOX_AF_INET6 (%d), got %u.", TOX_AF_INET6,
                   ip.family.value);
     ck_assert_msg(!memcmp(&ip.ip.v6, &ip6_loopback, sizeof(IP6)), "Expected ::1, got %s.",
-                  ip_ntoa(&ip, ip_str, sizeof(ip_str)));
+                  net_ip_ntoa(&ip, &ip_str));
 
     ck_assert_msg(net_family_is_ipv4(extra.family), "Expected family TOX_AF_INET (%d), got %u.", TOX_AF_INET,
                   extra.family.value);
     ck_assert_msg(extra.ip.v4.uint32 == loopback, "Expected 127.0.0.1, got %s.",
-                  ip_ntoa(&ip, ip_str, sizeof(ip_str)));
+                  net_ip_ntoa(&ip, &ip_str));
 #elif 0
     // TODO(iphydf): Fix this to work on IPv6-supporting systems.
     ck_assert_msg(net_family_is_ipv4(ip.family), "Expected family TOX_AF_INET (%d), got %u.", TOX_AF_INET, ip.family.value);
     ck_assert_msg(ip.ip.v4.uint32 == loopback, "Expected 127.0.0.1, got %s.",
-                  ip_ntoa(&ip, ip_str, sizeof(ip_str)));
+                  net_ip_ntoa(&ip, &ip_str));
 #endif
 }
 

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-4a2bfe7abf6060f252154062818541e485344b350cf975f7aeea78ff249bfa65  /usr/local/bin/tox-bootstrapd
+f3781691aed256efccda556f5663a4ab95c460aa8c1d665667c8b80c44e4d630  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -482,10 +482,10 @@ int pack_ip_port(const Logger *logger, uint8_t *data, uint16_t length, const IP_
         is_ipv4 = false;
         family = TOX_TCP_INET6;
     } else {
-        char ip_str[IP_NTOA_LEN];
+        Ip_Ntoa ip_str;
         // TODO(iphydf): Find out why we're trying to pack invalid IPs, stop
         // doing that, and turn this into an error.
-        LOGGER_TRACE(logger, "cannot pack invalid IP: %s", ip_ntoa(&ip_port->ip, ip_str, sizeof(ip_str)));
+        LOGGER_TRACE(logger, "cannot pack invalid IP: %s", net_ip_ntoa(&ip_port->ip, &ip_str));
         return -1;
     }
 
@@ -781,12 +781,13 @@ static void update_client(const Logger *log, const Mono_Time *mono_time, int ind
     }
 
     if (!ipport_equal(&assoc->ip_port, ip_port)) {
-        char ip_str[IP_NTOA_LEN];
+        Ip_Ntoa ip_str_from;
+        Ip_Ntoa ip_str_to;
         LOGGER_TRACE(log, "coipil[%u]: switching ipv%d from %s:%u to %s:%u",
                      index, ip_version,
-                     ip_ntoa(&assoc->ip_port.ip, ip_str, sizeof(ip_str)),
+                     net_ip_ntoa(&assoc->ip_port.ip, &ip_str_from),
                      net_ntohs(assoc->ip_port.port),
-                     ip_ntoa(&ip_port->ip, ip_str, sizeof(ip_str)),
+                     net_ip_ntoa(&ip_port->ip, &ip_str_to),
                      net_ntohs(ip_port->port));
     }
 

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2419,10 +2419,10 @@ void do_messenger(Messenger *m, void *userdata)
                         last_pinged = 999;
                     }
 
-                    char ip_str[IP_NTOA_LEN];
+                    Ip_Ntoa ip_str;
                     char id_str[IDSTRING_LEN];
                     LOGGER_TRACE(m->log, "C[%2u] %s:%u [%3u] %s",
-                                 client, ip_ntoa(&assoc->ip_port.ip, ip_str, sizeof(ip_str)),
+                                 client, net_ip_ntoa(&assoc->ip_port.ip, &ip_str),
                                  net_ntohs(assoc->ip_port.port), last_pinged,
                                  id_to_string(cptr->public_key, id_str, sizeof(id_str)));
                 }
@@ -2492,10 +2492,10 @@ void do_messenger(Messenger *m, void *userdata)
                             last_pinged = 999;
                         }
 
-                        char ip_str[IP_NTOA_LEN];
+                        Ip_Ntoa ip_str;
                         char id_str[IDSTRING_LEN];
                         LOGGER_TRACE(m->log, "F[%2u] => C[%2u] %s:%u [%3u] %s",
-                                     friend_idx, client, ip_ntoa(&assoc->ip_port.ip, ip_str, sizeof(ip_str)),
+                                     friend_idx, client, net_ip_ntoa(&assoc->ip_port.ip, &ip_str),
                                      net_ntohs(assoc->ip_port.port), last_pinged,
                                      id_to_string(cptr->public_key, id_str, sizeof(id_str)));
                     }

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -328,16 +328,21 @@ bool ipv6_ipv4_in_v6(const IP6 *a);
 
 /** this would be TOX_INET6_ADDRSTRLEN, but it might be too short for the error message */
 #define IP_NTOA_LEN 96 // TODO(irungentoo): magic number. Why not INET6_ADDRSTRLEN ?
-/** @brief converts ip into a string
+
+typedef struct Ip_Ntoa {
+    char buf[IP_NTOA_LEN];
+} Ip_Ntoa;
+
+/** @brief Converts IP into a string.
  *
- * @param ip_str must be of length at least IP_NTOA_LEN
+ * Writes error message into the buffer on error.
  *
- * writes error message into the buffer on error
+ * @param ip_str contains a buffer of the required size.
  *
- * @return ip_str
+ * @return Pointer to the buffer inside `ip_str` containing the IP string.
  */
 non_null()
-const char *ip_ntoa(const IP *ip, char *ip_str, size_t length);
+const char *net_ip_ntoa(const IP *ip, Ip_Ntoa *ip_str);
 
 /**
  * Parses IP structure into an address string.

--- a/toxcore/network_test.cc
+++ b/toxcore/network_test.cc
@@ -6,48 +6,33 @@ namespace {
 
 TEST(IpNtoa, DoesntWriteOutOfBounds)
 {
-    char ip_str[IP_NTOA_LEN];
+    Ip_Ntoa ip_str;
     IP ip;
     ip.family = net_family_ipv6;
     ip.ip.v6.uint64[0] = -1;
     ip.ip.v6.uint64[1] = -1;
 
-    ip_ntoa(&ip, ip_str, sizeof(ip_str));
+    net_ip_ntoa(&ip, &ip_str);
 
-    EXPECT_EQ(std::string(ip_str), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
-    EXPECT_LT(std::string(ip_str).length(), IP_NTOA_LEN);
-}
-
-TEST(IpNtoa, DoesntOverrunSmallBuffer)
-{
-    // We have to try really hard to trick the compiler here not to realise that
-    // 10 is too small a buffer for the snprintf inside ip_ntoa and error out.
-    std::istringstream ss("10");
-    size_t len;
-    ss >> len;
-    std::vector<char> ip_str(len);
-    IP *ip = nullptr;
-
-    ip_ntoa(ip, ip_str.data(), ip_str.size());
-
-    EXPECT_EQ(std::string(ip_str.data()), "Bad buf l");
+    EXPECT_EQ(std::string(ip_str.buf), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+    EXPECT_LT(std::string(ip_str.buf).length(), IP_NTOA_LEN);
 }
 
 TEST(IpNtoa, ReportsInvalidIpFamily)
 {
-    char ip_str[IP_NTOA_LEN];
+    Ip_Ntoa ip_str;
     IP ip;
     ip.family.value = 255 - net_family_ipv6.value;
     ip.ip.v4.uint32 = 0;
 
-    ip_ntoa(&ip, ip_str, sizeof(ip_str));
+    net_ip_ntoa(&ip, &ip_str);
 
-    EXPECT_EQ(std::string(ip_str), "(IP invalid, family 245)");
+    EXPECT_EQ(std::string(ip_str.buf), "(IP invalid, family 245)");
 }
 
 TEST(IpNtoa, FormatsIPv4)
 {
-    char ip_str[IP_NTOA_LEN];
+    Ip_Ntoa ip_str;
     IP ip;
     ip.family = net_family_ipv4;
     ip.ip.v4.uint8[0] = 192;
@@ -55,9 +40,9 @@ TEST(IpNtoa, FormatsIPv4)
     ip.ip.v4.uint8[2] = 0;
     ip.ip.v4.uint8[3] = 13;
 
-    ip_ntoa(&ip, ip_str, sizeof(ip_str));
+    net_ip_ntoa(&ip, &ip_str);
 
-    EXPECT_EQ(std::string(ip_str), "192.168.0.13");
+    EXPECT_EQ(std::string(ip_str.buf), "192.168.0.13");
 }
 
 TEST(IpParseAddr, FormatsIPv4)

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -315,10 +315,9 @@ static void tox_dht_get_nodes_response_handler(const DHT *dht, const Node_format
         return;
     }
 
-    char ip[IP_NTOA_LEN];
-    ip_ntoa(&node->ip_port.ip, ip, sizeof(ip));
-
-    tox_data->tox->dht_get_nodes_response_callback(tox_data->tox, node->public_key, ip, net_ntohs(node->ip_port.port),
+    Ip_Ntoa ip_str;
+    tox_data->tox->dht_get_nodes_response_callback(
+            tox_data->tox, node->public_key, net_ip_ntoa(&node->ip_port.ip, &ip_str), net_ntohs(node->ip_port.port),
             tox_data->user_data);
 }
 


### PR DESCRIPTION
Every use of this function needs to allocate the same buffer. None of
the callers uses a differently sized buffer, so we might as well put it
in a struct and have the type checker prove the buffer size is correct.

Also rename `ip_ntoa` to `net_ip_ntoa` to avoid clashes with ESP-IDF
system libraries which define this function as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2248)
<!-- Reviewable:end -->
