### PR TITLE
fix: DHTBootstrap should always respond to version packets with toxcore version

### DIFF
--- a/other/BUILD.bazel
+++ b/other/BUILD.bazel
@@ -16,6 +16,7 @@ cc_binary(
     testonly = 1,
     srcs = ["DHT_bootstrap.c"],
     deps = [
+        ":bootstrap_node_packets",
         "//c-toxcore/testing:misc_tools",
         "//c-toxcore/toxcore:DHT",
         "//c-toxcore/toxcore:LAN_discovery",

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -31,11 +31,16 @@
 
 #include "../testing/misc_tools.h"
 
+#define DHT_NODE_EXTRA_PACKETS
+
 #ifdef DHT_NODE_EXTRA_PACKETS
 #include "./bootstrap_node_packets.h"
 
-#define DHT_VERSION_NUMBER 1
-#define DHT_MOTD "This is a test motd"
+#ifndef DAEMON_VERSION_NUMBER
+#define DAEMON_VERSION_NUMBER (1000000000UL + TOX_VERSION_MAJOR*1000000UL + TOX_VERSION_MINOR*1000UL + TOX_VERSION_PATCH*1UL)
+#endif
+
+static const char *motd_str = ""; //Change this to anything within 256 bytes(but 96 bytes maximum prefered)
 #endif
 
 #define PORT 33445
@@ -152,7 +157,7 @@ int main(int argc, char *argv[])
     Onion_Announce *onion_a = new_onion_announce(logger, mem, rng, mono_time, dht);
 
 #ifdef DHT_NODE_EXTRA_PACKETS
-    bootstrap_set_callbacks(dht_get_net(dht), DHT_VERSION_NUMBER, DHT_MOTD, sizeof(DHT_MOTD));
+    bootstrap_set_callbacks(dht_get_net(dht), (uint32_t)DAEMON_VERSION_NUMBER, (const uint8_t *) motd_str, strlen(motd_str)+1);
 #endif
 
     if (!(onion && forwarding && onion_a)) {


### PR DESCRIPTION
The current implementation does not allow responding to bootstrap node packets which results in some of the nodes in nodes.tox.chat to not have a version. This also means that we do not know which of those nodes are actually up-to-date and which are not, making things complicated when it comes to contacting the server owners.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2354)
<!-- Reviewable:end -->
