### PR TITLE
cleanup: Enforce stricter identifier naming using clang-tidy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,10 +144,9 @@ jobs:
       - run:
           apt-get install -y --no-install-recommends
             ca-certificates
-            clang-tidy-12
+            clang-tidy-14
       - checkout
       - run: git submodule update --init --recursive
-      - run: cmake . -B_build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       - run:
           other/analysis/run-clang-tidy ||
           other/analysis/run-clang-tidy ||

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,35 @@
+# vim:ft=yaml
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           Camel_Snake_Case
+  - key:             readability-identifier-naming.ConstantCase
+    value:           lower_case
+  # bootstrap-daemon has these.
+  - key:             readability-identifier-naming.ConstantIgnoredRegexp
+    value:           "^NAME_.*"
+  - key:             readability-identifier-naming.EnumCase
+    value:           Camel_Snake_Case
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.FunctionCase
+    value:           lower_case
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           lower_case
+  - key:             readability-identifier-naming.MemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.MacroDefinitionCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.MacroDefinitionIgnoredRegexp
+    value:           "^_.*|nullable|non_null|nullptr|static_assert|ck_.*"
+  - key:             readability-identifier-naming.ParameterCase
+    value:           lower_case
+  - key:             readability-identifier-naming.StructCase
+    value:           Camel_Snake_Case
+  - key:             readability-identifier-naming.TypedefCase
+    value:           Camel_Snake_Case
+  - key:             readability-identifier-naming.TypedefIgnoredRegexp
+    value:           ".*_cb"
+  - key:             readability-identifier-naming.UnionCase
+    value:           Camel_Snake_Case
+  - key:             readability-identifier-naming.VariableCase
+    value:           lower_case

--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -34,11 +34,11 @@ static IP get_loopback(void)
     return ip;
 }
 
-static void do_TCP_server_delay(TCP_Server *tcp_s, Mono_Time *mono_time, int delay)
+static void do_tcp_server_delay(TCP_Server *tcp_s, Mono_Time *mono_time, int delay)
 {
     c_sleep(delay);
     mono_time_update(mono_time);
-    do_TCP_server(tcp_s, mono_time);
+    do_tcp_server(tcp_s, mono_time);
     c_sleep(delay);
 }
 static uint16_t ports[NUM_PORTS] = {13215, 33445, 25643};
@@ -60,7 +60,7 @@ static void test_basic(void)
     uint8_t self_public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t self_secret_key[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(rng, self_public_key, self_secret_key);
-    TCP_Server *tcp_s = new_TCP_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
+    TCP_Server *tcp_s = new_tcp_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
     ck_assert_msg(tcp_s != nullptr, "Failed to create a TCP relay server.");
     ck_assert_msg(tcp_server_listen_count(tcp_s) == NUM_PORTS,
                   "Failed to bind a TCP relay server to all %d attempted ports.", NUM_PORTS);
@@ -114,14 +114,14 @@ static void test_basic(void)
                            &localhost) == TCP_CLIENT_HANDSHAKE_SIZE - 1,
                   "An attempt to send the initial handshake minus last byte failed.");
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     ck_assert_msg(net_send(ns, logger, sock, handshake + (TCP_CLIENT_HANDSHAKE_SIZE - 1), 1, &localhost) == 1,
                   "The attempt to send the last byte of handshake failed.");
 
     free(handshake);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     // Receiving server response and decrypting it
     uint8_t response[TCP_SERVER_HANDSHAKE_SIZE];
@@ -161,7 +161,7 @@ static void test_basic(void)
 
         c_sleep(50);
         mono_time_update(mono_time);
-        do_TCP_server(tcp_s, mono_time);
+        do_tcp_server(tcp_s, mono_time);
     }
 
     // Receiving the second response and verifying its validity
@@ -185,7 +185,7 @@ static void test_basic(void)
 
     // Closing connections.
     kill_sock(ns, sock);
-    kill_TCP_server(tcp_s);
+    kill_tcp_server(tcp_s);
 
     logger_kill(logger);
     mono_time_free(mem, mono_time);
@@ -201,7 +201,7 @@ struct sec_TCP_con {
     uint8_t shared_key[CRYPTO_SHARED_KEY_SIZE];
 };
 
-static struct sec_TCP_con *new_TCP_con(const Logger *logger, const Memory *mem, const Random *rng, const Network *ns, TCP_Server *tcp_s, Mono_Time *mono_time)
+static struct sec_TCP_con *new_tcp_con(const Logger *logger, const Memory *mem, const Random *rng, const Network *ns, TCP_Server *tcp_s, Mono_Time *mono_time)
 {
     struct sec_TCP_con *sec_c = (struct sec_TCP_con *)malloc(sizeof(struct sec_TCP_con));
     ck_assert(sec_c != nullptr);
@@ -237,12 +237,12 @@ static struct sec_TCP_con *new_TCP_con(const Logger *logger, const Memory *mem, 
                            &localhost) == TCP_CLIENT_HANDSHAKE_SIZE - 1,
                   "Failed to send the first portion of the handshake to the TCP relay server.");
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     ck_assert_msg(net_send(ns, logger, sock, handshake + (TCP_CLIENT_HANDSHAKE_SIZE - 1), 1, &localhost) == 1,
                   "Failed to send last byte of handshake.");
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     uint8_t response[TCP_SERVER_HANDSHAKE_SIZE];
     uint8_t response_plain[TCP_HANDSHAKE_PLAIN_SIZE];
@@ -257,13 +257,13 @@ static struct sec_TCP_con *new_TCP_con(const Logger *logger, const Memory *mem, 
     return sec_c;
 }
 
-static void kill_TCP_con(struct sec_TCP_con *con)
+static void kill_tcp_con(struct sec_TCP_con *con)
 {
     kill_sock(con->ns, con->sock);
     free(con);
 }
 
