### PR TITLE
fix: Fix potential array out-of-bounds in DHT onion path building.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-624c610327a1288eb58196fb0e93d98d5a3c01ad86835799b90c1936fcbbc156  /usr/local/bin/tox-bootstrapd
+bded6f7ca320d8dfcb123a02c2c06aa9615b0e29e1d1d5b33b94bf88e85524d3  /usr/local/bin/tox-bootstrapd

--- a/testing/fuzzing/bootstrap_harness.cc
+++ b/testing/fuzzing/bootstrap_harness.cc
@@ -124,6 +124,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     Tox_Err_New error_new;
     Tox *tox = tox_new(opts, &error_new);
+    tox_options_free(opts);
 
     if (tox == nullptr) {
         // It might fail, because some I/O happens in tox_new, and the fuzzer
@@ -132,8 +133,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
 
     assert(error_new == TOX_ERR_NEW_OK);
-
-    tox_options_free(opts);
 
     uint8_t pub_key[TOX_PUBLIC_KEY_SIZE] = {0};
 

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2602,7 +2602,7 @@ uint16_t randfriends_nodes(const DHT *dht, Node_format *nodes, uint16_t max_num)
     const uint32_t r = random_range_u32(dht->rng, dht->num_friends - DHT_FAKE_FRIEND_NUMBER);
     uint16_t count = 0;
 
-    for (size_t i = 0; i < DHT_FAKE_FRIEND_NUMBER; ++i) {
+    for (uint32_t i = 0; i < DHT_FAKE_FRIEND_NUMBER && i < dht->num_friends; ++i) {
         count += list_nodes(dht->rng, dht->friends_list[r + i].client_list,
                             MAX_FRIEND_CLIENTS, dht->cur_time,
                             nodes + count, max_num - count);
@@ -2764,6 +2764,12 @@ DHT *new_dht(const Logger *log, const Random *rng, const Network *ns, Mono_Time 
             kill_dht(dht);
             return nullptr;
         }
+    }
+
+    if (dht->num_friends != DHT_FAKE_FRIEND_NUMBER) {
+        LOGGER_ERROR(log, "the RNG provided seems to be broken: it generated the same keypair twice");
+        kill_dht(dht);
+        return nullptr;
     }
 
     return dht;


### PR DESCRIPTION
It can't happen in almost every reality, except when the RNG is fairly
broken and doesn't add 2 fake DHT friends on startup. Still, this code
should be defensive and never index outside `num_friends` elements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2282)
<!-- Reviewable:end -->
