### PR TITLE
fix: Add missing `htons` call when adding configured TCP relay.

### DIFF
--- a/auto_tests/dht_getnodes_api_test.c
+++ b/auto_tests/dht_getnodes_api_test.c
@@ -123,7 +123,7 @@ static void test_dht_getnodes(AutoTox *autotoxes)
         tox_self_get_dht_id(autotoxes[i].tox, public_key_list[i]);
         tox_callback_dht_get_nodes_response(autotoxes[i].tox, getnodes_response_cb);
 
-        printf("Peer %zu dht closenode count total/annouce-capable: %d/%d\n",
+        printf("Peer %zu dht closenode count total/announce-capable: %d/%d\n",
             i,
             tox_dht_get_num_closelist(autotoxes[i].tox),
             tox_dht_get_num_closelist_announce_capable(autotoxes[i].tox)

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-05c389460de83d58533a658d0df625600bc3e6940bbcc738db9dddee249fac59  /usr/local/bin/tox-bootstrapd
+1608abb52cd16775216d01d06569e6437d86ed11e9fc8dc6dc9c1c28668ccd8b  /usr/local/bin/tox-bootstrapd

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2627,7 +2627,7 @@ void do_messenger(Messenger *m, void *userdata)
         if (m->tcp_server != nullptr) {
             /* Add self tcp server. */
             IP_Port local_ip_port;
-            local_ip_port.port = m->options.tcp_server_port;
+            local_ip_port.port = net_htons(m->options.tcp_server_port);
             local_ip_port.ip.family = net_family_ipv4();
             local_ip_port.ip.ip.v4 = get_ip4_loopback();
             add_tcp_relay(m->net_crypto, &local_ip_port, tcp_server_public_key(m->tcp_server));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2436)
<!-- Reviewable:end -->
