### PR TITLE
refactor: Add `mem` module to allow tests to override allocators.

### DIFF
--- a/.github/scripts/coverage-linux
+++ b/.github/scripts/coverage-linux
@@ -9,7 +9,7 @@ sudo apt-get install -y --no-install-recommends \
   libopus-dev \
   libsodium-dev \
   libvpx-dev \
-  llvm-11 \
+  llvm-14 \
   ninja-build
 git clone --depth=1 https://github.com/ralight/mallocfail /tmp/mallocfail
 cd /tmp/mallocfail # pushd
@@ -21,7 +21,7 @@ export CC=clang
 export CXX=clang++
 
 sudo install other/docker/coverage/run_mallocfail /usr/local/bin/run_mallocfail
-(cd other/proxy && go build)
+(cd other/proxy && go get && go build)
 other/proxy/proxy &
 
 . ".github/scripts/flags-coverage.sh"
@@ -58,4 +58,4 @@ cd - # popd
 #  --exclude testing \
 #  --gcov-options '\-lp'
 
-bash <(curl -s https://codecov.io/bash) -x "llvm-cov-11 gcov"
+bash <(curl -s https://codecov.io/bash) -x "llvm-cov-14 gcov"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,8 @@ set(toxcore_SOURCES
   toxcore/logger.h
   toxcore/Messenger.c
   toxcore/Messenger.h
+  toxcore/mem.c
+  toxcore/mem.h
   toxcore/mono_time.c
   toxcore/mono_time.h
   toxcore/net_crypto.c
@@ -434,6 +436,7 @@ unit_test(toxcore bin_pack)
 unit_test(toxcore crypto_core)
 unit_test(toxcore group_announce)
 unit_test(toxcore group_moderation)
+unit_test(toxcore mem)
 unit_test(toxcore mono_time)
 unit_test(toxcore ping_array)
 unit_test(toxcore tox)

--- a/auto_tests/announce_test.c
+++ b/auto_tests/announce_test.c
@@ -54,14 +54,17 @@ static void test_store_data(void)
     ck_assert(rng != nullptr);
     const Network *ns = system_network();
     ck_assert(ns != nullptr);
+    const Memory *mem = system_memory();
+    ck_assert(mem != nullptr);
+
     Logger *log = logger_new();
     ck_assert(log != nullptr);
     logger_callback_log(log, print_debug_logger, nullptr, nullptr);
-    Mono_Time *mono_time = mono_time_new(nullptr, nullptr);
-    Networking_Core *net = new_networking_no_udp(log, ns);
-    DHT *dht = new_dht(log, rng, ns, mono_time, net, true, true);
+    Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
+    Networking_Core *net = new_networking_no_udp(log, mem, ns);
+    DHT *dht = new_dht(log, mem, rng, ns, mono_time, net, true, true);
     Forwarding *forwarding = new_forwarding(log, rng, mono_time, dht);
-    Announcements *announce = new_announcements(log, rng, mono_time, forwarding);
+    Announcements *announce = new_announcements(log, mem, rng, mono_time, forwarding);
     ck_assert(announce != nullptr);
 
     /* Just to prevent CI from complaining that set_synch_offset is unused: */
@@ -103,7 +106,7 @@ static void test_store_data(void)
     kill_forwarding(forwarding);
     kill_dht(dht);
     kill_networking(net);
-    mono_time_free(mono_time);
+    mono_time_free(mem, mono_time);
     logger_kill(log);
 }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
         shared:
           conan.shared: "True"
     steps:
-      - bash: python -m pip install conan
+      - bash: python -m pip install conan==1.59.0
       - bash: git submodule update --init --recursive
       - bash: conan install -if _build -o with_tests=True -o shared=$(conan.shared) .
       - bash: CONAN_CPU_COUNT=50 CTEST_OUTPUT_ON_FAILURE=1 conan build -bf _build -if _build .

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,7 @@ coverage:
         # because of the above range, but toxcore coverage fluctuates a lot due
         # to low coverage of error paths that sometimes happen.
         threshold: 2%
+
+ignore:
+  - "auto_tests" # ignore tests in coverage analysis
+  - "other" # we don't test the bootstrap daemon

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -144,15 +144,17 @@ int main(int argc, char *argv[])
     }
 
     const Random *rng = system_random();
-    Mono_Time *mono_time = mono_time_new(nullptr, nullptr);
+    const Network *ns = system_network();
+    const Memory *mem = system_memory();
+
+    Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
     const uint16_t start_port = PORT;
     const uint16_t end_port = start_port + (TOX_PORTRANGE_TO - TOX_PORTRANGE_FROM);
-    const Network *ns = system_network();
-    DHT *dht = new_dht(logger, rng, ns, mono_time, new_networking_ex(logger, ns, &ip, start_port, end_port, nullptr), true, true);
-    Onion *onion = new_onion(logger, mono_time, rng, dht);
+    DHT *dht = new_dht(logger, mem, rng, ns, mono_time, new_networking_ex(logger, mem, ns, &ip, start_port, end_port, nullptr), true, true);
+    Onion *onion = new_onion(logger, mem, mono_time, rng, dht);
     Forwarding *forwarding = new_forwarding(logger, rng, mono_time, dht);
     GC_Announces_List *gc_announces_list = new_gca_list();
-    Onion_Announce *onion_a = new_onion_announce(logger, rng, mono_time, dht);
+    Onion_Announce *onion_a = new_onion_announce(logger, mem, rng, mono_time, dht);
 
 #ifdef DHT_NODE_EXTRA_PACKETS
     bootstrap_set_callbacks(dht_get_net(dht), DHT_VERSION_NUMBER, DHT_MOTD, sizeof(DHT_MOTD));
@@ -173,7 +175,7 @@ int main(int argc, char *argv[])
 #ifdef TCP_RELAY_ENABLED
 #define NUM_PORTS 3
     uint16_t ports[NUM_PORTS] = {443, 3389, PORT};
-    TCP_Server *tcp_s = new_TCP_server(logger, rng, ns, ipv6enabled, NUM_PORTS, ports, dht_get_self_secret_key(dht), onion, forwarding);
+    TCP_Server *tcp_s = new_TCP_server(logger, mem, rng, ns, ipv6enabled, NUM_PORTS, ports, dht_get_self_secret_key(dht), onion, forwarding);
 
     if (tcp_s == nullptr) {
         printf("TCP server failed to initialize.\n");

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-23e142729a72618462018b25c830dbad5b023d0fa3de9ae53d376f43dc46b481  /usr/local/bin/tox-bootstrapd
+6f4ec4239de5ea05ae341271bbda4cb78535f943a693321648ee1ab043a203d2  /usr/local/bin/tox-bootstrapd

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -280,15 +280,17 @@ int main(int argc, char *argv[])
     }
 
     const uint16_t end_port = start_port + (TOX_PORTRANGE_TO - TOX_PORTRANGE_FROM);
+    const Memory *mem = system_memory();
+    const Random *rng = system_random();
     const Network *ns = system_network();
