### PR TITLE
refactor: replace DEFAULT_TCP_RELAY_PORTS_COUNT with a compile-time calculation

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-8bf35cb22ca6d5d85f5fe8993a6ce9424d2048f9bd6a57ab45dc52a6c8444fb3  /usr/local/bin/tox-bootstrapd
+e0e1c3f1ba835f76faca9383b606ed1a5b778bd79caae9a1e3bb4bf3bfaed19a  /usr/local/bin/tox-bootstrapd

--- a/other/bootstrap_daemon/src/config_defaults.h
+++ b/other/bootstrap_daemon/src/config_defaults.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later
- * Copyright © 2016-2018 The TokTok team.
+ * Copyright © 2016-2023 The TokTok team.
  * Copyright © 2014-2016 Tox project.
  */
 
@@ -19,8 +19,7 @@
 #define DEFAULT_ENABLE_IPV4_FALLBACK  1 // 1 - true, 0 - false
 #define DEFAULT_ENABLE_LAN_DISCOVERY  1 // 1 - true, 0 - false
 #define DEFAULT_ENABLE_TCP_RELAY      1 // 1 - true, 0 - false
-#define DEFAULT_TCP_RELAY_PORTS       443, 3389, 33445 // comma-separated list of ports. make sure to adjust DEFAULT_TCP_RELAY_PORTS_COUNT accordingly
-#define DEFAULT_TCP_RELAY_PORTS_COUNT 3
+#define DEFAULT_TCP_RELAY_PORTS       443, 3389, 33445 // comma-separated list of ports
 #define DEFAULT_ENABLE_MOTD           1 // 1 - true, 0 - false
 #define DEFAULT_MOTD                  DAEMON_NAME
 


### PR DESCRIPTION
That way we don't have to rely on a human to remember to keep `DEFAULT_TCP_RELAY_PORTS_COUNT` in sync with `DEFAULT_TCP_RELAY_PORTS`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2452)
<!-- Reviewable:end -->
