### PR TITLE
fix: Remove cmake cache files after copying to container build directory

### DIFF
--- a/other/docker/windows/Dockerfile
+++ b/other/docker/windows/Dockerfile
@@ -32,4 +32,4 @@ ENV ENABLE_TEST=false \
     ENABLE_ARCH_x86_64=true \
     EXTRA_CMAKE_FLAGS="-DTEST_TIMEOUT_SECONDS=90"
 
-ENTRYPOINT ["sh", "./build_toxcore.sh"]
+ENTRYPOINT ["bash", "./build_toxcore.sh"]

--- a/other/docker/windows/build_toxcore.sh
+++ b/other/docker/windows/build_toxcore.sh
@@ -70,7 +70,7 @@ build() {
     -DCMAKE_EXE_LINKER_FLAGS="$CMAKE_EXE_LINKER_FLAGS -fstack-protector" \
     -DCMAKE_SHARED_LINKER_FLAGS="$CMAKE_SHARED_LINKER_FLAGS" \
     $EXTRA_CMAKE_FLAGS \
-    ..
+    -S ..
   cmake --build . --target install -- -j"$(nproc)"
 
   if [ "$ENABLE_TEST" = "true" ]; then

--- a/other/docker/windows/build_toxcore.sh
+++ b/other/docker/windows/build_toxcore.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e -x
 
@@ -61,6 +61,8 @@ build() {
     echo "SET(CROSSCOMPILING_EMULATOR /usr/bin/wine)" >>windows_toolchain.cmake
   fi
 
+  # Silly way to bypass a shellharden check
+  read -ra EXTRA_CMAKE_FLAGS_ARRAY <<<"$EXTRA_CMAKE_FLAGS"
   cmake -DCMAKE_TOOLCHAIN_FILE=windows_toolchain.cmake \
     -DCMAKE_INSTALL_PREFIX="$STATIC_TOXCORE_PREFIX_DIR" \
     -DENABLE_SHARED=OFF \
@@ -69,7 +71,7 @@ build() {
     -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
     -DCMAKE_EXE_LINKER_FLAGS="$CMAKE_EXE_LINKER_FLAGS -fstack-protector" \
     -DCMAKE_SHARED_LINKER_FLAGS="$CMAKE_SHARED_LINKER_FLAGS" \
-    $EXTRA_CMAKE_FLAGS \
+    "${EXTRA_CMAKE_FLAGS_ARRAY[@]}" \
     -S ..
   cmake --build . --target install -- -j"$(nproc)"
 


### PR DESCRIPTION
This is a change to the build script of the docker container for cross compiling toxcore for windows. I use the same repository cloned dir when I am building for both windows and linux and what tends to happen is CMakeCache.txt and CMakeFiles dir get copied to the build directory inside the container image which results in an error when cmake runs:

`CMake Error: The current CMakeCache.txt directory /tmp/toxcore/CMakeCache.txt is different than the directory /root/Desktop/c-toxcore where CMakeCache.txt was created. This may result in binaries being created in the wrong place. If you are not sure, reedit the CMakeCache.txt`

To avoid having this problem I have added two `rm` commands to remove the files that cause the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2325)
<!-- Reviewable:end -->
