### PR TITLE
fix: Allow onion paths to be built from more random nodes.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-ea227a21dcaed2f54d61bd9175c6deb02480ebd894ebd589061556a1708c0c9f  /usr/local/bin/tox-bootstrapd
+624c610327a1288eb58196fb0e93d98d5a3c01ad86835799b90c1936fcbbc156  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2598,11 +2598,12 @@ uint16_t randfriends_nodes(const DHT *dht, Node_format *nodes, uint16_t max_num)
         return 0;
     }
 
+    assert(dht->num_friends >= DHT_FAKE_FRIEND_NUMBER);
+    const uint32_t r = random_range_u32(dht->rng, dht->num_friends - DHT_FAKE_FRIEND_NUMBER);
     uint16_t count = 0;
-    const uint32_t r = random_u32(dht->rng);
 
     for (size_t i = 0; i < DHT_FAKE_FRIEND_NUMBER; ++i) {
-        count += list_nodes(dht->rng, dht->friends_list[(i + r) % DHT_FAKE_FRIEND_NUMBER].client_list,
+        count += list_nodes(dht->rng, dht->friends_list[r + i].client_list,
                             MAX_FRIEND_CLIENTS, dht->cur_time,
                             nodes + count, max_num - count);
 

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -501,6 +501,10 @@ non_null()
 static uint32_t sys_random_uniform(void *obj, uint32_t upper_bound)
 {
 #ifdef VANILLA_NACL
+    if (upper_bound == 0) {
+        return 0;
+    }
+
     uint32_t randnum;
     sys_random_bytes(obj, (uint8_t *)&randnum, sizeof(randnum));
     return randnum % upper_bound;


### PR DESCRIPTION
Right now it only gets built from the first 2 friends in the DHT friend
list: either friend 0 and then 1 or friend 1 and then 0. The randomness
in this code doesn't make sense unless the intention was to select from
all friends, which the code will now do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2283)
<!-- Reviewable:end -->
