### PR TITLE
test: Add control flow integrity sanitizer.

### DIFF
--- a/.circleci/cmake-cfisan
+++ b/.circleci/cmake-cfisan
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eu
+
+CACHEDIR="$HOME/cache"
+
+. ".github/scripts/flags-$CC.sh"
+add_flag -Werror
+add_flag -fdiagnostics-color=always
+add_flag -flto=thin  # for cfi
+add_flag -fno-omit-frame-pointer
+add_flag -fsanitize=cfi
+cmake -B_build -H. -GNinja \
+  -DCMAKE_C_FLAGS="$C_FLAGS" \
+  -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
+  -DCMAKE_EXE_LINKER_FLAGS="$LD_FLAGS" \
+  -DCMAKE_SHARED_LINKER_FLAGS="$LD_FLAGS" \
+  -DCMAKE_INSTALL_PREFIX:PATH="$PWD/_install" \
+  -DCMAKE_UNITY_BUILD=ON \
+  -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+  -DMIN_LOGGER_LEVEL=TRACE \
+  -DMUST_BUILD_TOXAV=ON \
+  -DNON_HERMETIC_TESTS=ON \
+  -DSTRICT_ABI=ON \
+  -DENABLE_SHARED=OFF \
+  -DTEST_TIMEOUT_SECONDS=120 \
+  -DUSE_IPV6=OFF \
+  -DAUTOTEST=ON
+
+cd _build
+
+ninja install -j"$(nproc)"
+
+ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
     jobs:
       # Dynamic analysis
       - asan
+      - cfisan
       - tsan
       - msan
       - ubsan
@@ -54,6 +55,17 @@ jobs:
       - checkout
       - run: git submodule update --init --recursive
       - run: CC=clang .circleci/cmake-tsan
+
+  cfisan:
+    working_directory: ~/work
+    docker:
+      - image: ubuntu
+
+    steps:
+      - run: *apt_install
+      - checkout
+      - run: git submodule update --init --recursive
+      - run: CC=clang .circleci/cmake-cfisan
 
   ubsan:
     working_directory: ~/work

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.12)
-cmake_policy(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(VERSION 3.9)
 project(toxcore)
 
 list(APPEND CMAKE_MODULE_PATH ${toxcore_SOURCE_DIR}/cmake)
@@ -74,6 +74,9 @@ include(GNUInstallDirs)
 if(APPLE)
   include(MacRpath)
 endif()
+
+include(CheckIPOSupported)
+check_ipo_supported()
 
 enable_testing()
 


### PR DESCRIPTION
This will check whether conversions to and casts from `void*` are correct. E.g. `int* -> void* -> float*` will trip the sanitizer.

https://clang.llvm.org/docs/ControlFlowIntegrity.html