### PR TITLE
fix: resolve_bootstrap_node() not checking net_getipport() returned count correctly

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-1fadb7de1ccf46186e33c13343e2c67f4c84e78fadfbfbbc8f3ce70e670907f2  /usr/local/bin/tox-bootstrapd
+3d28c914487efaae4336af17b221049c73249fb917d672f5ae6d9c092522a24f  /usr/local/bin/tox-bootstrapd

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -544,8 +544,9 @@ bool net_connect(const Logger *log, Socket sock, const IP_Port *ip_port);
  * Skip all addresses with socktype != type (use type = -1 to get all addresses)
  * To correctly deallocate array memory use `net_freeipport()`
  *
- * return number of elements in res array
- * and -1 on error.
+ * @return number of elements in res array.
+ * @retval 0 if res array empty.
+ * @retval -1 on error.
  */
 non_null()
 int32_t net_getipport(const char *node, IP_Port **res, int tox_type);

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1008,7 +1008,7 @@ static int32_t resolve_bootstrap_node(Tox *tox, const char *host, uint16_t port,
 
     const int32_t count = net_getipport(host, root, TOX_SOCK_DGRAM);
 
-    if (count == -1) {
+    if (count < 1) {
         LOGGER_DEBUG(tox->m->log, "could not resolve bootstrap node '%s'", host);
         net_freeipport(*root);
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_BAD_HOST);


### PR DESCRIPTION
fixes #2358 

potential security issue, if the DNS server can cause this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2361)
<!-- Reviewable:end -->
