### PR TITLE
fix: Messenger reading potentially uninitialized memory

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2705,7 +2705,9 @@ void do_messenger(Messenger *m, void *userdata)
         for (uint32_t friend_idx = 0; friend_idx < num_dhtfriends; ++friend_idx) {
             m2dht[friend_idx] = -1;
             dht2m[friend_idx] = -1;
+        }
 
+        for (uint32_t friend_idx = 0; friend_idx < num_dhtfriends; ++friend_idx) {
             if (friend_idx >= m->numfriends) {
                 continue;
             }


### PR DESCRIPTION
The Infer static code analysis tool [has found](https://app.circleci.com/pipelines/github/TokTok/c-toxcore/5828/workflows/877dceea-69c1-4c08-a95d-87de9cb7c248/jobs/46873):

```
toxcore/Messenger.c:2734: error: Uninitialized Value
  The value read from dht2m[_] was never initialized.
  2732.
  2733.         for (uint32_t friend_idx = 0; friend_idx < num_dhtfriends; ++friend_idx) {
  2734.             const Friend *const msgfptr = dht2m[friend_idx] >= 0 ?  &m->friendlist[dht2m[friend_idx]] : nullptr;
                                                  ^
  2735.             const DHT_Friend *const dhtfptr = dht_get_friend(m->dht, friend_idx);
  2736.

toxcore/Messenger.c:2739: error: Uninitialized Value
  The value read from dht2m[_] was never initialized.
  2737.             if (msgfptr != nullptr) {
  2738.                 char id_str[IDSTRING_LEN];
  2739.                 LOGGER_TRACE(m->log, "F[%2u:%2u] <%s> %s",
                        ^
  2740.                              dht2m[friend_idx], friend_idx, msgfptr->name,
  2741.                              id_to_string(msgfptr->real_pk, id_str, sizeof(id_str)));

toxcore/Messenger.c:2723: error: Uninitialized Value
  The value read from m2dht[_] was never initialized.
  2721.
  2722.         for (uint32_t friend_idx = 0; friend_idx < num_dhtfriends; ++friend_idx) {
  2723.             if (m2dht[friend_idx] >= 0) {
                        ^
  2724.                 assert(friend_idx < INT32_MAX);
  2725.                 dht2m[m2dht[friend_idx]] = (int32_t)friend_idx;
```

which look legitimate.

Note that doing `memset(m2dht, -1, num_dhtfriends)` would be wrong, as `memset()` interprets the passed array as `char*`, so it would be setting each byte of `m2dht` to -1, up to `num_dhtfriends` bytes, which is not the entire size of `m2dht`. Fixing the size with `memset(m2dht, -1, num_dhtfriends*sizeof(int32_t))` would work, as that's equivalent to setting all bytes in `m2dht` to 0xFF, which would be a -1 in two's complement, but I don't want to assume that the target platform uses two's complement to represent integers to keep the code more portable. That's why the arrays are initizliaed in a loop instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2464)
<!-- Reviewable:end -->
