### PR TITLE
refactor: Make some improvements to how often/when we announce a group

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-cbd8bea9d23a961f27aacd35c4509fc1c22d72356f61d1ec74cc469b6b14490d  /usr/local/bin/tox-bootstrapd
+5cf49ad258527f6a2734a9d1f863084f66189338f47ca9d0a49482b4217577fb  /usr/local/bin/tox-bootstrapd

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2573,6 +2573,13 @@ static bool self_announce_group(const Messenger *m, GC_Chat *chat, Onion_Friend 
 
     onion_friend_set_gc_data(onion_friend, gc_data, (uint16_t)length);
     chat->update_self_announces = false;
+    chat->last_time_self_announce = mono_time_get(chat->mono_time);
+
+    if (tcp_num > 0) {
+        pk_copy(chat->announced_tcp_relay_pk, announce.base_announce.tcp_relays[0].public_key);
+    } else {
+        memset(chat->announced_tcp_relay_pk, 0, sizeof(chat->announced_tcp_relay_pk));
+    }
 
     LOGGER_DEBUG(chat->log, "Published group announce. TCP relays: %d, UDP status: %d", tcp_num,
                  chat->self_udp_status);

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -277,7 +277,6 @@ static TCP_con *get_tcp_connection(const TCP_Connections *tcp_c, int tcp_connect
     return &tcp_c->tcp_connections[tcp_connections_number];
 }
 
-/** Returns the number of connected TCP relays */
 uint32_t tcp_connected_relays_count(const TCP_Connections *tcp_c)
 {
     uint32_t count = 0;
@@ -633,6 +632,11 @@ static int find_tcp_connection_relay(const TCP_Connections *tcp_c, const uint8_t
     }
 
     return -1;
+}
+
+bool tcp_relay_is_valid(const TCP_Connections *tcp_c, const uint8_t *relay_pk)
+{
+    return find_tcp_connection_relay(tcp_c, relay_pk) != -1;
 }
 
 /** @brief Create a new TCP connection to public_key.

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -78,9 +78,13 @@ const uint8_t *tcp_connections_public_key(const TCP_Connections *tcp_c);
 non_null()
 uint32_t tcp_connections_count(const TCP_Connections *tcp_c);
 
-/** Returns the number of connected TCP relays */
+/** @brief Returns the number of connected TCP relays. */
 non_null()
 uint32_t tcp_connected_relays_count(const TCP_Connections *tcp_c);
+
+/** @brief Returns true if we know of a valid TCP relay with the passed public key. */
+non_null()
+bool tcp_relay_is_valid(const TCP_Connections *tcp_c, const uint8_t *relay_pk);
 
 /** @brief Send a packet to the TCP connection.
  *

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -242,8 +242,7 @@ void gc_get_topic(const GC_Chat *chat, uint8_t *topic);
 
 /** @brief Returns the topic length.
  *
- * The return value is equal to the `length` agument received by the last topic
- * callback.
+ * The return value is equal to the `length` agument received by the last topic callback.
  */
 non_null()
 uint16_t gc_get_topic_size(const GC_Chat *chat);

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -249,13 +249,13 @@ typedef struct GC_Chat {
     const Logger    *log;
     const Random    *rng;
 
+    uint32_t        connected_tcp_relays;
     Self_UDP_Status self_udp_status;
     IP_Port         self_ip_port;
 
     Networking_Core *net;
     TCP_Connections *tcp_conn;
 
-    uint32_t        tcp_connections; // the number of global TCP relays we're connected to
     uint64_t        last_checked_tcp_relays;
     Group_Handshake_Join_Type join_type;
 
@@ -312,6 +312,8 @@ typedef struct GC_Chat {
 
     bool        update_self_announces;  // true if we should try to update our announcements
     uint64_t    last_self_announce_check;  // the last time we checked if we should update our announcements
+    uint64_t    last_time_self_announce;  // the last time we announced the group
+    uint8_t     announced_tcp_relay_pk[CRYPTO_PUBLIC_KEY_SIZE];  // The pk of the last TCP relay we announced
 
     uint8_t     m_group_public_key[CRYPTO_PUBLIC_KEY_SIZE];  // public key for group's messenger friend connection
     int         friend_connection_id;  // identifier for group's messenger friend connection


### PR DESCRIPTION
Instead of announcing a group whenever our connection status changes, including when we gain or lose a TCP relay connection, we now only announce when our UDP status changes, or if our previously announced TCP relay has gone offline. We also refresh our announcement every 20 minutes regardless of any connection changes (this is to rotate the TCP relay in case the chosen one is somehow broken).

This change should vastly reduce the amount of unnecessary DHT traffic related to group announcements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2348)
<!-- Reviewable:end -->
