### PR TITLE
cleanup: replace tabs with spaces

### DIFF
--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -454,7 +454,7 @@ int main(int argc, char *argv[])
         if (tcp_relay_port_count == 0) {
             log_write(LOG_LEVEL_ERROR, "No TCP relay ports read. Exiting.\n");
             kill_onion_announce(onion_a);
-	        kill_gca(group_announce);
+            kill_gca(group_announce);
             kill_announcements(announce);
             kill_forwarding(forwarding);
             kill_onion(onion);

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2024,7 +2024,7 @@ non_null(1, 3) nullable(5)
 static int m_handle_packet_offline(Messenger *m, const int i, const uint8_t *data, const uint16_t data_length, void *userdata)
 {
     if (data_length == 0) {
-    	set_friend_status(m, i, FRIEND_CONFIRMED, userdata);
+        set_friend_status(m, i, FRIEND_CONFIRMED, userdata);
     }
 
     return 0;
@@ -2403,8 +2403,8 @@ static int m_handle_packet(void *object, int i, const uint8_t *temp, uint16_t le
             return m_handle_packet_file_data(m, i, data, data_length, userdata);
         case PACKET_ID_MSI:
             return m_handle_packet_msi(m, i, data, data_length, userdata);
-	    case PACKET_ID_INVITE_GROUPCHAT:
-	        return m_handle_packet_invite_groupchat(m, i, data, data_length, userdata);
+        case PACKET_ID_INVITE_GROUPCHAT:
+            return m_handle_packet_invite_groupchat(m, i, data, data_length, userdata);
     }
 
     return handle_custom_lossless_packet(object, i, temp, len, userdata);


### PR DESCRIPTION
```sh
c-toxcore$ grep -Ps --line-number '\t' * -R | grep '\.[c|h]:[0-9]\+'
other/bootstrap_daemon/src/tox-bootstrapd.c:457:                kill_gca(group_announce);
toxcore/Messenger.c:2027:       set_friend_status(m, i, FRIEND_CONFIRMED, userdata);
toxcore/Messenger.c:2406:           case PACKET_ID_INVITE_GROUPCHAT:
toxcore/Messenger.c:2407:               return m_handle_packet_invite_groupchat(m, i, data, data_length, userdata);
```

@Green-Sky (d3819b23b3bac6445cc1654e60530c86df3fb191) and @JFreegman (0a277b52ea22fe297a8487ac05a0c507a74c6480)  have been charged with the heinous crime of tab-berdashery -- the unlawful act of indentation injustice that has left the codebase in a state of uneven spacing disbelief, causing unsuspecting developers to question the very fabric of code aesthetics. Authorities recommend a strict sentence of space-indentation rehabilitation by having to code-review the correctional action of tabs being replaced by spaces.