### PR TITLE
refactor: Always fail hard on allocation failure in tox_events.

### DIFF
--- a/auto_tests/tox_dispatch_test.c
+++ b/auto_tests/tox_dispatch_test.c
@@ -66,9 +66,9 @@ static bool await_message(Tox **toxes, const Tox_Dispatch *dispatch)
 {
     for (uint32_t i = 0; i < 100; ++i) {
         // Ignore events on tox 1.
-        print_events(tox_events_iterate(toxes[0], false, nullptr));
+        print_events(tox_events_iterate(toxes[0], nullptr));
         // Check if tox 2 got the message from tox 1.
-        Tox_Events *events = tox_events_iterate(toxes[1], false, nullptr);
+        Tox_Events *events = tox_events_iterate(toxes[1], nullptr);
 
         dump_events("/tmp/test.mp", events);
 
@@ -123,8 +123,8 @@ static void test_tox_events(void)
     while (tox_self_get_connection_status(toxes[0]) == TOX_CONNECTION_NONE ||
             tox_self_get_connection_status(toxes[1]) == TOX_CONNECTION_NONE) {
         // Ignore connection events for now.
-        print_events(tox_events_iterate(toxes[0], false, nullptr));
-        print_events(tox_events_iterate(toxes[1], false, nullptr));
+        print_events(tox_events_iterate(toxes[0], nullptr));
+        print_events(tox_events_iterate(toxes[1], nullptr));
 
         c_sleep(tox_iteration_interval(toxes[0]));
     }
@@ -134,8 +134,8 @@ static void test_tox_events(void)
     while (tox_friend_get_connection_status(toxes[0], 0, nullptr) == TOX_CONNECTION_NONE ||
             tox_friend_get_connection_status(toxes[1], 0, nullptr) == TOX_CONNECTION_NONE) {
         // Ignore connection events for now.
-        print_events(tox_events_iterate(toxes[0], false, nullptr));
-        print_events(tox_events_iterate(toxes[1], false, nullptr));
+        print_events(tox_events_iterate(toxes[0], nullptr));
+        print_events(tox_events_iterate(toxes[1], nullptr));
 
         c_sleep(tox_iteration_interval(toxes[0]));
     }

--- a/auto_tests/tox_events_test.c
+++ b/auto_tests/tox_events_test.c
@@ -17,9 +17,9 @@ static bool await_message(Tox **toxes)
 {
     for (uint32_t i = 0; i < 100; ++i) {
         // Ignore events on tox 1.
-        tox_events_free(tox_events_iterate(toxes[0], false, nullptr));
+        tox_events_free(tox_events_iterate(toxes[0], nullptr));
         // Check if tox 2 got the message from tox 1.
-        Tox_Events *events = tox_events_iterate(toxes[1], false, nullptr);
+        Tox_Events *events = tox_events_iterate(toxes[1], nullptr);
 
         if (events != nullptr) {
             ck_assert(tox_events_get_friend_message_size(events) == 1);
@@ -82,8 +82,8 @@ static void test_tox_events(void)
     while (tox_self_get_connection_status(toxes[0]) == TOX_CONNECTION_NONE ||
             tox_self_get_connection_status(toxes[1]) == TOX_CONNECTION_NONE) {
         // Ignore connection events for now.
-        tox_events_free(tox_events_iterate(toxes[0], false, nullptr));
-        tox_events_free(tox_events_iterate(toxes[1], false, nullptr));
+        tox_events_free(tox_events_iterate(toxes[0], nullptr));
+        tox_events_free(tox_events_iterate(toxes[1], nullptr));
 
         clock += 100;
         c_sleep(5);
@@ -94,8 +94,8 @@ static void test_tox_events(void)
     while (tox_friend_get_connection_status(toxes[0], 0, nullptr) == TOX_CONNECTION_NONE ||
             tox_friend_get_connection_status(toxes[1], 0, nullptr) == TOX_CONNECTION_NONE) {
         // Ignore connection events for now.
-        tox_events_free(tox_events_iterate(toxes[0], false, nullptr));
-        tox_events_free(tox_events_iterate(toxes[1], false, nullptr));
+        tox_events_free(tox_events_iterate(toxes[0], nullptr));
+        tox_events_free(tox_events_iterate(toxes[1], nullptr));
 
         clock += 100;
         c_sleep(5);

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-5581c3dda4277afb002dcb6c047e6ebfe08a1d97ae9622c37f795002c0c22074  /usr/local/bin/tox-bootstrapd
+2e9a3b8d23916e9a592c10db689ebc11161244c2473da44c51729ffc2327ac9c  /usr/local/bin/tox-bootstrapd

--- a/testing/fuzzing/bootstrap_harness.cc
+++ b/testing/fuzzing/bootstrap_harness.cc
@@ -163,7 +163,8 @@ void TestBootstrap(Fuzz_Data &input)
 
     while (input.size > 0) {
         Tox_Err_Events_Iterate error_iterate;
-        Tox_Events *events = tox_events_iterate(tox, true, &error_iterate);
+        Tox_Events *events = tox_events_iterate(tox, &error_iterate);
+        assert(error_iterate == TOX_ERR_EVENTS_ITERATE_OK);
         assert(tox_events_equal(events, events));
         tox_dispatch_invoke(dispatch, events, tox, nullptr);
         tox_events_free(events);

--- a/toxcore/tox_dispatch.h
+++ b/toxcore/tox_dispatch.h
@@ -2,6 +2,11 @@
  * Copyright © 2022 The TokTok team.
  */
 
+/**
+ * Tox events object visitor/callback dispatcher.
+ *
+ * XXX: This API is not stable yet and will change drastically in the future.
+ */
 #ifndef C_TOXCORE_TOXCORE_TOX_DISPATCH_H
 #define C_TOXCORE_TOXCORE_TOX_DISPATCH_H
 

--- a/toxcore/tox_events.c
+++ b/toxcore/tox_events.c
@@ -46,7 +46,7 @@ void tox_events_init(Tox *tox)
     tox_callback_self_connection_status(tox, tox_events_handle_self_connection_status);
 }
 
-Tox_Events *tox_events_iterate(Tox *tox, bool fail_hard, Tox_Err_Events_Iterate *error)
+Tox_Events *tox_events_iterate(Tox *tox, Tox_Err_Events_Iterate *error)
 {
     Tox_Events_State state = {TOX_ERR_EVENTS_ITERATE_OK};
     tox_iterate(tox, &state);
@@ -55,7 +55,7 @@ Tox_Events *tox_events_iterate(Tox *tox, bool fail_hard, Tox_Err_Events_Iterate 
         *error = state.error;
     }
 
-    if (fail_hard && state.error != TOX_ERR_EVENTS_ITERATE_OK) {
+    if (state.error != TOX_ERR_EVENTS_ITERATE_OK) {
         tox_events_free(state.events);
         return nullptr;
     }


### PR DESCRIPTION
Partial success is not much more helpful, because at the point of
allocation failure, the client will probably need to shut down or drop
caches to free memory and request re-sends from friends. Those requests
don't exist in current Tox messages, but future history-sync based
messaging would be able to handle temporary allocation failures.

Also in the future, a single iteration will have a limited number of
events it can process at a time, configurable through Tox_Options. This
way there is an upper limit on how much memory an events iteration can
allocate. This will be necessary for security (avoiding Resource
Exhaustion Attacks, which the current events system is somewhat
vulnerable to).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2264)
<!-- Reviewable:end -->
