### PR TITLE
cleanup: Use a struct for public keys.

### DIFF
--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -75,6 +75,10 @@ extern "C" {
  */
 #define CRYPTO_SHA512_SIZE             64
 
+typedef struct Public_Key {
+    uint8_t data[CRYPTO_PUBLIC_KEY_SIZE];
+} Public_Key;
+
 typedef void crypto_random_bytes_cb(void *obj, uint8_t *bytes, size_t length);
 typedef uint32_t crypto_random_uniform_cb(void *obj, uint32_t upper_bound);
 


### PR DESCRIPTION
This way we're more explicit about when we're dealing with arrays that happen to be public keys vs. some other, perhaps more private, data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2445)
<!-- Reviewable:end -->
