### PR TITLE
feat: get the number of close dht nodes with announce/store support

### DIFF
--- a/auto_tests/dht_getnodes_api_test.c
+++ b/auto_tests/dht_getnodes_api_test.c
@@ -122,6 +122,12 @@ static void test_dht_getnodes(AutoTox *autotoxes)
 
         tox_self_get_dht_id(autotoxes[i].tox, public_key_list[i]);
         tox_callback_dht_get_nodes_response(autotoxes[i].tox, getnodes_response_cb);
+
+        printf("Peer %zu dht closenode count total/annouce-capable: %d/%d\n",
+            i,
+            tox_dht_get_num_closelist(autotoxes[i].tox),
+            tox_dht_get_num_closelist_announce_capable(autotoxes[i].tox)
+        );
     }
 
     while (!all_nodes_crawled(autotoxes, NUM_TOXES, public_key_list)) {

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-c71f87c6ff30393d748bbdc118248eff90a4874cfa015b3113534f2333154555  /usr/local/bin/tox-bootstrapd
+9bec65f2a3093ebb49c3751dfad267482bc80d4b29ef9171f11d5ba53058d713  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2965,6 +2965,34 @@ bool dht_non_lan_connected(const DHT *dht)
     return false;
 }
 
+uint16_t dht_get_num_closelist(const DHT *dht) {
+    uint16_t num_valid_close_clients = 0;
+    for (uint32_t i = 0; i < LCLIENT_LIST; ++i) {
+        const Client_data *const client = dht_get_close_client(dht, i);
+
+        // check if client is valid
+        if (!(assoc_timeout(dht->cur_time, &client->assoc4) && assoc_timeout(dht->cur_time, &client->assoc6))) {
+            ++num_valid_close_clients;
+        }
+    }
+
+    return num_valid_close_clients;
+}
+
+uint16_t dht_get_num_closelist_announce_capable(const DHT *dht) {
+    uint16_t num_valid_close_clients_with_cap = 0;
+    for (uint32_t i = 0; i < LCLIENT_LIST; ++i) {
+        const Client_data *const client = dht_get_close_client(dht, i);
+
+        // check if client is valid
+        if (!(assoc_timeout(dht->cur_time, &client->assoc4) && assoc_timeout(dht->cur_time, &client->assoc6)) && client->announce_node) {
+            ++num_valid_close_clients_with_cap;
+        }
+    }
+
+    return num_valid_close_clients_with_cap;
+}
+
 unsigned int ipport_self_copy(const DHT *dht, IP_Port *dest)
 {
     ipport_reset(dest);

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -515,6 +515,24 @@ bool dht_isconnected(const DHT *dht);
 non_null()
 bool dht_non_lan_connected(const DHT *dht);
 
+/**
+ * This function returns the ratio of close dht nodes that are known to support announce/store.
+ * This function returns the number of DHT nodes in the closelist.
+ *
+ * @return number
+ */
+non_null()
+uint16_t dht_get_num_closelist(const DHT *dht);
+
+/**
+ * This function returns the number of DHT nodes in the closelist,
+ * that are capable to store annouce data (introduced in version 0.2.18).
+ *
+ * @return number
+ */
+non_null()
+uint16_t dht_get_num_closelist_announce_capable(const DHT *dht);
+
 /** @brief Attempt to add client with ip_port and public_key to the friends client list
  * and close_clientlist.
  *

--- a/toxcore/tox_private.c
+++ b/toxcore/tox_private.c
@@ -149,3 +149,20 @@ bool tox_dht_get_nodes(const Tox *tox, const uint8_t *public_key, const char *ip
 
     return true;
 }
+
+uint16_t tox_dht_get_num_closelist(const Tox *tox) {
+    tox_lock(tox);
+    const uint16_t num_total = dht_get_num_closelist(tox->m->dht);
+    tox_unlock(tox);
+
+    return num_total;
+}
+
+uint16_t tox_dht_get_num_closelist_announce_capable(const Tox *tox){
+    tox_lock(tox);
+    const uint16_t num_cap = dht_get_num_closelist_announce_capable(tox->m->dht);
+    tox_unlock(tox);
+
+    return num_cap;
+}
+

--- a/toxcore/tox_private.h
+++ b/toxcore/tox_private.h
@@ -140,6 +140,22 @@ typedef enum Tox_Err_Dht_Get_Nodes {
 bool tox_dht_get_nodes(const Tox *tox, const uint8_t *public_key, const char *ip, uint16_t port,
                        const uint8_t *target_public_key, Tox_Err_Dht_Get_Nodes *error);
 
+/**
+ * This function returns the ratio of close dht nodes that are known to support announce/store.
+ * This function returns the number of DHT nodes in the closelist.
+ *
+ * @return number
+ */
+uint16_t tox_dht_get_num_closelist(const Tox *tox);
+
+/**
+ * This function returns the number of DHT nodes in the closelist,
+ * that are capable to store annouce data (introduced in version 0.2.18).
+ *
+ * @return number
+ */
+uint16_t tox_dht_get_num_closelist_announce_capable(const Tox *tox);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
number of total and how many >= 0.2.18 peers you are connected with.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2357)
<!-- Reviewable:end -->
