### PR TITLE
fix: Don't allow onion paths to be built from real friends.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-a12aa241a079e5f014a6689e48905a5a32c2fd455676cad431773908bda9245c  /usr/local/bin/tox-bootstrapd
+f20ba5a6917e5faee9a2a6439b448d3ced7cd177ba666ff1804882f494ea7b90  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -411,6 +411,9 @@ int get_close_nodes(const DHT *dht, const uint8_t *public_key, Node_format *node
 
 /** @brief Put up to max_num nodes in nodes from the random friends.
  *
+ * Important: this function relies on the first two DHT friends *not* being real
+ * friends to avoid leaking information about real friends into the onion paths.
+ *
  * @return the number of nodes.
  */
 non_null()


### PR DESCRIPTION
Revert "fix: Allow onion paths to be built from more random nodes."

This reverts commit 5073882e0f0ea114e4f0efe719a72ecf7b168926.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2287)
<!-- Reviewable:end -->
