### PR TITLE
cleanup: clarify disabling of static assert checks

### DIFF
--- a/other/analysis/run-clang-tidy
+++ b/other/analysis/run-clang-tidy
@@ -60,7 +60,23 @@ CHECKS="$CHECKS,-readability-redundant-control-flow"
 CHECKS="$CHECKS,-bugprone-narrowing-conversions"
 CHECKS="$CHECKS,-cppcoreguidelines-narrowing-conversions"
 
-# TODO(iphydf): Probably fix this in tox-bootstrapd.c.
+# Mistakenly thinks that
+#   const int a = 0, b = 1;
+#   assert(a < b);
+# is a constant expression in C (it is in C++ though, which is probably why it's
+# mistaken), suggesting to replace 'assert()' with 'static_assert()' in cases
+# where that won't work.
+#
+# There are ways to make 'static_assert()' work, but they are rather annoying --
+# they are somewhat ugly, hurting the readability, and some are error-prone:
+#
+# - Turning 'a' and 'b' into enum constants would make it work, but this falls
+#   apart if the enum types are compared against non-enums down the line
+#     error: enumerated and non-enumerated type in conditional expression [-Werror=extra]
+#
+# - Turning 'a' and 'b' into pre-processor macros is the only option left, but
+#   #defines and #undefs in the middle of a function hurt the readability and
+#   are less idiomatic than simply using 'const int'.
 CHECKS="$CHECKS,-cert-dcl03-c"
 CHECKS="$CHECKS,-hicpp-static-assert"
 CHECKS="$CHECKS,-misc-static-assert"


### PR DESCRIPTION
Since we have now switched to C11 for all compilers but MSVC.

(tox-bootstrapd is Unix-only while MSVC is Windows-only, so MSVC using C99 is not an issue as it never builds tox-bootstrapd).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2451)
<!-- Reviewable:end -->
