### PR TITLE
fix: behaviour of group api function

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-3d28c914487efaae4336af17b221049c73249fb917d672f5ae6d9c092522a24f  /usr/local/bin/tox-bootstrapd
+b0fafb30bffe21889f06a95edd3867f29a2203d30c2d7e7bf3ef646267f08d64  /usr/local/bin/tox-bootstrapd

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -3050,7 +3050,7 @@ bool tox_group_is_connected(const Tox *tox, uint32_t group_number, Tox_Err_Group
 
     SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_IS_CONNECTED_OK);
 
-    const bool ret = chat->connection_state == CS_CONNECTED;
+    const bool ret = chat->connection_state == CS_CONNECTED || chat->connection_state == CS_CONNECTING;
     tox_unlock(tox);
 
     return ret;


### PR DESCRIPTION
The function that tells us if we're connected to a group now behaves according to the documentation and returns true if we're attempting to connect to a group, rather than only returning true if we've connected with other peers.

The original purpose of this function was to inform us if we've manually disconnected from a group. In all other instances, we are effectively "connected" in the sense that we're actively searching for the group in the DHT, if not outright connected to other peers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/c-toxcore/2370)
<!-- Reviewable:end -->
