### PR TITLE
test: Enable fuzzing for TCP.

### DIFF
--- a/.github/scripts/coverage-linux
+++ b/.github/scripts/coverage-linux
@@ -21,9 +21,8 @@ export CC=clang
 export CXX=clang++
 
 sudo install other/docker/coverage/run_mallocfail /usr/local/bin/run_mallocfail
-go get github.com/things-go/go-socks5
-go build other/proxy/proxy_server.go
-./proxy_server &
+(cd other/proxy && go build)
+other/proxy/proxy &
 
 . ".github/scripts/flags-coverage.sh"
 

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-f20ba5a6917e5faee9a2a6439b448d3ced7cd177ba666ff1804882f494ea7b90  /usr/local/bin/tox-bootstrapd
+4302ebfb454cfd087a919ac41ea513e04a9cdddfd9518c9c1959058bc244c06f  /usr/local/bin/tox-bootstrapd

--- a/other/proxy/go.mod
+++ b/other/proxy/go.mod
@@ -1,0 +1,5 @@
+module github.com/TokTok/c-toxcore/other/proxy
+
+go 1.16
+
+require github.com/things-go/go-socks5 v0.0.2

--- a/other/proxy/go.sum
+++ b/other/proxy/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/things-go/go-socks5 v0.0.2 h1:dFi5iZ/LqgHRTQ6n3XlipTLDWHAQsejvJ300bH2VFWo=
+github.com/things-go/go-socks5 v0.0.2/go.mod h1:dhnDTBbIg31cbJdROP4/Zz6Iw7JPEpiMvOl2LdHSSjE=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/testing/fuzzing/fuzz_support.cc
+++ b/testing/fuzzing/fuzz_support.cc
@@ -47,10 +47,9 @@ static constexpr Network_Funcs fuzz_network_funcs = {
     /* .bind = */ [](void *obj, int sock, const Network_Addr *addr) { return 0; },
     /* .listen = */ [](void *obj, int sock, int backlog) { return 0; },
     /* .recvbuf = */
-    [](void *obj, int sock) {
-        // TODO(iphydf): Return something sensible here (from the fuzzer): number of
-        // bytes to be read from the socket.
-        return 0;
+    ![](Fuzz_System *self, int sock) {
+        const size_t count = random_u16(self->rng.get());
+        return static_cast<int>(std::min(count, self->data.size));
     },
     /* .recv = */
     ![](Fuzz_System *self, int sock, uint8_t *buf, size_t len) {
@@ -107,10 +106,13 @@ static constexpr Random_Funcs fuzz_random_funcs = {
     },
     /* .random_uniform = */
     ![](Fuzz_System *self, uint32_t upper_bound) {
-        uint32_t randnum;
-        self->rng->funcs->random_bytes(
-            self, reinterpret_cast<uint8_t *>(&randnum), sizeof(randnum));
-        return randnum % upper_bound;
+        uint32_t randnum = 0;
+        if (upper_bound > 0) {
+            self->rng->funcs->random_bytes(
+                self, reinterpret_cast<uint8_t *>(&randnum), sizeof(randnum));
+            randnum %= upper_bound;
+        }
+        return randnum;
     },
 };
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -648,7 +648,7 @@ static uint32_t data_1(uint16_t buflen, const uint8_t *buffer)
 {
     uint32_t data = 0;
 
-    if (buflen > 7) {
+    if (buflen > 8) {
         net_unpack_u32(buffer + 5, &data);
     }
 


### PR DESCRIPTION
If the `recvbuf` network function returns 0 all the time, that means
there is never any data available on the TCP socket. This change makes
it so there is a random amount of data available on the TCP socket.

Also allow the fuzzer to enable proxy mode.

All of the above invalidate the bootstrap fuzzer corpus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2279)
<!-- Reviewable:end -->
