### PR TITLE
refactor: Install header for private/experimental API functions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,16 +8,19 @@ genrule(
     srcs = [
         "//c-toxcore/toxav:toxav.h",
         "//c-toxcore/toxcore:tox.h",
+        "//c-toxcore/toxcore:tox_private.h",
         "//c-toxcore/toxencryptsave:toxencryptsave.h",
     ],
     outs = [
         "tox/toxav.h",
         "tox/tox.h",
+        "tox/tox_private.h",
         "tox/toxencryptsave.h",
     ],
     cmd = """
         cp $(location //c-toxcore/toxav:toxav.h) $(GENDIR)/c-toxcore/tox/toxav.h
         cp $(location //c-toxcore/toxcore:tox.h) $(GENDIR)/c-toxcore/tox/tox.h
+        cp $(location //c-toxcore/toxcore:tox_private.h) $(GENDIR)/c-toxcore/tox/tox_private.h
         cp $(location //c-toxcore/toxencryptsave:toxencryptsave.h) $(GENDIR)/c-toxcore/tox/toxencryptsave.h
     """,
     visibility = ["//visibility:public"],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,8 @@ set(toxcore_PKGCONFIG_REQUIRES ${toxcore_PKGCONFIG_REQUIRES} libsodium)
 set(toxcore_API_HEADERS
   ${toxcore_SOURCE_DIR}/toxcore/tox.h^tox
   ${toxcore_SOURCE_DIR}/toxcore/tox_events.h^tox
-  ${toxcore_SOURCE_DIR}/toxcore/tox_dispatch.h^tox)
+  ${toxcore_SOURCE_DIR}/toxcore/tox_dispatch.h^tox
+  ${toxcore_SOURCE_DIR}/toxcore/tox_private.h^tox)
 
 ################################################################################
 #

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -3,7 +3,10 @@ load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 load("//tools:no_undefined.bzl", "cc_library")
 
 exports_files(
-    srcs = ["tox.h"],
+    srcs = [
+        "tox.h",
+        "tox_private.h",
+    ],
     visibility = ["//c-toxcore:__pkg__"],
 )
 


### PR DESCRIPTION
This allows client developers to use the private API without needing to manually specify the header path in the source code, which may vary from system to system.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2453)
<!-- Reviewable:end -->
