### PR TITLE
refactor: Avoid `static_cast` in `Fuzz_System` functions.

### DIFF
--- a/testing/fuzzing/BUILD.bazel
+++ b/testing/fuzzing/BUILD.bazel
@@ -5,7 +5,10 @@ package(features = ["layering_check"])
 
 cc_library(
     name = "fuzz_support",
-    srcs = ["fuzz_support.cc"],
+    srcs = [
+        "func_conversion.h",
+        "fuzz_support.cc",
+    ],
     hdrs = ["fuzz_support.h"],
     visibility = ["//c-toxcore:__subpackages__"],
     deps = [

--- a/testing/fuzzing/CMakeLists.txt
+++ b/testing/fuzzing/CMakeLists.txt
@@ -2,7 +2,7 @@
 target_compile_definitions(toxcore_static PUBLIC "FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION")
 
 # Override network and random functions
-add_library(fuzz_support fuzz_support.cc fuzz_support.h)
+add_library(fuzz_support func_conversion.h fuzz_support.cc fuzz_support.h)
 
 set(LIBFUZZER_LINKER_FLAGS)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/testing/fuzzing/func_conversion.h
+++ b/testing/fuzzing/func_conversion.h
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022 The TokTok team.
+ */
+
+#ifndef C_TOXCORE_TESTING_FUZZING_FUNC_CONVERSION_H
+#define C_TOXCORE_TESTING_FUZZING_FUNC_CONVERSION_H
+
+namespace detail {
+
+template <typename F, F f>
+struct func_conversion {
+private:
+    template <typename R, typename... Args>
+    using func_pointer = R (*)(Args...);
+
+    template <typename From>
+    struct static_caster {
+        From obj;
+
+        template <typename To>
+        operator To() const
+        {
+            return static_cast<To>(obj);
+        }
+    };
+
+public:
+    template <typename R, typename Arg, typename... Args>
+    constexpr operator func_pointer<R, Arg, Args...>()
+    {
+        return [](Arg obj, auto... args) { return f(static_caster<Arg>{obj}, args...); };
+    }
+};
+
+template <typename F>
+struct make_funptr;
+
+template <typename T, typename R, typename... Args>
+struct make_funptr<R (T::*)(Args...) const> {
+    using type = R (*)(Args...);
+};
+
+/** @brief Turn a memfunptr type into a plain funptr type.
+ *
+ * Not needed in C++20, because we can pass the lambda itself as template
+ * argument, but in C++17, we need to do an early conversion.
+ */
+template <typename F>
+using make_funptr_t = typename make_funptr<F>::type;
+
+}
+
+/** @brief Turn a C++ lambda into a C function pointer with `void*` param.
+ *
+ * Takes a lambda function with any pointer type as first parameter and turns it
+ * into a C function pointer with `void*` as the first parameter. Internally, it
+ * `static_cast`s that `void*` to the lambda's parameter type, avoiding a bunch
+ * of casts inside the lambdas.
+ *
+ * This works on any type `T` that can be `static_cast` to `U`, not just `void*`
+ * to `U*`, but the common case for C callbacks is `void*`.
+ */
+template <typename F>
+static constexpr auto operator!(F f)
+{
+    return detail::func_conversion<detail::make_funptr_t<decltype(&F::operator())>, f>{};
+}
+
+#endif  // C_TOXCORE_TESTING_FUZZING_FUNC_CONVERSION_H


### PR DESCRIPTION
Declutters the fuzz system code a bit, hiding the cast behind a `!` operator.

This doesn't do perfect forwarding, because we don't need it and it complicates the code a bit (littering `std::forward` all over the place).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2277)
<!-- Reviewable:end -->
