### PR TITLE
test: Add an s390x build (on alpine) for CI.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/_build
+/_install

--- a/.github/scripts/cmake-alpine-s390x
+++ b/.github/scripts/cmake-alpine-s390x
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright (C) 2018-2023 nurupo
+
+# Toxcore building
+
+set -eux
+
+cd .. # /work
+. cmake-alpine-run.sh
+
+# === Get VM ready to build the code ===
+
+start_vm
+
+RUN apk add cmake g++ ninja
+
+mv c-toxcore /
+
+# Copy over toxcore code from host to qemu
+scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P "$SSH_PORT" -r /c-toxcore root@localhost:~
+
+cd /c-toxcore
+. ".github/scripts/flags-gcc.sh"
+
+# Make compilation error on a warning
+add_flag -Werror
+
+# - disabling toxav because vpx doesn't work on s390x.
+# - disabling bootstrap daemons because we don't need them for testing (saving time).
+# - disabling shared libraries because it saves a lot of time on building PIC objects.
+# - enable unity build because it saves a lot of time as well (fewer objects to build).
+RUN "cmake -B_build -Hc-toxcore -GNinja \
+  -DCMAKE_C_FLAGS='$C_FLAGS' \
+  -DCMAKE_CXX_FLAGS='$CXX_FLAGS' \
+  -DCMAKE_EXE_LINKER_FLAGS='$LD_FLAGS' \
+  -DCMAKE_SHARED_LINKER_FLAGS='$LD_FLAGS' \
+  -DCMAKE_INSTALL_PREFIX:PATH='_install' \
+  -DCMAKE_UNITY_BUILD=ON \
+  -DMIN_LOGGER_LEVEL=TRACE \
+  -DNON_HERMETIC_TESTS=ON \
+  -DENABLE_SHARED=OFF \
+  -DBUILD_TOXAV=OFF \
+  -DDHT_BOOTSTRAP=OFF \
+  -DBOOTSTRAP_DAEMON=OFF \
+  -DSTRICT_ABI=ON \
+  -DTEST_TIMEOUT_SECONDS=90 \
+  -DUSE_IPV6=OFF \
+  -DAUTOTEST=ON"
+
+RUN 'cmake --build _build --parallel 2 --target install -- -k 0'
+RUN 'cd _build && ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:1 --timeout 90 || true' &
+
+# Give the tests 5 minutes to run. Sometimes, the per-test timeout doesn't
+# work, so we put a global timeout here for everything.
+sleep 300

--- a/.github/scripts/cmake-freebsd
+++ b/.github/scripts/cmake-freebsd
@@ -1,22 +1,18 @@
 #!/bin/bash
-# Copyright (C) 2018-2021 nurupo
+# Copyright (C) 2018-2023 nurupo
 
 # Toxcore building
 
 set -eux
 
-if [ "$PWD" != "/work" ]; then
-  cd ..
-  mv c-toxcore /
-  mkdir c-toxcore
-  cd /work
-fi
-
+cd .. # /work
 . cmake-freebsd-run.sh
 
 # === Get VM ready to build the code ===
 
 gunzip "$IMAGE_NAME.gz"
+
+mv c-toxcore /
 
 start_vm
 
@@ -26,27 +22,34 @@ scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P "$SSH_PORT" -
 RUN ls -lh
 
 cd /c-toxcore
-. ".github/scripts/flags-clang.sh"
+. '.github/scripts/flags-clang.sh'
 
 add_ld_flag -Wl,-z,defs
 
-# Make compilation error on a warning
+# Make compilation error on a warning.
 add_flag -Werror
 
