### PR TITLE
refactor: Rename announce functions into their own namespace.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-4e6c181b03e20cdd0669296fae53a9433e31a7c37beed5430272fbefbf501bbb  /usr/local/bin/tox-bootstrapd
+146fb36bf3100115f913a07583c096c8dc98ab26e1220567e465b2ca86a69583  /usr/local/bin/tox-bootstrapd

--- a/toxcore/announce.c
+++ b/toxcore/announce.c
@@ -17,7 +17,7 @@
 #include "timed_auth.h"
 #include "util.h"
 
-uint8_t response_of_request_type(uint8_t request_type)
+uint8_t announce_response_of_request_type(uint8_t request_type)
 {
     switch (request_type) {
         case NET_PACKET_DATA_SEARCH_REQUEST:
@@ -63,7 +63,7 @@ struct Announcements {
     Announce_Entry entries[ANNOUNCE_BUCKETS * ANNOUNCE_BUCKET_SIZE];
 };
 
-void set_synch_offset(Announcements *announce, int32_t synch_offset)
+void announce_set_synch_offset(Announcements *announce, int32_t synch_offset)
 {
     announce->synch_offset = synch_offset;
 }
@@ -95,7 +95,7 @@ static uint8_t truncate_pk_at_index(const uint8_t *pk, uint16_t index, uint16_t 
            ((i + 1 < CRYPTO_PUBLIC_KEY_SIZE ? pk[i + 1] : 0) >> (16 - bits - j));
 }
 
-uint16_t get_bucketnum(const uint8_t *base, const uint8_t *pk)
+uint16_t announce_get_bucketnum(const uint8_t *base, const uint8_t *pk)
 {
     const uint16_t index = bit_by_bit_cmp(base, pk);
 
@@ -106,7 +106,7 @@ uint16_t get_bucketnum(const uint8_t *base, const uint8_t *pk)
 non_null()
 static Announce_Entry *bucket_of_key(Announcements *announce, const uint8_t *pk)
 {
-    return &announce->entries[get_bucketnum(announce->public_key, pk) * ANNOUNCE_BUCKET_SIZE];
+    return &announce->entries[announce_get_bucketnum(announce->public_key, pk) * ANNOUNCE_BUCKET_SIZE];
 }
 
 non_null()
@@ -130,7 +130,7 @@ static Announce_Entry *get_stored(Announcements *announce, const uint8_t *data_p
 non_null()
 static const Announce_Entry *bucket_of_key_const(const Announcements *announce, const uint8_t *pk)
 {
-    return &announce->entries[get_bucketnum(announce->public_key, pk) * ANNOUNCE_BUCKET_SIZE];
+    return &announce->entries[announce_get_bucketnum(announce->public_key, pk) * ANNOUNCE_BUCKET_SIZE];
 }
 
 non_null()
@@ -152,8 +152,8 @@ static const Announce_Entry *get_stored_const(const Announcements *announce, con
 }
 
 
-bool on_stored(const Announcements *announce, const uint8_t *data_public_key,
-               on_retrieve_cb *on_retrieve_callback, void *object)
+bool announce_on_stored(const Announcements *announce, const uint8_t *data_public_key,
+                        announce_on_retrieve_cb *on_retrieve_callback, void *object)
 {
     const Announce_Entry *const entry = get_stored_const(announce, data_public_key);
 
@@ -210,8 +210,8 @@ static bool would_accept_store_request(Announcements *announce, const uint8_t *d
     return find_entry_slot(announce, data_public_key) != nullptr;
 }
 
-bool store_data(Announcements *announce, const uint8_t *data_public_key,
-                const uint8_t *data, uint32_t length, uint32_t timeout)
+bool announce_store_data(Announcements *announce, const uint8_t *data_public_key,
+                         const uint8_t *data, uint32_t length, uint32_t timeout)
 {
     if (length > MAX_ANNOUNCEMENT_SIZE) {
         return false;
@@ -479,7 +479,7 @@ static int create_reply_plain_store_announce_request(Announcements *announce,
             stored->store_until = mono_time_get(announce->mono_time) + timeout;
         }
     } else {
-        if (!store_data(announce, data_public_key, announcement, announcement_len, timeout)) {
+        if (!announce_store_data(announce, data_public_key, announcement, announcement_len, timeout)) {
             return -1;
         }
     }
@@ -585,7 +585,7 @@ static int create_reply(Announcements *announce, const IP_Port *source,
 
     const uint16_t plain_reply_len = plain_reply_noping_len + sizeof(uint64_t);
 
-    const uint8_t response_type = response_of_request_type(data[0]);
+    const uint8_t response_type = announce_response_of_request_type(data[0]);
 
     return dht_create_packet(announce->rng, announce->public_key, shared_key, response_type,
                              plain_reply, plain_reply_len, reply, reply_max_length);

--- a/toxcore/announce.h
+++ b/toxcore/announce.h
@@ -9,9 +9,9 @@
 
 #define MAX_ANNOUNCEMENT_SIZE 512
 
-typedef void on_retrieve_cb(void *object, const uint8_t *data, uint16_t length);
+typedef void announce_on_retrieve_cb(void *object, const uint8_t *data, uint16_t length);
 
-uint8_t response_of_request_type(uint8_t request_type);
+uint8_t announce_response_of_request_type(uint8_t request_type);
 
 typedef struct Announcements Announcements;
 
@@ -24,11 +24,11 @@ Announcements *new_announcements(const Logger *log, const Random *rng, const Mon
  * @return true if data is stored, false otherwise.
  */
 non_null(1, 2) nullable(3, 4)
-bool on_stored(const Announcements *announce, const uint8_t *data_public_key,
-               on_retrieve_cb *on_retrieve_callback, void *object);
+bool announce_on_stored(const Announcements *announce, const uint8_t *data_public_key,
+                        announce_on_retrieve_cb *on_retrieve_callback, void *object);
 
 non_null()
-void set_synch_offset(Announcements *announce, int32_t synch_offset);
+void announce_set_synch_offset(Announcements *announce, int32_t synch_offset);
 
 nullable(1)
 void kill_announcements(Announcements *announce);
@@ -41,12 +41,12 @@ void kill_announcements(Announcements *announce);
  * base and pk first differ
  */
 non_null()
-uint16_t get_bucketnum(const uint8_t *base, const uint8_t *pk);
+uint16_t announce_get_bucketnum(const uint8_t *base, const uint8_t *pk);
 
 /** @private */
 non_null(1, 2) nullable(3)
-bool store_data(Announcements *announce, const uint8_t *data_public_key,
-                const uint8_t *data, uint32_t length, uint32_t timeout);
+bool announce_store_data(Announcements *announce, const uint8_t *data_public_key,
+                         const uint8_t *data, uint32_t length, uint32_t timeout);
 
 /** @private */
 #define MAX_MAX_ANNOUNCEMENT_TIMEOUT 900


### PR DESCRIPTION
This avoids common names like `on_stored` and `store_data` in global
symbols. Turns out, toxic also has a `store_data`.

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2258)
<!-- Reviewable:end -->
