### PR TITLE
chore: Fix the Android CI job

### DIFF
--- a/.github/scripts/cmake-android
+++ b/.github/scripts/cmake-android
@@ -10,7 +10,7 @@ ABI=${1:-"armeabi-v7a"}
 case $ABI in
   armeabi-v7a)
     TARGET=armv7a-linux-androideabi
-    NDK_API=16
+    NDK_API=19
     ;;
   arm64-v8a)
     TARGET=aarch64-linux-android
@@ -18,7 +18,7 @@ case $ABI in
     ;;
   x86)
     TARGET=i686-linux-android
-    NDK_API=16
+    NDK_API=19
     ;;
   x86_64)
     TARGET=x86_64-linux-android
@@ -47,7 +47,7 @@ fi
 cd libsodium
 git clean -ffdx
 autoreconf -fi
-./configure --prefix="$PREFIX" --host="$TARGET" --with-sysroot="$SYSROOT" --disable-shared
+./configure --prefix="$PREFIX" --host="$TARGET" --with-sysroot="$SYSROOT" --disable-shared --disable-pie
 make -j"$(nproc)" install
 cd ..
 


### PR DESCRIPTION
* Bump the targeted API on armeabi and x86 to 19
  - Starting with the r24 NDK, Jelly Bean (APIs 16, 17, and 18) is no longer supported.

* Build libsodium w/ --disable-pie
  - Workaround for `ld: error: relocation R_386_PC32 cannot be used against symbol 'crypto_auth_hmacsha512_init'; recompile with -fPIC`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2390)
<!-- Reviewable:end -->
