### PR TITLE
fix: flaky tcp test

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -525,8 +525,9 @@ static void test_client(void)
     ip_port_tcp_s.ip = get_loopback();
 
     TCP_Client_Connection *conn = new_tcp_connection(logger, mem, mono_time, rng, ns, &ip_port_tcp_s, self_public_key, f_public_key, f_secret_key, nullptr);
-    do_tcp_connection(logger, mono_time, conn, nullptr);
+    // TCP sockets might need a moment before they can be written to.
     c_sleep(50);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
 
     // The connection status should be unconfirmed here because we have finished
     // sending our data and are awaiting a response.
@@ -560,6 +561,7 @@ static void test_client(void)
     ip_port_tcp_s.port = net_htons(ports[random_u32(rng) % NUM_PORTS]);
     TCP_Client_Connection *conn2 = new_tcp_connection(logger, mem, mono_time, rng, ns, &ip_port_tcp_s, self_public_key, f2_public_key,
                                    f2_secret_key, nullptr);
+    c_sleep(50);
 
     // The client should call this function (defined earlier) during the routing process.
     routing_response_handler(conn, response_callback, (char *)conn + 2);


### PR DESCRIPTION
UPDATE: I am not pretty sure that the fail occurs when the creation of tcp sockets takes a while, because other processes need to run first. In my case its the firewall (eg `opensnitch`) which needs to check and allow the connection first.

Adding a sleep of 50ms after every tcp connection creation fixes the test case, but it might still point to real error, because waiting longer after the actions and before the asserts does not make it recover.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2369)
<!-- Reviewable:end -->