-RUN 'cmake -B_build -Hc-toxcore \
-  -DCMAKE_C_FLAGS="$C_FLAGS" \
-  -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
-  -DCMAKE_EXE_LINKER_FLAGS="$LD_FLAGS" \
-  -DCMAKE_SHARED_LINKER_FLAGS="$LD_FLAGS" \
-  -DCMAKE_INSTALL_PREFIX:PATH="_install" \
+# This triggers on FreeBSD's clang.
+add_flag -Wno-format
+add_flag -Wno-unsafe-buffer-usage
+
+RUN "cmake -B_build -Hc-toxcore \
+  -DCMAKE_C_FLAGS='$C_FLAGS' \
+  -DCMAKE_CXX_FLAGS='$CXX_FLAGS' \
+  -DCMAKE_EXE_LINKER_FLAGS='$LD_FLAGS' \
+  -DCMAKE_SHARED_LINKER_FLAGS='$LD_FLAGS' \
+  -DCMAKE_INSTALL_PREFIX:PATH='_install' \
   -DMIN_LOGGER_LEVEL=TRACE \
   -DMUST_BUILD_TOXAV=ON \
   -DNON_HERMETIC_TESTS=ON \
   -DSTRICT_ABI=ON \
   -DTEST_TIMEOUT_SECONDS=90 \
   -DUSE_IPV6=OFF \
-  -DAUTOTEST=ON'
+  -DAUTOTEST=ON"
 
-# We created the VM with the same number of cores as the host, so the host-ran `nproc` here is fine
+# We created the VM with the same number of cores as the host, so the host-ran `nproc` here is fine.
 RUN 'gmake "-j$NPROC" -k install -C_build'
 RUN 'gmake "-j$NPROC" test ARGS="-j50" -C_build || true'
+
+# Gracefully shut down the VM.
+stop_vm

--- a/.github/scripts/flags.sh
+++ b/.github/scripts/flags.sh
@@ -28,8 +28,6 @@ add_flag -O3 -march=native
 
 # Warn on non-ISO C.
 add_c_flag -pedantic
-add_c_flag -std=c99
-add_cxx_flag -std=c++11
 
 add_flag -g3
 add_flag -ftrapv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,26 @@ jobs:
         with:
           file: other/docker/compcert/Dockerfile
 
+  build-alpine-s390x:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          file: other/docker/alpine-s390x/Dockerfile
+
+  build-freebsd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          file: other/docker/freebsd/Dockerfile
+
   cimplefmt:
     runs-on: ubuntu-latest
     steps:
@@ -116,16 +136,6 @@ jobs:
           submodules: recursive
       - name: Cross compilation
         run: .github/scripts/cmake-win64 script
-
-  build-freebsd:
-    runs-on: ubuntu-latest
-    container: toxchat/freebsd
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Build on FreeBSD
-        run: .github/scripts/cmake-freebsd-stage2
 
   build-macos:
     runs-on: macos-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.12)
