### PR TITLE
fix: incorrect documentation

### DIFF
--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -3973,8 +3973,8 @@ Tox_Connection tox_group_peer_get_connection_status(const Tox *tox, uint32_t gro
 /**
  * Write the group public key with the designated peer_id for the designated group number to public_key.
  *
- * This key will be permanently tied to a particular peer until they explicitly leave the group or
- * get kicked, and is the only way to reliably identify the same peer across client restarts.
+ * This key will be permanently tied to a particular peer until they explicitly leave the group and is
+ * the only way to reliably identify the same peer across client restarts.
  *
  * `public_key` should have room for at least TOX_GROUP_PEER_PUBLIC_KEY_SIZE bytes. If `public_key` is null
  * this function has no effect.


### PR DESCRIPTION
This used to be the case but is no longer.