### PR TITLE
feat: Add groupchat API function that returns an IP address string for a peer

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-e0fa59db7d25204f917e4b114e1607cb3819fe9da74de5f9e807bcf76abefe42  /usr/local/bin/tox-bootstrapd
+8cb8b2f7bbc0ce71551365ed72ae468c731eafdce93e01d8c9a04ed5d904fcd9  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -390,6 +390,29 @@ int gc_get_peer_nick_size(const GC_Chat *chat, uint32_t peer_id);
 non_null(1) nullable(3)
 int gc_get_peer_public_key_by_peer_id(const GC_Chat *chat, uint32_t peer_id, uint8_t *public_key);
 
+/** @brief Returns the length of the IP address for the peer designated by `peer_id`.
+ * Returns -1 if peer_id is invalid.
+ */
+non_null()
+int gc_get_peer_ip_address_size(const GC_Chat *chat, uint32_t peer_id);
+
+/** @brief Copies peer_id's IP address to `ip_addr`.
+ *
+ * If the peer is forcing TCP connections this will be a placeholder value indicating
+ * that their real IP address is unknown to us.
+ *
+ * If `peer_id` designates ourself, it will write either our own IP address or a
+ * placeholder value, depending on whether or not we're forcing TCP connections.
+ *
+ * `ip_addr` should have room for at least IP_NTOA_LEN bytes.
+ *
+ * Returns 0 on success.
+ * Returns -1 if peer_id is invalid or doesn't correspond to a valid peer connection.
+ * Returns -2 if `ip_addr` is null.
+ */
+non_null(1) nullable(3)
+int gc_get_peer_ip_address(const GC_Chat *chat, uint32_t peer_id, uint8_t *ip_addr);
+
 /** @brief Gets the connection status for peer associated with `peer_id`.
  *
  * If `peer_id` designates ourself, the return value indicates whether we're capable

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1514,30 +1514,29 @@ void ipport_copy(IP_Port *target, const IP_Port *source)
     *target = *source;
 }
 
-/** @brief Converts IP into a string.
- *
- * Writes error message into the buffer on error.
- *
- * @param ip_str contains a buffer of the required size.
- *
- * @return Pointer to the buffer inside `ip_str` containing the IP string.
- */
 const char *net_ip_ntoa(const IP *ip, Ip_Ntoa *ip_str)
 {
     assert(ip_str != nullptr);
 
+    ip_str->ip_is_valid = false;
+
     if (ip == nullptr) {
         snprintf(ip_str->buf, sizeof(ip_str->buf), "(IP invalid: NULL)");
+        ip_str->length = (uint16_t)strlen(ip_str->buf);
         return ip_str->buf;
     }
 
     if (!ip_parse_addr(ip, ip_str->buf, sizeof(ip_str->buf))) {
         snprintf(ip_str->buf, sizeof(ip_str->buf), "(IP invalid, family %u)", ip->family.value);
+        ip_str->length = (uint16_t)strlen(ip_str->buf);
         return ip_str->buf;
     }
 
     /* brute force protection against lacking termination */
     ip_str->buf[sizeof(ip_str->buf) - 1] = '\0';
+    ip_str->length = (uint16_t)strlen(ip_str->buf);
+    ip_str->ip_is_valid = true;
+
     return ip_str->buf;
 }
 

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -343,11 +343,14 @@ bool ipv6_ipv4_in_v6(const IP6 *a);
 /** this would be TOX_INET6_ADDRSTRLEN, but it might be too short for the error message */
 #define IP_NTOA_LEN 96 // TODO(irungentoo): magic number. Why not INET6_ADDRSTRLEN ?
 
+/** Contains a null terminated string of an IP address. */
 typedef struct Ip_Ntoa {
-    char buf[IP_NTOA_LEN];
+    char     buf[IP_NTOA_LEN];  // a string formatted IP address or an error message.
+    uint16_t length;  // the length of the string (not including the null byte).
+    bool     ip_is_valid;  // if this is false `buf` will contain an error message.
 } Ip_Ntoa;
 
