### PR TITLE
refactor: Protect array unpacking against invalid lengths.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-146fb36bf3100115f913a07583c096c8dc98ab26e1220567e465b2ca86a69583  /usr/local/bin/tox-bootstrapd
+95ae45707c9a19ea9c8c0a537c5defb228f8d7eca1c51c0225a3bc07a50891c6  /usr/local/bin/tox-bootstrapd

--- a/toxcore/bin_pack_test.cc
+++ b/toxcore/bin_pack_test.cc
@@ -122,4 +122,13 @@ TEST(BinPack, BinCanHoldArbitraryData)
     EXPECT_EQ(str, (std::array<uint8_t, 5>{'h', 'e', 'l', 'l', 'o'}));
 }
 
+TEST(BinPack, OversizedArrayFailsUnpack)
+{
+    std::array<uint8_t, 1> buf = {0x91};
+
+    Bin_Unpack_Ptr bu(bin_unpack_new(buf.data(), buf.size()));
+    uint32_t size;
+    EXPECT_FALSE(bin_unpack_array(bu.get(), &size));
+}
+
 }  // namespace

--- a/toxcore/bin_unpack.c
+++ b/toxcore/bin_unpack.c
@@ -70,7 +70,7 @@ void bin_unpack_free(Bin_Unpack *bu)
 
 bool bin_unpack_array(Bin_Unpack *bu, uint32_t *size)
 {
-    return cmp_read_array(&bu->ctx, size);
+    return cmp_read_array(&bu->ctx, size) && *size <= bu->bytes_size;
 }
 
 bool bin_unpack_array_fixed(Bin_Unpack *bu, uint32_t required_size)


### PR DESCRIPTION
Each array element is at least 1 byte, so if there are fewer bytes than
array elements, the array size is invalid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2261)
<!-- Reviewable:end -->
