### PR TITLE
feat: Enable ubsan on bootstrap nodes.

### DIFF
--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -1,15 +1,16 @@
 ###########################################################
 # Builder image: we compile the code here (static build)
-FROM alpine:3.18.5 AS build
+FROM alpine:3.19.0 AS build
 
 RUN ["apk", "--no-cache", "add",\
- "build-base",\
+ "clang",\
  "cmake",\
  "linux-headers",\
  "libconfig-dev",\
  "libconfig-static",\
  "libsodium-dev",\
  "libsodium-static",\
+ "musl-dev",\
  "ninja",\
  "python3"\
 ]
@@ -34,9 +35,9 @@ COPY CMakeLists.txt so.version ./
 COPY other/bootstrap_daemon/CMakeLists.txt other/bootstrap_daemon/CMakeLists.txt
 COPY testing/CMakeLists.txt testing/CMakeLists.txt
 
-RUN cmake -B_build -H. \
+RUN CC=clang cmake -B_build -H. \
       -GNinja \
-      -DCMAKE_C_FLAGS="-DTCP_SERVER_USE_EPOLL -fstack-protector-all -fisolate-erroneous-paths-attribute" \
+      -DCMAKE_C_FLAGS="-DTCP_SERVER_USE_EPOLL -fsanitize=alignment,return,returns-nonnull-attribute,vla-bound,unreachable,float-cast-overflow,null -fsanitize-trap=all -fstack-protector-all" \
       -DCMAKE_UNITY_BUILD=ON \
       -DCMAKE_BUILD_TYPE=Release \
       -DFULLY_STATIC=ON \

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-5aac1df4d6c1de289e8e9f646d06099c84fd4d9b80d19f45e3254eec3ece2bff  /usr/local/bin/tox-bootstrapd
+849ec5686eeaea448f4ef99650b016c883e6ea13d5fa2e7b2a344c9275a10431  /usr/local/bin/tox-bootstrapd


### PR DESCRIPTION
Not all sanitizers are enabled, but the cheap ones are, making the bootstrap node quite a bit more secure at a small runtime cost.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2472)
<!-- Reviewable:end -->