-    Networking_Core *net = new_networking_ex(logger, ns, &ip, start_port, end_port, nullptr);
+    Networking_Core *net = new_networking_ex(logger, mem, ns, &ip, start_port, end_port, nullptr);
 
     if (net == nullptr) {
         if (enable_ipv6 && enable_ipv4_fallback) {
             log_write(LOG_LEVEL_WARNING, "Couldn't initialize IPv6 networking. Falling back to using IPv4.\n");
             enable_ipv6 = 0;
             ip_init(&ip, enable_ipv6);
-            net = new_networking_ex(logger, ns, &ip, start_port, end_port, nullptr);
+            net = new_networking_ex(logger, mem, ns, &ip, start_port, end_port, nullptr);
 
             if (net == nullptr) {
                 log_write(LOG_LEVEL_ERROR, "Couldn't fallback to IPv4. Exiting.\n");
@@ -308,7 +310,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    Mono_Time *const mono_time = mono_time_new(nullptr, nullptr);
+    Mono_Time *const mono_time = mono_time_new(mem, nullptr, nullptr);
 
     if (mono_time == nullptr) {
         log_write(LOG_LEVEL_ERROR, "Couldn't initialize monotonic timer. Exiting.\n");
@@ -322,12 +324,11 @@ int main(int argc, char *argv[])
 
     mono_time_update(mono_time);
 
-    const Random *rng = system_random();
-    DHT *const dht = new_dht(logger, rng, ns, mono_time, net, true, enable_lan_discovery);
+    DHT *const dht = new_dht(logger, mem, rng, ns, mono_time, net, true, enable_lan_discovery);
 
     if (dht == nullptr) {
         log_write(LOG_LEVEL_ERROR, "Couldn't initialize Tox DHT instance. Exiting.\n");
-        mono_time_free(mono_time);
+        mono_time_free(mem, mono_time);
         kill_networking(net);
         logger_kill(logger);
         free(motd);
@@ -341,7 +342,7 @@ int main(int argc, char *argv[])
     if (forwarding == nullptr) {
         log_write(LOG_LEVEL_ERROR, "Couldn't initialize forwarding. Exiting.\n");
         kill_dht(dht);
-        mono_time_free(mono_time);
+        mono_time_free(mem, mono_time);
         kill_networking(net);
         logger_kill(logger);
         free(motd);
@@ -350,13 +351,13 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    Announcements *announce = new_announcements(logger, rng, mono_time, forwarding);
+    Announcements *announce = new_announcements(logger, mem, rng, mono_time, forwarding);
 
     if (announce == nullptr) {
         log_write(LOG_LEVEL_ERROR, "Couldn't initialize DHT announcements. Exiting.\n");
         kill_forwarding(forwarding);
         kill_dht(dht);
-        mono_time_free(mono_time);
+        mono_time_free(mem, mono_time);
         kill_networking(net);
         logger_kill(logger);
         free(motd);
@@ -372,7 +373,7 @@ int main(int argc, char *argv[])
         kill_announcements(announce);
         kill_forwarding(forwarding);
         kill_dht(dht);
-        mono_time_free(mono_time);
+        mono_time_free(mem, mono_time);
         kill_networking(net);
         logger_kill(logger);
         free(motd);
@@ -381,14 +382,14 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    Onion *onion = new_onion(logger, mono_time, rng, dht);
+    Onion *onion = new_onion(logger, mem, mono_time, rng, dht);
 
     if (!onion) {
         log_write(LOG_LEVEL_ERROR, "Couldn't initialize Tox Onion. Exiting.\n");
         kill_announcements(announce);
         kill_forwarding(forwarding);
         kill_dht(dht);
-        mono_time_free(mono_time);
+        mono_time_free(mem, mono_time);
         kill_networking(net);
         logger_kill(logger);
         free(motd);
@@ -397,7 +398,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    Onion_Announce *onion_a = new_onion_announce(logger, rng, mono_time, dht);
+    Onion_Announce *onion_a = new_onion_announce(logger, mem, rng, mono_time, dht);
 
     if (!onion_a) {
         log_write(LOG_LEVEL_ERROR, "Couldn't initialize Tox Onion Announce. Exiting.\n");
@@ -406,7 +407,7 @@ int main(int argc, char *argv[])
         kill_announcements(announce);
         kill_forwarding(forwarding);
         kill_dht(dht);
-        mono_time_free(mono_time);
+        mono_time_free(mem, mono_time);
         kill_networking(net);
         logger_kill(logger);
         free(motd);
@@ -429,7 +430,7 @@ int main(int argc, char *argv[])
             kill_announcements(announce);
             kill_forwarding(forwarding);
             kill_dht(dht);
-            mono_time_free(mono_time);
+            mono_time_free(mem, mono_time);
             kill_networking(net);
             logger_kill(logger);
             free(motd);
@@ -450,7 +451,7 @@ int main(int argc, char *argv[])
         kill_announcements(announce);
         kill_forwarding(forwarding);
         kill_dht(dht);
-        mono_time_free(mono_time);
+        mono_time_free(mem, mono_time);
         kill_networking(net);
         logger_kill(logger);
         free(tcp_relay_ports);
@@ -469,14 +470,15 @@ int main(int argc, char *argv[])
             kill_forwarding(forwarding);
             kill_onion(onion);
             kill_dht(dht);
-            mono_time_free(mono_time);
+            mono_time_free(mem, mono_time);
             kill_networking(net);
             logger_kill(logger);
             free(tcp_relay_ports);
             return 1;
         }
 
-        tcp_server = new_TCP_server(logger, rng, ns, enable_ipv6, tcp_relay_port_count, tcp_relay_ports,
+        tcp_server = new_TCP_server(logger, mem, rng, ns, enable_ipv6,
+                                    tcp_relay_port_count, tcp_relay_ports,
                                     dht_get_self_secret_key(dht), onion, forwarding);
 
         free(tcp_relay_ports);
@@ -515,7 +517,7 @@ int main(int argc, char *argv[])
             kill_announcements(announce);
             kill_forwarding(forwarding);
             kill_dht(dht);
-            mono_time_free(mono_time);
+            mono_time_free(mem, mono_time);
             kill_networking(net);
             logger_kill(logger);
             return 1;
@@ -533,7 +535,7 @@ int main(int argc, char *argv[])
         kill_announcements(announce);
         kill_forwarding(forwarding);
         kill_dht(dht);
-        mono_time_free(mono_time);
+        mono_time_free(mem, mono_time);
         kill_networking(net);
         logger_kill(logger);
         return 1;
@@ -616,7 +618,7 @@ int main(int argc, char *argv[])
     kill_announcements(announce);
     kill_forwarding(forwarding);
     kill_dht(dht);
-    mono_time_free(mono_time);
+    mono_time_free(mem, mono_time);
     kill_networking(net);
     logger_kill(logger);
 

--- a/other/docker/coverage/Dockerfile
+++ b/other/docker/coverage/Dockerfile
@@ -1,5 +1,5 @@
 FROM toxchat/c-toxcore:sources AS src
-FROM ubuntu:20.04 AS build
+FROM ubuntu:22.04 AS build
 
 RUN apt-get update && \
  DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
@@ -31,8 +31,8 @@ SHELL ["/bin/bash", "-c"]
 WORKDIR /work
 COPY --from=src /src/ /work/
 RUN source .github/scripts/flags-coverage.sh \
- && go get github.com/things-go/go-socks5 \
- && go build other/proxy/proxy_server.go \
+ && go version \
+ && (cd other/proxy && go get github.com/things-go/go-socks5 && go build proxy_server.go) \
  && cmake -B_build -H. -GNinja \
  -DCMAKE_C_FLAGS="$C_FLAGS" \
  -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
@@ -46,6 +46,7 @@ RUN source .github/scripts/flags-coverage.sh \
  -DAUTOTEST=ON \
  -DPROXY_TEST=ON \
  -DUSE_IPV6=OFF \
+ -DTEST_TIMEOUT_SECONDS=30 \
  && cmake --build _build --parallel 8 --target install
 
 WORKDIR /work/_build

--- a/other/proxy/go.mod
+++ b/other/proxy/go.mod
@@ -1,5 +1,5 @@
 module github.com/TokTok/c-toxcore/other/proxy
 
-go 1.16
+go 1.18
 
-require github.com/things-go/go-socks5 v0.0.2
+require github.com/things-go/go-socks5 v0.0.3

--- a/other/proxy/go.sum
+++ b/other/proxy/go.sum
@@ -4,6 +4,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/things-go/go-socks5 v0.0.2 h1:dFi5iZ/LqgHRTQ6n3XlipTLDWHAQsejvJ300bH2VFWo=
 github.com/things-go/go-socks5 v0.0.2/go.mod h1:dhnDTBbIg31cbJdROP4/Zz6Iw7JPEpiMvOl2LdHSSjE=
+github.com/things-go/go-socks5 v0.0.3 h1:QtlIhkwDuLNCwW3wnt2uTjn1mQzpyjnwct2xdPuqroI=
+github.com/things-go/go-socks5 v0.0.3/go.mod h1:f8Zx+n8kfzyT90hXM767cP6sysAud93+t9rV90IgMcg=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -92,7 +92,8 @@ int main(int argc, char *argv[])
         exit(0);
     }
 
-    Mono_Time *const mono_time = mono_time_new(nullptr, nullptr);
+    const Memory *mem = system_memory();
+    Mono_Time *const mono_time = mono_time_new(mem, nullptr, nullptr);
 
     if (mono_time == nullptr) {
         fputs("Failed to allocate monotonic timer datastructure\n", stderr);
@@ -102,7 +103,7 @@ int main(int argc, char *argv[])
     Messenger_Options options = {0};
     options.ipv6enabled = ipv6enabled;
     Messenger_Error err;
-    m = new_messenger(mono_time, system_random(), system_network(), &options, &err);
+    m = new_messenger(mono_time, mem, system_random(), system_network(), &options, &err);
 
     if (!m) {
         fprintf(stderr, "Failed to allocate messenger datastructure: %d\n", err);

--- a/testing/fuzzing/BUILD.bazel
+++ b/testing/fuzzing/BUILD.bazel
@@ -28,6 +28,7 @@ cc_library(
 
 cc_fuzz_test(
     name = "bootstrap_fuzz_test",
+    #size = "small",
     srcs = ["bootstrap_harness.cc"],
     copts = ["-UNDEBUG"],
     corpus = ["//tools/toktok-fuzzer/corpus:bootstrap_fuzzer"],
@@ -42,6 +43,7 @@ cc_fuzz_test(
 
 cc_fuzz_test(
     name = "e2e_fuzz_test",
+    #size = "small",
     srcs = ["e2e_fuzz_test.cc"],
     copts = ["-UNDEBUG"],
     corpus = ["//tools/toktok-fuzzer/corpus:e2e_fuzz_test"],
@@ -57,6 +59,7 @@ cc_fuzz_test(
 
 cc_fuzz_test(
     name = "toxsave_fuzz_test",
+    #size = "small",
     srcs = ["toxsave_harness.cc"],
     copts = ["-UNDEBUG"],
     corpus = ["//tools/toktok-fuzzer/corpus:toxsave_fuzzer"],
@@ -89,6 +92,7 @@ fuzzing_binary(
 
 cc_fuzz_test(
     name = "protodump_reduce",
+    #size = "small",
     srcs = ["protodump_reduce.cc"],
     copts = ["-UNDEBUG"],
     deps = [

--- a/testing/fuzzing/bootstrap_harness.cc
+++ b/testing/fuzzing/bootstrap_harness.cc
@@ -169,7 +169,7 @@ void TestBootstrap(Fuzz_Data &input)
     while (input.size > 0) {
         Tox_Err_Events_Iterate error_iterate;
         Tox_Events *events = tox_events_iterate(tox, true, &error_iterate);
-        assert(tox_events_equal(events, events));
+        assert(tox_events_equal(sys.sys.get(), events, events));
         tox_dispatch_invoke(dispatch, events, tox, nullptr);
         tox_events_free(events);
         // Move the clock forward a decent amount so all the time-based checks

--- a/testing/fuzzing/e2e_fuzz_test.cc
+++ b/testing/fuzzing/e2e_fuzz_test.cc
@@ -134,6 +134,8 @@ void setup_callbacks(Tox_Dispatch *dispatch)
 void TestEndToEnd(Fuzz_Data &input)
 {
     Fuzz_System sys(input);
+    // Used for places where we want all allocations to succeed.
+    Null_System null_sys;
 
     Ptr<Tox_Options> opts(tox_options_new(nullptr), tox_options_free);
     assert(opts != nullptr);
@@ -170,7 +172,7 @@ void TestEndToEnd(Fuzz_Data &input)
     while (input.size > 0) {
         Tox_Err_Events_Iterate error_iterate;
         Tox_Events *events = tox_events_iterate(tox, true, &error_iterate);
-        assert(tox_events_equal(events, events));
+        assert(tox_events_equal(null_sys.sys.get(), events, events));
         tox_dispatch_invoke(dispatch, events, tox, nullptr);
         tox_events_free(events);
         // Move the clock forward a decent amount so all the time-based checks

--- a/testing/fuzzing/fuzz_support.h
+++ b/testing/fuzzing/fuzz_support.h
@@ -59,6 +59,23 @@ struct Fuzz_Data {
     }                                   \
     DECL = INPUT.consume1()
 
+/** @brief Consumes 1 byte of the fuzzer input or returns a value if no data
+ * available.
+ *
+ * This advances the fuzzer input data by 1 byte and consumes that byte in the
+ * declaration.
+ *
+ * @example
+ * @code
+ * CONSUME1_OR_RETURN_VAL(const uint8_t one_byte, input, nullptr);
+ * @endcode
+ */
+#define CONSUME1_OR_RETURN_VAL(DECL, INPUT, VAL) \
+    if (INPUT.size < 1) {                        \
+        return VAL;                              \
+    }                                            \
+    DECL = INPUT.consume1()
+
 /** @brief Consumes SIZE bytes of the fuzzer input or returns if not enough data available.
  *
  * This advances the fuzzer input data by SIZE byte and consumes those bytes in
@@ -100,11 +117,13 @@ void fuzz_select_target(const uint8_t *data, std::size_t size, Args &&... args)
     return fuzz_select_target(selector, input, std::forward<Args>(args)...);
 }
 
+struct Memory;
 struct Network;
 struct Random;
 
 struct System {
     std::unique_ptr<Tox_System> sys;
+    std::unique_ptr<Memory> mem;
     std::unique_ptr<Network> ns;
     std::unique_ptr<Random> rng;
 

--- a/testing/fuzzing/fuzz_tox.h
+++ b/testing/fuzzing/fuzz_tox.h
@@ -62,13 +62,14 @@ struct with<IP_Port> {
 
 /** @brief Construct a Networking_Core object using the Network vtable passed.
  *
- * Use `with<Logger>{} >> with<Networking_Core>{input, ns} >> ...` to construct
+ * Use `with<Logger>{} >> with<Networking_Core>{input, ns, mem} >> ...` to construct
  * a logger and pass it to the Networking_Core constructor function.
  */
 template <>
 struct with<Networking_Core> {
     Fuzz_Data &input_;
     const Network *ns_;
+    const Memory *mem_;
     Ptr<Logger> logger_{nullptr, logger_kill};
 
     friend with operator>>(with<Logger> f, with self)
@@ -82,7 +83,7 @@ struct with<Networking_Core> {
     {
         with<IP_Port>{input_} >> [&f, this](const IP_Port &ipp) {
             Ptr<Networking_Core> net(
-                new_networking_ex(logger_.get(), ns_, &ipp.ip, ipp.port, ipp.port + 100, nullptr),
+                new_networking_ex(logger_.get(), mem_, ns_, &ipp.ip, ipp.port, ipp.port + 100, nullptr),
                 kill_networking);
             if (net == nullptr) {
                 return;

--- a/testing/fuzzing/protodump.cc
+++ b/testing/fuzzing/protodump.cc
@@ -244,12 +244,12 @@ void RecordBootstrap()
         Tox_Events *events;
 
         events = tox_events_iterate(tox1, true, &error_iterate);
-        assert(tox_events_equal(events, events));
+        assert(tox_events_equal(sys1.sys.get(), events, events));
         tox_dispatch_invoke(dispatch, events, tox1, &done1);
         tox_events_free(events);
 
         events = tox_events_iterate(tox2, true, &error_iterate);
-        assert(tox_events_equal(events, events));
+        assert(tox_events_equal(sys2.sys.get(), events, events));
         tox_dispatch_invoke(dispatch, events, tox2, &done2);
         tox_events_free(events);
 

--- a/testing/fuzzing/protodump_reduce.cc
+++ b/testing/fuzzing/protodump_reduce.cc
@@ -172,7 +172,7 @@ void TestEndToEnd(Fuzz_Data &input)
     while (input.size > 0) {
         Tox_Err_Events_Iterate error_iterate;
         Tox_Events *events = tox_events_iterate(tox, true, &error_iterate);
-        assert(tox_events_equal(events, events));
+        assert(tox_events_equal(tox_get_system(tox), events, events));
         tox_dispatch_invoke(dispatch, events, tox, nullptr);
         tox_events_free(events);
         sys.clock += std::max(System::MIN_ITERATION_INTERVAL, random_u08(sys.rng.get()));

--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -536,7 +536,7 @@ bool groupchat_av_enabled(const Group_Chats *g_c, uint32_t groupnumber)
  */
 int add_av_groupchat(const Logger *log, Tox *tox, Group_Chats *g_c, audio_data_cb *audio_callback, void *userdata)
 {
-    const int groupnumber = add_groupchat(g_c, &tox->rng, GROUPCHAT_TYPE_AV);
+    const int groupnumber = add_groupchat(g_c, tox->sys.rng, GROUPCHAT_TYPE_AV);
 
     if (groupnumber == -1) {
         return -1;

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -181,7 +181,7 @@ ToxAV *toxav_new(Tox *tox, Toxav_Err_New *error)
 
     av->tox = tox;
     av->m = m;
-    av->toxav_mono_time = mono_time_new(nullptr, nullptr);
+    av->toxav_mono_time = mono_time_new(tox->sys.mem, nullptr, nullptr);
     av->msi = msi_new(av->m);
 
     if (av->msi == nullptr) {
@@ -239,7 +239,7 @@ void toxav_kill(ToxAV *av)
         }
     }
 
-    mono_time_free(av->toxav_mono_time);
+    mono_time_free(av->tox->sys.mem, av->toxav_mono_time);
 
     pthread_mutex_unlock(av->mutex);
     pthread_mutex_destroy(av->mutex);

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -24,6 +24,28 @@ cc_library(
 )
 
 cc_library(
+    name = "mem",
+    srcs = ["mem.c"],
+    hdrs = ["mem.h"],
+    visibility = ["//c-toxcore:__subpackages__"],
+    deps = [
+        ":attributes",
+        ":ccompat",
+    ],
+)
+
+cc_test(
+    name = "mem_test",
+    size = "small",
+    srcs = ["mem_test.cc"],
+    deps = [
+        ":mem",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "util",
     srcs = ["util.c"],
     hdrs = ["util.h"],
@@ -37,6 +59,7 @@ cc_library(
     deps = [
         ":attributes",
         ":ccompat",
+        ":mem",
         "@pthread",
     ],
 )
@@ -175,6 +198,7 @@ cc_library(
     deps = [
         ":attributes",
         ":ccompat",
+        ":mem",
         "@pthread",
     ],
 )
@@ -204,6 +228,7 @@ cc_library(
     deps = [
         ":ccompat",
         ":crypto_core",
+        ":mem",
         ":mono_time",
     ],
 )
@@ -223,6 +248,7 @@ cc_library(
         ":ccompat",
         ":crypto_core",
         ":logger",
+        ":mem",
         ":mono_time",
         ":util",
         "@libsodium",
@@ -260,6 +286,7 @@ cc_library(
     deps = [
         ":ccompat",
         ":crypto_core",
+        ":mem",
         ":mono_time",
         ":util",
     ],
@@ -315,6 +342,7 @@ cc_library(
         ":ccompat",
         ":crypto_core",
         ":logger",
+        ":mem",
         ":mono_time",
         ":network",
         ":ping_array",
@@ -413,6 +441,7 @@ cc_library(
         ":attributes",
         ":ccompat",
         ":crypto_core",
+        ":mem",
         ":network",
     ],
 )
@@ -766,6 +795,7 @@ cc_library(
         ":group",
         ":group_moderation",
         ":logger",
+        ":mem",
         ":mono_time",
         ":network",
         "//c-toxcore/toxencryptsave:defines",
@@ -810,6 +840,7 @@ cc_library(
         ":bin_pack",
         ":bin_unpack",
         ":ccompat",
+        ":mem",
         ":tox",
         ":tox_unpack",
         "//c-toxcore/third_party:cmp",
@@ -822,6 +853,7 @@ cc_test(
     srcs = ["tox_events_test.cc"],
     deps = [
         ":crypto_core",
+        ":tox",
         ":tox_events",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
@@ -832,7 +864,10 @@ cc_fuzz_test(
     name = "tox_events_fuzz_test",
     srcs = ["tox_events_fuzz_test.cc"],
     corpus = ["//tools/toktok-fuzzer/corpus:tox_events_fuzz_test"],
-    deps = [":tox_events"],
+    deps = [
+        ":tox_events",
+        "//c-toxcore/testing/fuzzing:fuzz_support",
+    ],
 )
 
 cc_library(

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -14,6 +14,7 @@
 #include "attributes.h"
 #include "crypto_core.h"
 #include "logger.h"
+#include "mem.h"
 #include "mono_time.h"
 #include "network.h"
 #include "ping_array.h"
@@ -219,7 +220,7 @@ int pack_ip_port(const Logger *logger, uint8_t *data, uint16_t length, const IP_
  * @retval -1 on failure.
  */
 non_null()
-int dht_create_packet(const Random *rng,
+int dht_create_packet(const Memory *mem, const Random *rng,
                       const uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE],
                       const uint8_t *shared_key, const uint8_t type,
                       const uint8_t *plain, size_t plain_length,
@@ -494,8 +495,8 @@ int dht_load(DHT *dht, const uint8_t *data, uint32_t length);
 
 /** Initialize DHT. */
 non_null()
-DHT *new_dht(const Logger *log, const Random *rng, const Network *ns, Mono_Time *mono_time, Networking_Core *net,
-             bool hole_punching_enabled, bool lan_discovery_enabled);
+DHT *new_dht(const Logger *log, const Memory *mem, const Random *rng, const Network *ns,
+             Mono_Time *mono_time, Networking_Core *net, bool hole_punching_enabled, bool lan_discovery_enabled);
 
 nullable(1)
 void kill_dht(DHT *dht);

--- a/toxcore/DHT_test.cc
+++ b/toxcore/DHT_test.cc
@@ -187,12 +187,14 @@ TEST(Request, CreateAndParse)
 
 TEST(AnnounceNodes, SetAndTest)
 {
-    Logger *log = logger_new();
-    Mono_Time *mono_time = mono_time_new(nullptr, nullptr);
     const Random *rng = system_random();
     const Network *ns = system_network();
-    Networking_Core *net = new_networking_no_udp(log, ns);
-    DHT *dht = new_dht(log, rng, ns, mono_time, net, true, true);
+    const Memory *mem = system_memory();
+
+    Logger *log = logger_new();
+    Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
+    Networking_Core *net = new_networking_no_udp(log, mem, ns);
+    DHT *dht = new_dht(log, mem, rng, ns, mono_time, net, true, true);
     ASSERT_NE(dht, nullptr);
 
     uint8_t pk_data[CRYPTO_PUBLIC_KEY_SIZE];
@@ -224,7 +226,7 @@ TEST(AnnounceNodes, SetAndTest)
 
     kill_dht(dht);
     kill_networking(net);
-    mono_time_free(mono_time);
+    mono_time_free(mem, mono_time);
     logger_kill(log);
 }
 

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -39,6 +39,8 @@ libtoxcore_la_SOURCES = ../third_party/cmp/cmp.c \
                         ../toxcore/events/self_connection_status.c \
                         ../toxcore/DHT.h \
                         ../toxcore/DHT.c \
+                        ../toxcore/mem.h \
+                        ../toxcore/mem.c \
                         ../toxcore/mono_time.h \
                         ../toxcore/mono_time.c \
                         ../toxcore/network.h \

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -245,6 +245,7 @@ typedef struct Friend {
 struct Messenger {
     Logger *log;
     Mono_Time *mono_time;
+    const Memory *mem;
     const Random *rng;
     const Network *ns;
 
@@ -813,7 +814,8 @@ typedef enum Messenger_Error {
  * if error is not NULL it will be set to one of the values in the enum above.
  */
 non_null()
-Messenger *new_messenger(Mono_Time *mono_time, const Random *rng, const Network *ns, Messenger_Options *options, Messenger_Error *error);
+Messenger *new_messenger(Mono_Time *mono_time, const Memory *mem, const Random *rng, const Network *ns,
+                         Messenger_Options *options, Messenger_Error *error);
 
 /** @brief Run this before closing shop.
  *

--- a/toxcore/TCP_client.h
+++ b/toxcore/TCP_client.h
@@ -57,10 +57,10 @@ non_null()
 void tcp_con_set_custom_uint(TCP_Client_Connection *con, uint32_t value);
 
 /** Create new TCP connection to ip_port/public_key */
-non_null(1, 2, 3, 4, 5, 6, 7, 8) nullable(9)
+non_null(1, 2, 3, 4, 5, 6, 7, 8, 9) nullable(10)
 TCP_Client_Connection *new_TCP_connection(
-        const Logger *logger, const Mono_Time *mono_time, const Random *rng, const Network *ns, const IP_Port *ip_port,
-        const uint8_t *public_key, const uint8_t *self_public_key, const uint8_t *self_secret_key,
+        const Logger *logger, const Memory *mem, const Mono_Time *mono_time, const Random *rng, const Network *ns,
+        const IP_Port *ip_port, const uint8_t *public_key, const uint8_t *self_public_key, const uint8_t *self_secret_key,
         const TCP_Proxy_Info *proxy_info);
 
 /** Run the TCP connection */

--- a/toxcore/TCP_common.h
+++ b/toxcore/TCP_common.h
@@ -7,6 +7,7 @@
 #define C_TOXCORE_TOXCORE_TCP_COMMON_H
 
 #include "crypto_core.h"
+#include "mem.h"
 #include "network.h"
 
 typedef struct TCP_Priority_List TCP_Priority_List;
@@ -17,8 +18,8 @@ struct TCP_Priority_List {
     uint8_t *data;
 };
 
-nullable(1)
-void wipe_priority_list(TCP_Priority_List *p);
+non_null(1) nullable(2)
+void wipe_priority_list(const Memory *mem, TCP_Priority_List *p);
 
 #define NUM_RESERVED_PORTS 16
 #define NUM_CLIENT_CONNECTIONS (256 - NUM_RESERVED_PORTS)
@@ -63,6 +64,7 @@ void wipe_priority_list(TCP_Priority_List *p);
 #define MAX_PACKET_SIZE 2048
 
 typedef struct TCP_Connection {
+    const Memory *mem;
     const Random *rng;
     const Network *ns;
     Socket sock;
@@ -108,7 +110,7 @@ int write_packet_TCP_secure_connection(
  */
 non_null()
 int read_TCP_packet(
-        const Logger *logger, const Network *ns, Socket sock, uint8_t *data, uint16_t length, const IP_Port *ip_port);
+        const Logger *logger, const Memory *mem, const Network *ns, Socket sock, uint8_t *data, uint16_t length, const IP_Port *ip_port);
 
 /**
  * @return length of received packet on success.
@@ -117,7 +119,8 @@ int read_TCP_packet(
  */
 non_null()
 int read_packet_TCP_secure_connection(
-        const Logger *logger, const Network *ns, Socket sock, uint16_t *next_packet_length,
+        const Logger *logger, const Memory *mem, const Network *ns,
+        Socket sock, uint16_t *next_packet_length,
         const uint8_t *shared_key, uint8_t *recv_nonce, uint8_t *data,
         uint16_t max_len, const IP_Port *ip_port);
 

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -19,6 +19,7 @@
 
 struct TCP_Connections {
     const Logger *logger;
+    const Memory *mem;
     const Random *rng;
     Mono_Time *mono_time;
     const Network *ns;
@@ -69,20 +70,20 @@ uint32_t tcp_connections_count(const TCP_Connections *tcp_c)
 
 /** @brief Set the size of the array to num.
  *
- * @retval -1 if realloc fails.
+ * @retval -1 if mem_vrealloc fails.
  * @retval 0 if it succeeds.
  */
 non_null()
-static int realloc_TCP_Connection_to(TCP_Connection_to **array, size_t num)
+static int realloc_TCP_Connection_to(const Memory *mem, TCP_Connection_to **array, size_t num)
 {
     if (num == 0) {
-        free(*array);
+        mem_delete(mem, *array);
         *array = nullptr;
         return 0;
     }
 
     TCP_Connection_to *temp_pointer =
-        (TCP_Connection_to *)realloc(*array, num * sizeof(TCP_Connection_to));
+        (TCP_Connection_to *)mem_vrealloc(mem, *array, num, sizeof(TCP_Connection_to));
 
     if (temp_pointer == nullptr) {
         return -1;
@@ -94,15 +95,15 @@ static int realloc_TCP_Connection_to(TCP_Connection_to **array, size_t num)
 }
 
 non_null()
-static int realloc_TCP_con(TCP_con **array, size_t num)
+static int realloc_TCP_con(const Memory *mem, TCP_con **array, size_t num)
 {
     if (num == 0) {
-        free(*array);
+        mem_delete(mem, *array);
         *array = nullptr;
         return 0;
     }
 
-    TCP_con *temp_pointer = (TCP_con *)realloc(*array, num * sizeof(TCP_con));
+    TCP_con *temp_pointer = (TCP_con *)mem_vrealloc(mem, *array, num, sizeof(TCP_con));
 
     if (temp_pointer == nullptr) {
         return -1;
@@ -164,7 +165,7 @@ static int create_connection(TCP_Connections *tcp_c)
 
     int id = -1;
 
-    if (realloc_TCP_Connection_to(&tcp_c->connections, tcp_c->connections_length + 1) == 0) {
+    if (realloc_TCP_Connection_to(tcp_c->mem, &tcp_c->connections, tcp_c->connections_length + 1) == 0) {
         id = tcp_c->connections_length;
         ++tcp_c->connections_length;
         tcp_c->connections[id] = empty_tcp_connection_to;
@@ -189,7 +190,7 @@ static int create_tcp_connection(TCP_Connections *tcp_c)
 
     int id = -1;
 
-    if (realloc_TCP_con(&tcp_c->tcp_connections, tcp_c->tcp_connections_length + 1) == 0) {
+    if (realloc_TCP_con(tcp_c->mem, &tcp_c->tcp_connections, tcp_c->tcp_connections_length + 1) == 0) {
         id = tcp_c->tcp_connections_length;
         ++tcp_c->tcp_connections_length;
         tcp_c->tcp_connections[id] = empty_tcp_con;
@@ -221,7 +222,9 @@ static int wipe_connection(TCP_Connections *tcp_c, int connections_number)
 
     if (tcp_c->connections_length != i) {
         tcp_c->connections_length = i;
-        realloc_TCP_Connection_to(&tcp_c->connections, tcp_c->connections_length);
+        if (realloc_TCP_Connection_to(tcp_c->mem, &tcp_c->connections, tcp_c->connections_length) != 0) {
+            return -1;
+        }
     }
 
     return 0;
@@ -251,7 +254,9 @@ static int wipe_tcp_connection(TCP_Connections *tcp_c, int tcp_connections_numbe
 
     if (tcp_c->tcp_connections_length != i) {
         tcp_c->tcp_connections_length = i;
-        realloc_TCP_con(&tcp_c->tcp_connections, tcp_c->tcp_connections_length);
+        if (realloc_TCP_con(tcp_c->mem, &tcp_c->tcp_connections, tcp_c->tcp_connections_length) != 0) {
+            return -1;
+        }
     }
 
     return 0;
@@ -920,7 +925,7 @@ static int reconnect_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connec
     uint8_t relay_pk[CRYPTO_PUBLIC_KEY_SIZE];
     memcpy(relay_pk, tcp_con_public_key(tcp_con->connection), CRYPTO_PUBLIC_KEY_SIZE);
     kill_TCP_connection(tcp_con->connection);
-    tcp_con->connection = new_TCP_connection(tcp_c->logger, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &ip_port, relay_pk, tcp_c->self_public_key, tcp_c->self_secret_key, &tcp_c->proxy_info);
+    tcp_con->connection = new_TCP_connection(tcp_c->logger, tcp_c->mem, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &ip_port, relay_pk, tcp_c->self_public_key, tcp_c->self_secret_key, &tcp_c->proxy_info);
 
     if (tcp_con->connection == nullptr) {
         kill_tcp_relay_connection(tcp_c, tcp_connections_number);
@@ -1008,7 +1013,7 @@ static int unsleep_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connecti
     }
 
     tcp_con->connection = new_TCP_connection(
-            tcp_c->logger, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &tcp_con->ip_port,
+            tcp_c->logger, tcp_c->mem, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &tcp_con->ip_port,
             tcp_con->relay_pk, tcp_c->self_public_key, tcp_c->self_secret_key, &tcp_c->proxy_info);
 
     if (tcp_con->connection == nullptr) {
@@ -1304,7 +1309,7 @@ static int add_tcp_relay_instance(TCP_Connections *tcp_c, const IP_Port *ip_port
     TCP_con *tcp_con = &tcp_c->tcp_connections[tcp_connections_number];
 
     tcp_con->connection = new_TCP_connection(
-            tcp_c->logger, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &ipp_copy,
+            tcp_c->logger, tcp_c->mem, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &ipp_copy,
             relay_pk, tcp_c->self_public_key, tcp_c->self_secret_key, &tcp_c->proxy_info);
 
     if (tcp_con->connection == nullptr) {
@@ -1580,21 +1585,27 @@ int set_tcp_onion_status(TCP_Connections *tcp_c, bool status)
  *
  * Returns NULL on failure.
  */
-TCP_Connections *new_tcp_connections(
-        const Logger *logger, const Random *rng, const Network *ns, Mono_Time *mono_time, const uint8_t *secret_key,
-        const TCP_Proxy_Info *proxy_info)
+TCP_Connections *new_tcp_connections(const Logger *logger, const Memory *mem, const Random *rng, const Network *ns,
+                                     Mono_Time *mono_time, const uint8_t *secret_key, const TCP_Proxy_Info *proxy_info)
 {
+    assert(logger != nullptr);
+    assert(mem != nullptr);
+    assert(rng != nullptr);
+    assert(ns != nullptr);
+    assert(mono_time != nullptr);
+
     if (secret_key == nullptr) {
         return nullptr;
     }
 
-    TCP_Connections *temp = (TCP_Connections *)calloc(1, sizeof(TCP_Connections));
+    TCP_Connections *temp = (TCP_Connections *)mem_alloc(mem, sizeof(TCP_Connections));
 
     if (temp == nullptr) {
         return nullptr;
     }
 
     temp->logger = logger;
+    temp->mem = mem;
     temp->rng = rng;
     temp->mono_time = mono_time;
     temp->ns = ns;
@@ -1707,7 +1718,7 @@ void kill_tcp_connections(TCP_Connections *tcp_c)
 
     crypto_memzero(tcp_c->self_secret_key, sizeof(tcp_c->self_secret_key));
 
-    free(tcp_c->tcp_connections);
-    free(tcp_c->connections);
-    free(tcp_c);
+    mem_delete(tcp_c->mem, tcp_c->tcp_connections);
+    mem_delete(tcp_c->mem, tcp_c->connections);
+    mem_delete(tcp_c->mem, tcp_c);
 }

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -298,9 +298,8 @@ uint32_t tcp_copy_connected_relays_index(const TCP_Connections *tcp_c, Node_form
  * Returns NULL on failure.
  */
 non_null()
-TCP_Connections *new_tcp_connections(
-        const Logger *logger, const Random *rng, const Network *ns, Mono_Time *mono_time,
-        const uint8_t *secret_key, const TCP_Proxy_Info *proxy_info);
+TCP_Connections *new_tcp_connections(const Logger *logger, const Memory *mem, const Random *rng, const Network *ns,
+                                     Mono_Time *mono_time, const uint8_t *secret_key, const TCP_Proxy_Info *proxy_info);
 
 non_null()
 int kill_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connections_number);

--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -34,8 +34,8 @@ non_null()
 size_t tcp_server_listen_count(const TCP_Server *tcp_server);
 
 /** Create new TCP server instance. */
-non_null(1, 2, 3, 6, 7) nullable(8, 9)
-TCP_Server *new_TCP_server(const Logger *logger, const Random *rng, const Network *ns,
+non_null(1, 2, 3, 4, 7, 8) nullable(9, 10)
+TCP_Server *new_TCP_server(const Logger *logger, const Memory *mem, const Random *rng, const Network *ns,
                            bool ipv6_enabled, uint16_t num_sockets, const uint16_t *ports,
                            const uint8_t *secret_key, Onion *onion, Forwarding *forwarding);
 

--- a/toxcore/announce.h
+++ b/toxcore/announce.h
@@ -16,7 +16,8 @@ uint8_t announce_response_of_request_type(uint8_t request_type);
 typedef struct Announcements Announcements;
 
 non_null()
-Announcements *new_announcements(const Logger *log, const Random *rng, const Mono_Time *mono_time, Forwarding *forwarding);
+Announcements *new_announcements(const Logger *log, const Memory *mem, const Random *rng, const Mono_Time *mono_time,
+                                 Forwarding *forwarding);
 
 /**
  * @brief If data is stored, run `on_retrieve_callback` on it.

--- a/toxcore/forwarding_fuzz_test.cc
+++ b/toxcore/forwarding_fuzz_test.cc
@@ -12,8 +12,10 @@ void TestSendForwardRequest(Fuzz_Data &input)
 {
     const Network *ns = system_network();  // TODO(iphydf): fuzz_network
     assert(ns != nullptr);
+    const Memory *mem = system_memory();  // TODO(iphydf): fuzz_memory
+    assert(mem != nullptr);
 
-    with<Logger>{} >> with<Networking_Core>{input, ns} >> [&input](Ptr<Networking_Core> net) {
+    with<Logger>{} >> with<Networking_Core>{input, ns, mem} >> [&input](Ptr<Networking_Core> net) {
         with<IP_Port>{input} >> [net = std::move(net), &input](const IP_Port &forwarder) {
             CONSUME1_OR_RETURN(const uint16_t chain_length, input);
             const uint16_t chain_keys_size = chain_length * CRYPTO_PUBLIC_KEY_SIZE;
@@ -29,8 +31,10 @@ void TestForwardReply(Fuzz_Data &input)
 {
     const Network *ns = system_network();  // TODO(iphydf): fuzz_network
     assert(ns != nullptr);
+    const Memory *mem = system_memory();  // TODO(iphydf): fuzz_memory
+    assert(mem != nullptr);
 
-    with<Logger>{} >> with<Networking_Core>{input, ns} >> [&input](Ptr<Networking_Core> net) {
+    with<Logger>{} >> with<Networking_Core>{input, ns, mem} >> [&input](Ptr<Networking_Core> net) {
         with<IP_Port>{input} >> [net = std::move(net), &input](const IP_Port &forwarder) {
             CONSUME1_OR_RETURN(const uint16_t sendback_length, input);
             CONSUME_OR_RETURN(const uint8_t *sendback, input, sendback_length);

--- a/toxcore/group_announce_fuzz_test.cc
+++ b/toxcore/group_announce_fuzz_test.cc
@@ -1,6 +1,7 @@
 #include "group_announce.h"
 
 #include <cassert>
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -44,9 +45,10 @@ void TestUnpackPublicAnnounce(Fuzz_Data &input)
 
 void TestDoGca(Fuzz_Data &input)
 {
+    const Memory *mem = system_memory();
     std::unique_ptr<Logger, void (*)(Logger *)> logger(logger_new(), logger_kill);
-    std::unique_ptr<Mono_Time, void (*)(Mono_Time *)> mono_time(
-        mono_time_new(nullptr, nullptr), mono_time_free);
+    std::unique_ptr<Mono_Time, std::function<void(Mono_Time *)>> mono_time(
+        mono_time_new(mem, nullptr, nullptr), [mem](Mono_Time *ptr) { mono_time_free(mem, ptr); });
     assert(mono_time != nullptr);
     uint64_t clock = 1;
     mono_time_set_current_time_callback(

--- a/toxcore/group_announce_test.cc
+++ b/toxcore/group_announce_test.cc
@@ -8,6 +8,7 @@ namespace {
 
 struct Announces : ::testing::Test {
 protected:
+    const Memory *mem_ = system_memory();
     uint64_t clock_ = 0;
     Mono_Time *mono_time_ = nullptr;
     GC_Announces_List *gca_ = nullptr;
@@ -16,7 +17,7 @@ protected:
 
     void SetUp() override
     {
-        mono_time_ = mono_time_new(nullptr, nullptr);
+        mono_time_ = mono_time_new(mem_, nullptr, nullptr);
         ASSERT_NE(mono_time_, nullptr);
         mono_time_set_current_time_callback(
             mono_time_, [](void *user_data) { return *static_cast<uint64_t *>(user_data); },
@@ -28,7 +29,7 @@ protected:
     ~Announces() override
     {
         kill_gca(gca_);
-        mono_time_free(mono_time_);
+        mono_time_free(mem_, mono_time_);
     }
 
     void advance_clock(uint64_t increment)

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -7250,7 +7250,7 @@ static bool init_gc_tcp_connection(const GC_Session *c, GC_Chat *chat)
 {
     const Messenger *m = c->messenger;
 
-    chat->tcp_conn = new_tcp_connections(chat->log, chat->rng, m->ns, chat->mono_time, chat->self_secret_key,
+    chat->tcp_conn = new_tcp_connections(chat->log, chat->mem, chat->rng, m->ns, chat->mono_time, chat->self_secret_key,
                                          &m->options.proxy_info);
 
     if (chat->tcp_conn == nullptr) {
@@ -7305,6 +7305,7 @@ static void init_gc_moderation(GC_Chat *chat)
     memcpy(chat->moderation.self_secret_sig_key, get_sig_pk(chat->self_secret_key), SIG_SECRET_KEY_SIZE);
     chat->moderation.shared_state_version = chat->shared_state.version;
     chat->moderation.log = chat->log;
+    chat->moderation.mem = chat->mem;
 }
 
 non_null()
@@ -7332,6 +7333,7 @@ static int create_new_group(GC_Session *c, const uint8_t *nick, size_t nick_leng
     GC_Chat *chat = &c->chats[group_number];
 
     chat->log = m->log;
+    chat->mem = m->mem;
     chat->rng = m->rng;
 
     const uint64_t tm = mono_time_get(m->mono_time);
@@ -7476,6 +7478,7 @@ int gc_group_load(GC_Session *c, Bin_Unpack *bu)
     chat->net = m->net;
     chat->mono_time = m->mono_time;
     chat->log = m->log;
+    chat->mem = m->mem;
     chat->rng = m->rng;
     chat->last_ping_interval = tm;
     chat->friend_connection_id = -1;

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -247,6 +247,7 @@ typedef struct GC_TopicInfo {
 typedef struct GC_Chat {
     Mono_Time       *mono_time;
     const Logger    *log;
+    const Memory    *mem;
     const Random    *rng;
 
     uint32_t        connected_tcp_relays;

--- a/toxcore/group_moderation.c
+++ b/toxcore/group_moderation.c
@@ -61,7 +61,7 @@ int mod_list_unpack(Moderation *moderation, const uint8_t *data, uint16_t length
         tmp_list[i] = (uint8_t *)malloc(sizeof(uint8_t) * MOD_LIST_ENTRY_SIZE);
 
         if (tmp_list[i] == nullptr) {
-            free_uint8_t_pointer_array(tmp_list, i);
+            free_uint8_t_pointer_array(moderation->mem, tmp_list, i);
             return -1;
         }
 
@@ -221,7 +221,7 @@ bool mod_list_add_entry(Moderation *moderation, const uint8_t *mod_data)
 
 void mod_list_cleanup(Moderation *moderation)
 {
-    free_uint8_t_pointer_array(moderation->mod_list, moderation->num_mods);
+    free_uint8_t_pointer_array(moderation->mem, moderation->mod_list, moderation->num_mods);
     moderation->num_mods = 0;
     moderation->mod_list = nullptr;
 }

--- a/toxcore/group_moderation.h
+++ b/toxcore/group_moderation.h
@@ -78,6 +78,7 @@ typedef struct Mod_Sanction {
 } Mod_Sanction;
 
 typedef struct Moderation {
+    const       Memory *mem;
     const       Logger *log;
 
     Mod_Sanction *sanctions;

--- a/toxcore/group_moderation_fuzz_test.cc
+++ b/toxcore/group_moderation_fuzz_test.cc
@@ -7,7 +7,7 @@ namespace {
 void TestModListUnpack(Fuzz_Data &input)
 {
     CONSUME1_OR_RETURN(const uint16_t num_mods, input);
-    Moderation mods{};
+    Moderation mods{system_memory()};
     mod_list_unpack(&mods, input.data, input.size, num_mods);
     mod_list_cleanup(&mods);
 }

--- a/toxcore/group_moderation_test.cc
+++ b/toxcore/group_moderation_test.cc
@@ -18,7 +18,7 @@ using ModerationHash = std::array<uint8_t, MOD_MODERATION_HASH_SIZE>;
 
 TEST(ModList, PackedSizeOfEmptyModListIsZero)
 {
-    Moderation mods{};
+    Moderation mods{system_memory()};
     EXPECT_EQ(mod_list_packed_size(&mods), 0);
 
     uint8_t byte = 1;
@@ -28,14 +28,14 @@ TEST(ModList, PackedSizeOfEmptyModListIsZero)
 
 TEST(ModList, UnpackingZeroSizeArrayIsNoop)
 {
-    Moderation mods{};
+    Moderation mods{system_memory()};
     const uint8_t byte = 1;
     EXPECT_EQ(mod_list_unpack(&mods, &byte, 0, 0), 0);
 }
 
 TEST(ModList, AddRemoveMultipleMods)
 {
-    Moderation mods{};
+    Moderation mods{system_memory()};
     uint8_t sig_pk1[32] = {1};
     uint8_t sig_pk2[32] = {2};
     EXPECT_TRUE(mod_list_add_entry(&mods, sig_pk1));
@@ -47,7 +47,7 @@ TEST(ModList, AddRemoveMultipleMods)
 TEST(ModList, PackingAndUnpackingList)
 {
     using ModListEntry = std::array<uint8_t, MOD_LIST_ENTRY_SIZE>;
-    Moderation mods{};
+    Moderation mods{system_memory()};
     EXPECT_TRUE(mod_list_add_entry(&mods, ModListEntry{}.data()));
 
     std::vector<uint8_t> packed(mod_list_packed_size(&mods));
@@ -55,7 +55,7 @@ TEST(ModList, PackingAndUnpackingList)
 
     EXPECT_TRUE(mod_list_remove_entry(&mods, ModListEntry{}.data()));
 
-    Moderation mods2{};
+    Moderation mods2{system_memory()};
     EXPECT_EQ(mod_list_unpack(&mods2, packed.data(), packed.size(), 1), packed.size());
     EXPECT_TRUE(mod_list_remove_entry(&mods2, ModListEntry{}.data()));
 }
@@ -63,13 +63,13 @@ TEST(ModList, PackingAndUnpackingList)
 TEST(ModList, UnpackingTooManyModsFails)
 {
     using ModListEntry = std::array<uint8_t, MOD_LIST_ENTRY_SIZE>;
-    Moderation mods{};
+    Moderation mods{system_memory()};
     EXPECT_TRUE(mod_list_add_entry(&mods, ModListEntry{}.data()));
 
     std::vector<uint8_t> packed(mod_list_packed_size(&mods));
     mod_list_pack(&mods, packed.data());
 
-    Moderation mods2{};
+    Moderation mods2{system_memory()};
     EXPECT_EQ(mod_list_unpack(&mods2, packed.data(), packed.size(), 2), -1);
     EXPECT_TRUE(mod_list_remove_entry(&mods, ModListEntry{}.data()));
 }
@@ -78,7 +78,7 @@ TEST(ModList, UnpackingFromEmptyBufferFails)
 {
     std::vector<uint8_t> packed(1);
 
-    Moderation mods{};
+    Moderation mods{system_memory()};
     EXPECT_EQ(mod_list_unpack(&mods, packed.end().base(), 0, 1), -1);
 }
 
@@ -87,7 +87,7 @@ TEST(ModList, HashOfEmptyModListZeroesOutBuffer)
     const Random *rng = system_random();
     ASSERT_NE(rng, nullptr);
 
-    Moderation mods{};
+    Moderation mods{system_memory()};
 
     // Fill with random data, check that it's zeroed.
     ModerationHash hash;
@@ -98,21 +98,21 @@ TEST(ModList, HashOfEmptyModListZeroesOutBuffer)
 
 TEST(ModList, RemoveIndexFromEmptyModListFails)
 {
-    Moderation mods{};
+    Moderation mods{system_memory()};
     EXPECT_FALSE(mod_list_remove_index(&mods, 0));
     EXPECT_FALSE(mod_list_remove_index(&mods, UINT16_MAX));
 }
 
 TEST(ModList, RemoveEntryFromEmptyModListFails)
 {
-    Moderation mods{};
+    Moderation mods{system_memory()};
     uint8_t sig_pk[32] = {0};
     EXPECT_FALSE(mod_list_remove_entry(&mods, sig_pk));
 }
 
 TEST(ModList, ModListRemoveIndex)
 {
-    Moderation mods{};
+    Moderation mods{system_memory()};
     uint8_t sig_pk[32] = {1};
     EXPECT_TRUE(mod_list_add_entry(&mods, sig_pk));
     EXPECT_TRUE(mod_list_remove_index(&mods, 0));
@@ -120,20 +120,20 @@ TEST(ModList, ModListRemoveIndex)
 
 TEST(ModList, CleanupOnEmptyModsIsNoop)
 {
-    Moderation mods{};
+    Moderation mods{system_memory()};
     mod_list_cleanup(&mods);
 }
 
 TEST(ModList, EmptyModListCannotVerifyAnySigPk)
 {
-    Moderation mods{};
+    Moderation mods{system_memory()};
     uint8_t sig_pk[32] = {1};
     EXPECT_FALSE(mod_list_verify_sig_pk(&mods, sig_pk));
 }
 
 TEST(ModList, ModListAddVerifyRemoveSigPK)
 {
-    Moderation mods{};
+    Moderation mods{system_memory()};
     uint8_t sig_pk[32] = {1};
     EXPECT_TRUE(mod_list_add_entry(&mods, sig_pk));
     EXPECT_TRUE(mod_list_verify_sig_pk(&mods, sig_pk));
@@ -143,7 +143,7 @@ TEST(ModList, ModListAddVerifyRemoveSigPK)
 
 TEST(ModList, ModListHashCheck)
 {
-    Moderation mods1{};
+    Moderation mods1{system_memory()};
     uint8_t sig_pk1[32] = {1};
     std::array<uint8_t, MOD_MODERATION_HASH_SIZE> hash1;
 
@@ -165,7 +165,7 @@ TEST(SanctionsList, PackingIntoUndersizedBufferFails)
 
 TEST(SanctionsList, PackUnpackSanctionsCreds)
 {
-    Moderation mod{};
+    Moderation mod{system_memory()};
     std::array<uint8_t, MOD_SANCTIONS_CREDS_SIZE> packed;
     EXPECT_EQ(sanctions_creds_pack(&mod.sanctions_creds, packed.data()), MOD_SANCTIONS_CREDS_SIZE);
     EXPECT_EQ(
@@ -177,7 +177,7 @@ protected:
     ExtPublicKey pk;
     ExtSecretKey sk;
     Logger *log = logger_new();
-    Moderation mod{};
+    Moderation mod{system_memory()};
 
     Mod_Sanction sanctions[2] = {};
     const uint8_t sanctioned_pk1[32] = {1};

--- a/toxcore/mem.c
+++ b/toxcore/mem.c
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2016-2018 The TokTok team.
+ * Copyright © 2013 Tox project.
+ */
+
+#include "mem.h"
+
+#include <stdlib.h>
+
+#include "ccompat.h"
+
+nullable(1)
+static void *sys_malloc(void *obj, uint32_t size)
+{
+    return malloc(size);
+}
+
+nullable(1)
+static void *sys_calloc(void *obj, uint32_t nmemb, uint32_t size)
+{
+    return calloc(nmemb, size);
+}
+
+nullable(1, 2)
+static void *sys_realloc(void *obj, void *ptr, uint32_t size)
+{
+    return realloc(ptr, size);
+}
+
+nullable(1, 2)
+static void sys_free(void *obj, void *ptr)
+{
+    free(ptr);
+}
+
+static const Memory_Funcs system_memory_funcs = {
+    sys_malloc,
+    sys_calloc,
+    sys_realloc,
+    sys_free,
+};
+static const Memory system_memory_obj = {&system_memory_funcs};
+
+const Memory *system_memory(void)
+{
+    return &system_memory_obj;
+}
+
+void *mem_balloc(const Memory *mem, uint32_t size)
+{
+    void *const ptr = mem->funcs->malloc(mem->obj, size);
+    return ptr;
+}
+
+void *mem_alloc(const Memory *mem, uint32_t size)
+{
+    void *const ptr = mem->funcs->calloc(mem->obj, 1, size);
+    return ptr;
+}
+
+void *mem_valloc(const Memory *mem, uint32_t nmemb, uint32_t size)
+{
+    const uint32_t bytes = nmemb * size;
+
+    if (size != 0 && bytes / size != nmemb) {
+        return nullptr;
+    }
+
+    void *const ptr = mem->funcs->calloc(mem->obj, nmemb, size);
+    return ptr;
+}
+
+void *mem_vrealloc(const Memory *mem, void *ptr, uint32_t nmemb, uint32_t size)
+{
+    const uint32_t bytes = nmemb * size;
+
+    if (size != 0 && bytes / size != nmemb) {
+        return nullptr;
+    }
+
+    void *const new_ptr = mem->funcs->realloc(mem->obj, ptr, bytes);
+    return new_ptr;
+}
+
+void mem_delete(const Memory *mem, void *ptr)
+{
+    mem->funcs->free(mem->obj, ptr);
+}

--- a/toxcore/mem.h
+++ b/toxcore/mem.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2016-2018 The TokTok team.
+ * Copyright © 2013 Tox project.
+ */
+
+/**
+ * Memory allocation and deallocation functions.
+ */
+#ifndef C_TOXCORE_TOXCORE_MEM_H
+#define C_TOXCORE_TOXCORE_MEM_H
+
+#include <stdint.h>     // uint*_t
+
+#include "attributes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *mem_malloc_cb(void *obj, uint32_t size);
+typedef void *mem_calloc_cb(void *obj, uint32_t nmemb, uint32_t size);
+typedef void *mem_realloc_cb(void *obj, void *ptr, uint32_t size);
+typedef void mem_free_cb(void *obj, void *ptr);
+
+/** @brief Functions wrapping standard C memory allocation functions. */
+typedef struct Memory_Funcs {
+    mem_malloc_cb *malloc;
+    mem_calloc_cb *calloc;
+    mem_realloc_cb *realloc;
+    mem_free_cb *free;
+} Memory_Funcs;
+
+typedef struct Memory {
+    const Memory_Funcs *funcs;
+    void *obj;
+} Memory;
+
+const Memory *system_memory(void);
+
+/**
+ * @brief Allocate an array of a given size for built-in types.
+ *
+ * The array will not be initialised. Supported built-in types are
+ * `uint8_t`, `int8_t`, and `int16_t`.
+ */
+non_null() void *mem_balloc(const Memory *mem, uint32_t size);
+
+/**
+ * @brief Allocate a single object.
+ *
+ * Always use as `(T *)mem_alloc(mem, sizeof(T))`.
+ */
+non_null() void *mem_alloc(const Memory *mem, uint32_t size);
+
+/**
+ * @brief Allocate a vector (array) of objects.
+ *
+ * Always use as `(T *)mem_valloc(mem, N, sizeof(T))`.
+ */
+non_null() void *mem_valloc(const Memory *mem, uint32_t nmemb, uint32_t size);
+
+/**
+ * @brief Resize an object vector.
+ *
+ * Changes the size of (and possibly moves) the memory block pointed to by
+ * @p ptr to be large enough for an array of @p nmemb elements, each of which
+ * is @p size bytes. It is similar to the call
+ *
+ * @code
+ * realloc(ptr, nmemb * size);
+ * @endcode
+ *
+ * However, unlike that `realloc()` call, `mem_vrealloc()` fails safely in the
+ * case where the multiplication would overflow. If such an overflow occurs,
+ * `mem_vrealloc()` returns `nullptr`.
+ */
+non_null(1) nullable(2) void *mem_vrealloc(const Memory *mem, void *ptr, uint32_t nmemb, uint32_t size);
+
+/** @brief Free an array, object, or object vector. */
+non_null(1) nullable(2) void mem_delete(const Memory *mem, void *ptr);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif

--- a/toxcore/mem_test.cc
+++ b/toxcore/mem_test.cc
@@ -1,0 +1,40 @@
+#include "mem.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Mem, AllocLarge)
+{
+    // Mebi prefix: https://en.wikipedia.org/wiki/Binary_prefix.
+    constexpr uint32_t MI = 1024 * 1024;
+
+    const Memory *mem = system_memory();
+
+    void *ptr = mem_valloc(mem, 4, MI);
+    EXPECT_NE(ptr, nullptr);
+
+    mem_delete(mem, ptr);
+}
+
+TEST(Mem, AllocOverflow)
+{
+    // Gibi prefix.
+    constexpr uint32_t GI = 1024 * 1024 * 1024;
+
+    const Memory *mem = system_memory();
+
+    // 1 gibi-elements of 100 bytes each.
+    void *ptr = mem_valloc(mem, GI, 100);
+    EXPECT_EQ(ptr, nullptr);
+
+    // 100 elements of 1 gibibyte each.
+    ptr = mem_valloc(mem, 100, GI);
+    EXPECT_EQ(ptr, nullptr);
+
+    // 128 (a multiple of 2) elements of 1 gibibyte each.
+    ptr = mem_valloc(mem, 128, GI);
+    EXPECT_EQ(ptr, nullptr);
+}
+
+}  // namespace

--- a/toxcore/mono_time.h
+++ b/toxcore/mono_time.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "attributes.h"
+#include "mem.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,11 +48,11 @@ typedef struct Mono_Time Mono_Time;
 
 typedef uint64_t mono_time_current_time_cb(void *user_data);
 
-nullable(1, 2)
-Mono_Time *mono_time_new(mono_time_current_time_cb *current_time_callback, void *user_data);
+non_null(1) nullable(2, 3)
+Mono_Time *mono_time_new(const Memory *mem, mono_time_current_time_cb *current_time_callback, void *user_data);
 
-nullable(1)
-void mono_time_free(Mono_Time *mono_time);
+non_null(1) nullable(2)
+void mono_time_free(const Memory *mem, Mono_Time *mono_time);
 
 /**
  * Update mono_time; subsequent calls to mono_time_get or mono_time_is_timeout

--- a/toxcore/mono_time_test.cc
+++ b/toxcore/mono_time_test.cc
@@ -6,7 +6,8 @@ namespace {
 
 TEST(MonoTime, UnixTimeIncreasesOverTime)
 {
-    Mono_Time *mono_time = mono_time_new(nullptr, nullptr);
+    const Memory *mem = system_memory();
+    Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
     ASSERT_NE(mono_time, nullptr);
 
     mono_time_update(mono_time);
@@ -19,12 +20,13 @@ TEST(MonoTime, UnixTimeIncreasesOverTime)
     uint64_t const end = mono_time_get(mono_time);
     EXPECT_GT(end, start);
 
-    mono_time_free(mono_time);
+    mono_time_free(mem, mono_time);
 }
 
 TEST(MonoTime, IsTimeout)
 {
-    Mono_Time *mono_time = mono_time_new(nullptr, nullptr);
+    const Memory *mem = system_memory();
+    Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
     ASSERT_NE(mono_time, nullptr);
 
     uint64_t const start = mono_time_get(mono_time);
@@ -36,12 +38,13 @@ TEST(MonoTime, IsTimeout)
 
     EXPECT_TRUE(mono_time_is_timeout(mono_time, start, 1));
 
-    mono_time_free(mono_time);
+    mono_time_free(mem, mono_time);
 }
 
 TEST(MonoTime, CustomTime)
 {
-    Mono_Time *mono_time = mono_time_new(nullptr, nullptr);
+    const Memory *mem = system_memory();
+    Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
     ASSERT_NE(mono_time, nullptr);
 
     uint64_t test_time = current_time_monotonic(mono_time) + 42137;
@@ -61,7 +64,7 @@ TEST(MonoTime, CustomTime)
 
     EXPECT_EQ(current_time_monotonic(mono_time), test_time);
 
-    mono_time_free(mono_time);
+    mono_time_free(mem, mono_time);
 }
 
 }  // namespace

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -398,7 +398,8 @@ void load_secret_key(Net_Crypto *c, const uint8_t *sk);
  * Sets all the global connection variables to their default values.
  */
 non_null()
-Net_Crypto *new_net_crypto(const Logger *log, const Random *rng, const Network *ns, Mono_Time *mono_time, DHT *dht, const TCP_Proxy_Info *proxy_info);
+Net_Crypto *new_net_crypto(const Logger *log, const Memory *mem, const Random *rng, const Network *ns,
+                           Mono_Time *mono_time, DHT *dht, const TCP_Proxy_Info *proxy_info);
 
 /** return the optimal interval in ms for running do_net_crypto. */
 non_null()

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -14,6 +14,7 @@
 #include <stdint.h>     // uint*_t
 
 #include "logger.h"
+#include "mem.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -533,7 +534,7 @@ void networking_poll(const Networking_Core *net, void *userdata);
  * Return false on failure.
  */
 non_null()
-bool net_connect(const Logger *log, Socket sock, const IP_Port *ip_port);
+bool net_connect(const Memory *mem, const Logger *log, Socket sock, const IP_Port *ip_port);
 
 /** @brief High-level getaddrinfo implementation.
  *
@@ -549,11 +550,11 @@ bool net_connect(const Logger *log, Socket sock, const IP_Port *ip_port);
  * @retval -1 on error.
  */
 non_null()
-int32_t net_getipport(const char *node, IP_Port **res, int tox_type);
+int32_t net_getipport(const Memory *mem, const char *node, IP_Port **res, int tox_type);
 
 /** Deallocates memory allocated by net_getipport */
-nullable(1)
-void net_freeipport(IP_Port *ip_ports);
+non_null(1) nullable(2)
+void net_freeipport(const Memory *mem, IP_Port *ip_ports);
 
 /**
  * @return true on success, false on failure.
@@ -600,13 +601,13 @@ void net_kill_strerror(char *strerror);
  *
  * If error is non NULL it is set to 0 if no issues, 1 if socket related error, 2 if other.
  */
-non_null(1, 2, 3) nullable(6)
+non_null(1, 2, 3, 4) nullable(7)
 Networking_Core *new_networking_ex(
-        const Logger *log, const Network *ns, const IP *ip,
+        const Logger *log, const Memory *mem, const Network *ns, const IP *ip,
         uint16_t port_from, uint16_t port_to, unsigned int *error);
 
 non_null()
-Networking_Core *new_networking_no_udp(const Logger *log, const Network *ns);
+Networking_Core *new_networking_no_udp(const Logger *log, const Memory *mem, const Network *ns);
 
 /** Function to cleanup networking stuff (doesn't do much right now). */
 nullable(1)

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -668,13 +668,13 @@ void set_callback_handle_recv_1(Onion *onion, onion_recv_1_cb *function, void *o
     onion->callback_object = object;
 }
 
-Onion *new_onion(const Logger *log, const Mono_Time *mono_time, const Random *rng, DHT *dht)
+Onion *new_onion(const Logger *log, const Memory *mem, const Mono_Time *mono_time, const Random *rng, DHT *dht)
 {
     if (dht == nullptr) {
         return nullptr;
     }
 
-    Onion *onion = (Onion *)calloc(1, sizeof(Onion));
+    Onion *onion = (Onion *)mem_alloc(mem, sizeof(Onion));
 
     if (onion == nullptr) {
         return nullptr;
@@ -685,13 +685,14 @@ Onion *new_onion(const Logger *log, const Mono_Time *mono_time, const Random *rn
     onion->net = dht_get_net(dht);
     onion->mono_time = mono_time;
     onion->rng = rng;
+    onion->mem = mem;
     new_symmetric_key(rng, onion->secret_symmetric_key);
     onion->timestamp = mono_time_get(onion->mono_time);
 
     const uint8_t *secret_key = dht_get_self_secret_key(dht);
-    onion->shared_keys_1 = shared_key_cache_new(mono_time, secret_key, KEYS_TIMEOUT, MAX_KEYS_PER_SLOT);
-    onion->shared_keys_2 = shared_key_cache_new(mono_time, secret_key, KEYS_TIMEOUT, MAX_KEYS_PER_SLOT);
-    onion->shared_keys_3 = shared_key_cache_new(mono_time, secret_key, KEYS_TIMEOUT, MAX_KEYS_PER_SLOT);
+    onion->shared_keys_1 = shared_key_cache_new(mono_time, mem, secret_key, KEYS_TIMEOUT, MAX_KEYS_PER_SLOT);
+    onion->shared_keys_2 = shared_key_cache_new(mono_time, mem, secret_key, KEYS_TIMEOUT, MAX_KEYS_PER_SLOT);
+    onion->shared_keys_3 = shared_key_cache_new(mono_time, mem, secret_key, KEYS_TIMEOUT, MAX_KEYS_PER_SLOT);
 
     if (onion->shared_keys_1 == nullptr ||
         onion->shared_keys_2 == nullptr ||
@@ -732,5 +733,5 @@ void kill_onion(Onion *onion)
     shared_key_cache_free(onion->shared_keys_2);
     shared_key_cache_free(onion->shared_keys_3);
 
-    free(onion);
+    mem_delete(onion->mem, onion);
 }

--- a/toxcore/onion.h
+++ b/toxcore/onion.h
@@ -20,6 +20,7 @@ typedef struct Onion {
     const Logger *log;
     const Mono_Time *mono_time;
     const Random *rng;
+    const Memory *mem;
     DHT *dht;
     Networking_Core *net;
     uint8_t secret_symmetric_key[CRYPTO_SYMMETRIC_KEY_SIZE];
@@ -147,7 +148,7 @@ non_null(1) nullable(2, 3)
 void set_callback_handle_recv_1(Onion *onion, onion_recv_1_cb *function, void *object);
 
 non_null()
-Onion *new_onion(const Logger *log, const Mono_Time *mono_time, const Random *rng, DHT *dht);
+Onion *new_onion(const Logger *log, const Memory *mem, const Mono_Time *mono_time, const Random *rng, DHT *dht);
 
 nullable(1)
 void kill_onion(Onion *onion);

--- a/toxcore/onion_announce.h
+++ b/toxcore/onion_announce.h
@@ -131,7 +131,7 @@ void onion_announce_extra_data_callback(Onion_Announce *onion_a, uint16_t extra_
                                         pack_extra_data_cb *extra_data_callback, void *extra_data_object);
 
 non_null()
-Onion_Announce *new_onion_announce(const Logger *log, const Random *rng, const Mono_Time *mono_time, DHT *dht);
+Onion_Announce *new_onion_announce(const Logger *log, const Memory *mem, const Random *rng, const Mono_Time *mono_time, DHT *dht);
 
 nullable(1)
 void kill_onion_announce(Onion_Announce *onion_a);

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -208,7 +208,7 @@ non_null()
 void do_onion_client(Onion_Client *onion_c);
 
 non_null()
-Onion_Client *new_onion_client(const Logger *logger, const Random *rng, const Mono_Time *mono_time, Net_Crypto *c);
+Onion_Client *new_onion_client(const Logger *logger, const Memory *mem, const Random *rng, const Mono_Time *mono_time, Net_Crypto *c);
 
 nullable(1)
 void kill_onion_client(Onion_Client *onion_c);

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -336,18 +336,18 @@ void ping_iterate(Ping *ping)
 }
 
 
-Ping *ping_new(const Mono_Time *mono_time, const Random *rng, DHT *dht)
+Ping *ping_new(const Memory *mem, const Mono_Time *mono_time, const Random *rng, DHT *dht)
 {
-    Ping *ping = (Ping *)calloc(1, sizeof(Ping));
+    Ping *ping = (Ping *)mem_alloc(mem, sizeof(Ping));
 
     if (ping == nullptr) {
         return nullptr;
     }
 
-    ping->ping_array = ping_array_new(PING_NUM_MAX, PING_TIMEOUT);
+    ping->ping_array = ping_array_new(mem, PING_NUM_MAX, PING_TIMEOUT);
 
     if (ping->ping_array == nullptr) {
-        free(ping);
+        mem_delete(mem, ping);
         return nullptr;
     }
 
@@ -360,7 +360,7 @@ Ping *ping_new(const Mono_Time *mono_time, const Random *rng, DHT *dht)
     return ping;
 }
 
-void ping_kill(Ping *ping)
+void ping_kill(const Memory *mem, Ping *ping)
 {
     if (ping == nullptr) {
         return;
@@ -370,5 +370,5 @@ void ping_kill(Ping *ping)
     networking_registerhandler(dht_get_net(ping->dht), NET_PACKET_PING_RESPONSE, nullptr, nullptr);
     ping_array_kill(ping->ping_array);
 
-    free(ping);
+    mem_delete(mem, ping);
 }

--- a/toxcore/ping.h
+++ b/toxcore/ping.h
@@ -18,10 +18,10 @@
 typedef struct Ping Ping;
 
 non_null()
-Ping *ping_new(const Mono_Time *mono_time, const Random *rng, DHT *dht);
+Ping *ping_new(const Memory *mem, const Mono_Time *mono_time, const Random *rng, DHT *dht);
 
-nullable(1)
-void ping_kill(Ping *ping);
+non_null(1) nullable(2)
+void ping_kill(const Memory *mem, Ping *ping);
 
 /** @brief Add nodes to the to_ping list.
  * All nodes in this list are pinged every TIME_TO_PING seconds

--- a/toxcore/ping_array.h
+++ b/toxcore/ping_array.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 
 #include "crypto_core.h"
+#include "mem.h"
 #include "mono_time.h"
 
 #ifdef __cplusplus
@@ -29,7 +30,8 @@ typedef struct Ping_Array Ping_Array;
  *
  * @return pointer to allocated Ping_Array on success, nullptr on failure.
  */
-struct Ping_Array *ping_array_new(uint32_t size, uint32_t timeout);
+non_null()
+struct Ping_Array *ping_array_new(const Memory *mem, uint32_t size, uint32_t timeout);
 
 /**
  * @brief Free all the allocated memory in a @ref Ping_Array.

--- a/toxcore/ping_array_test.cc
+++ b/toxcore/ping_array_test.cc
@@ -15,41 +15,54 @@ struct Ping_Array_Deleter {
 using Ping_Array_Ptr = std::unique_ptr<Ping_Array, Ping_Array_Deleter>;
 
 struct Mono_Time_Deleter {
-    void operator()(Mono_Time *arr) { mono_time_free(arr); }
+    Mono_Time_Deleter(const Memory *mem)
+        : mem_(mem)
+    {
+    }
+    void operator()(Mono_Time *arr) { mono_time_free(mem_, arr); }
+
+private:
+    const Memory *mem_;
 };
 
 using Mono_Time_Ptr = std::unique_ptr<Mono_Time, Mono_Time_Deleter>;
 
 TEST(PingArray, MinimumTimeoutIsOne)
 {
-    EXPECT_EQ(ping_array_new(1, 0), nullptr);
-    EXPECT_NE(Ping_Array_Ptr(ping_array_new(1, 1)), nullptr);
+    const Memory *mem = system_memory();
+    EXPECT_EQ(ping_array_new(mem, 1, 0), nullptr);
+    EXPECT_NE(Ping_Array_Ptr(ping_array_new(mem, 1, 1)), nullptr);
 }
 
 TEST(PingArray, MinimumArraySizeIsOne)
 {
-    EXPECT_EQ(ping_array_new(0, 1), nullptr);
-    EXPECT_NE(Ping_Array_Ptr(ping_array_new(1, 1)), nullptr);
+    const Memory *mem = system_memory();
+    EXPECT_EQ(ping_array_new(mem, 0, 1), nullptr);
+    EXPECT_NE(Ping_Array_Ptr(ping_array_new(mem, 1, 1)), nullptr);
 }
 
 TEST(PingArray, ArraySizeMustBePowerOfTwo)
 {
+    const Memory *mem = system_memory();
+
     Ping_Array_Ptr arr;
-    arr.reset(ping_array_new(2, 1));
+    arr.reset(ping_array_new(mem, 2, 1));
     EXPECT_NE(arr, nullptr);
-    arr.reset(ping_array_new(4, 1));
+    arr.reset(ping_array_new(mem, 4, 1));
     EXPECT_NE(arr, nullptr);
-    arr.reset(ping_array_new(1024, 1));
+    arr.reset(ping_array_new(mem, 1024, 1));
     EXPECT_NE(arr, nullptr);
 
-    EXPECT_EQ(ping_array_new(1023, 1), nullptr);
-    EXPECT_EQ(ping_array_new(1234, 1), nullptr);
+    EXPECT_EQ(ping_array_new(mem, 1023, 1), nullptr);
+    EXPECT_EQ(ping_array_new(mem, 1234, 1), nullptr);
 }
 
 TEST(PingArray, StoredDataCanBeRetrieved)
 {
-    Ping_Array_Ptr const arr(ping_array_new(2, 1));
-    Mono_Time_Ptr const mono_time(mono_time_new(nullptr, nullptr));
+    const Memory *mem = system_memory();
+
+    Ping_Array_Ptr const arr(ping_array_new(mem, 2, 1));
+    Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
     const Random *rng = system_random();
     ASSERT_NE(rng, nullptr);
@@ -65,8 +78,10 @@ TEST(PingArray, StoredDataCanBeRetrieved)
 
 TEST(PingArray, RetrievingDataWithTooSmallOutputBufferHasNoEffect)
 {
-    Ping_Array_Ptr const arr(ping_array_new(2, 1));
-    Mono_Time_Ptr const mono_time(mono_time_new(nullptr, nullptr));
+    const Memory *mem = system_memory();
+
+    Ping_Array_Ptr const arr(ping_array_new(mem, 2, 1));
+    Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
     const Random *rng = system_random();
     ASSERT_NE(rng, nullptr);
@@ -86,8 +101,10 @@ TEST(PingArray, RetrievingDataWithTooSmallOutputBufferHasNoEffect)
 
 TEST(PingArray, ZeroLengthDataCanBeAdded)
 {
-    Ping_Array_Ptr const arr(ping_array_new(2, 1));
-    Mono_Time_Ptr const mono_time(mono_time_new(nullptr, nullptr));
+    const Memory *mem = system_memory();
+
+    Ping_Array_Ptr const arr(ping_array_new(mem, 2, 1));
+    Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
     const Random *rng = system_random();
     ASSERT_NE(rng, nullptr);
@@ -101,8 +118,10 @@ TEST(PingArray, ZeroLengthDataCanBeAdded)
 
 TEST(PingArray, PingId0IsInvalid)
 {
-    Ping_Array_Ptr const arr(ping_array_new(2, 1));
-    Mono_Time_Ptr const mono_time(mono_time_new(nullptr, nullptr));
+    const Memory *mem = system_memory();
+
+    Ping_Array_Ptr const arr(ping_array_new(mem, 2, 1));
+    Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
 
     uint8_t c = 0;
@@ -112,8 +131,10 @@ TEST(PingArray, PingId0IsInvalid)
 // Protection against replay attacks.
 TEST(PingArray, DataCanOnlyBeRetrievedOnce)
 {
-    Ping_Array_Ptr const arr(ping_array_new(2, 1));
-    Mono_Time_Ptr const mono_time(mono_time_new(nullptr, nullptr));
+    const Memory *mem = system_memory();
+
+    Ping_Array_Ptr const arr(ping_array_new(mem, 2, 1));
+    Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
     const Random *rng = system_random();
     ASSERT_NE(rng, nullptr);
@@ -128,8 +149,10 @@ TEST(PingArray, DataCanOnlyBeRetrievedOnce)
 
 TEST(PingArray, PingIdMustMatchOnCheck)
 {
-    Ping_Array_Ptr const arr(ping_array_new(1, 1));
-    Mono_Time_Ptr const mono_time(mono_time_new(nullptr, nullptr));
+    const Memory *mem = system_memory();
+
+    Ping_Array_Ptr const arr(ping_array_new(mem, 1, 1));
+    Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
     const Random *rng = system_random();
     ASSERT_NE(rng, nullptr);

--- a/toxcore/shared_key_cache.h
+++ b/toxcore/shared_key_cache.h
@@ -8,6 +8,7 @@
 #include <stdint.h>     // uint*_t
 
 #include "crypto_core.h"
+#include "mem.h"
 #include "mono_time.h"
 
 /**
@@ -18,7 +19,7 @@ typedef struct Shared_Key_Cache Shared_Key_Cache;
 
 /**
  * @brief Initializes a new shared key cache.
- * @param time Time object for retrieving current time.
+ * @param mono_time Time object for retrieving current time.
  * @param self_secret_key Our own secret key of length CRYPTO_SECRET_KEY_SIZE,
  * it must not change during the lifetime of the cache.
  * @param timeout Number of milliseconds, after which a key should be evicted.
@@ -26,7 +27,7 @@ typedef struct Shared_Key_Cache Shared_Key_Cache;
  * @return nullptr on error.
  */
 non_null()
-Shared_Key_Cache *shared_key_cache_new(const Mono_Time *time,
+Shared_Key_Cache *shared_key_cache_new(const Mono_Time *mono_time, const Memory *mem,
                                        const uint8_t *self_secret_key,
                                        uint64_t timeout, uint8_t keys_per_slot);
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -684,8 +684,8 @@ struct Tox_Options {
     bool experimental_thread_safety;
 
     /**
-     * Low level operating system functionality such as send/recv and random
-     * number generation.
+     * Low level operating system functionality such as send/recv, random
+     * number generation, and memory allocation.
      */
     const Tox_System *operating_system;
 
@@ -910,6 +910,8 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error);
  * functions can be called, and the pointer value can no longer be read.
  */
 void tox_kill(Tox *tox);
+
+const Tox_System *tox_get_system(Tox *tox);
 
 /**
  * @brief Calculates the number of bytes required to store the tox instance with

--- a/toxcore/tox_events.h
+++ b/toxcore/tox_events.h
@@ -343,9 +343,9 @@ void tox_events_free(Tox_Events *events);
 uint32_t tox_events_bytes_size(const Tox_Events *events);
 void tox_events_get_bytes(const Tox_Events *events, uint8_t *bytes);
 
-Tox_Events *tox_events_load(const uint8_t *bytes, uint32_t bytes_size);
+Tox_Events *tox_events_load(const Tox_System *sys, const uint8_t *bytes, uint32_t bytes_size);
 
-bool tox_events_equal(const Tox_Events *a, const Tox_Events *b);
+bool tox_events_equal(const Tox_System *sys, const Tox_Events *a, const Tox_Events *b);
 
 #ifdef __cplusplus
 }

--- a/toxcore/tox_events_fuzz_test.cc
+++ b/toxcore/tox_events_fuzz_test.cc
@@ -1,13 +1,33 @@
 #include "tox_events.h"
 
 #include <cstdint>
+#include <cstring>
 #include <vector>
+
+#include "../testing/fuzzing/fuzz_support.h"
 
 namespace {
 
-void TestUnpack(const uint8_t *data, size_t size)
+void TestUnpack(Fuzz_Data data)
 {
-    Tox_Events *events = tox_events_load(data, size);
+    // 2 bytes: size of the events data
+    CONSUME_OR_RETURN(const uint8_t *events_size_bytes, data, sizeof(uint16_t));
+    uint16_t events_size;
+    std::memcpy(&events_size, events_size_bytes, sizeof(uint16_t));
+
+    // events_size bytes: events data (max 64K)
+    CONSUME_OR_RETURN(const uint8_t *events_data, data, events_size);
+
+    if (data.size == 0) {
+        // If there's no more input, no malloc failure paths can possibly be
+        // tested, so we ignore this input.
+        return;
+    }
+
+    // rest of the fuzz data is input for malloc
+    Fuzz_System sys{data};
+
+    Tox_Events *events = tox_events_load(sys.sys.get(), events_data, events_size);
     if (events) {
         std::vector<uint8_t> packed(tox_events_bytes_size(events));
         tox_events_get_bytes(events, packed.data());
@@ -20,6 +40,6 @@ void TestUnpack(const uint8_t *data, size_t size)
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    TestUnpack(data, size);
+    TestUnpack(Fuzz_Data(data, size));
     return 0;
 }

--- a/toxcore/tox_events_test.cc
+++ b/toxcore/tox_events_test.cc
@@ -6,29 +6,32 @@
 #include <vector>
 
 #include "crypto_core.h"
+#include "tox_private.h"
 
 namespace {
 
 TEST(ToxEvents, UnpackRandomDataDoesntCrash)
 {
-    const Random *rng = system_random();
-    ASSERT_NE(rng, nullptr);
+    const Tox_System sys = tox_default_system();
+    ASSERT_NE(sys.rng, nullptr);
     std::array<uint8_t, 128> data;
-    random_bytes(rng, data.data(), data.size());
-    tox_events_free(tox_events_load(data.data(), data.size()));
+    random_bytes(sys.rng, data.data(), data.size());
+    tox_events_free(tox_events_load(&sys, data.data(), data.size()));
 }
 
 TEST(ToxEvents, UnpackEmptyDataFails)
 {
+    const Tox_System sys = tox_default_system();
     std::array<uint8_t, 1> data;
-    Tox_Events *events = tox_events_load(data.end(), 0);
+    Tox_Events *events = tox_events_load(&sys, data.end(), 0);
     EXPECT_EQ(events, nullptr);
 }
 
 TEST(ToxEvents, UnpackEmptyArrayCreatesEmptyEvents)
 {
+    const Tox_System sys = tox_default_system();
     std::array<uint8_t, 1> data{0x90};  // empty msgpack array
-    Tox_Events *events = tox_events_load(data.data(), data.size());
+    Tox_Events *events = tox_events_load(&sys, data.data(), data.size());
     ASSERT_NE(events, nullptr);
     EXPECT_EQ(tox_events_get_conference_connected_size(events), 0);
     tox_events_free(events);
@@ -44,9 +47,10 @@ TEST(ToxEvents, NullEventsPacksToEmptyArray)
 
 TEST(ToxEvents, PackedEventsCanBeUnpacked)
 {
+    const Tox_System sys = tox_default_system();
     // [[0, 1]] == Tox_Self_Connection_Status { .connection_status = TOX_CONNECTION_TCP }
     std::array<uint8_t, 6> packed{0x91, 0x92, 0xcc, 0x00, 0xcc, 0x01};
-    Tox_Events *events = tox_events_load(packed.data(), packed.size());
+    Tox_Events *events = tox_events_load(&sys, packed.data(), packed.size());
     ASSERT_NE(events, nullptr);
     std::array<uint8_t, 4> bytes;
     ASSERT_EQ(tox_events_bytes_size(events), bytes.size());
@@ -57,8 +61,9 @@ TEST(ToxEvents, PackedEventsCanBeUnpacked)
 
 TEST(ToxEvents, DealsWithHugeMsgpackArrays)
 {
+    const Tox_System sys = tox_default_system();
     std::vector<uint8_t> data{0xdd, 0xff, 0xff, 0xff, 0xff};
-    EXPECT_EQ(tox_events_load(data.data(), data.size()), nullptr);
+    EXPECT_EQ(tox_events_load(&sys, data.data(), data.size()), nullptr);
 }
 
 }  // namespace

--- a/toxcore/tox_private.c
+++ b/toxcore/tox_private.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 
 #include "ccompat.h"
+#include "mem.h"
 #include "network.h"
 #include "tox_struct.h"
 
@@ -28,6 +29,7 @@ Tox_System tox_default_system(void)
         nullptr,  // mono_time_user_data
         system_random(),
         system_network(),
+        system_memory(),
     };
     return sys;
 }
@@ -115,11 +117,11 @@ bool tox_dht_get_nodes(const Tox *tox, const uint8_t *public_key, const char *ip
 
     IP_Port *root;
 
-    const int32_t count = net_getipport(ip, &root, TOX_SOCK_DGRAM);
+    const int32_t count = net_getipport(tox->sys.mem, ip, &root, TOX_SOCK_DGRAM);
 
     if (count < 1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_DHT_GET_NODES_BAD_IP);
-        net_freeipport(root);
+        net_freeipport(tox->sys.mem, root);
         tox_unlock(tox);
         return false;
     }
@@ -136,7 +138,7 @@ bool tox_dht_get_nodes(const Tox *tox, const uint8_t *public_key, const char *ip
 
     tox_unlock(tox);
 
-    net_freeipport(root);
+    net_freeipport(tox->sys.mem, root);
 
     if (!success) {
         SET_ERROR_PARAMETER(error, TOX_ERR_DHT_GET_NODES_FAIL);

--- a/toxcore/tox_private.h
+++ b/toxcore/tox_private.h
@@ -23,6 +23,7 @@ struct Tox_System {
     void *mono_time_user_data;
     const struct Random *rng;
     const struct Network *ns;
+    const struct Memory *mem;
 };
 
 Tox_System tox_default_system(void);

--- a/toxcore/tox_struct.h
+++ b/toxcore/tox_struct.h
@@ -7,6 +7,7 @@
 #define C_TOXCORE_TOXCORE_TOX_STRUCT_H
 
 #include "Messenger.h"
+#include "mem.h"
 #include "tox.h"
 #include "tox_private.h"
 
@@ -17,8 +18,7 @@ extern "C" {
 struct Tox {
     Messenger *m;
     Mono_Time *mono_time;
-    Random rng;
-    Network ns;
+    Tox_System sys;
     pthread_mutex_t *mutex;
 
     tox_log_cb *log_callback;

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -24,7 +24,7 @@ bool is_power_of_2(uint64_t x)
     return x != 0 && (x & (~x + 1)) == x;
 }
 
-void free_uint8_t_pointer_array(uint8_t **ary, size_t n_items)
+void free_uint8_t_pointer_array(const Memory *mem, uint8_t **ary, size_t n_items)
 {
     if (ary == nullptr) {
         return;
@@ -32,11 +32,11 @@ void free_uint8_t_pointer_array(uint8_t **ary, size_t n_items)
 
     for (size_t i = 0; i < n_items; ++i) {
         if (ary[i] != nullptr) {
-            free(ary[i]);
+            mem_delete(mem, ary[i]);
         }
     }
 
-    free(ary);
+    mem_delete(mem, ary);
 }
 
 uint16_t data_checksum(const uint8_t *data, uint32_t length)

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -16,6 +16,7 @@
 #include <stdint.h>
 
 #include "attributes.h"
+#include "mem.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,8 +25,8 @@ extern "C" {
 bool is_power_of_2(uint64_t x);
 
 /** @brief Frees all pointers in a uint8_t pointer array, as well as the array itself. */
-nullable(1)
-void free_uint8_t_pointer_array(uint8_t **ary, size_t n_items);
+non_null(1) nullable(2)
+void free_uint8_t_pointer_array(const Memory *mem, uint8_t **ary, size_t n_items);
 
 /** Returns -1 if failed or 0 if success */
 non_null() int create_recursive_mutex(pthread_mutex_t *mutex);


### PR DESCRIPTION
This will allow us to do more interesting things with memory allocation within toxcore, and allow fuzzers to explore various allocation failure paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2393)
<!-- Reviewable:end -->
