### PR TITLE
refactor: Move crypto utilities from util to crypto_core.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-bded6f7ca320d8dfcb123a02c2c06aa9615b0e29e1d1d5b33b94bf88e85524d3  /usr/local/bin/tox-bootstrapd
+a12aa241a079e5f014a6689e48905a5a32c2fd455676cad431773908bda9245c  /usr/local/bin/tox-bootstrapd

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -16,6 +16,44 @@ cc_library(
 )
 
 cc_library(
+    name = "ccompat",
+    srcs = ["ccompat.c"],
+    hdrs = ["ccompat.h"],
+    visibility = ["//c-toxcore:__subpackages__"],
+    deps = [":attributes"],
+)
+
+cc_library(
+    name = "util",
+    srcs = ["util.c"],
+    hdrs = ["util.h"],
+    visibility = [
+        "//c-toxcore/auto_tests:__pkg__",
+        "//c-toxcore/other:__pkg__",
+        "//c-toxcore/other/bootstrap_daemon:__pkg__",
+        "//c-toxcore/testing/fuzzing:__pkg__",
+        "//c-toxcore/toxav:__pkg__",
+    ],
+    deps = [
+        ":attributes",
+        ":ccompat",
+        "@pthread",
+    ],
+)
+
+cc_test(
+    name = "util_test",
+    size = "small",
+    srcs = ["util_test.cc"],
+    deps = [
+        ":crypto_core",
+        ":util",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "bin_pack",
     srcs = ["bin_pack.c"],
     hdrs = ["bin_pack.h"],
@@ -47,14 +85,6 @@ cc_test(
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
-)
-
-cc_library(
-    name = "ccompat",
-    srcs = ["ccompat.c"],
-    hdrs = ["ccompat.h"],
-    visibility = ["//c-toxcore:__subpackages__"],
-    deps = [":attributes"],
 )
 
 cc_library(
@@ -151,25 +181,6 @@ cc_test(
 )
 
 cc_library(
-    name = "util",
-    srcs = ["util.c"],
-    hdrs = ["util.h"],
-    visibility = [
-        "//c-toxcore/auto_tests:__pkg__",
-        "//c-toxcore/other:__pkg__",
-        "//c-toxcore/other/bootstrap_daemon:__pkg__",
-        "//c-toxcore/testing/fuzzing:__pkg__",
-        "//c-toxcore/toxav:__pkg__",
-    ],
-    deps = [
-        ":attributes",
-        ":ccompat",
-        ":crypto_core",
-        "@pthread",
-    ],
-)
-
-cc_library(
     name = "network",
     srcs = ["network.c"],
     hdrs = ["network.h"],
@@ -198,18 +209,6 @@ cc_test(
     srcs = ["network_test.cc"],
     deps = [
         ":network",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "util_test",
-    size = "small",
-    srcs = ["util_test.cc"],
-    deps = [
-        ":crypto_core",
-        ":util",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -61,7 +61,7 @@ static_assert(CRYPTO_SHA256_SIZE == crypto_hash_sha256_BYTES,
 static_assert(CRYPTO_SHA512_SIZE == crypto_hash_sha512_BYTES,
               "CRYPTO_SHA512_SIZE should be equal to crypto_hash_sha512_BYTES");
 static_assert(CRYPTO_PUBLIC_KEY_SIZE == 32,
-              "CRYPTO_PUBLIC_KEY_SIZE is required to be 32 bytes for public_key_eq to work");
+              "CRYPTO_PUBLIC_KEY_SIZE is required to be 32 bytes for pk_equal to work");
 
 #ifndef VANILLA_NACL
 static_assert(CRYPTO_SIGNATURE_SIZE == crypto_sign_BYTES,
@@ -88,6 +88,31 @@ bool create_extended_keypair(uint8_t *pk, uint8_t *sk)
 
     return res1 == 0 && res2 == 0;
 #endif
+}
+
+const uint8_t *get_enc_key(const uint8_t *key)
+{
+    return key;
+}
+
+const uint8_t *get_sig_pk(const uint8_t *key)
+{
+    return key + ENC_PUBLIC_KEY_SIZE;
+}
+
+void set_sig_pk(uint8_t *key, const uint8_t *sig_pk)
+{
+    memcpy(key + ENC_PUBLIC_KEY_SIZE, sig_pk, SIG_PUBLIC_KEY_SIZE);
+}
+
+const uint8_t *get_sig_sk(const uint8_t *key)
+{
+    return key + ENC_SECRET_KEY_SIZE;
+}
+
+const uint8_t *get_chat_id(const uint8_t *key)
+{
+    return key + ENC_PUBLIC_KEY_SIZE;
 }
 
 #if !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
@@ -151,7 +176,7 @@ bool crypto_memunlock(void *data, size_t length)
 #endif
 }
 
-bool public_key_eq(const uint8_t *pk1, const uint8_t *pk2)
+bool pk_equal(const uint8_t *pk1, const uint8_t *pk2)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     // Hope that this is better for the fuzzer
@@ -159,6 +184,11 @@ bool public_key_eq(const uint8_t *pk1, const uint8_t *pk2)
 #else
     return crypto_verify_32(pk1, pk2) == 0;
 #endif
+}
+
+void pk_copy(uint8_t *dest, const uint8_t *src)
+{
+    memcpy(dest, src, CRYPTO_PUBLIC_KEY_SIZE);
 }
 
 bool crypto_sha512_eq(const uint8_t *cksum1, const uint8_t *cksum2)

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -182,7 +182,13 @@ bool crypto_hmac_verify(const uint8_t auth[CRYPTO_HMAC_SIZE], const uint8_t key[
  * @retval false if they are not
  */
 non_null()
-bool public_key_eq(const uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE], const uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE]);
+bool pk_equal(const uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE], const uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE]);
+
+/**
+ * @brief Copy a public key from `src` to `dest`.
+ */
+non_null()
+void pk_copy(uint8_t dest[CRYPTO_PUBLIC_KEY_SIZE], const uint8_t src[CRYPTO_PUBLIC_KEY_SIZE]);
 
 /**
  * @brief Compare 2 SHA512 checksums of length CRYPTO_SHA512_SIZE, not vulnerable to
@@ -297,6 +303,13 @@ bool public_key_valid(const uint8_t *public_key);
  */
 non_null()
 bool create_extended_keypair(uint8_t *pk, uint8_t *sk);
+
+/** Functions for groupchat extended keys */
+non_null() const uint8_t *get_enc_key(const uint8_t *key);
+non_null() const uint8_t *get_sig_pk(const uint8_t *key);
+non_null() void set_sig_pk(uint8_t *key, const uint8_t *sig_pk);
+non_null() const uint8_t *get_sig_sk(const uint8_t *key);
+non_null() const uint8_t *get_chat_id(const uint8_t *key);
 
 /**
  * @brief Generate a new random keypair.

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -388,8 +388,8 @@ static void make_announce_payload_helper(const Onion_Announce *onion_a, const ui
         return;
     }
 
-    if (public_key_eq(onion_a->entries[index].public_key, packet_public_key)) {
-        if (!public_key_eq(onion_a->entries[index].data_public_key, data_public_key)) {
+    if (pk_equal(onion_a->entries[index].public_key, packet_public_key)) {
+        if (!pk_equal(onion_a->entries[index].data_public_key, data_public_key)) {
             response[0] = 0;
             memcpy(response + 1, ping_id, ONION_PING_ID_SIZE);
         } else {

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -18,46 +18,10 @@
 #include <time.h>
 
 #include "ccompat.h"
-#include "crypto_core.h" // for CRYPTO_PUBLIC_KEY_SIZE
 
 bool is_power_of_2(uint64_t x)
 {
     return x != 0 && (x & (~x + 1)) == x;
-}
-
-const uint8_t *get_enc_key(const uint8_t *key)
-{
-    return key;
-}
-
-const uint8_t *get_sig_pk(const uint8_t *key)
-{
-    return key + ENC_PUBLIC_KEY_SIZE;
-}
-
-void set_sig_pk(uint8_t *key, const uint8_t *sig_pk)
-{
-    memcpy(key + ENC_PUBLIC_KEY_SIZE, sig_pk, SIG_PUBLIC_KEY_SIZE);
-}
-
-const uint8_t *get_sig_sk(const uint8_t *key)
-{
-    return key + ENC_SECRET_KEY_SIZE;
-}
-
-const uint8_t *get_chat_id(const uint8_t *key)
-{
-    return key + ENC_PUBLIC_KEY_SIZE;
-}
-
-bool pk_equal(const uint8_t *dest, const uint8_t *src)
-{
-    return public_key_eq(dest, src);
-}
-
-void pk_copy(uint8_t *dest, const uint8_t *src)
-{
-    memcpy(dest, src, CRYPTO_PUBLIC_KEY_SIZE);
 }
 
 void free_uint8_t_pointer_array(uint8_t **ary, size_t n_items)

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -16,28 +16,12 @@
 #include <stdint.h>
 
 #include "attributes.h"
-#include "crypto_core.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 bool is_power_of_2(uint64_t x);
-
-/** Functions for groupchat extended keys */
-non_null() const uint8_t *get_enc_key(const uint8_t *key);
-non_null() const uint8_t *get_sig_pk(const uint8_t *key);
-non_null() void set_sig_pk(uint8_t *key, const uint8_t *sig_pk);
-non_null() const uint8_t *get_sig_sk(const uint8_t *key);
-non_null() const uint8_t *get_chat_id(const uint8_t *key);
-
-
-/** @brief Equality function for public keys. */
-non_null() bool pk_equal(const uint8_t *dest, const uint8_t *src);
-/**
- * @brief Copy a public key from `src` to `dest`.
- */
-non_null() void pk_copy(uint8_t *dest, const uint8_t *src);
 
 /** @brief Frees all pointers in a uint8_t pointer array, as well as the array itself. */
 nullable(1)


### PR DESCRIPTION
This makes more sense as a module for them to live in. Now, util no
longer depends on crypto_core and can thus potentially be used in
crypto_core in the future (functions like min/max may be useful).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2284)
<!-- Reviewable:end -->
