### PR TITLE
cleanup: Make group saving/loading more forgiving with data errors

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-92d0601d778487206505dce0bf89242b89b37424dc756808472fef3c22621ade  /usr/local/bin/tox-bootstrapd
+6468ae67bae96ca47fec38e3aff22809ea8a865df294c8a41cdb681b58a00830  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -401,7 +401,8 @@ int unpack_gc_saved_peers(GC_Chat *chat, const uint8_t *data, uint16_t length);
 
 /** @brief Packs all valid entries from saved peerlist into `data`.
  *
- * If `processed` is non-null it will be set to the length of the packed data.
+ * If `processed` is non-null it will be set to the length of the packed data
+ * on success, and will be untouched on error.
  *
  * Return the number of packed saved peers on success.
  * Return -1 if buffer is too small.

--- a/toxcore/group_pack.c
+++ b/toxcore/group_pack.c
@@ -9,7 +9,6 @@
 
 #include "group_pack.h"
 
-#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -151,7 +150,7 @@ static bool load_unpack_mod_list(GC_Chat *chat, Bin_Unpack *bu)
 
     if (chat->moderation.num_mods > MOD_MAX_NUM_MODERATORS) {
         LOGGER_ERROR(chat->log, "moderation count %u exceeds maximum %u", chat->moderation.num_mods, MOD_MAX_NUM_MODERATORS);
-        return false;
+        chat->moderation.num_mods = MOD_MAX_NUM_MODERATORS;
     }
 
     uint8_t *packed_mod_list = (uint8_t *)malloc(chat->moderation.num_mods * MOD_LIST_ENTRY_SIZE);
@@ -219,7 +218,10 @@ static bool load_unpack_self_info(GC_Chat *chat, Bin_Unpack *bu)
         return false;
     }
 
-    assert(self_nick_len <= MAX_GC_NICK_SIZE);
+    if (self_nick_len > MAX_GC_NICK_SIZE) {
+        LOGGER_ERROR(chat->log, "self_nick too big (%u bytes), truncating to %d", self_nick_len, MAX_GC_NICK_SIZE);
+        self_nick_len = MAX_GC_NICK_SIZE;
+    }
 
     if (!bin_unpack_bin_fixed(bu, self_nick, self_nick_len)) {
         LOGGER_ERROR(chat->log, "Failed to unpack self nick bytes");
@@ -232,7 +234,10 @@ static bool load_unpack_self_info(GC_Chat *chat, Bin_Unpack *bu)
         return false;
     }
 
-    assert(chat->numpeers > 0);
+    if (chat->numpeers == 0) {
+        LOGGER_ERROR(chat->log, "Failed to unpack self: numpeers should be > 0");
+        return false;
+    }
 
     GC_Peer *self = &chat->group[0];
 
@@ -395,9 +400,12 @@ static void save_pack_self_info(const GC_Chat *chat, Bin_Pack *bp)
 {
     bin_pack_array(bp, 4);
 
-    const GC_Peer *self = &chat->group[0];
+    GC_Peer *self = &chat->group[0];
 
-    assert(self->nick_length <= MAX_GC_NICK_SIZE);
+    if (self->nick_length > MAX_GC_NICK_SIZE) {
+        LOGGER_ERROR(chat->log, "self_nick is too big (%u). Truncating to %d", self->nick_length, MAX_GC_NICK_SIZE);
+        self->nick_length = MAX_GC_NICK_SIZE;
+    }
 
     bin_pack_u16(bp, self->nick_length); // 1
     bin_pack_u08(bp, (uint8_t)self->role); // 2


### PR DESCRIPTION
Rather than aborting the process on invalid group save data we either try to continue if possible, or abort the saving/loading instead of the entire process. This addresses https://github.com/TokTok/c-toxcore/issues/2426

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2466)
<!-- Reviewable:end -->