-static int write_packet_TCP_test_connection(const Logger *logger, struct sec_TCP_con *con, const uint8_t *data,
+static int write_packet_tcp_test_connection(const Logger *logger, struct sec_TCP_con *con, const uint8_t *data,
         uint16_t length)
 {
     VLA(uint8_t, packet, sizeof(uint16_t) + length + CRYPTO_MAC_SIZE);
@@ -287,7 +287,7 @@ static int write_packet_TCP_test_connection(const Logger *logger, struct sec_TCP
     return 0;
 }
 
-static int read_packet_sec_TCP(const Logger *logger, struct sec_TCP_con *con, uint8_t *data, uint16_t length)
+static int read_packet_sec_tcp(const Logger *logger, struct sec_TCP_con *con, uint8_t *data, uint16_t length)
 {
     IP_Port localhost;
     localhost.ip = get_loopback();
@@ -316,35 +316,35 @@ static void test_some(void)
     uint8_t self_public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t self_secret_key[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(rng, self_public_key, self_secret_key);
-    TCP_Server *tcp_s = new_TCP_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
+    TCP_Server *tcp_s = new_tcp_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
     ck_assert_msg(tcp_s != nullptr, "Failed to create TCP relay server");
     ck_assert_msg(tcp_server_listen_count(tcp_s) == NUM_PORTS, "Failed to bind to all ports.");
 
-    struct sec_TCP_con *con1 = new_TCP_con(logger, mem, rng, ns, tcp_s, mono_time);
-    struct sec_TCP_con *con2 = new_TCP_con(logger, mem, rng, ns, tcp_s, mono_time);
-    struct sec_TCP_con *con3 = new_TCP_con(logger, mem, rng, ns, tcp_s, mono_time);
+    struct sec_TCP_con *con1 = new_tcp_con(logger, mem, rng, ns, tcp_s, mono_time);
+    struct sec_TCP_con *con2 = new_tcp_con(logger, mem, rng, ns, tcp_s, mono_time);
+    struct sec_TCP_con *con3 = new_tcp_con(logger, mem, rng, ns, tcp_s, mono_time);
 
     uint8_t requ_p[1 + CRYPTO_PUBLIC_KEY_SIZE];
     requ_p[0] = TCP_PACKET_ROUTING_REQUEST;
 
     // Sending wrong public keys to test server response.
     memcpy(requ_p + 1, con3->public_key, CRYPTO_PUBLIC_KEY_SIZE);
-    write_packet_TCP_test_connection(logger, con1, requ_p, sizeof(requ_p));
+    write_packet_tcp_test_connection(logger, con1, requ_p, sizeof(requ_p));
     memcpy(requ_p + 1, con1->public_key, CRYPTO_PUBLIC_KEY_SIZE);
-    write_packet_TCP_test_connection(logger, con3, requ_p, sizeof(requ_p));
+    write_packet_tcp_test_connection(logger, con3, requ_p, sizeof(requ_p));
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     // Testing response from connection 1
     uint8_t data[2048];
-    int len = read_packet_sec_TCP(logger, con1, data, 2 + 1 + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_MAC_SIZE);
+    int len = read_packet_sec_tcp(logger, con1, data, 2 + 1 + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == 1 + 1 + CRYPTO_PUBLIC_KEY_SIZE, "Wrong response packet length of %d.", len);
     ck_assert_msg(data[0] == TCP_PACKET_ROUTING_RESPONSE, "Wrong response packet id of %d.", data[0]);
     ck_assert_msg(data[1] == 16, "Server didn't refuse connection using wrong public key.");
     ck_assert_msg(pk_equal(data + 2, con3->public_key), "Key in response packet wrong.");
 
     // Connection 3
-    len = read_packet_sec_TCP(logger, con3, data, 2 + 1 + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_MAC_SIZE);
+    len = read_packet_sec_tcp(logger, con3, data, 2 + 1 + 1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == 1 + 1 + CRYPTO_PUBLIC_KEY_SIZE, "Wrong response packet length of %d.", len);
     ck_assert_msg(data[0] == TCP_PACKET_ROUTING_RESPONSE, "Wrong response packet id of %d.", data[0]);
     ck_assert_msg(data[1] == 16, "Server didn't refuse connection using wrong public key.");
@@ -352,64 +352,64 @@ static void test_some(void)
 
     uint8_t test_packet[512] = {16, 17, 16, 86, 99, 127, 255, 189, 78}; // What is this packet????
 
-    write_packet_TCP_test_connection(logger, con3, test_packet, sizeof(test_packet));
-    write_packet_TCP_test_connection(logger, con3, test_packet, sizeof(test_packet));
-    write_packet_TCP_test_connection(logger, con3, test_packet, sizeof(test_packet));
+    write_packet_tcp_test_connection(logger, con3, test_packet, sizeof(test_packet));
+    write_packet_tcp_test_connection(logger, con3, test_packet, sizeof(test_packet));
+    write_packet_tcp_test_connection(logger, con3, test_packet, sizeof(test_packet));
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
-    len = read_packet_sec_TCP(logger, con1, data, 2 + 2 + CRYPTO_MAC_SIZE);
+    len = read_packet_sec_tcp(logger, con1, data, 2 + 2 + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == 2, "wrong len %d", len);
     ck_assert_msg(data[0] == TCP_PACKET_CONNECTION_NOTIFICATION, "wrong packet id %u", data[0]);
     ck_assert_msg(data[1] == 16, "wrong peer id %u", data[1]);
-    len = read_packet_sec_TCP(logger, con3, data, 2 + 2 + CRYPTO_MAC_SIZE);
+    len = read_packet_sec_tcp(logger, con3, data, 2 + 2 + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == 2, "wrong len %d", len);
     ck_assert_msg(data[0] == TCP_PACKET_CONNECTION_NOTIFICATION, "wrong packet id %u", data[0]);
     ck_assert_msg(data[1] == 16, "wrong peer id %u", data[1]);
-    len = read_packet_sec_TCP(logger, con1, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
+    len = read_packet_sec_tcp(logger, con1, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == sizeof(test_packet), "wrong len %d", len);
     ck_assert_msg(memcmp(data, test_packet, sizeof(test_packet)) == 0, "packet is wrong %u %u %u %u", data[0], data[1],
                   data[sizeof(test_packet) - 2], data[sizeof(test_packet) - 1]);
-    len = read_packet_sec_TCP(logger, con1, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
+    len = read_packet_sec_tcp(logger, con1, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == sizeof(test_packet), "wrong len %d", len);
     ck_assert_msg(memcmp(data, test_packet, sizeof(test_packet)) == 0, "packet is wrong %u %u %u %u", data[0], data[1],
                   data[sizeof(test_packet) - 2], data[sizeof(test_packet) - 1]);
-    len = read_packet_sec_TCP(logger, con1, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
+    len = read_packet_sec_tcp(logger, con1, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == sizeof(test_packet), "wrong len %d", len);
     ck_assert_msg(memcmp(data, test_packet, sizeof(test_packet)) == 0, "packet is wrong %u %u %u %u", data[0], data[1],
                   data[sizeof(test_packet) - 2], data[sizeof(test_packet) - 1]);
-    write_packet_TCP_test_connection(logger, con1, test_packet, sizeof(test_packet));
-    write_packet_TCP_test_connection(logger, con1, test_packet, sizeof(test_packet));
-    write_packet_TCP_test_connection(logger, con1, test_packet, sizeof(test_packet));
-    do_TCP_server_delay(tcp_s, mono_time, 50);
-    len = read_packet_sec_TCP(logger, con3, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
+    write_packet_tcp_test_connection(logger, con1, test_packet, sizeof(test_packet));
+    write_packet_tcp_test_connection(logger, con1, test_packet, sizeof(test_packet));
+    write_packet_tcp_test_connection(logger, con1, test_packet, sizeof(test_packet));
+    do_tcp_server_delay(tcp_s, mono_time, 50);
+    len = read_packet_sec_tcp(logger, con3, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == sizeof(test_packet), "wrong len %d", len);
     ck_assert_msg(memcmp(data, test_packet, sizeof(test_packet)) == 0, "packet is wrong %u %u %u %u", data[0], data[1],
                   data[sizeof(test_packet) - 2], data[sizeof(test_packet) - 1]);
-    len = read_packet_sec_TCP(logger, con3, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
+    len = read_packet_sec_tcp(logger, con3, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == sizeof(test_packet), "wrong len %d", len);
     ck_assert_msg(memcmp(data, test_packet, sizeof(test_packet)) == 0, "packet is wrong %u %u %u %u", data[0], data[1],
                   data[sizeof(test_packet) - 2], data[sizeof(test_packet) - 1]);
-    len = read_packet_sec_TCP(logger, con3, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
+    len = read_packet_sec_tcp(logger, con3, data, 2 + sizeof(test_packet) + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == sizeof(test_packet), "wrong len %d", len);
     ck_assert_msg(memcmp(data, test_packet, sizeof(test_packet)) == 0, "packet is wrong %u %u %u %u", data[0], data[1],
                   data[sizeof(test_packet) - 2], data[sizeof(test_packet) - 1]);
 
     uint8_t ping_packet[1 + sizeof(uint64_t)] = {TCP_PACKET_PING, 8, 6, 9, 67};
-    write_packet_TCP_test_connection(logger, con1, ping_packet, sizeof(ping_packet));
+    write_packet_tcp_test_connection(logger, con1, ping_packet, sizeof(ping_packet));
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
-    len = read_packet_sec_TCP(logger, con1, data, 2 + sizeof(ping_packet) + CRYPTO_MAC_SIZE);
+    len = read_packet_sec_tcp(logger, con1, data, 2 + sizeof(ping_packet) + CRYPTO_MAC_SIZE);
     ck_assert_msg(len == sizeof(ping_packet), "wrong len %d", len);
     ck_assert_msg(data[0] == TCP_PACKET_PONG, "wrong packet id %u", data[0]);
     ck_assert_msg(memcmp(ping_packet + 1, data + 1, sizeof(uint64_t)) == 0, "wrong packet data");
 
     // Kill off the connections
-    kill_TCP_server(tcp_s);
-    kill_TCP_con(con1);
-    kill_TCP_con(con2);
-    kill_TCP_con(con3);
+    kill_tcp_server(tcp_s);
+    kill_tcp_con(con1);
+    kill_tcp_con(con2);
+    kill_tcp_con(con3);
 
     logger_kill(logger);
     mono_time_free(mem, mono_time);
@@ -511,7 +511,7 @@ static void test_client(void)
     uint8_t self_public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t self_secret_key[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(rng, self_public_key, self_secret_key);
-    TCP_Server *tcp_s = new_TCP_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
+    TCP_Server *tcp_s = new_tcp_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
     ck_assert_msg(tcp_s != nullptr, "Failed to create a TCP relay server.");
     ck_assert_msg(tcp_server_listen_count(tcp_s) == NUM_PORTS, "Failed to bind the relay server to all ports.");
 
@@ -523,8 +523,8 @@ static void test_client(void)
     ip_port_tcp_s.port = net_htons(ports[random_u32(rng) % NUM_PORTS]);
     ip_port_tcp_s.ip = get_loopback();
 
-    TCP_Client_Connection *conn = new_TCP_connection(logger, mem, mono_time, rng, ns, &ip_port_tcp_s, self_public_key, f_public_key, f_secret_key, nullptr);
-    do_TCP_connection(logger, mono_time, conn, nullptr);
+    TCP_Client_Connection *conn = new_tcp_connection(logger, mem, mono_time, rng, ns, &ip_port_tcp_s, self_public_key, f_public_key, f_secret_key, nullptr);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
     c_sleep(50);
 
     // The connection status should be unconfirmed here because we have finished
@@ -532,22 +532,22 @@ static void test_client(void)
     ck_assert_msg(tcp_con_status(conn) == TCP_CLIENT_UNCONFIRMED, "Wrong connection status. Expected: %d, is: %d.",
                   TCP_CLIENT_UNCONFIRMED, tcp_con_status(conn));
 
-    do_TCP_server_delay(tcp_s, mono_time, 50); // Now let the server handle requests...
+    do_tcp_server_delay(tcp_s, mono_time, 50); // Now let the server handle requests...
 
-    const uint8_t LOOP_SIZE = 3;
+    const uint8_t loop_size = 3;
 
-    for (uint8_t i = 0; i < LOOP_SIZE; i++) {
+    for (uint8_t i = 0; i < loop_size; i++) {
         mono_time_update(mono_time);
-        do_TCP_connection(logger, mono_time, conn, nullptr); // Run the connection loop.
+        do_tcp_connection(logger, mono_time, conn, nullptr); // Run the connection loop.
 
-        // The status of the connection should continue to be TCP_CLIENT_CONFIRMED after multiple subsequent do_TCP_connection() calls.
+        // The status of the connection should continue to be TCP_CLIENT_CONFIRMED after multiple subsequent do_tcp_connection() calls.
         ck_assert_msg(tcp_con_status(conn) == TCP_CLIENT_CONFIRMED, "Wrong connection status. Expected: %d, is: %d",
                       TCP_CLIENT_CONFIRMED, tcp_con_status(conn));
 
-        c_sleep(i == LOOP_SIZE - 1 ? 0 : 500); // Sleep for 500ms on all except third loop.
+        c_sleep(i == loop_size - 1 ? 0 : 500); // Sleep for 500ms on all except third loop.
     }
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     // And still after the server runs again.
     ck_assert_msg(tcp_con_status(conn) == TCP_CLIENT_CONFIRMED, "Wrong status. Expected: %d, is: %d", TCP_CLIENT_CONFIRMED,
@@ -557,7 +557,7 @@ static void test_client(void)
     uint8_t f2_secret_key[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(rng, f2_public_key, f2_secret_key);
     ip_port_tcp_s.port = net_htons(ports[random_u32(rng) % NUM_PORTS]);
-    TCP_Client_Connection *conn2 = new_TCP_connection(logger, mem, mono_time, rng, ns, &ip_port_tcp_s, self_public_key, f2_public_key,
+    TCP_Client_Connection *conn2 = new_tcp_connection(logger, mem, mono_time, rng, ns, &ip_port_tcp_s, self_public_key, f2_public_key,
                                    f2_secret_key, nullptr);
 
     // The client should call this function (defined earlier) during the routing process.
@@ -572,13 +572,13 @@ static void test_client(void)
     // These integers will increment per successful callback.
     oob_data_callback_good = response_callback_good = status_callback_good = data_callback_good = 0;
 
-    do_TCP_connection(logger, mono_time, conn, nullptr);
-    do_TCP_connection(logger, mono_time, conn2, nullptr);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
+    do_tcp_connection(logger, mono_time, conn2, nullptr);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
-    do_TCP_connection(logger, mono_time, conn, nullptr);
-    do_TCP_connection(logger, mono_time, conn2, nullptr);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
+    do_tcp_connection(logger, mono_time, conn2, nullptr);
     c_sleep(50);
 
     uint8_t data[5] = {1, 2, 3, 4, 5};
@@ -587,10 +587,10 @@ static void test_client(void)
     send_routing_request(logger, conn, f2_public_key);
     send_routing_request(logger, conn2, f_public_key);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
-    do_TCP_connection(logger, mono_time, conn, nullptr);
-    do_TCP_connection(logger, mono_time, conn2, nullptr);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
+    do_tcp_connection(logger, mono_time, conn2, nullptr);
 
     // All callback methods save data should have run during the above network prodding.
     ck_assert_msg(oob_data_callback_good == 1, "OOB callback not called");
@@ -601,29 +601,29 @@ static void test_client(void)
     ck_assert_msg(status_callback_connection_id == response_callback_connection_id,
                   "Status and response callback connection IDs are not equal.");
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     ck_assert_msg(send_data(logger, conn2, 0, data, 5) == 1, "Failed a send_data() call.");
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
-    do_TCP_connection(logger, mono_time, conn, nullptr);
-    do_TCP_connection(logger, mono_time, conn2, nullptr);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
+    do_tcp_connection(logger, mono_time, conn2, nullptr);
     ck_assert_msg(data_callback_good == 1, "Data callback was not called.");
     status_callback_good = 0;
     send_disconnect_request(logger, conn2, 0);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
-    do_TCP_connection(logger, mono_time, conn, nullptr);
-    do_TCP_connection(logger, mono_time, conn2, nullptr);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
+    do_tcp_connection(logger, mono_time, conn2, nullptr);
     ck_assert_msg(status_callback_good == 1, "Status callback not called");
     ck_assert_msg(status_callback_status == 1, "Wrong status callback status.");
 
     // Kill off all connections and servers.
-    kill_TCP_server(tcp_s);
-    kill_TCP_connection(conn);
-    kill_TCP_connection(conn2);
+    kill_tcp_server(tcp_s);
+    kill_tcp_connection(conn);
+    kill_tcp_connection(conn2);
 
     logger_kill(logger);
     mono_time_free(mem, mono_time);
@@ -653,12 +653,12 @@ static void test_client_invalid(void)
 
     ip_port_tcp_s.port = net_htons(ports[random_u32(rng) % NUM_PORTS]);
     ip_port_tcp_s.ip = get_loopback();
-    TCP_Client_Connection *conn = new_TCP_connection(logger, mem, mono_time, rng, ns, &ip_port_tcp_s,
+    TCP_Client_Connection *conn = new_tcp_connection(logger, mem, mono_time, rng, ns, &ip_port_tcp_s,
                                                      self_public_key, f_public_key, f_secret_key, nullptr);
 
     // Run the client's main loop but not the server.
     mono_time_update(mono_time);
-    do_TCP_connection(logger, mono_time, conn, nullptr);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
     c_sleep(50);
 
     // After 50ms of no response...
@@ -667,17 +667,17 @@ static void test_client_invalid(void)
     // After 5s...
     c_sleep(5000);
     mono_time_update(mono_time);
-    do_TCP_connection(logger, mono_time, conn, nullptr);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
     ck_assert_msg(tcp_con_status(conn) == TCP_CLIENT_CONNECTING, "Wrong status. Expected: %d, is: %d.",
                   TCP_CLIENT_CONNECTING, tcp_con_status(conn));
     // 11s... (Should wait for 10 before giving up.)
     c_sleep(6000);
     mono_time_update(mono_time);
-    do_TCP_connection(logger, mono_time, conn, nullptr);
+    do_tcp_connection(logger, mono_time, conn, nullptr);
     ck_assert_msg(tcp_con_status(conn) == TCP_CLIENT_DISCONNECTED, "Wrong status. Expected: %d, is: %d.",
                   TCP_CLIENT_DISCONNECTED, tcp_con_status(conn));
 
-    kill_TCP_connection(conn);
+    kill_tcp_connection(conn);
 
     logger_kill(logger);
     mono_time_free(mem, mono_time);
@@ -725,7 +725,7 @@ static void test_tcp_connection(void)
     uint8_t self_public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t self_secret_key[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(rng, self_public_key, self_secret_key);
-    TCP_Server *tcp_s = new_TCP_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
+    TCP_Server *tcp_s = new_tcp_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
     ck_assert_msg(pk_equal(tcp_server_public_key(tcp_s), self_public_key), "Wrong public key");
 
     TCP_Proxy_Info proxy_info;
@@ -757,17 +757,17 @@ static void test_tcp_connection(void)
     ck_assert_msg(new_tcp_connection_to(tc_2, tcp_connections_public_key(tc_1), 123) == -1,
                   "Managed to read same connection\n");
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
@@ -776,7 +776,7 @@ static void test_tcp_connection(void)
     ck_assert_msg(ret == 0, "could not send packet.");
     set_packet_tcp_connection_callback(tc_2, &tcp_data_callback, (void *) 120397);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
@@ -785,7 +785,7 @@ static void test_tcp_connection(void)
     ck_assert_msg(tcp_connection_to_online_tcp_relays(tc_1, 0) == 1, "Wrong number of connected relays");
     ck_assert_msg(kill_tcp_connection_to(tc_1, 0) == 0, "could not kill connection to\n");
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
@@ -793,7 +793,7 @@ static void test_tcp_connection(void)
     ck_assert_msg(send_packet_tcp_connection(tc_1, 0, (const uint8_t *)"Gentoo", 6) == -1, "could send packet.");
     ck_assert_msg(kill_tcp_connection_to(tc_2, 0) == 0, "could not kill connection to\n");
 
-    kill_TCP_server(tcp_s);
+    kill_tcp_server(tcp_s);
     kill_tcp_connections(tc_1);
     kill_tcp_connections(tc_2);
 
@@ -840,7 +840,7 @@ static void test_tcp_connection2(void)
     uint8_t self_public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t self_secret_key[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(rng, self_public_key, self_secret_key);
-    TCP_Server *tcp_s = new_TCP_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
+    TCP_Server *tcp_s = new_tcp_server(logger, mem, rng, ns, USE_IPV6, NUM_PORTS, ports, self_secret_key, nullptr, nullptr);
     ck_assert_msg(pk_equal(tcp_server_public_key(tcp_s), self_public_key), "Wrong public key");
 
     TCP_Proxy_Info proxy_info;
@@ -866,17 +866,17 @@ static void test_tcp_connection2(void)
     ck_assert_msg(add_tcp_relay_global(tc_2, &ip_port_tcp_s, tcp_server_public_key(tcp_s)) == 0,
                   "Could not add global relay");
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
@@ -886,14 +886,14 @@ static void test_tcp_connection2(void)
     set_oob_packet_tcp_connection_callback(tc_2, &tcp_oobdata_callback, tc_2);
     set_packet_tcp_connection_callback(tc_1, &tcp_data_callback, (void *) 120397);
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
 
     ck_assert_msg(tcp_oobdata_callback_called, "could not recv packet.");
 
-    do_TCP_server_delay(tcp_s, mono_time, 50);
+    do_tcp_server_delay(tcp_s, mono_time, 50);
 
     do_tcp_connections(logger, tc_1, nullptr);
     do_tcp_connections(logger, tc_2, nullptr);
@@ -901,7 +901,7 @@ static void test_tcp_connection2(void)
     ck_assert_msg(tcp_data_callback_called, "could not recv packet.");
     ck_assert_msg(kill_tcp_connection_to(tc_1, 0) == 0, "could not kill connection to\n");
 
-    kill_TCP_server(tcp_s);
+    kill_tcp_server(tcp_s);
     kill_tcp_connections(tc_1);
     kill_tcp_connections(tc_2);
 
@@ -909,7 +909,7 @@ static void test_tcp_connection2(void)
     mono_time_free(mem, mono_time);
 }
 
-static void TCP_suite(void)
+static void tcp_suite(void)
 {
     test_basic();
     test_some();
@@ -922,6 +922,6 @@ static void TCP_suite(void)
 int main(void)
 {
     setvbuf(stdout, nullptr, _IONBF, 0);
-    TCP_suite();
+    tcp_suite();
     return 0;
 }

--- a/auto_tests/auto_test_support.c
+++ b/auto_tests/auto_test_support.c
@@ -13,7 +13,7 @@
 #define ABORT_ON_LOG_ERROR true
 #endif
 
-Run_Auto_Options default_run_auto_options()
+Run_Auto_Options default_run_auto_options(void)
 {
     return (Run_Auto_Options) {
         .graph = GRAPH_COMPLETE,
@@ -27,7 +27,7 @@ static const struct BootstrapNodes {
     const char   *ip;
     uint16_t      port;
     const uint8_t key[32];
-} BootstrapNodes[] = {
+} bootstrap_nodes[] = {
 #ifndef USE_TEST_NETWORK
     {
         "tox.abilinski.com", 33445,
@@ -80,10 +80,10 @@ void bootstrap_tox_live_network(Tox *tox, bool enable_tcp)
 {
     ck_assert(tox != nullptr);
 
-    for (size_t j = 0; BootstrapNodes[j].ip != nullptr; ++j) {
-        const char *ip = BootstrapNodes[j].ip;
-        uint16_t port = BootstrapNodes[j].port;
-        const uint8_t *key = BootstrapNodes[j].key;
+    for (size_t j = 0; bootstrap_nodes[j].ip != nullptr; ++j) {
+        const char *ip = bootstrap_nodes[j].ip;
+        uint16_t port = bootstrap_nodes[j].port;
+        const uint8_t *key = bootstrap_nodes[j].key;
 
         Tox_Err_Bootstrap err;
         tox_bootstrap(tox, ip, port, key, &err);

--- a/auto_tests/conference_av_test.c
+++ b/auto_tests/conference_av_test.c
@@ -217,7 +217,7 @@ static bool test_audio(AutoTox *autotoxes, const bool *disabled, bool quiet)
         printf("testing sending and receiving audio\n");
     }
 
-    const int16_t PCM[GROUP_AV_TEST_SAMPLES] = {0};
+    const int16_t pcm[GROUP_AV_TEST_SAMPLES] = {0};
 
     reset_received_audio(autotoxes);
 
@@ -227,7 +227,7 @@ static bool test_audio(AutoTox *autotoxes, const bool *disabled, bool quiet)
                 continue;
             }
 
-            if (toxav_group_send_audio(autotoxes[i].tox, 0, PCM, GROUP_AV_TEST_SAMPLES, 1, 48000) != 0) {
+            if (toxav_group_send_audio(autotoxes[i].tox, 0, pcm, GROUP_AV_TEST_SAMPLES, 1, 48000) != 0) {
                 if (!quiet) {
                     ck_abort_msg("#%u failed to send audio", autotoxes[i].index);
                 }
@@ -268,12 +268,12 @@ static void test_eventual_audio(AutoTox *autotoxes, const bool *disabled, uint64
 
 static void do_audio(AutoTox *autotoxes, uint32_t iterations)
 {
-    const int16_t PCM[GROUP_AV_TEST_SAMPLES] = {0};
+    const int16_t pcm[GROUP_AV_TEST_SAMPLES] = {0};
     printf("running audio for %u iterations\n", iterations);
 
     for (uint32_t f = 0; f < iterations; ++f) {
         for (uint32_t i = 0; i < NUM_AV_GROUP_TOX; ++i) {
-            ck_assert_msg(toxav_group_send_audio(autotoxes[i].tox, 0, PCM, GROUP_AV_TEST_SAMPLES, 1, 48000) == 0,
+            ck_assert_msg(toxav_group_send_audio(autotoxes[i].tox, 0, pcm, GROUP_AV_TEST_SAMPLES, 1, 48000) == 0,
                           "#%u failed to send audio", autotoxes[i].index);
             iterate_all_wait(autotoxes, NUM_AV_GROUP_TOX, ITERATION_INTERVAL);
         }

--- a/auto_tests/file_transfer_test.c
+++ b/auto_tests/file_transfer_test.c
@@ -172,12 +172,12 @@ static void file_transfer_test(void)
     uint32_t test = tox_friend_add(tox3, address, (const uint8_t *)"Gentoo", 7, nullptr);
     ck_assert_msg(test == 0, "Failed to add friend error code: %u", test);
 
-    uint8_t dhtKey[TOX_PUBLIC_KEY_SIZE];
-    tox_self_get_dht_id(tox1, dhtKey);
-    uint16_t dhtPort = tox_self_get_udp_port(tox1, nullptr);
+    uint8_t dht_key[TOX_PUBLIC_KEY_SIZE];
+    tox_self_get_dht_id(tox1, dht_key);
+    uint16_t dht_port = tox_self_get_udp_port(tox1, nullptr);
 
-    tox_bootstrap(tox2, TOX_LOCALHOST, dhtPort, dhtKey, nullptr);
-    tox_bootstrap(tox3, TOX_LOCALHOST, dhtPort, dhtKey, nullptr);
+    tox_bootstrap(tox2, TOX_LOCALHOST, dht_port, dht_key, nullptr);
+    tox_bootstrap(tox3, TOX_LOCALHOST, dht_port, dht_key, nullptr);
 
     printf("Waiting for toxes to come online\n");
 

--- a/auto_tests/tox_strncasecmp_test.c
+++ b/auto_tests/tox_strncasecmp_test.c
@@ -10,7 +10,7 @@ typedef enum {
     POSITIVE
 } Comparison;
 
-static const char *Comparison_Str[] = { "NEGATIVE", "ZERO", "POSITIVE" };
+static const char *comparison_str[] = { "NEGATIVE", "ZERO", "POSITIVE" };
 
 static void verify(const char *s1, const char *s2, size_t n, Comparison expected)
 {
@@ -19,7 +19,7 @@ static void verify(const char *s1, const char *s2, size_t n, Comparison expected
 
     ck_assert_msg(actual == expected,
                   "tox_strncasecmp(\"%s\", \"%s\", %u) == %s, but expected %s.",
-                  s1, s2, (unsigned)n, Comparison_Str[actual], Comparison_Str[expected]);
+                  s1, s2, (unsigned)n, comparison_str[actual], comparison_str[expected]);
 }
 
 static void test_general(void)

--- a/auto_tests/version_test.c
+++ b/auto_tests/version_test.c
@@ -1,7 +1,7 @@
 #include "../toxcore/tox.h"
 #include "check_compat.h"
 
-#define check(major, minor, patch, expected)                            \
+#define CHECK(major, minor, patch, expected)                            \
   do_check(TOX_VERSION_MAJOR, TOX_VERSION_MINOR, TOX_VERSION_PATCH,     \
            major, minor, patch,                                         \
            TOX_VERSION_IS_API_COMPATIBLE(major, minor, patch), expected)
@@ -26,11 +26,11 @@ int main(void)
 #define TOX_VERSION_MINOR 0
 #define TOX_VERSION_PATCH 4
     // Tox versions from 0.0.* are only compatible with themselves.
-    check(0, 0, 0, false);
-    check(0, 0, 3, false);
-    check(0, 0, 4, true);
-    check(0, 0, 5, false);
-    check(1, 0, 4, false);
+    CHECK(0, 0, 0, false);
+    CHECK(0, 0, 3, false);
+    CHECK(0, 0, 4, true);
+    CHECK(0, 0, 5, false);
+    CHECK(1, 0, 4, false);
 #undef TOX_VERSION_MAJOR
 #undef TOX_VERSION_MINOR
 #undef TOX_VERSION_PATCH
@@ -39,19 +39,19 @@ int main(void)
 #define TOX_VERSION_MINOR 1
 #define TOX_VERSION_PATCH 4
     // Tox versions from 0.1.* are only compatible with themselves or 0.1.<*
-    check(0, 0, 0, false);
-    check(0, 0, 4, false);
-    check(0, 0, 5, false);
-    check(0, 1, 0, true);
-    check(0, 1, 4, true);
-    check(0, 1, 5, false);
-    check(0, 2, 0, false);
-    check(0, 2, 4, false);
-    check(0, 2, 5, false);
-    check(1, 0, 0, false);
-    check(1, 0, 4, false);
-    check(1, 0, 5, false);
-    check(1, 1, 4, false);
+    CHECK(0, 0, 0, false);
+    CHECK(0, 0, 4, false);
+    CHECK(0, 0, 5, false);
+    CHECK(0, 1, 0, true);
+    CHECK(0, 1, 4, true);
+    CHECK(0, 1, 5, false);
+    CHECK(0, 2, 0, false);
+    CHECK(0, 2, 4, false);
+    CHECK(0, 2, 5, false);
+    CHECK(1, 0, 0, false);
+    CHECK(1, 0, 4, false);
+    CHECK(1, 0, 5, false);
+    CHECK(1, 1, 4, false);
 #undef TOX_VERSION_MAJOR
 #undef TOX_VERSION_MINOR
 #undef TOX_VERSION_PATCH
@@ -60,14 +60,14 @@ int main(void)
 #define TOX_VERSION_MINOR 0
 #define TOX_VERSION_PATCH 4
     // Beyond 0.*.* Tox is comfortable with any lower version within their major
-    check(0, 0, 4, false);
-    check(1, 0, 0, true);
-    check(1, 0, 1, true);
-    check(1, 0, 4, true);
-    check(1, 0, 5, false);
-    check(1, 1, 0, false);
-    check(2, 0, 0, false);
-    check(2, 0, 4, false);
+    CHECK(0, 0, 4, false);
+    CHECK(1, 0, 0, true);
+    CHECK(1, 0, 1, true);
+    CHECK(1, 0, 4, true);
+    CHECK(1, 0, 5, false);
+    CHECK(1, 1, 0, false);
+    CHECK(2, 0, 0, false);
+    CHECK(2, 0, 4, false);
 #undef TOX_VERSION_MAJOR
 #undef TOX_VERSION_MINOR
 #undef TOX_VERSION_PATCH
@@ -75,19 +75,19 @@ int main(void)
 #define TOX_VERSION_MAJOR 1
 #define TOX_VERSION_MINOR 1
 #define TOX_VERSION_PATCH 4
-    check(0, 0, 4, false);
-    check(1, 0, 0, true);
-    check(1, 0, 4, true);
-    check(1, 0, 5, true);
-    check(1, 1, 0, true);
-    check(1, 1, 1, true);
-    check(1, 1, 4, true);
-    check(1, 1, 5, false);
-    check(1, 2, 0, false);
-    check(1, 2, 4, false);
-    check(1, 2, 5, false);
-    check(2, 0, 0, false);
-    check(2, 1, 4, false);
+    CHECK(0, 0, 4, false);
+    CHECK(1, 0, 0, true);
+    CHECK(1, 0, 4, true);
+    CHECK(1, 0, 5, true);
+    CHECK(1, 1, 0, true);
+    CHECK(1, 1, 1, true);
+    CHECK(1, 1, 4, true);
+    CHECK(1, 1, 5, false);
+    CHECK(1, 2, 0, false);
+    CHECK(1, 2, 4, false);
+    CHECK(1, 2, 5, false);
+    CHECK(2, 0, 0, false);
+    CHECK(2, 1, 4, false);
 #undef TOX_VERSION_MAJOR
 #undef TOX_VERSION_MINOR
 #undef TOX_VERSION_PATCH

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -175,7 +175,7 @@ int main(int argc, char *argv[])
 #ifdef TCP_RELAY_ENABLED
 #define NUM_PORTS 3
     uint16_t ports[NUM_PORTS] = {443, 3389, PORT};
-    TCP_Server *tcp_s = new_TCP_server(logger, mem, rng, ns, ipv6enabled, NUM_PORTS, ports, dht_get_self_secret_key(dht), onion, forwarding);
+    TCP_Server *tcp_s = new_tcp_server(logger, mem, rng, ns, ipv6enabled, NUM_PORTS, ports, dht_get_self_secret_key(dht), onion, forwarding);
 
     if (tcp_s == nullptr) {
         printf("TCP server failed to initialize.\n");
@@ -228,7 +228,7 @@ int main(int argc, char *argv[])
 
     int is_waiting_for_dht_connection = 1;
 
-    uint64_t last_LANdiscovery = 0;
+    uint64_t last_lan_discovery = 0;
     const Broadcast_Info *broadcast = lan_discovery_init(ns);
 
     while (1) {
@@ -241,13 +241,13 @@ int main(int argc, char *argv[])
 
         do_dht(dht);
 
-        if (mono_time_is_timeout(mono_time, last_LANdiscovery, is_waiting_for_dht_connection ? 5 : LAN_DISCOVERY_INTERVAL)) {
+        if (mono_time_is_timeout(mono_time, last_lan_discovery, is_waiting_for_dht_connection ? 5 : LAN_DISCOVERY_INTERVAL)) {
             lan_discovery_send(dht_get_net(dht), broadcast, dht_get_self_public_key(dht), net_htons(PORT));
-            last_LANdiscovery = mono_time_get(mono_time);
+            last_lan_discovery = mono_time_get(mono_time);
         }
 
 #ifdef TCP_RELAY_ENABLED
-        do_TCP_server(tcp_s, mono_time);
+        do_tcp_server(tcp_s, mono_time);
 #endif
         networking_poll(dht_get_net(dht), nullptr);
 

--- a/other/analysis/run-clang-tidy
+++ b/other/analysis/run-clang-tidy
@@ -6,18 +6,32 @@ CHECKS="*"
 CHECKS="$CHECKS,-clang-diagnostic-pointer-bool-conversion"
 CHECKS="$CHECKS,-clang-diagnostic-tautological-pointer-compare"
 
-# TODO(iphydf): We might want some of these. For the ones we don't want, add a
-# comment explaining why not.
+CHECKS="$CHECKS,-clang-diagnostic-unknown-warning-option"
+
+# Short variable names are used quite a lot, and we don't consider them a
+# readability issue.
+CHECKS="$CHECKS,-readability-identifier-length"
+
+# This finds all the do {} while (0) loops and tells us to unroll them.
 CHECKS="$CHECKS,-altera-unroll-loops"
+
+# We target systems other than Android, so we don't want to use non-standard
+# functions from the Android libc.
 CHECKS="$CHECKS,-android-cloexec-accept"
 CHECKS="$CHECKS,-android-cloexec-fopen"
-CHECKS="$CHECKS,-bugprone-not-null-terminated-result"
+
+# This catches all the feature test macros (_POSIX_SOURCE etc.).
 CHECKS="$CHECKS,-bugprone-reserved-identifier"
-CHECKS="$CHECKS,-bugprone-sizeof-expression"
 CHECKS="$CHECKS,-cert-dcl37-c"
 CHECKS="$CHECKS,-cert-dcl51-cpp"
+
+# We intentionally send some not null-terminated strings in tests and use it for
+# the toxencryptsave magic number.
+CHECKS="$CHECKS,-bugprone-not-null-terminated-result"
+
+# TODO(iphydf): We might want some of these. For the ones we don't want, add a
+# comment explaining why not.
 CHECKS="$CHECKS,-clang-analyzer-optin.performance.Padding"
-CHECKS="$CHECKS,-cppcoreguidelines-avoid-magic-numbers"
 CHECKS="$CHECKS,-cppcoreguidelines-init-variables"
 CHECKS="$CHECKS,-hicpp-multiway-paths-covered"
 CHECKS="$CHECKS,-hicpp-signed-bitwise"
@@ -50,6 +64,11 @@ CHECKS="$CHECKS,-cppcoreguidelines-narrowing-conversions"
 CHECKS="$CHECKS,-google-readability-casting"
 CHECKS="$CHECKS,-misc-no-recursion"
 
+# TODO(iphydf): Probably fix these.
+CHECKS="$CHECKS,-cert-err33-c"
+CHECKS="$CHECKS,-cppcoreguidelines-avoid-magic-numbers"
+CHECKS="$CHECKS,-modernize-macro-to-enum"
+
 ERRORS="*"
 
 # TODO(iphydf): Fix these.
@@ -60,7 +79,6 @@ ERRORS="$ERRORS,-cert-err34-c"
 ERRORS="$ERRORS,-cert-str34-c"
 ERRORS="$ERRORS,-hicpp-uppercase-literal-suffix"
 ERRORS="$ERRORS,-readability-suspicious-call-argument"
-ERRORS="$ERRORS,-readability-uppercase-literal-suffix"
 
 set -eux
 
@@ -70,7 +88,7 @@ run() {
   for i in "${!EXTRA_ARGS[@]}"; do
     EXTRA_ARGS[$i]="--extra-arg=${EXTRA_ARGS[$i]}"
   done
-  clang-tidy-12 \
+  clang-tidy-14 \
     -p=_build \
     --extra-arg=-DMIN_LOGGER_LEVEL=LOGGER_LEVEL_TRACE \
     "${EXTRA_ARGS[@]}" \
@@ -83,5 +101,7 @@ run() {
     toxcore/*.c \
     toxencryptsave/*.c
 }
+
+cmake . -B_build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 . other/analysis/variants.sh

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-6f4ec4239de5ea05ae341271bbda4cb78535f943a693321648ee1ab043a203d2  /usr/local/bin/tox-bootstrapd
+a8917dcace422e2a6644f140463da7b9e70e67a7e15f5209c572b72650d87368  /usr/local/bin/tox-bootstrapd

--- a/other/bootstrap_daemon/src/config.c
+++ b/other/bootstrap_daemon/src/config.c
@@ -29,7 +29,7 @@
  */
 static void parse_tcp_relay_ports_config(config_t *cfg, uint16_t **tcp_relay_ports, int *tcp_relay_port_count)
 {
-    const char *NAME_TCP_RELAY_PORTS = "tcp_relay_ports";
+    const char *const NAME_TCP_RELAY_PORTS = "tcp_relay_ports";
 
     *tcp_relay_port_count = 0;
 
@@ -129,15 +129,15 @@ int get_general_config(const char *cfg_file_path, char **pid_file_path, char **k
 {
     config_t cfg;
 
-    const char *NAME_PORT                 = "port";
-    const char *NAME_PID_FILE_PATH        = "pid_file_path";
-    const char *NAME_KEYS_FILE_PATH       = "keys_file_path";
-    const char *NAME_ENABLE_IPV6          = "enable_ipv6";
-    const char *NAME_ENABLE_IPV4_FALLBACK = "enable_ipv4_fallback";
-    const char *NAME_ENABLE_LAN_DISCOVERY = "enable_lan_discovery";
-    const char *NAME_ENABLE_TCP_RELAY     = "enable_tcp_relay";
-    const char *NAME_ENABLE_MOTD          = "enable_motd";
-    const char *NAME_MOTD                 = "motd";
+    const char *const NAME_PORT                 = "port";
+    const char *const NAME_PID_FILE_PATH        = "pid_file_path";
+    const char *const NAME_KEYS_FILE_PATH       = "keys_file_path";
+    const char *const NAME_ENABLE_IPV6          = "enable_ipv6";
+    const char *const NAME_ENABLE_IPV4_FALLBACK = "enable_ipv4_fallback";
+    const char *const NAME_ENABLE_LAN_DISCOVERY = "enable_lan_discovery";
+    const char *const NAME_ENABLE_TCP_RELAY     = "enable_tcp_relay";
+    const char *const NAME_ENABLE_MOTD          = "enable_motd";
+    const char *const NAME_MOTD                 = "motd";
 
     config_init(&cfg);
 
@@ -307,11 +307,11 @@ static uint8_t *bootstrap_hex_string_to_bin(const char *hex_string)
 
 int bootstrap_from_config(const char *cfg_file_path, DHT *dht, int enable_ipv6)
 {
-    const char *NAME_BOOTSTRAP_NODES = "bootstrap_nodes";
+    const char *const NAME_BOOTSTRAP_NODES = "bootstrap_nodes";
 
-    const char *NAME_PUBLIC_KEY = "public_key";
-    const char *NAME_PORT       = "port";
-    const char *NAME_ADDRESS    = "address";
+    const char *const NAME_PUBLIC_KEY = "public_key";
+    const char *const NAME_PORT       = "port";
+    const char *const NAME_ADDRESS    = "address";
 
     config_t cfg;
 

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -477,7 +477,7 @@ int main(int argc, char *argv[])
             return 1;
         }
 
-        tcp_server = new_TCP_server(logger, mem, rng, ns, enable_ipv6,
+        tcp_server = new_tcp_server(logger, mem, rng, ns, enable_ipv6,
                                     tcp_relay_port_count, tcp_relay_ports,
                                     dht_get_self_secret_key(dht), onion, forwarding);
 
@@ -528,7 +528,7 @@ int main(int argc, char *argv[])
         log_write(LOG_LEVEL_INFO, "List of bootstrap nodes read successfully.\n");
     } else {
         log_write(LOG_LEVEL_ERROR, "Couldn't read list of bootstrap nodes in %s. Exiting.\n", cfg_file_path);
-        kill_TCP_server(tcp_server);
+        kill_tcp_server(tcp_server);
         kill_onion_announce(onion_a);
         kill_gca(group_announce);
         kill_onion(onion);
@@ -543,7 +543,7 @@ int main(int argc, char *argv[])
 
     print_public_key(dht_get_self_public_key(dht));
 
-    uint64_t last_LANdiscovery = 0;
+    uint64_t last_lan_discovery = 0;
     const uint16_t net_htons_port = net_htons(start_port);
 
     int waiting_for_dht_connection = 1;
@@ -578,13 +578,13 @@ int main(int argc, char *argv[])
 
         do_dht(dht);
 
-        if (enable_lan_discovery && mono_time_is_timeout(mono_time, last_LANdiscovery, LAN_DISCOVERY_INTERVAL)) {
+        if (enable_lan_discovery && mono_time_is_timeout(mono_time, last_lan_discovery, LAN_DISCOVERY_INTERVAL)) {
             lan_discovery_send(dht_get_net(dht), broadcast, dht_get_self_public_key(dht), net_htons_port);
-            last_LANdiscovery = mono_time_get(mono_time);
+            last_lan_discovery = mono_time_get(mono_time);
         }
 
         if (enable_tcp_relay) {
-            do_TCP_server(tcp_server, mono_time);
+            do_tcp_server(tcp_server, mono_time);
         }
 
         networking_poll(dht_get_net(dht), nullptr);
@@ -611,7 +611,7 @@ int main(int argc, char *argv[])
     }
 
     lan_discovery_kill(broadcast);
-    kill_TCP_server(tcp_server);
+    kill_tcp_server(tcp_server);
     kill_onion_announce(onion_a);
     kill_gca(group_announce);
     kill_onion(onion);

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -394,7 +394,7 @@ void set_announce_node(DHT *dht, const uint8_t *public_key);
  */
 non_null()
 int get_close_nodes(const DHT *dht, const uint8_t *public_key, Node_format *nodes_list, Family sa_family,
-                    bool is_LAN, bool want_announce);
+                    bool is_lan, bool want_announce);
 
 
 /** @brief Put up to max_num nodes in nodes from the random friends.

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2640,7 +2640,7 @@ void do_messenger(Messenger *m, void *userdata)
     }
 
     if (m->tcp_server != nullptr) {
-        do_TCP_server(m->tcp_server, m->mono_time);
+        do_tcp_server(m->tcp_server, m->mono_time);
     }
 
     do_net_crypto(m->net_crypto, userdata);
@@ -3664,7 +3664,7 @@ Messenger *new_messenger(Mono_Time *mono_time, const Memory *mem, const Random *
 #endif /* VANILLA_NACL */
 
     if (options->tcp_server_port != 0) {
-        m->tcp_server = new_TCP_server(m->log, m->mem, m->rng, m->ns, options->ipv6enabled, 1,
+        m->tcp_server = new_tcp_server(m->log, m->mem, m->rng, m->ns, options->ipv6enabled, 1,
                                        &options->tcp_server_port, dht_get_self_secret_key(m->dht),
                                        m->onion, m->forwarding);
 
@@ -3725,7 +3725,7 @@ void kill_messenger(Messenger *m)
     }
 
     if (m->tcp_server != nullptr) {
-        kill_TCP_server(m->tcp_server);
+        kill_tcp_server(m->tcp_server);
     }
 
     kill_onion(m->onion);

--- a/toxcore/TCP_client.h
+++ b/toxcore/TCP_client.h
@@ -58,19 +58,19 @@ void tcp_con_set_custom_uint(TCP_Client_Connection *con, uint32_t value);
 
 /** Create new TCP connection to ip_port/public_key */
 non_null(1, 2, 3, 4, 5, 6, 7, 8, 9) nullable(10)
-TCP_Client_Connection *new_TCP_connection(
+TCP_Client_Connection *new_tcp_connection(
         const Logger *logger, const Memory *mem, const Mono_Time *mono_time, const Random *rng, const Network *ns,
         const IP_Port *ip_port, const uint8_t *public_key, const uint8_t *self_public_key, const uint8_t *self_secret_key,
         const TCP_Proxy_Info *proxy_info);
 
 /** Run the TCP connection */
 non_null(1, 2, 3) nullable(4)
-void do_TCP_connection(const Logger *logger, const Mono_Time *mono_time,
+void do_tcp_connection(const Logger *logger, const Mono_Time *mono_time,
                        TCP_Client_Connection *tcp_connection, void *userdata);
 
 /** Kill the TCP connection */
 nullable(1)
-void kill_TCP_connection(TCP_Client_Connection *tcp_connection);
+void kill_tcp_connection(TCP_Client_Connection *tcp_connection);
 
 typedef int tcp_onion_response_cb(void *object, const uint8_t *data, uint16_t length, void *userdata);
 

--- a/toxcore/TCP_common.c
+++ b/toxcore/TCP_common.c
@@ -129,7 +129,7 @@ static bool add_priority(TCP_Connection *con, const uint8_t *packet, uint16_t si
  * @retval 0 if could not send packet.
  * @retval -1 on failure (connection must be killed).
  */
-int write_packet_TCP_secure_connection(const Logger *logger, TCP_Connection *con, const uint8_t *data, uint16_t length,
+int write_packet_tcp_secure_connection(const Logger *logger, TCP_Connection *con, const uint8_t *data, uint16_t length,
                                        bool priority)
 {
     if (length + CRYPTO_MAC_SIZE > MAX_PACKET_SIZE) {
@@ -195,7 +195,7 @@ int write_packet_TCP_secure_connection(const Logger *logger, TCP_Connection *con
  * return length on success
  * return -1 on failure/no data in buffer.
  */
-int read_TCP_packet(
+int read_tcp_packet(
         const Logger *logger, const Memory *mem, const Network *ns, Socket sock, uint8_t *data, uint16_t length, const IP_Port *ip_port)
 {
     const uint16_t count = net_socket_data_recv_buffer(ns, sock);
@@ -223,7 +223,7 @@ int read_TCP_packet(
  * return -1 on failure.
  */
 non_null()
-static uint16_t read_TCP_length(const Logger *logger, const Memory *mem, const Network *ns, Socket sock, const IP_Port *ip_port)
+static uint16_t read_tcp_length(const Logger *logger, const Memory *mem, const Network *ns, Socket sock, const IP_Port *ip_port)
 {
     const uint16_t count = net_socket_data_recv_buffer(ns, sock);
 
@@ -255,14 +255,14 @@ static uint16_t read_TCP_length(const Logger *logger, const Memory *mem, const N
  * @retval 0 if could not read any packet.
  * @retval -1 on failure (connection must be killed).
  */
-int read_packet_TCP_secure_connection(
+int read_packet_tcp_secure_connection(
         const Logger *logger, const Memory *mem, const Network *ns,
         Socket sock, uint16_t *next_packet_length,
         const uint8_t *shared_key, uint8_t *recv_nonce, uint8_t *data,
         uint16_t max_len, const IP_Port *ip_port)
 {
     if (*next_packet_length == 0) {
-        const uint16_t len = read_TCP_length(logger, mem, ns, sock, ip_port);
+        const uint16_t len = read_tcp_length(logger, mem, ns, sock, ip_port);
 
         if (len == (uint16_t) -1) {
             return -1;
@@ -281,7 +281,7 @@ int read_packet_TCP_secure_connection(
     }
 
     VLA(uint8_t, data_encrypted, (int) *next_packet_length);
-    const int len_packet = read_TCP_packet(logger, mem, ns, sock, data_encrypted, *next_packet_length, ip_port);
+    const int len_packet = read_tcp_packet(logger, mem, ns, sock, data_encrypted, *next_packet_length, ip_port);
 
     if (len_packet == -1) {
         return 0;

--- a/toxcore/TCP_common.h
+++ b/toxcore/TCP_common.h
@@ -99,7 +99,7 @@ int send_pending_data(const Logger *logger, TCP_Connection *con);
  * @retval -1 on failure (connection must be killed).
  */
 non_null()
-int write_packet_TCP_secure_connection(
+int write_packet_tcp_secure_connection(
         const Logger *logger, TCP_Connection *con, const uint8_t *data, uint16_t length,
         bool priority);
 
@@ -109,7 +109,7 @@ int write_packet_TCP_secure_connection(
  * return -1 on failure/no data in buffer.
  */
 non_null()
-int read_TCP_packet(
+int read_tcp_packet(
         const Logger *logger, const Memory *mem, const Network *ns, Socket sock, uint8_t *data, uint16_t length, const IP_Port *ip_port);
 
 /**
@@ -118,7 +118,7 @@ int read_TCP_packet(
  * @retval -1 on failure (connection must be killed).
  */
 non_null()
-int read_packet_TCP_secure_connection(
+int read_packet_tcp_secure_connection(
         const Logger *logger, const Memory *mem, const Network *ns,
         Socket sock, uint16_t *next_packet_length,
         const uint8_t *shared_key, uint8_t *recv_nonce, uint8_t *data,

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -74,7 +74,7 @@ uint32_t tcp_connections_count(const TCP_Connections *tcp_c)
  * @retval 0 if it succeeds.
  */
 non_null()
-static int realloc_TCP_Connection_to(const Memory *mem, TCP_Connection_to **array, size_t num)
+static int realloc_tcp_connection_to(const Memory *mem, TCP_Connection_to **array, size_t num)
 {
     if (num == 0) {
         mem_delete(mem, *array);
@@ -95,7 +95,7 @@ static int realloc_TCP_Connection_to(const Memory *mem, TCP_Connection_to **arra
 }
 
 non_null()
-static int realloc_TCP_con(const Memory *mem, TCP_con **array, size_t num)
+static int realloc_tcp_con(const Memory *mem, TCP_con **array, size_t num)
 {
     if (num == 0) {
         mem_delete(mem, *array);
@@ -165,7 +165,7 @@ static int create_connection(TCP_Connections *tcp_c)
 
     int id = -1;
 
-    if (realloc_TCP_Connection_to(tcp_c->mem, &tcp_c->connections, tcp_c->connections_length + 1) == 0) {
+    if (realloc_tcp_connection_to(tcp_c->mem, &tcp_c->connections, tcp_c->connections_length + 1) == 0) {
         id = tcp_c->connections_length;
         ++tcp_c->connections_length;
         tcp_c->connections[id] = empty_tcp_connection_to;
@@ -190,7 +190,7 @@ static int create_tcp_connection(TCP_Connections *tcp_c)
 
     int id = -1;
 
-    if (realloc_TCP_con(tcp_c->mem, &tcp_c->tcp_connections, tcp_c->tcp_connections_length + 1) == 0) {
+    if (realloc_tcp_con(tcp_c->mem, &tcp_c->tcp_connections, tcp_c->tcp_connections_length + 1) == 0) {
         id = tcp_c->tcp_connections_length;
         ++tcp_c->tcp_connections_length;
         tcp_c->tcp_connections[id] = empty_tcp_con;
@@ -222,7 +222,7 @@ static int wipe_connection(TCP_Connections *tcp_c, int connections_number)
 
     if (tcp_c->connections_length != i) {
         tcp_c->connections_length = i;
-        if (realloc_TCP_Connection_to(tcp_c->mem, &tcp_c->connections, tcp_c->connections_length) != 0) {
+        if (realloc_tcp_connection_to(tcp_c->mem, &tcp_c->connections, tcp_c->connections_length) != 0) {
             return -1;
         }
     }
@@ -254,7 +254,7 @@ static int wipe_tcp_connection(TCP_Connections *tcp_c, int tcp_connections_numbe
 
     if (tcp_c->tcp_connections_length != i) {
         tcp_c->tcp_connections_length = i;
-        if (realloc_TCP_con(tcp_c->mem, &tcp_c->tcp_connections, tcp_c->tcp_connections_length) != 0) {
+        if (realloc_tcp_con(tcp_c->mem, &tcp_c->tcp_connections, tcp_c->tcp_connections_length) != 0) {
             return -1;
         }
     }
@@ -903,7 +903,7 @@ int kill_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connections_number
         --tcp_c->onion_num_conns;
     }
 
-    kill_TCP_connection(tcp_con->connection);
+    kill_tcp_connection(tcp_con->connection);
 
     return wipe_tcp_connection(tcp_c, tcp_connections_number);
 }
@@ -924,8 +924,8 @@ static int reconnect_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connec
     IP_Port ip_port = tcp_con_ip_port(tcp_con->connection);
     uint8_t relay_pk[CRYPTO_PUBLIC_KEY_SIZE];
     memcpy(relay_pk, tcp_con_public_key(tcp_con->connection), CRYPTO_PUBLIC_KEY_SIZE);
-    kill_TCP_connection(tcp_con->connection);
-    tcp_con->connection = new_TCP_connection(tcp_c->logger, tcp_c->mem, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &ip_port, relay_pk, tcp_c->self_public_key, tcp_c->self_secret_key, &tcp_c->proxy_info);
+    kill_tcp_connection(tcp_con->connection);
+    tcp_con->connection = new_tcp_connection(tcp_c->logger, tcp_c->mem, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &ip_port, relay_pk, tcp_c->self_public_key, tcp_c->self_secret_key, &tcp_c->proxy_info);
 
     if (tcp_con->connection == nullptr) {
         kill_tcp_relay_connection(tcp_c, tcp_connections_number);
@@ -974,7 +974,7 @@ static int sleep_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connection
     tcp_con->ip_port = tcp_con_ip_port(tcp_con->connection);
     memcpy(tcp_con->relay_pk, tcp_con_public_key(tcp_con->connection), CRYPTO_PUBLIC_KEY_SIZE);
 
-    kill_TCP_connection(tcp_con->connection);
+    kill_tcp_connection(tcp_con->connection);
     tcp_con->connection = nullptr;
 
     for (uint32_t i = 0; i < tcp_c->connections_length; ++i) {
@@ -1012,7 +1012,7 @@ static int unsleep_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connecti
         return -1;
     }
 
-    tcp_con->connection = new_TCP_connection(
+    tcp_con->connection = new_tcp_connection(
             tcp_c->logger, tcp_c->mem, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &tcp_con->ip_port,
             tcp_con->relay_pk, tcp_c->self_public_key, tcp_c->self_secret_key, &tcp_c->proxy_info);
 
@@ -1308,7 +1308,7 @@ static int add_tcp_relay_instance(TCP_Connections *tcp_c, const IP_Port *ip_port
 
     TCP_con *tcp_con = &tcp_c->tcp_connections[tcp_connections_number];
 
-    tcp_con->connection = new_TCP_connection(
+    tcp_con->connection = new_tcp_connection(
             tcp_c->logger, tcp_c->mem, tcp_c->mono_time, tcp_c->rng, tcp_c->ns, &ipp_copy,
             relay_pk, tcp_c->self_public_key, tcp_c->self_secret_key, &tcp_c->proxy_info);
 
@@ -1628,7 +1628,7 @@ static void do_tcp_conns(const Logger *logger, TCP_Connections *tcp_c, void *use
         }
 
         if (tcp_con->status != TCP_CONN_SLEEPING) {
-            do_TCP_connection(logger, tcp_c->mono_time, tcp_con->connection, userdata);
+            do_tcp_connection(logger, tcp_c->mono_time, tcp_con->connection, userdata);
 
             /* callbacks can change TCP connection address. */
             tcp_con = get_tcp_connection(tcp_c, i);
@@ -1713,7 +1713,7 @@ void kill_tcp_connections(TCP_Connections *tcp_c)
     }
 
     for (uint32_t i = 0; i < tcp_c->tcp_connections_length; ++i) {
-        kill_TCP_connection(tcp_c->tcp_connections[i].connection);
+        kill_tcp_connection(tcp_c->tcp_connections[i].connection);
     }
 
     crypto_memzero(tcp_c->self_secret_key, sizeof(tcp_c->self_secret_key));

--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -35,17 +35,17 @@ size_t tcp_server_listen_count(const TCP_Server *tcp_server);
 
 /** Create new TCP server instance. */
 non_null(1, 2, 3, 4, 7, 8) nullable(9, 10)
-TCP_Server *new_TCP_server(const Logger *logger, const Memory *mem, const Random *rng, const Network *ns,
+TCP_Server *new_tcp_server(const Logger *logger, const Memory *mem, const Random *rng, const Network *ns,
                            bool ipv6_enabled, uint16_t num_sockets, const uint16_t *ports,
                            const uint8_t *secret_key, Onion *onion, Forwarding *forwarding);
 
 /** Run the TCP_server */
 non_null()
-void do_TCP_server(TCP_Server *tcp_server, const Mono_Time *mono_time);
+void do_tcp_server(TCP_Server *tcp_server, const Mono_Time *mono_time);
 
 /** Kill the TCP server */
 nullable(1)
-void kill_TCP_server(TCP_Server *tcp_server);
+void kill_tcp_server(TCP_Server *tcp_server);
 
 
 #endif

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -461,7 +461,7 @@ static void dht_pk_callback(void *object, int32_t number, const uint8_t *dht_pub
     }
 
     friend_new_connection(fr_c, number);
-    onion_set_friend_DHT_pubkey(fr_c->onion_c, friend_con->onion_friendnum, dht_public_key);
+    onion_set_friend_dht_pubkey(fr_c->onion_c, friend_con->onion_friendnum, dht_public_key);
 }
 
 non_null()

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -5691,13 +5691,13 @@ static int handle_gc_handshake_request(GC_Chat *chat, const IP_Port *ipp, const 
         return -1;
     }
 
-    if (chat->connection_O_metre >= GC_NEW_PEER_CONNECTION_LIMIT) {
+    if (chat->connection_o_metre >= GC_NEW_PEER_CONNECTION_LIMIT) {
         chat->block_handshakes = true;
         LOGGER_DEBUG(chat->log, "Handshake overflow. Blocking handshakes.");
         return -1;
     }
 
-    ++chat->connection_O_metre;
+    ++chat->connection_o_metre;
 
     const uint8_t *public_sig_key = data + ENC_PUBLIC_KEY_SIZE;
 
@@ -7015,7 +7015,7 @@ static void do_gc_ping_and_key_rotation(GC_Chat *chat)
 non_null()
 static void do_new_connection_cooldown(GC_Chat *chat)
 {
-    if (chat->connection_O_metre == 0) {
+    if (chat->connection_o_metre == 0) {
         return;
     }
 
@@ -7023,9 +7023,9 @@ static void do_new_connection_cooldown(GC_Chat *chat)
 
     if (chat->connection_cooldown_timer < tm) {
         chat->connection_cooldown_timer = tm;
-        --chat->connection_O_metre;
+        --chat->connection_o_metre;
 
-        if (chat->connection_O_metre == 0 && chat->block_handshakes) {
+        if (chat->connection_o_metre == 0 && chat->block_handshakes) {
             chat->block_handshakes = false;
             LOGGER_DEBUG(chat->log, "Unblocking handshakes");
         }

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -292,7 +292,7 @@ typedef struct GC_Chat {
     uint64_t    last_time_peers_loaded;
 
     /* keeps track of frequency of new inbound connections */
-    uint8_t     connection_O_metre;
+    uint8_t     connection_o_metre;
     uint64_t    connection_cooldown_timer;
     bool        block_handshakes;
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -139,15 +139,15 @@ static const char *inet_ntop6(const struct in6_addr *addr, char *buf, size_t buf
 }
 
 non_null()
-static int inet_pton4(const char *addrString, struct in_addr *addrbuf)
+static int inet_pton4(const char *addr_string, struct in_addr *addrbuf)
 {
-    return inet_pton(AF_INET, addrString, addrbuf);
+    return inet_pton(AF_INET, addr_string, addrbuf);
 }
 
 non_null()
-static int inet_pton6(const char *addrString, struct in6_addr *addrbuf)
+static int inet_pton6(const char *addr_string, struct in6_addr *addrbuf)
 {
-    return inet_pton(AF_INET6, addrString, addrbuf);
+    return inet_pton(AF_INET6, addr_string, addrbuf);
 }
 
 #else
@@ -377,47 +377,47 @@ IP6 get_ip6_loopback(void)
 
 const Socket net_invalid_socket = { (int)INVALID_SOCKET };
 
-Family net_family_unspec()
+Family net_family_unspec(void)
 {
     return family_unspec;
 }
 
-Family net_family_ipv4()
+Family net_family_ipv4(void)
 {
     return family_ipv4;
 }
 
-Family net_family_ipv6()
+Family net_family_ipv6(void)
 {
     return family_ipv6;
 }
 
-Family net_family_tcp_server()
+Family net_family_tcp_server(void)
 {
     return family_tcp_server;
 }
 
-Family net_family_tcp_client()
+Family net_family_tcp_client(void)
 {
     return family_tcp_client;
 }
 
-Family net_family_tcp_ipv4()
+Family net_family_tcp_ipv4(void)
 {
     return family_tcp_ipv4;
 }
 
-Family net_family_tcp_ipv6()
+Family net_family_tcp_ipv6(void)
 {
     return family_tcp_ipv6;
 }
 
-Family net_family_tox_tcp_ipv4()
+Family net_family_tox_tcp_ipv4(void)
 {
     return family_tox_tcp_ipv4;
 }
 
-Family net_family_tox_tcp_ipv6()
+Family net_family_tox_tcp_ipv6(void)
 {
     return family_tox_tcp_ipv6;
 }

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -1162,7 +1162,7 @@ static int handle_dhtpk_announce(void *object, const uint8_t *source_pubkey, con
                 onion_c->friends_list[friend_num].dht_pk_callback_number, data + 1 + sizeof(uint64_t), userdata);
     }
 
-    onion_set_friend_DHT_pubkey(onion_c, friend_num, data + 1 + sizeof(uint64_t));
+    onion_set_friend_dht_pubkey(onion_c, friend_num, data + 1 + sizeof(uint64_t));
 
     const uint16_t len_nodes = length - DHTPK_DATA_MIN_LENGTH;
 
@@ -1602,7 +1602,7 @@ int onion_dht_pk_callback(Onion_Client *onion_c, int friend_num,
  * return -1 on failure.
  * return 0 on success.
  */
-int onion_set_friend_DHT_pubkey(Onion_Client *onion_c, int friend_num, const uint8_t *dht_key)
+int onion_set_friend_dht_pubkey(Onion_Client *onion_c, int friend_num, const uint8_t *dht_key)
 {
     if ((uint32_t)friend_num >= onion_c->num_friends) {
         return -1;
@@ -1629,7 +1629,7 @@ int onion_set_friend_DHT_pubkey(Onion_Client *onion_c, int friend_num, const uin
  * return 0 on failure (no key copied).
  * return 1 on success (key copied).
  */
-unsigned int onion_getfriend_DHT_pubkey(const Onion_Client *onion_c, int friend_num, uint8_t *dht_key)
+unsigned int onion_getfriend_dht_pubkey(const Onion_Client *onion_c, int friend_num, uint8_t *dht_key)
 {
     if ((uint32_t)friend_num >= onion_c->num_friends) {
         return 0;
@@ -1657,7 +1657,7 @@ int onion_getfriendip(const Onion_Client *onion_c, int friend_num, IP_Port *ip_p
 {
     uint8_t dht_public_key[CRYPTO_PUBLIC_KEY_SIZE];
 
-    if (onion_getfriend_DHT_pubkey(onion_c, friend_num, dht_public_key) == 0) {
+    if (onion_getfriend_dht_pubkey(onion_c, friend_num, dht_public_key) == 0) {
         return -1;
     }
 

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -165,7 +165,7 @@ int onion_dht_pk_callback(Onion_Client *onion_c, int friend_num, onion_dht_pk_cb
  * return 0 on success.
  */
 non_null()
-int onion_set_friend_DHT_pubkey(Onion_Client *onion_c, int friend_num, const uint8_t *dht_key);
+int onion_set_friend_dht_pubkey(Onion_Client *onion_c, int friend_num, const uint8_t *dht_key);
 
 /** @brief Copy friends DHT public key into dht_key.
  *
@@ -173,7 +173,7 @@ int onion_set_friend_DHT_pubkey(Onion_Client *onion_c, int friend_num, const uin
  * return 1 on success (key copied).
  */
 non_null()
-unsigned int onion_getfriend_DHT_pubkey(const Onion_Client *onion_c, int friend_num, uint8_t *dht_key);
+unsigned int onion_getfriend_dht_pubkey(const Onion_Client *onion_c, int friend_num, uint8_t *dht_key);
 
 #define ONION_DATA_IN_RESPONSE_MIN_SIZE (CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_MAC_SIZE)
 #define ONION_CLIENT_MAX_DATA_SIZE (MAX_DATA_REQUEST_SIZE - ONION_DATA_IN_RESPONSE_MIN_SIZE)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2404)
<!-- Reviewable:end -->
