### PR TITLE
fix: Docker tox-bootstrapd hash update failing when using BuildKit

### DIFF
--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -1,6 +1,6 @@
 ###########################################################
 # Builder image: we compile the code here (static build)
-FROM alpine:3.15.0 AS build
+FROM alpine:3.18.5 AS build
 
 RUN ["apk", "--no-cache", "add",\
  "build-base",\
@@ -62,7 +62,7 @@ RUN ["other/bootstrap_daemon/docker/get-nodes.py", "other/bootstrap_daemon/tox-b
 
 ###########################################################
 # Final image build: this is what runs the bootstrap node
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY --from=build /usr/local/bin/tox-bootstrapd /usr/local/bin/
 COPY --from=build /src/c-toxcore/other/bootstrap_daemon/tox-bootstrapd.conf /etc/tox-bootstrapd.conf

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-1608abb52cd16775216d01d06569e6437d86ed11e9fc8dc6dc9c1c28668ccd8b  /usr/local/bin/tox-bootstrapd
+12972fcd956654a18e367e03d6bcaab12fbe2ae166dfc937474a7bd123e0910f  /usr/local/bin/tox-bootstrapd

--- a/other/bootstrap_daemon/docker/update-sha256
+++ b/other/bootstrap_daemon/docker/update-sha256
@@ -3,7 +3,7 @@
 set -eux
 
 docker_build() {
-  docker build -f other/bootstrap_daemon/docker/Dockerfile -t toxchat/bootstrap-node .
+  DOCKER_BUILDKIT=1 docker build --progress=plain -f other/bootstrap_daemon/docker/Dockerfile -t toxchat/bootstrap-node .
 }
 
 # Run Docker build once. If it succeeds, we're good.
@@ -12,12 +12,11 @@ if docker_build; then
 fi
 
 # We're not good. Run it again, but now capture the output.
-OUTPUT=$(docker_build || true 2>&1)
+OUTPUT=$(docker_build 2>&1 || true)
 
 if echo "$OUTPUT" | grep '/usr/local/bin/tox-bootstrapd: FAILED'; then
   # This is a checksum warning, so we need to update it.
-  IMAGE=$(echo "$OUTPUT" | grep '^ ---> [0-9a-f]*$' | grep -o '[0-9a-f]*$' | tail -n1)
-  docker run --rm "$IMAGE" sha256sum /usr/local/bin/tox-bootstrapd >other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+  echo "$OUTPUT" | grep -Eo '[0-9a-f]{64}  /usr/local/bin/tox-bootstrapd' | tail -n1 >other/bootstrap_daemon/docker/tox-bootstrapd.sha256
 fi
 
 # Run once last time to complete the build.


### PR DESCRIPTION
Docker is defaulting to using BuildKit for building images since version
23.0 (2023-02-01), which is not compatible with this script. The script
was fishing the hash of the intermediate build container in which the
build has failed, in order to run the sha256sum in that image, however
with BuildKit there are no longer any intermediate build containers,
which breaks the script.

The legacy builder is supposedly getting removed in a future version of
Docker, which is why we embrace BuildKit instead of reverting to the
legacy builder via DOCKER_BUILDKIT=0:

    $ DOCKER_BUILDKIT=0 docker build ...
    DEPRECATED: The legacy builder is deprecated and will be removed in a
                future release. BuildKit is currently disabled; enable it
                by removing the DOCKER_BUILDKIT=0 environment-variable.

While DOCKER_BUILDKIT=1 is unnecessary on Docker >= 23.0, it's needed
for anyone running older Docker, so it makes sense to have it in for
now, while everyone transitions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2447)
<!-- Reviewable:end -->
