### PR TITLE
fix: Format IP as string again in error log.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-37e68ca853cd8b01b26c8d8c61d1db6546c08ed294f5650b691b7aadaf47ee18  /usr/local/bin/tox-bootstrapd
+b3fb4157d7fc6cd3455f40020bb6b69e5bab4bbdb6ce66d5bc7095146ba5a49e  /usr/local/bin/tox-bootstrapd

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1689,7 +1689,7 @@ bool net_connect(const Logger *log, Socket sock, const IP_Port *ip_port)
         if (!should_ignore_connect_error(error)) {
             char *net_strerror = net_new_strerror(error);
             LOGGER_ERROR(log, "failed to connect to %s:%d: %d (%s)",
-                         ip_str.buf, ip_port->port, error, net_strerror);
+                         net_ip_ntoa(&ip_port->ip, &ip_str), ip_port->port, error, net_strerror);
             net_kill_strerror(net_strerror);
             return false;
         }


### PR DESCRIPTION
In case DEBUG logging is disabled, the formatting done in the
`LOGGER_DEBUG` statement above will not occur, leaving uninitialised
memory here.

Addresses issue 1 in https://github.com/TokTok/c-toxcore/issues/2256

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2257)
<!-- Reviewable:end -->
