### PR TITLE
fix: Fix a stack overflow triggered by small DHT packets.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-139fe825b90c022bbefd3837c2a427ab9215be3ca62144ea7ff12ae7389c78ba  /usr/local/bin/tox-bootstrapd
+37e68ca853cd8b01b26c8d8c61d1db6546c08ed294f5650b691b7aadaf47ee18  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -1079,7 +1079,7 @@ static int handle_data_search_response(void *object, const IP_Port *source,
 
     const int32_t plain_len = (int32_t)length - (1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE + CRYPTO_MAC_SIZE);
 
-    if (plain_len < CRYPTO_PUBLIC_KEY_SIZE + sizeof(uint64_t)) {
+    if (plain_len < (int32_t)(CRYPTO_PUBLIC_KEY_SIZE + sizeof(uint64_t))) {
         return 1;
     }
 

--- a/toxcore/announce.c
+++ b/toxcore/announce.c
@@ -544,7 +544,7 @@ static int create_reply(Announcements *announce, const IP_Port *source,
 {
     const int plain_len = (int)length - (1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE + CRYPTO_MAC_SIZE);
 
-    if (plain_len < sizeof(uint64_t)) {
+    if (plain_len < (int)sizeof(uint64_t)) {
         return -1;
     }
 


### PR DESCRIPTION
This isn't in production yet. It's in the new announce store code. The
problem was that a negative plain_len was converted to unsigned, which
made it a very large number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2255)
<!-- Reviewable:end -->
