### PR TITLE
fix(test): tests use ipv6 by default, even with USE_IPV6 set to 0

### DIFF
--- a/auto_tests/auto_test_support.c
+++ b/auto_tests/auto_test_support.c
@@ -13,6 +13,10 @@
 #define ABORT_ON_LOG_ERROR true
 #endif
 
+#ifndef USE_IPV6
+#define USE_IPV6 1
+#endif
+
 Run_Auto_Options default_run_auto_options(void)
 {
     return (Run_Auto_Options) {
@@ -193,6 +197,7 @@ void reload(AutoTox *autotox)
 
     struct Tox_Options *const options = tox_options_new(nullptr);
     ck_assert(options != nullptr);
+    tox_options_set_ipv6_enabled(options, USE_IPV6);
     tox_options_set_savedata_type(options, TOX_SAVEDATA_TYPE_TOX_SAVE);
     tox_options_set_savedata_data(options, autotox->save_state, autotox->save_size);
     autotox->tox = tox_new_log(options, nullptr, &autotox->index);
@@ -213,6 +218,8 @@ static void initialise_autotox(struct Tox_Options *options, AutoTox *autotox, ui
     if (index == 0) {
         struct Tox_Options *default_opts = tox_options_new(nullptr);
         ck_assert(default_opts != nullptr);
+
+        tox_options_set_ipv6_enabled(default_opts, USE_IPV6);
 
         if (options == nullptr) {
             options = default_opts;
@@ -426,6 +433,7 @@ Tox *tox_new_log_lan(struct Tox_Options *options, Tox_Err_New *err, void *log_us
 
     assert(log_options != nullptr);
 
+    tox_options_set_ipv6_enabled(log_options, USE_IPV6);
     tox_options_set_local_discovery_enabled(log_options, lan_discovery);
     // Use a higher start port for non-LAN-discovery tests so it's more likely for the LAN discovery
     // test to get the default port 33445.

--- a/auto_tests/file_streaming_test.c
+++ b/auto_tests/file_streaming_test.c
@@ -13,9 +13,14 @@
 #include "auto_test_support.h"
 #include "check_compat.h"
 
-/* The Travis-CI container responds poorly to ::1 as a localhost address
- * You're encouraged to -D FORCE_TESTS_IPV6 on a local test  */
-#ifdef FORCE_TESTS_IPV6
+#ifndef USE_IPV6
+#define USE_IPV6 1
+#endif
+
+#ifdef TOX_LOCALHOST
+#undef TOX_LOCALHOST
+#endif
+#if USE_IPV6
 #define TOX_LOCALHOST "::1"
 #else
 #define TOX_LOCALHOST "127.0.0.1"

--- a/auto_tests/file_transfer_test.c
+++ b/auto_tests/file_transfer_test.c
@@ -13,9 +13,14 @@
 #include "auto_test_support.h"
 #include "check_compat.h"
 
-/* The Travis-CI container responds poorly to ::1 as a localhost address
- * You're encouraged to -D FORCE_TESTS_IPV6 on a local test  */
-#ifdef FORCE_TESTS_IPV6
+#ifndef USE_IPV6
+#define USE_IPV6 1
+#endif
+
+#ifdef TOX_LOCALHOST
+#undef TOX_LOCALHOST
+#endif
+#if USE_IPV6
 #define TOX_LOCALHOST "::1"
 #else
 #define TOX_LOCALHOST "127.0.0.1"

--- a/auto_tests/save_load_test.c
+++ b/auto_tests/save_load_test.c
@@ -14,12 +14,14 @@
 #include "auto_test_support.h"
 #include "check_compat.h"
 
-/* The Travis-CI container responds poorly to ::1 as a localhost address
- * You're encouraged to -D FORCE_TESTS_IPV6 on a local test  */
+#ifndef USE_IPV6
+#define USE_IPV6 1
+#endif
+
 #ifdef TOX_LOCALHOST
 #undef TOX_LOCALHOST
 #endif
-#ifdef FORCE_TESTS_IPV6
+#if USE_IPV6
 #define TOX_LOCALHOST "::1"
 #else
 #define TOX_LOCALHOST "127.0.0.1"
@@ -74,6 +76,7 @@ static void reload_tox(Tox **tox, struct Tox_Options *const in_opts, void *user_
     }
 
     struct Tox_Options *const options = (in_opts == nullptr) ? tox_options_new(nullptr) : in_opts;
+    tox_options_set_ipv6_enabled(options, USE_IPV6);
 
     tox_options_set_savedata_type(options, TOX_SAVEDATA_TYPE_TOX_SAVE);
 
@@ -138,6 +141,7 @@ static void test_few_clients(void)
     time_t con_time = 0, cur_time = time(nullptr);
 
     struct Tox_Options *opts1 = tox_options_new(nullptr);
+    tox_options_set_ipv6_enabled(opts1, USE_IPV6);
     tox_options_set_tcp_port(opts1, TCP_RELAY_PORT);
     Tox_Err_New t_n_error;
     Tox *tox1 = tox_new_log(opts1, &t_n_error, &index[0]);
@@ -145,12 +149,14 @@ static void test_few_clients(void)
     tox_options_free(opts1);
 
     struct Tox_Options *opts2 = tox_options_new(nullptr);
+    tox_options_set_ipv6_enabled(opts2, USE_IPV6);
     tox_options_set_udp_enabled(opts2, false);
     tox_options_set_local_discovery_enabled(opts2, false);
     Tox *tox2 = tox_new_log(opts2, &t_n_error, &index[1]);
     ck_assert_msg(t_n_error == TOX_ERR_NEW_OK, "Failed to create tox instance: %d", t_n_error);
 
     struct Tox_Options *opts3 = tox_options_new(nullptr);
+    tox_options_set_ipv6_enabled(opts3, USE_IPV6);
     tox_options_set_local_discovery_enabled(opts3, false);
     Tox *tox3 = tox_new_log(opts3, &t_n_error, &index[2]);
     ck_assert_msg(t_n_error == TOX_ERR_NEW_OK, "Failed to create tox instance: %d", t_n_error);

--- a/auto_tests/tox_many_tcp_test.c
+++ b/auto_tests/tox_many_tcp_test.c
@@ -13,9 +13,14 @@
 #include "auto_test_support.h"
 #include "check_compat.h"
 
-/* The Travis-CI container responds poorly to ::1 as a localhost address
- * You're encouraged to -D FORCE_TESTS_IPV6 on a local test  */
-#ifdef FORCE_TESTS_IPV6
+#ifndef USE_IPV6
+#define USE_IPV6 1
+#endif
+
+#ifdef TOX_LOCALHOST
+#undef TOX_LOCALHOST
+#endif
+#if USE_IPV6
 #define TOX_LOCALHOST "::1"
 #else
 #define TOX_LOCALHOST "127.0.0.1"

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-5061f92a95ba45cfa49d78175fa8fb6e4d66a58d86634ea3fd3ae6d80cb0558a  /usr/local/bin/tox-bootstrapd
+ccaf7a29c16d97068952d872b8663e38cc3d958aff01baeafee04e0ac6f3ac98  /usr/local/bin/tox-bootstrapd

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -946,8 +946,9 @@ int send_packet(const Networking_Core *net, const IP_Port *ip_port, Packet packe
     if (net_family_is_ipv4(net->family) && !net_family_is_ipv4(ipp_copy.ip.family)) {
         // TODO(iphydf): Make this an error. Occasionally we try to send to an
         // all-zero ip_port.
-        LOGGER_WARNING(net->log, "attempted to send message with network family %d (probably IPv6) on IPv4 socket",
-                       ipp_copy.ip.family.value);
+        Ip_Ntoa ip_str;
+        LOGGER_WARNING(net->log, "attempted to send message with network family %d (probably IPv6) on IPv4 socket (%s)",
+                       ipp_copy.ip.family.value, net_ip_ntoa(&ipp_copy.ip, &ip_str));
         return -1;
     }
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1058,6 +1058,11 @@ bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t publ
     bool udp_success = tox->m->options.udp_disabled;
 
     for (int32_t i = 0; i < count; ++i) {
+        if (!tox->m->options.ipv6enabled && net_family_is_ipv6(root[i].ip.family)) {
+            // We can't use ipv6 when it's disabled.
+            continue;
+        }
+
         root[i].port = net_htons(port);
 
         if (onion_add_bs_path_node(tox->m->onion_c, &root[i], public_key)) {


### PR DESCRIPTION
fixes: https://github.com/TokTok/c-toxcore/issues/2335
It also fixes resolving to ipv6 addresses when its disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2468)
<!-- Reviewable:end -->
