### PR TITLE
chore: Retry freebsd tests 2 times.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ bazel-opt_task:
     - /src/workspace/tools/inject-repo c-toxcore
   test_all_script:
     - cd /src/workspace && bazel test -k
-        --config=ci
+        --config=remote
         --build_tag_filters=-haskell
         --test_tag_filters=-haskell
         --
@@ -26,7 +26,7 @@ bazel-dbg_task:
     - /src/workspace/tools/inject-repo c-toxcore
   test_all_script:
     - cd /src/workspace && bazel test -k
-        --config=ci
+        --config=remote
         --build_tag_filters=-haskell
         --test_tag_filters=-haskell
         --
@@ -43,8 +43,19 @@ cimple_task:
     - /src/workspace/tools/inject-repo c-toxcore
   test_all_script:
     - cd /src/workspace && bazel test -k
-        --config=ci
         --build_tag_filters=haskell
         --test_tag_filters=haskell
         --
         //c-toxcore/...
+
+freebsd_task:
+  container:
+    image: toxchat/freebsd:latest
+    cpu: 2
+    memory: 4G
+    kvm: true
+  configure_script:
+    - git submodule update --init --recursive
+    - cd .. && mv cirrus-ci-build /work/c-toxcore && mkdir cirrus-ci-build
+  test_all_script:
+    - cd /work/c-toxcore && .github/scripts/cmake-freebsd

--- a/.github/scripts/cmake-freebsd
+++ b/.github/scripts/cmake-freebsd
@@ -10,7 +10,10 @@ cd .. # /work
 
 # === Get VM ready to build the code ===
 
-gunzip "$IMAGE_NAME.gz"
+# Unpack image only if it's compressed.
+if [ -f "$IMAGE_NAME.gz" ]; then
+  gunzip "$IMAGE_NAME.gz"
+fi
 
 mv c-toxcore /
 
@@ -43,13 +46,13 @@ RUN "cmake -B_build -Hc-toxcore \
   -DMUST_BUILD_TOXAV=ON \
   -DNON_HERMETIC_TESTS=ON \
   -DSTRICT_ABI=ON \
-  -DTEST_TIMEOUT_SECONDS=90 \
+  -DTEST_TIMEOUT_SECONDS=120 \
   -DUSE_IPV6=OFF \
   -DAUTOTEST=ON"
 
 # We created the VM with the same number of cores as the host, so the host-ran `nproc` here is fine.
-RUN 'gmake "-j$NPROC" -k install -C_build'
-RUN 'gmake "-j$NPROC" test ARGS="-j50" -C_build || true'
+RUN 'cmake --build _build --parallel "$NPROC" --target install -- -k'
+RUN 'cd _build && ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:2 --timeout 120 || true'
 
 # Gracefully shut down the VM.
 stop_vm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,16 +100,6 @@ jobs:
         with:
           file: other/docker/alpine-s390x/Dockerfile
 
-  build-freebsd:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Docker Build
-        uses: docker/build-push-action@v2
-        with:
-          file: other/docker/freebsd/Dockerfile
-
   cimplefmt:
     runs-on: ubuntu-latest
     steps:

--- a/auto_tests/crypto_test.c
+++ b/auto_tests/crypto_test.c
@@ -269,6 +269,30 @@ static void test_large_data_symmetric(void)
     free(m1);
 }
 
+static void test_very_large_data(void)
+{
+    const Random *rng = system_random();
+    ck_assert(rng != nullptr);
+
+    uint8_t nonce[CRYPTO_NONCE_SIZE] = {0};
+    uint8_t pk[CRYPTO_PUBLIC_KEY_SIZE];
+    uint8_t sk[CRYPTO_SECRET_KEY_SIZE];
+    crypto_new_keypair(rng, pk, sk);
+
+    // 100 MiB of data (all zeroes, doesn't matter what's inside).
+    const uint32_t plain_size = 100 * 1024 * 1024;
+    uint8_t *plain = (uint8_t *)malloc(plain_size);
+    uint8_t *encrypted = (uint8_t *)malloc(plain_size + CRYPTO_MAC_SIZE);
+
+    ck_assert(plain != nullptr);
+    ck_assert(encrypted != nullptr);
+
+    encrypt_data(pk, sk, nonce, plain, plain_size, encrypted);
+
+    free(encrypted);
+    free(plain);
+}
+
 static void increment_nonce_number_cmp(uint8_t *nonce, uint32_t num)
 {
     uint32_t num1 = 0;
@@ -340,6 +364,7 @@ int main(void)
     test_endtoend(); /* waiting up to 15 seconds */
     test_large_data();
     test_large_data_symmetric();
+    test_very_large_data();
     test_increment_nonce();
     test_memzero();
 

--- a/toxcore/crypto_core_test.cc
+++ b/toxcore/crypto_core_test.cc
@@ -12,10 +12,29 @@ namespace {
 
 using HmacKey = std::array<uint8_t, CRYPTO_HMAC_KEY_SIZE>;
 using Hmac = std::array<uint8_t, CRYPTO_HMAC_SIZE>;
+using PublicKey = std::array<uint8_t, CRYPTO_PUBLIC_KEY_SIZE>;
+using SecretKey = std::array<uint8_t, CRYPTO_SECRET_KEY_SIZE>;
 using ExtPublicKey = std::array<uint8_t, EXT_PUBLIC_KEY_SIZE>;
 using ExtSecretKey = std::array<uint8_t, EXT_SECRET_KEY_SIZE>;
 using Signature = std::array<uint8_t, CRYPTO_SIGNATURE_SIZE>;
 using Nonce = std::array<uint8_t, CRYPTO_NONCE_SIZE>;
+
+TEST(CryptoCore, EncryptLargeData)
+{
+    const Random *rng = system_random();
+    ASSERT_NE(rng, nullptr);
+
+    Nonce nonce{};
+    PublicKey pk;
+    SecretKey sk;
+    crypto_new_keypair(rng, pk.data(), sk.data());
+
+    // 100 MiB of data (all zeroes, doesn't matter what's inside).
+    std::vector<uint8_t> plain(100 * 1024 * 1024);
+    std::vector<uint8_t> encrypted(plain.size() + CRYPTO_MAC_SIZE);
+
+    encrypt_data(pk.data(), sk.data(), nonce.data(), plain.data(), plain.size(), encrypted.data());
+}
 
 TEST(CryptoCore, IncrementNonce)
 {


### PR DESCRIPTION
Also, use `cmake --build` instead of manually calling `gmake`. This allows us to maybe later use `ninja` instead of `gmake` without changing this build invocation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2430)
<!-- Reviewable:end -->
