### PR TITLE
fix: add missing ngc constants getter declarations and definitions

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-57f46dbb45034232c62e29ad31fd433ad298591fd9d3ea06b92040d33b8d8660  /usr/local/bin/tox-bootstrapd
+93c9c4ba12e450afd01aabd31ae1da970c841e13984b68969d183b11e6266e1a  /usr/local/bin/tox-bootstrapd

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -3303,15 +3303,21 @@ uint32_t tox_group_max_part_length(void);
  */
 #define TOX_GROUP_MAX_MESSAGE_LENGTH    1372
 
+uint32_t tox_group_max_message_length(void);
+
 /**
  * Maximum length of a group custom lossy packet.
  */
 #define TOX_GROUP_MAX_CUSTOM_LOSSY_PACKET_LENGTH 500
 
+uint32_t tox_group_max_custom_lossy_packet_length(void);
+
 /**
  * Maximum length of a group custom lossless packet.
  */
 #define TOX_GROUP_MAX_CUSTOM_LOSSLESS_PACKET_LENGTH 1373
+
+uint32_t tox_group_max_custom_lossless_packet_length(void);
 
 /**
  * Maximum length of a group name.

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -88,6 +88,42 @@ uint32_t tox_max_hostname_length(void)
 {
     return TOX_MAX_HOSTNAME_LENGTH;
 }
+uint32_t tox_group_max_topic_length(void)
+{
+    return TOX_GROUP_MAX_TOPIC_LENGTH;
+}
+uint32_t tox_group_max_part_length(void)
+{
+    return TOX_GROUP_MAX_PART_LENGTH;
+}
+uint32_t tox_group_max_message_length(void)
+{
+    return TOX_GROUP_MAX_MESSAGE_LENGTH;
+}
+uint32_t tox_group_max_custom_lossy_packet_length(void)
+{
+    return TOX_GROUP_MAX_CUSTOM_LOSSY_PACKET_LENGTH;
+}
+uint32_t tox_group_max_custom_lossless_packet_length(void)
+{
+    return TOX_GROUP_MAX_CUSTOM_LOSSLESS_PACKET_LENGTH;
+}
+uint32_t tox_group_max_group_name_length(void)
+{
+    return TOX_GROUP_MAX_GROUP_NAME_LENGTH;
+}
+uint32_t tox_group_max_password_size(void)
+{
+    return TOX_GROUP_MAX_PASSWORD_SIZE;
+}
+uint32_t tox_group_chat_id_size(void)
+{
+    return TOX_GROUP_CHAT_ID_SIZE;
+}
+uint32_t tox_group_peer_public_key_size(void)
+{
+    return TOX_GROUP_PEER_PUBLIC_KEY_SIZE;
+}
 uint32_t tox_dht_node_ip_string_size(void)
 {
     return TOX_DHT_NODE_IP_STRING_SIZE;

--- a/toxcore/tox_test.cc
+++ b/toxcore/tox_test.cc
@@ -48,6 +48,15 @@ TEST(Tox, ConstantsAreNonZero)
     EXPECT_GT(tox_file_id_length(), 0);
     EXPECT_GT(tox_max_filename_length(), 0);
     EXPECT_GT(tox_max_hostname_length(), 0);
+    EXPECT_GT(tox_group_max_topic_length(), 0);
+    EXPECT_GT(tox_group_max_part_length(), 0);
+    EXPECT_GT(tox_group_max_message_length(), 0);
+    EXPECT_GT(tox_group_max_custom_lossy_packet_length(), 0);
+    EXPECT_GT(tox_group_max_custom_lossless_packet_length(), 0);
+    EXPECT_GT(tox_group_max_group_name_length(), 0);
+    EXPECT_GT(tox_group_max_password_size(), 0);
+    EXPECT_GT(tox_group_chat_id_size(), 0);
+    EXPECT_GT(tox_group_peer_public_key_size(), 0);
     EXPECT_GT(tox_dht_node_ip_string_size(), 0);
     EXPECT_GT(tox_dht_node_public_key_size(), 0);
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2383)
<!-- Reviewable:end -->
