### PR TITLE
Refactor: Extract shared key cache into separate file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,8 @@ set(toxcore_SOURCES
   toxcore/ping_array.h
   toxcore/ping.c
   toxcore/ping.h
+  toxcore/shared_key_cache.c
+  toxcore/shared_key_cache.h
   toxcore/state.c
   toxcore/state.h
   toxcore/TCP_client.c

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     - job_name: shared
 
 install:
-  - set PATH=C:\Python310-x64\Scripts;%PATH%
+  - set PATH=C:\Python311-x64\Scripts;%PATH%
   - py -3 -m pip install conan
   - git submodule update --init --recursive
 

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-b2bee729be40b0a0d8a4c6f0e2a527854d9a9d37712b73b915d7470bc91f5e6a  /usr/local/bin/tox-bootstrapd
+769233afaac07be03c094411e6ec8f031bde41beae475c74e154e51e51e9168b  /usr/local/bin/tox-bootstrapd

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -181,6 +181,24 @@ cc_test(
 )
 
 cc_library(
+    name = "shared_key_cache",
+    srcs = ["shared_key_cache.c"],
+    hdrs = ["shared_key_cache.h"],
+    visibility = [
+        "//c-toxcore/auto_tests:__pkg__",
+        "//c-toxcore/other:__pkg__",
+        "//c-toxcore/other/bootstrap_daemon:__pkg__",
+        "//c-toxcore/testing:__pkg__",
+        "//c-toxcore/toxav:__pkg__",
+    ],
+    deps = [
+        ":ccompat",
+        ":crypto_core",
+        ":mono_time",
+    ],
+)
+
+cc_library(
     name = "network",
     srcs = ["network.c"],
     hdrs = ["network.h"],
@@ -289,6 +307,7 @@ cc_library(
         ":mono_time",
         ":network",
         ":ping_array",
+        ":shared_key_cache",
         ":state",
         ":util",
     ],
@@ -326,6 +345,7 @@ cc_library(
         ":ccompat",
         ":crypto_core",
         ":mono_time",
+        ":shared_key_cache",
         ":util",
     ],
 )
@@ -366,6 +386,7 @@ cc_library(
         ":LAN_discovery",
         ":ccompat",
         ":forwarding",
+        ":shared_key_cache",
         ":timed_auth",
         ":util",
     ],
@@ -480,6 +501,7 @@ cc_library(
         ":ccompat",
         ":mono_time",
         ":onion",
+        ":shared_key_cache",
         ":timed_auth",
         ":util",
     ],

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -1899,7 +1899,7 @@ int dht_getfriendip(const DHT *dht, const uint8_t *public_key, IP_Port *ip_port)
     const DHT_Friend *const frnd = &dht->friends_list[friend_index];
     const uint32_t client_index = index_of_client_pk(frnd->client_list, MAX_FRIEND_CLIENTS, public_key);
 
-    if (client_index == -1) {
+    if (client_index == UINT32_MAX) {
         return 0;
     }
 

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -254,24 +254,6 @@ non_null(1, 4) nullable(3)
 int unpack_nodes(Node_format *nodes, uint16_t max_num_nodes, uint16_t *processed_data_len, const uint8_t *data,
                  uint16_t length, bool tcp_enabled);
 
-
-/*----------------------------------------------------------------------------------*/
-/* struct to store some shared keys so we don't have to regenerate them for each request. */
-#define MAX_KEYS_PER_SLOT 4
-#define KEYS_TIMEOUT 600
-
-typedef struct Shared_Key {
-    uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t shared_key[CRYPTO_SHARED_KEY_SIZE];
-    uint32_t times_requested;
-    bool stored;
-    uint64_t time_last_requested;
-} Shared_Key;
-
-typedef struct Shared_Keys {
-    Shared_Key keys[256 * MAX_KEYS_PER_SLOT];
-} Shared_Keys;
-
 /*----------------------------------------------------------------------------------*/
 
 typedef int cryptopacket_handler_cb(void *object, const IP_Port *ip_port, const uint8_t *source_pubkey,
@@ -296,30 +278,18 @@ non_null() const uint8_t *dht_get_friend_public_key(const DHT *dht, uint32_t fri
 /*----------------------------------------------------------------------------------*/
 
 /**
- * Shared key generations are costly, it is therefore smart to store commonly used
- * ones so that they can be re-used later without being computed again.
- *
- * If a shared key is already in shared_keys, copy it to shared_key.
- * Otherwise generate it into shared_key and copy it to shared_keys
- */
-non_null()
-void get_shared_key(
-    const Mono_Time *mono_time, Shared_Keys *shared_keys, uint8_t *shared_key,
-    const uint8_t *secret_key, const uint8_t *public_key);
-
-/**
  * Copy shared_key to encrypt/decrypt DHT packet from public_key into shared_key
  * for packets that we receive.
  */
 non_null()
-void dht_get_shared_key_recv(DHT *dht, uint8_t *shared_key, const uint8_t *public_key);
+const uint8_t *dht_get_shared_key_recv(DHT *dht, const uint8_t *public_key);
 
 /**
  * Copy shared_key to encrypt/decrypt DHT packet from public_key into shared_key
  * for packets that we send.
  */
 non_null()
-void dht_get_shared_key_sent(DHT *dht, uint8_t *shared_key, const uint8_t *public_key);
+const uint8_t *dht_get_shared_key_sent(DHT *dht, const uint8_t *public_key);
 
 /**
  * Sends a getnodes request to `ip_port` with the public key `public_key` for nodes

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -61,6 +61,8 @@ libtoxcore_la_SOURCES = ../third_party/cmp/cmp.c \
                         ../toxcore/Messenger.c \
                         ../toxcore/ping.h \
                         ../toxcore/ping.c \
+                        ../toxcore/shared_key_cache.h \
+                        ../toxcore/shared_key_cache.c \
                         ../toxcore/state.h \
                         ../toxcore/state.c \
                         ../toxcore/tox.h \

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -223,8 +223,8 @@ static int create_cookie_request(const Net_Crypto *c, uint8_t *packet, const uin
     memcpy(plain, c->self_public_key, CRYPTO_PUBLIC_KEY_SIZE);
     memcpy(plain + CRYPTO_PUBLIC_KEY_SIZE, padding, CRYPTO_PUBLIC_KEY_SIZE);
     memcpy(plain + (CRYPTO_PUBLIC_KEY_SIZE * 2), &number, sizeof(uint64_t));
-
-    dht_get_shared_key_sent(c->dht, shared_key, dht_public_key);
+    const uint8_t *tmp_shared_key = dht_get_shared_key_sent(c->dht, dht_public_key);
+    memcpy(shared_key, tmp_shared_key, CRYPTO_SHARED_KEY_SIZE);
     uint8_t nonce[CRYPTO_NONCE_SIZE];
     random_nonce(c->rng, nonce);
     packet[0] = NET_PACKET_COOKIE_REQUEST;
@@ -341,7 +341,8 @@ static int handle_cookie_request(const Net_Crypto *c, uint8_t *request_plain, ui
     }
 
     memcpy(dht_public_key, packet + 1, CRYPTO_PUBLIC_KEY_SIZE);
-    dht_get_shared_key_sent(c->dht, shared_key, dht_public_key);
+    const uint8_t *tmp_shared_key = dht_get_shared_key_sent(c->dht, dht_public_key);
+    memcpy(shared_key, tmp_shared_key, CRYPTO_SHARED_KEY_SIZE);
     const int len = decrypt_data_symmetric(shared_key, packet + 1 + CRYPTO_PUBLIC_KEY_SIZE,
                                            packet + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE, COOKIE_REQUEST_PLAIN_LENGTH + CRYPTO_MAC_SIZE,
                                            request_plain);

--- a/toxcore/onion.h
+++ b/toxcore/onion.h
@@ -12,6 +12,7 @@
 #include "DHT.h"
 #include "logger.h"
 #include "mono_time.h"
+#include "shared_key_cache.h"
 
 typedef int onion_recv_1_cb(void *object, const IP_Port *dest, const uint8_t *data, uint16_t length);
 
@@ -24,9 +25,9 @@ typedef struct Onion {
     uint8_t secret_symmetric_key[CRYPTO_SYMMETRIC_KEY_SIZE];
     uint64_t timestamp;
 
-    Shared_Keys shared_keys_1;
-    Shared_Keys shared_keys_2;
-    Shared_Keys shared_keys_3;
+    Shared_Key_Cache *shared_keys_1;
+    Shared_Key_Cache *shared_keys_2;
+    Shared_Key_Cache *shared_keys_3;
 
     onion_recv_1_cb *recv_1_function;
     void *callback_object;

--- a/toxcore/shared_key_cache.c
+++ b/toxcore/shared_key_cache.c
@@ -1,0 +1,161 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022 The TokTok team.
+ */
+
+#include "shared_key_cache.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>     // calloc(...)
+#include <string.h>     // memcpy(...)
+
+#include "ccompat.h"
+#include "crypto_core.h"
+#include "mono_time.h"
+
+typedef struct Shared_Key {
+    uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE];
+    uint8_t shared_key[CRYPTO_SHARED_KEY_SIZE];
+    uint64_t time_last_requested;
+} Shared_Key;
+
+struct Shared_Key_Cache {
+    Shared_Key *keys;
+    const uint8_t* self_secret_key;
+    uint64_t timeout; /** After this time (in seconds), a key is erased on the next housekeeping cycle */
+    const Mono_Time *time;
+    uint8_t keys_per_slot;
+};
+
+non_null()
+static bool shared_key_is_empty(const Shared_Key *k) {
+    assert(k != nullptr);
+    /*
+     * Since time can never be 0, we use that to determine if a key slot is empty.
+     * Additionally this allows us to use crypto_memzero and leave the slot in a valid state.
+     */
+    return k->time_last_requested == 0;
+}
+
+non_null()
+static void shared_key_set_empty(Shared_Key *k) {
+    crypto_memzero(k, sizeof (Shared_Key));
+    assert(shared_key_is_empty(k));
+}
+
+Shared_Key_Cache *shared_key_cache_new(const Mono_Time *time, const uint8_t *self_secret_key, uint64_t timeout, uint8_t keys_per_slot)
+{
+    if (time == nullptr || self_secret_key == nullptr || timeout == 0 || keys_per_slot == 0) {
+        return nullptr;
+    }
+
+    // Time must not be zero, since we use that as special value for empty slots
+    if (mono_time_get(time) == 0) {
+        // Fail loudly in debug environments
+        assert(false);
+        return nullptr;
+    }
+
+    Shared_Key_Cache *res = (Shared_Key_Cache *)calloc(1, sizeof (Shared_Key_Cache));
+    if (res == nullptr) {
+        return nullptr;
+    }
+
+    res->self_secret_key = self_secret_key;
+    res->time = time;
+    res->keys_per_slot = keys_per_slot;
+    // We take one byte from the public key for each bucket and store keys_per_slot elements there
+    const size_t cache_size = 256 * keys_per_slot;
+    res->keys = (Shared_Key *)calloc(cache_size, sizeof (Shared_Key));
+
+    if (res->keys == nullptr) {
+        free(res);
+        return nullptr;
+    }
+
+    crypto_memlock(res->keys, cache_size * sizeof (Shared_Key));
+
+    return res;
+}
+
+void shared_key_cache_free(Shared_Key_Cache *cache)
+{
+    if (cache == nullptr) {
+        return;
+    }
+
+    const size_t cache_size = 256 * cache->keys_per_slot;
+    // Don't leave key material in memory
+    crypto_memzero(cache->keys, cache_size * sizeof (Shared_Key));
+    crypto_memunlock(cache->keys, cache_size * sizeof (Shared_Key));
+    free(cache->keys);
+    free(cache);
+}
+
+/* NOTE: On each lookup housekeeping is performed to evict keys that did timeout. */
+const uint8_t *shared_key_cache_lookup(Shared_Key_Cache *cache, const uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE])
+{
+    // caching the time is not necessary, but calls to mono_time_get(...) are not free
+    const uint64_t cur_time = mono_time_get(cache->time);
+    // We can't use the first and last bytes because they are masked in curve25519. Selected 8 for good alignment.
+    const uint8_t bucket_idx = public_key[8];
+    Shared_Key* bucket_start = &cache->keys[bucket_idx*cache->keys_per_slot];
+
+    const uint8_t* found = nullptr;
+
+    // Perform lookup
+    for(size_t i = 0; i < cache->keys_per_slot; ++i) {
+        if (shared_key_is_empty(&bucket_start[i])) {
+            continue;
+        }
+
+        if (pk_equal(public_key, bucket_start[i].public_key)) {
+            found = bucket_start[i].shared_key;
+            bucket_start[i].time_last_requested = cur_time;
+            break;
+        }
+    }
+
+    // Perform housekeeping for this bucket
+    for (size_t i = 0; i < cache->keys_per_slot; ++i) {
+        if (shared_key_is_empty(&bucket_start[i])) {
+            continue;
+        }
+
+        const bool timed_out = (bucket_start[i].time_last_requested + cache->timeout) < cur_time;
+        if (timed_out) {
+            shared_key_set_empty(&bucket_start[i]);
+        }
+    }
+
+    if (found == nullptr) {
+        // Insert into cache
+
+        uint64_t oldest_timestamp = UINT64_MAX;
+        size_t oldest_index = 0;
+
+        /*
+         *  Find least recently used entry, unused entries are prioritised,
+         *  because their time_last_requested field is zeroed.
+         */
+        for (size_t i = 0; i < cache->keys_per_slot; ++i) {
+            if (bucket_start[i].time_last_requested < oldest_timestamp) {
+                oldest_timestamp = bucket_start[i].time_last_requested;
+                oldest_index = i;
+            }
+        }
+
+        // Compute the shared key for the cache
+        if (encrypt_precompute(public_key, cache->self_secret_key, bucket_start[oldest_index].shared_key) != 0) {
+            // Don't put anything in the cache on error
+            return nullptr;
+        }
+
+        // update cache entry
+        memcpy(bucket_start[oldest_index].public_key, public_key, CRYPTO_PUBLIC_KEY_SIZE);
+        bucket_start[oldest_index].time_last_requested = cur_time;
+        found = bucket_start[oldest_index].shared_key;
+    }
+
+    return found;
+}

--- a/toxcore/shared_key_cache.h
+++ b/toxcore/shared_key_cache.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022 The TokTok team.
+ */
+
+#ifndef C_TOXCORE_TOXCORE_SHARED_KEY_CACHE_H
+#define C_TOXCORE_TOXCORE_SHARED_KEY_CACHE_H
+
+#include <stdint.h>     // uint*_t
+
+#include "crypto_core.h"
+#include "mono_time.h"
+
+/**
+ * This implements a cache for shared keys, since key generation is expensive.
+ */
+
+typedef struct Shared_Key_Cache Shared_Key_Cache;
+
+/**
+ * @brief Initializes a new shared key cache.
+ * @param time Time object for retrieving current time.
+ * @param self_secret_key Our own secret key of length CRYPTO_SECRET_KEY_SIZE,
+ * it must not change during the lifetime of the cache.
+ * @param timeout Number of milliseconds, after which a key should be evicted.
+ * @param keys_per_slot There are 256 slots, this controls how many keys are stored per slot and the size of the cache.
+ * @return nullptr on error.
+ */
+non_null()
+Shared_Key_Cache *shared_key_cache_new(const Mono_Time *time,
+                                       const uint8_t *self_secret_key,
+                                       uint64_t timeout, uint8_t keys_per_slot);
+
+/**
+ * @brief Deletes the cache and frees all resources.
+ * @param cache Cache to delete or nullptr.
+ */
+nullable(1)
+void shared_key_cache_free(Shared_Key_Cache *cache);
+
+/**
+ * @brief Looks up a key from the cache or computes it if it didn't exist yet.
+ * @param cache Cache to perform the lookup on.
+ * @param public_key Public key, used for the lookup and computation.
+ *
+ * @return The shared key of length CRYPTO_SHARED_KEY_SIZE, matching the public key and our secret key.
+ * @return nullptr on error.
+ */
+non_null()
+const uint8_t* shared_key_cache_lookup(Shared_Key_Cache *cache, const uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE]);
+
+#endif // C_TOXCORE_TOXCORE_SHARED_KEY_CACHE_H


### PR DESCRIPTION
This removes the old and badly documented/designed shared key cache from DHT.c and moves the implemenation to a separate file. This makes it more testable and allows a better overview of how many caches exist (currently 7, total ~0,5MB). Additionally I think this fixes several missed `crypto_memzero` calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2317)
<!-- Reviewable:end -->
