### PR TITLE
fix: #1144 by forcing misc_tools to be a static lib

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(misc_tools_SOURCES
   misc_tools.c
   misc_tools.h)
-add_library(misc_tools ${misc_tools_SOURCES})
+add_library(misc_tools STATIC ${misc_tools_SOURCES})
 target_link_modules(misc_tools toxcore)
 
 ################################################################################


### PR DESCRIPTION
not sure if this works as intended, but i saw a [.patch](https://src.fedoraproject.org/rpms/toxcore/blob/rawhide/f/toxcore-0.2.12-install_libmisc.patch) file in the fedora pkg source and was displeased.
an alternative would be to use a cmake OBJECT library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2341)
<!-- Reviewable:end -->
