### PR TITLE
test: Don't abort fuzz test when tox_new fails.

### DIFF
--- a/testing/fuzzing/bootstrap_harness.cc
+++ b/testing/fuzzing/bootstrap_harness.cc
@@ -125,7 +125,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     Tox_Err_New error_new;
     Tox *tox = tox_new(opts, &error_new);
 
-    assert(tox != nullptr);
+    if (tox == nullptr) {
+        // It might fail, because some I/O happens in tox_new, and the fuzzer
+        // might do things that make that I/O fail.
+        return 0;
+    }
+
     assert(error_new == TOX_ERR_NEW_OK);
 
     tox_options_free(opts);


### PR DESCRIPTION
Right now, it can't fail, but later we want the fuzzer to randomly let
I/O functions fail, so we shouldn't assert that tox_new succeeded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2285)
<!-- Reviewable:end -->