-cmake_policy(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
+cmake_policy(VERSION 3.5)
 project(toxcore)
 
 list(APPEND CMAKE_MODULE_PATH ${toxcore_SOURCE_DIR}/cmake)
@@ -79,21 +79,14 @@ enable_testing()
 
 set(CMAKE_MACOSX_RPATH ON)
 
-if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
-  if(NOT MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-  endif()
-else()
-  # Set standard version for compiler.
-  set(CMAKE_C_STANDARD 99)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_C_EXTENSIONS OFF)
-  set(CMAKE_CXX_EXTENSIONS OFF)
+# Set standard version for compiler.
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-  message(STATUS "Supported C compiler features = ${CMAKE_C_COMPILE_FEATURES}")
-  message(STATUS "Supported C++ compiler features = ${CMAKE_CXX_COMPILE_FEATURES}")
-endif()
+message(STATUS "Supported C compiler features = ${CMAKE_C_COMPILE_FEATURES}")
+message(STATUS "Supported C++ compiler features = ${CMAKE_CXX_COMPILE_FEATURES}")
 
 set(MIN_LOGGER_LEVEL "" CACHE STRING "Logging level to use (TRACE, DEBUG, INFO, WARNING, ERROR)")
 if(MIN_LOGGER_LEVEL)

--- a/cmake/StrictAbi.cmake
+++ b/cmake/StrictAbi.cmake
@@ -29,7 +29,7 @@ function(_make_version_script target)
     list(GET sublib 1 ns)
 
     execute_process(
-      COMMAND ${SHELL} -c "egrep '^\\w' ${header} | grep '${ns}_[a-z0-9_]*(' | grep -v '^typedef' | grep -o '${ns}_[a-z0-9_]*(' | egrep -o '\\w+' | sort -u"
+      COMMAND ${SHELL} -c "egrep '^\\w' ${header} | grep '${ns}_[a-z0-9_]*(' | grep -v '^typedef' | grep -o '${ns}_[a-z0-9_]*(' | egrep -o '[a-z0-9_]+' | sort -u"
       OUTPUT_VARIABLE sublib_SYMS
       OUTPUT_STRIP_TRAILING_WHITESPACE)
     string(REPLACE "\n" ";" sublib_SYMS ${sublib_SYMS})

--- a/other/analysis/run-clang-tidy
+++ b/other/analysis/run-clang-tidy
@@ -2,6 +2,9 @@
 
 CHECKS="*"
 
+# We don't use memcpy_s.
+CHECKS="$CHECKS,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling"
+
 # __attribute__((nonnull)) causes this warning on defensive null checks.
 CHECKS="$CHECKS,-clang-diagnostic-pointer-bool-conversion"
 CHECKS="$CHECKS,-clang-diagnostic-tautological-pointer-compare"
@@ -56,6 +59,11 @@ CHECKS="$CHECKS,-readability-redundant-control-flow"
 # very helpful as a diagnostic.
 CHECKS="$CHECKS,-bugprone-narrowing-conversions"
 CHECKS="$CHECKS,-cppcoreguidelines-narrowing-conversions"
+
+# TODO(iphydf): Probably fix this in tox-bootstrapd.c.
+CHECKS="$CHECKS,-cert-dcl03-c"
+CHECKS="$CHECKS,-hicpp-static-assert"
+CHECKS="$CHECKS,-misc-static-assert"
 
 # TODO(iphydf): We might want some of these. For the ones we don't want, add a
 # comment explaining why not.

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-b18557c5c89ac6a06137a692418270ab08adc0544ed631545b862fca21502743  /usr/local/bin/tox-bootstrapd
+05c389460de83d58533a658d0df625600bc3e6940bbcc738db9dddee249fac59  /usr/local/bin/tox-bootstrapd

--- a/other/docker/alpine-s390x/Dockerfile
+++ b/other/docker/alpine-s390x/Dockerfile
@@ -1,0 +1,6 @@
+FROM toxchat/alpine-s390x:latest
+
+WORKDIR /work/c-toxcore
+COPY . /work/c-toxcore/
+
+RUN .github/scripts/cmake-alpine-s390x

--- a/other/docker/alpine-s390x/run
+++ b/other/docker/alpine-s390x/run
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 set -eux
-BUILD=misra
+BUILD=alpine-s390x
 docker build -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/Dockerfile" .

--- a/other/docker/autotools/run
+++ b/other/docker/autotools/run
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-docker build -t toxchat/c-toxcore:autotools -f other/docker/autotools/Dockerfile .
+set -eux
+BUILD=autotools
+docker build -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/Dockerfile" .

--- a/other/docker/cimplefmt/run
+++ b/other/docker/cimplefmt/run
@@ -5,4 +5,4 @@ if [ "$1" = "-u" ]; then
   docker pull toxchat/haskell:hs-cimple
   docker build -t toxchat/cimplefmt -f other/docker/cimplefmt/Dockerfile .
 fi
-docker run --rm -v "$PWD:/work" toxchat/cimplefmt "$@"
+docker run --name toxcore-cimplefmt --rm -v "$PWD:/work" toxchat/cimplefmt "$@"

--- a/other/docker/circleci/run
+++ b/other/docker/circleci/run
@@ -3,4 +3,4 @@
 SANITIZER="${1:-asan}"
 
 docker build -t toxchat/c-toxcore:circleci other/docker/circleci
-docker run --rm -it -v "$PWD:/c-toxcore" toxchat/c-toxcore:circleci "$SANITIZER"
+docker run --name toxcore-circleci --rm -it -v "$PWD:/c-toxcore" toxchat/c-toxcore:circleci "$SANITIZER"

--- a/other/docker/compcert/run
+++ b/other/docker/compcert/run
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 set -eux
-
-docker build -t toxchat/c-toxcore:compcert -f other/docker/compcert/Dockerfile .
+BUILD=compcert
+docker build -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/Dockerfile" .

--- a/other/docker/coverage/run
+++ b/other/docker/coverage/run
@@ -4,4 +4,4 @@ set -eux
 
 docker build -t toxchat/c-toxcore:sources -f other/docker/sources/Dockerfile .
 docker build -t toxchat/c-toxcore:coverage other/docker/coverage
-docker run --rm -it -p "28192:80" toxchat/c-toxcore:coverage
+docker run --name toxcore-coverage --rm -it -p "28192:80" toxchat/c-toxcore:coverage

--- a/other/docker/doxygen/run
+++ b/other/docker/doxygen/run
@@ -3,4 +3,4 @@
 set -eux
 
 docker build -t toxchat/c-toxcore:docs -f other/docker/doxygen/Dockerfile .
-docker run --rm -it -p "28192:80" toxchat/c-toxcore:docs
+docker run --name toxcore-docs --rm -it -p "28192:80" toxchat/c-toxcore:docs

--- a/other/docker/freebsd/Dockerfile
+++ b/other/docker/freebsd/Dockerfile
@@ -1,0 +1,6 @@
+FROM toxchat/freebsd:latest
+
+WORKDIR /work/c-toxcore
+COPY . /work/c-toxcore/
+
+RUN .github/scripts/cmake-freebsd

--- a/other/docker/freebsd/run
+++ b/other/docker/freebsd/run
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 set -eux
-BUILD=misra
+BUILD=freebsd
 docker build -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/Dockerfile" .

--- a/other/docker/perf/run
+++ b/other/docker/perf/run
@@ -3,7 +3,7 @@
 set -eux
 
 docker build -t toxchat/c-toxcore:perf -f other/docker/perf/Dockerfile .
-docker run --privileged --rm -it \
+docker run --name toxcore-perf --privileged --rm -it \
   -v "$PWD:/work/c-toxcore" \
   toxchat/c-toxcore:perf \
   "$@"

--- a/other/docker/tcc/run
+++ b/other/docker/tcc/run
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 set -eux
-
-docker build -t toxchat/c-toxcore:tcc -f other/docker/tcc/Dockerfile .
+BUILD=tcc
+docker build -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/Dockerfile" .

--- a/other/docker/tokstyle/run
+++ b/other/docker/tokstyle/run
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-docker build -f other/docker/tokstyle/Dockerfile .
+set -eux
+BUILD=tokstyle
+docker build -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/Dockerfile" .

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1184,11 +1184,11 @@ Networking_Core *new_networking_ex(
     int n = 1024 * 1024 * 2;
 
     if (net_setsockopt(ns, temp->sock, SOL_SOCKET, SO_RCVBUF, &n, sizeof(n)) != 0) {
-        LOGGER_ERROR(log, "failed to set socket option %d", SO_RCVBUF);
+        LOGGER_WARNING(log, "failed to set socket option %d", SO_RCVBUF);
     }
 
     if (net_setsockopt(ns, temp->sock, SOL_SOCKET, SO_SNDBUF, &n, sizeof(n)) != 0) {
-        LOGGER_ERROR(log, "failed to set socket option %d", SO_SNDBUF);
+        LOGGER_WARNING(log, "failed to set socket option %d", SO_SNDBUF);
     }
 
     /* Enable broadcast on socket */


### PR DESCRIPTION
It doesn't work at all, because we're missing something in the net code to do with endian conversions. I haven't investigated, yet, but at least now we have a failing test that can be investigated.

Also moved to cmake 3.5 at minimum. CMake will stop supporting lower versions than that, soon.

Also moved to C11 from C99 to get `static_assert`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2429)
<!-- Reviewable:end -->