-/** @brief Converts IP into a string.
+/** @brief Converts IP into a null terminated string.
  *
  * Writes error message into the buffer on error.
  *

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -43,6 +43,8 @@ static_assert(FILE_ID_LENGTH == CRYPTO_SYMMETRIC_KEY_SIZE,
               "FILE_ID_LENGTH is assumed to be equal to CRYPTO_SYMMETRIC_KEY_SIZE");
 static_assert(TOX_DHT_NODE_IP_STRING_SIZE == IP_NTOA_LEN,
               "TOX_DHT_NODE_IP_STRING_SIZE is assumed to be equal to IP_NTOA_LEN");
+static_assert(TOX_GROUP_PEER_IP_STRING_MAX_LENGTH == IP_NTOA_LEN,
+              "TOX_GROUP_PEER_IP_STRING_MAX_LENGTH is assumed to be equal to IP_NTOA_LEN");
 static_assert(TOX_DHT_NODE_PUBLIC_KEY_SIZE == CRYPTO_PUBLIC_KEY_SIZE,
               "TOX_DHT_NODE_PUBLIC_KEY_SIZE is assumed to be equal to CRYPTO_PUBLIC_KEY_SIZE");
 static_assert(TOX_FILE_ID_LENGTH == CRYPTO_SYMMETRIC_KEY_SIZE,

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -124,6 +124,10 @@ uint32_t tox_group_peer_public_key_size(void)
 {
     return TOX_GROUP_PEER_PUBLIC_KEY_SIZE;
 }
+uint32_t tox_group_peer_ip_string_max_length(void)
+{
+    return TOX_GROUP_PEER_IP_STRING_MAX_LENGTH;
+}
 uint32_t tox_dht_node_ip_string_size(void)
 {
     return TOX_DHT_NODE_IP_STRING_SIZE;

--- a/toxcore/tox_private.h
+++ b/toxcore/tox_private.h
@@ -156,6 +156,51 @@ uint16_t tox_dht_get_num_closelist(const Tox *tox);
  */
 uint16_t tox_dht_get_num_closelist_announce_capable(const Tox *tox);
 
+
+/*******************************************************************************
+ *
+ * :: DHT groupchat queries.
+ *
+ ******************************************************************************/
+
+/**
+ * Maximum size of a peer IP address string.
+ */
+#define TOX_GROUP_PEER_IP_STRING_MAX_LENGTH 96
+
+uint32_t tox_group_peer_ip_string_max_length(void);
+
+/**
+ * Return the length of the peer's IP address in string form. If the group number or ID
+ * is invalid, the return value is unspecified.
+ *
+ * @param group_number The group number of the group we wish to query.
+ * @param peer_id The ID of the peer whose IP address length we want to retrieve.
+ */
+size_t tox_group_peer_get_ip_address_size(const Tox *tox, uint32_t group_number, uint32_t peer_id,
+                                          Tox_Err_Group_Peer_Query *error);
+/**
+ * Write the IP address associated with the designated peer_id for the designated group number
+ * to ip_addr.
+ *
+ * If the peer is forcing TCP connections a placeholder value will be written instead,
+ * indicating that their real IP address is unknown to us.
+ *
+ * If `peer_id` designates ourself, it will write either our own IP address or a placeholder value,
+ * depending on whether or not we're forcing TCP connections.
+ *
+ * Call tox_group_peer_get_ip_address_size to determine the allocation size for the `ip_addr` parameter.
+ *
+ * @param group_number The group number of the group we wish to query.
+ * @param peer_id The ID of the peer whose public key we wish to retrieve.
+ * @param ip_addr A valid memory region large enough to store the IP address string.
+ *   If this parameter is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_peer_get_ip_address(const Tox *tox, uint32_t group_number, uint32_t peer_id, uint8_t *ip_addr,
+                                   Tox_Err_Group_Peer_Query *error);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This function will return an IP address string associated with a peer.
If the peer is not accepting direct connections a placeholder value
will be returned, indicating that their real IP address is unknown.
We do not return TCP relay IP addresses because a TCP connection
with a peer may use multiple relays simultaneously.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2446)
<!-- Reviewable:end -->
