### PR TITLE
fix: bug causing friend group invites to sometimes fail & improve logging

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-e94176c6c2aa1f2bdb1e17cedd2e0df91a88c6897b89a5447ca587ec99edbfad  /usr/local/bin/tox-bootstrapd
+895a21873dc8c2e99fd42358c7bd133503d1b9071284b0c38fccbde045f6924b  /usr/local/bin/tox-bootstrapd


### PR DESCRIPTION
The group privacy status was incorrectly set to private when a peer accepted a friend's group invite, which would cause handshake requests to fail in certain scenarios

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2338)
<!-- Reviewable:end -->
