### PR TITLE
cleanup: remove populate_path_nodes_tcp

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-f3781691aed256efccda556f5663a4ab95c460aa8c1d665667c8b80c44e4d630  /usr/local/bin/tox-bootstrapd
+e1464fd52269f481bd529805f0e81f717c8586b0df93a0767507a6b2b8f3678b  /usr/local/bin/tox-bootstrapd

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1251,7 +1251,6 @@ Networking_Core *new_networking_no_udp(const Logger *log, const Network *ns)
 
     net->ns = ns;
     net->log = log;
-    net->ns = ns;
 
     return net;
 }

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -1540,19 +1540,6 @@ static void populate_path_nodes(Onion_Client *onion_c)
     }
 }
 
-non_null()
-static void populate_path_nodes_tcp(Onion_Client *onion_c)
-{
-    Node_format node_list[MAX_SENT_NODES];
-
-    const unsigned int num_nodes = copy_connected_tcp_relays(onion_c->c, node_list, MAX_SENT_NODES);
-
-    for (unsigned int i = 0; i < num_nodes; ++i) {
-        // XXX: but ip_port is TCP, so will be rejected by onion_add_bs_path_node...
-        onion_add_bs_path_node(onion_c, &node_list[i].ip_port, node_list[i].public_key);
-    }
-}
-
 /* How often we ping new friends per node */
 #define ANNOUNCE_FRIEND_NEW_INTERVAL 3
 
@@ -1900,8 +1887,6 @@ void do_onion_client(Onion_Client *onion_c)
             ++onion_c->onion_connected;
         }
     } else {
-        populate_path_nodes_tcp(onion_c);
-
         if (onion_c->onion_connected != 0) {
             --onion_c->onion_connected;
         }


### PR DESCRIPTION
It was a no-op.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2250)
<!-- Reviewable:end -->
