### PR TITLE
refactor: Give `enum-from-int` functions the ability to report errors.

### DIFF
--- a/auto_tests/tox_dispatch_test.c
+++ b/auto_tests/tox_dispatch_test.c
@@ -164,13 +164,13 @@ static void test_tox_events(void)
 static void fake_test_unpack(void)
 {
     // TODO(Green-Sky): add proper unpack tests and/or implement ngc events
-    (void)tox_unpack_group_privacy_state;
-    (void)tox_unpack_group_privacy_state;
-    (void)tox_unpack_group_voice_state;
-    (void)tox_unpack_group_topic_lock;
-    (void)tox_unpack_group_join_fail;
-    (void)tox_unpack_group_mod_event;
-    (void)tox_unpack_group_exit_type;
+    (void)tox_group_privacy_state_unpack;
+    (void)tox_group_privacy_state_unpack;
+    (void)tox_group_voice_state_unpack;
+    (void)tox_group_topic_lock_unpack;
+    (void)tox_group_join_fail_unpack;
+    (void)tox_group_mod_event_unpack;
+    (void)tox_group_exit_type_unpack;
 }
 
 int main(void)

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-21cf23b1a2e46712663dc4f8daa322991af51b9e82626a127cf1bc8dc583b598  /usr/local/bin/tox-bootstrapd
+f117aa0e2cf3f1b42f7e38beec55cb970025692c5753b1159aa22c6e52281393  /usr/local/bin/tox-bootstrapd

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -15,7 +15,7 @@ sh_test(
         "-Wno-callback-names",
         "-Wno-enum-names",
         "+RTS",
-        "-N3",
+        "-N4",
         "-RTS",
     ],
     data = CIMPLE_FILES,
@@ -32,7 +32,11 @@ sh_test(
         "-Iexternal/libvpx",
         "-Iexternal/opus/include",
         "-Ihs-tokstyle/include",
-    ] + ["$(locations %s)" % f for f in CIMPLE_FILES],
+    ] + ["$(locations %s)" % f for f in CIMPLE_FILES] + [
+        "+RTS",
+        "-N4",
+        "-RTS",
+    ],
     data = CIMPLE_FILES + [
         "//c-toxcore/third_party:headers",
         "//hs-tokstyle:headers",

--- a/toxcore/events/conference_invite.c
+++ b/toxcore/events/conference_invite.c
@@ -125,7 +125,7 @@ static bool tox_event_conference_invite_unpack(
     }
 
     return bin_unpack_u32(bu, &event->friend_number)
-           && tox_unpack_conference_type(bu, &event->type)
+           && tox_conference_type_unpack(bu, &event->type)
            && bin_unpack_bin(bu, &event->cookie, &event->cookie_length);
 }
 

--- a/toxcore/events/conference_message.c
+++ b/toxcore/events/conference_message.c
@@ -141,7 +141,7 @@ static bool tox_event_conference_message_unpack(
 
     return bin_unpack_u32(bu, &event->conference_number)
            && bin_unpack_u32(bu, &event->peer_number)
-           && tox_unpack_message_type(bu, &event->type)
+           && tox_message_type_unpack(bu, &event->type)
            && bin_unpack_bin(bu, &event->message, &event->message_length);
 }
 

--- a/toxcore/events/file_recv_control.c
+++ b/toxcore/events/file_recv_control.c
@@ -105,7 +105,7 @@ static bool tox_event_file_recv_control_unpack(
 
     return bin_unpack_u32(bu, &event->friend_number)
            && bin_unpack_u32(bu, &event->file_number)
-           && tox_unpack_file_control(bu, &event->control);
+           && tox_file_control_unpack(bu, &event->control);
 }
 
 

--- a/toxcore/events/friend_connection_status.c
+++ b/toxcore/events/friend_connection_status.c
@@ -91,7 +91,7 @@ static bool tox_event_friend_connection_status_unpack(
     }
 
     return bin_unpack_u32(bu, &event->friend_number)
-           && tox_unpack_connection(bu, &event->connection_status);
+           && tox_connection_unpack(bu, &event->connection_status);
 }
 
 

--- a/toxcore/events/friend_message.c
+++ b/toxcore/events/friend_message.c
@@ -124,7 +124,7 @@ static bool tox_event_friend_message_unpack(
     }
 
     return bin_unpack_u32(bu, &event->friend_number)
-           && tox_unpack_message_type(bu, &event->type)
+           && tox_message_type_unpack(bu, &event->type)
            && bin_unpack_bin(bu, &event->message, &event->message_length);
 }
 

--- a/toxcore/events/friend_status.c
+++ b/toxcore/events/friend_status.c
@@ -89,7 +89,7 @@ static bool tox_event_friend_status_unpack(
     }
 
     return bin_unpack_u32(bu, &event->friend_number)
-           && tox_unpack_user_status(bu, &event->status);
+           && tox_user_status_unpack(bu, &event->status);
 }
 
 

--- a/toxcore/events/self_connection_status.c
+++ b/toxcore/events/self_connection_status.c
@@ -69,7 +69,7 @@ static bool tox_event_self_connection_status_unpack(
     Tox_Event_Self_Connection_Status *event, Bin_Unpack *bu)
 {
     assert(event != nullptr);
-    return tox_unpack_connection(bu, &event->connection_status);
+    return tox_connection_unpack(bu, &event->connection_status);
 }
 
 

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -1280,8 +1280,8 @@ static uint16_t unpack_gc_shared_state(GC_SharedState *shared_state, const uint8
     memcpy(&voice_state, data + len_processed, sizeof(uint8_t));
     len_processed += sizeof(uint8_t);
 
-    shared_state->voice_state = group_voice_state_from_int(voice_state);
-    shared_state->privacy_state = group_privacy_state_from_int(privacy_state);
+    group_voice_state_from_int(voice_state, &shared_state->voice_state);
+    group_privacy_state_from_int(privacy_state, &shared_state->privacy_state);
 
     return len_processed;
 }

--- a/toxcore/group_pack.c
+++ b/toxcore/group_pack.c
@@ -18,29 +18,48 @@
 #include "ccompat.h"
 #include "util.h"
 
-Group_Privacy_State group_privacy_state_from_int(uint8_t value)
+bool group_privacy_state_from_int(uint8_t value, Group_Privacy_State *out)
 {
     switch (value) {
-        case 0:
-            return GI_PUBLIC;
-        case 1:
-            return GI_PRIVATE;
-        default:
-            return GI_PUBLIC;
+        case GI_PUBLIC: {
+            *out = GI_PUBLIC;
+            return true;
+        }
+
+        case GI_PRIVATE: {
+            *out = GI_PRIVATE;
+            return true;
+        }
+
+        default: {
+            *out = GI_PUBLIC;
+            return false;
+        }
     }
 }
 
-Group_Voice_State group_voice_state_from_int(uint8_t value)
+bool group_voice_state_from_int(uint8_t value, Group_Voice_State *out)
 {
     switch (value) {
-        case 0:
-            return GV_ALL;
-        case 1:
-            return GV_MODS;
-        case 2:
-            return GV_FOUNDER;
-        default:
-            return GV_ALL;
+        case GV_ALL: {
+            *out = GV_ALL;
+            return true;
+        }
+
+        case GV_MODS: {
+            *out = GV_MODS;
+            return true;
+        }
+
+        case GV_FOUNDER: {
+            *out = GV_FOUNDER;
+            return true;
+        }
+
+        default: {
+            *out = GV_ALL;
+            return false;
+        }
     }
 }
 
@@ -69,8 +88,8 @@ static bool load_unpack_state_values(GC_Chat *chat, Bin_Unpack *bu)
     }
 
     chat->connection_state = manually_disconnected ? CS_DISCONNECTED : CS_CONNECTING;
-    chat->shared_state.privacy_state = group_privacy_state_from_int(privacy_state);
-    chat->shared_state.voice_state = group_voice_state_from_int(voice_state);
+    group_privacy_state_from_int(privacy_state, &chat->shared_state.privacy_state);
+    group_voice_state_from_int(voice_state, &chat->shared_state.voice_state);
 
     // we always load saved groups as private in case the group became private while we were offline.
     // this will have no detrimental effect if the group is public, as the correct privacy

--- a/toxcore/group_pack.h
+++ b/toxcore/group_pack.h
@@ -32,7 +32,9 @@ void gc_save_pack_group(const GC_Chat *chat, Bin_Pack *bp);
 non_null()
 bool gc_load_unpack_group(GC_Chat *chat, Bin_Unpack *bu);
 
-Group_Privacy_State group_privacy_state_from_int(uint8_t value);
-Group_Voice_State group_voice_state_from_int(uint8_t value);
+non_null()
+bool group_privacy_state_from_int(uint8_t value, Group_Privacy_State *out);
+non_null()
+bool group_voice_state_from_int(uint8_t value, Group_Voice_State *out);
 
 #endif // GROUP_PACK_H

--- a/toxcore/tox_events.c
+++ b/toxcore/tox_events.c
@@ -115,7 +115,7 @@ bool tox_events_pack(const Tox_Events *events, Bin_Pack *bp)
 }
 
 non_null()
-static bool tox_event_unpack(Tox_Events *events, Bin_Unpack *bu)
+static bool tox_events_unpack_event(Tox_Events *events, Bin_Unpack *bu)
 {
     uint32_t size;
     if (!bin_unpack_array(bu, &size)) {
@@ -210,7 +210,7 @@ bool tox_events_unpack(Tox_Events *events, Bin_Unpack *bu)
     }
 
     for (uint32_t i = 0; i < size; ++i) {
-        if (!tox_event_unpack(events, bu)) {
+        if (!tox_events_unpack_event(events, bu)) {
             return false;
         }
     }

--- a/toxcore/tox_unpack.c
+++ b/toxcore/tox_unpack.c
@@ -9,276 +9,337 @@
 #include "bin_unpack.h"
 #include "ccompat.h"
 
-static Tox_Conference_Type tox_conference_type_from_int(uint32_t value)
+non_null()
+static bool tox_conference_type_from_int(uint32_t value, Tox_Conference_Type *out)
 {
     switch (value) {
-        case 0:
-            return TOX_CONFERENCE_TYPE_TEXT;
-        case 1:
-            return TOX_CONFERENCE_TYPE_AV;
-        default:
-            return TOX_CONFERENCE_TYPE_TEXT;
+        case TOX_CONFERENCE_TYPE_TEXT: {
+            *out = TOX_CONFERENCE_TYPE_TEXT;
+            return true;
+        }
+
+        case TOX_CONFERENCE_TYPE_AV: {
+            *out = TOX_CONFERENCE_TYPE_AV;
+            return true;
+        }
+
+        default: {
+            *out = TOX_CONFERENCE_TYPE_TEXT;
+            return false;
+        }
     }
 }
-bool tox_unpack_conference_type(Bin_Unpack *bu, Tox_Conference_Type *val)
+bool tox_conference_type_unpack(Bin_Unpack *bu, Tox_Conference_Type *val)
 {
     uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
-    }
-
-    *val = tox_conference_type_from_int(u32);
-    return true;
+    return bin_unpack_u32(bu, &u32)
+           && tox_conference_type_from_int(u32, val);
 }
 
-static Tox_Connection tox_connection_from_int(uint32_t value)
+non_null()
+static bool tox_connection_from_int(uint32_t value, Tox_Connection *out)
 {
     switch (value) {
-        case 0:
-            return TOX_CONNECTION_NONE;
-        case 1:
-            return TOX_CONNECTION_TCP;
-        case 2:
-            return TOX_CONNECTION_UDP;
-        default:
-            return TOX_CONNECTION_NONE;
+        case TOX_CONNECTION_NONE: {
+            *out = TOX_CONNECTION_NONE;
+            return true;
+        }
+
+        case TOX_CONNECTION_TCP: {
+            *out = TOX_CONNECTION_TCP;
+            return true;
+        }
+
+        case TOX_CONNECTION_UDP: {
+            *out = TOX_CONNECTION_UDP;
+            return true;
+        }
+
+        default: {
+            *out = TOX_CONNECTION_NONE;
+            return false;
+        }
     }
 }
-bool tox_unpack_connection(Bin_Unpack *bu, Tox_Connection *val)
+
+bool tox_connection_unpack(Bin_Unpack *bu, Tox_Connection *val)
 {
     uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
-    }
-
-    *val = tox_connection_from_int(u32);
-    return true;
+    return bin_unpack_u32(bu, &u32)
+           && tox_connection_from_int(u32, val);
 }
 
-static Tox_File_Control tox_file_control_from_int(uint32_t value)
+non_null()
+static bool tox_file_control_from_int(uint32_t value, Tox_File_Control *out)
 {
     switch (value) {
-        case 0:
-            return TOX_FILE_CONTROL_RESUME;
-        case 1:
-            return TOX_FILE_CONTROL_PAUSE;
-        case 2:
-            return TOX_FILE_CONTROL_CANCEL;
-        default:
-            return TOX_FILE_CONTROL_RESUME;
+        case TOX_FILE_CONTROL_RESUME: {
+            *out = TOX_FILE_CONTROL_RESUME;
+            return true;
+        }
+
+        case TOX_FILE_CONTROL_PAUSE: {
+            *out = TOX_FILE_CONTROL_PAUSE;
+            return true;
+        }
+
+        case TOX_FILE_CONTROL_CANCEL: {
+            *out = TOX_FILE_CONTROL_CANCEL;
+            return true;
+        }
+
+        default: {
+            *out = TOX_FILE_CONTROL_RESUME;
+            return false;
+        }
     }
 }
-bool tox_unpack_file_control(Bin_Unpack *bu, Tox_File_Control *val)
+
+bool tox_file_control_unpack(Bin_Unpack *bu, Tox_File_Control *val)
 {
     uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
-    }
-
-    *val = tox_file_control_from_int(u32);
-    return true;
+    return bin_unpack_u32(bu, &u32)
+           && tox_file_control_from_int(u32, val);
 }
 
-static Tox_Message_Type tox_message_type_from_int(uint32_t value)
+non_null()
+static bool tox_message_type_from_int(uint32_t value, Tox_Message_Type *out)
 {
     switch (value) {
-        case 0:
-            return TOX_MESSAGE_TYPE_NORMAL;
-        case 1:
-            return TOX_MESSAGE_TYPE_ACTION;
-        default:
-            return TOX_MESSAGE_TYPE_NORMAL;
+        case TOX_MESSAGE_TYPE_NORMAL: {
+            *out = TOX_MESSAGE_TYPE_NORMAL;
+            return true;
+        }
+
+        case TOX_MESSAGE_TYPE_ACTION: {
+            *out = TOX_MESSAGE_TYPE_ACTION;
+            return true;
+        }
+
+        default: {
+            *out = TOX_MESSAGE_TYPE_NORMAL;
+            return false;
+        }
     }
 }
-bool tox_unpack_message_type(Bin_Unpack *bu, Tox_Message_Type *val)
+
+bool tox_message_type_unpack(Bin_Unpack *bu, Tox_Message_Type *val)
 {
     uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
-    }
-
-    *val = tox_message_type_from_int(u32);
-    return true;
+    return bin_unpack_u32(bu, &u32)
+           && tox_message_type_from_int(u32, val);
 }
 
-static Tox_User_Status tox_user_status_from_int(uint32_t value)
+non_null()
+static bool tox_user_status_from_int(uint32_t value, Tox_User_Status *out)
 {
     switch (value) {
-        case 0:
-            return TOX_USER_STATUS_NONE;
-        case 1:
-            return TOX_USER_STATUS_AWAY;
-        case 2:
-            return TOX_USER_STATUS_BUSY;
-        default:
-            return TOX_USER_STATUS_NONE;
+        case TOX_USER_STATUS_NONE: {
+            *out = TOX_USER_STATUS_NONE;
+            return true;
+        }
+
+        case TOX_USER_STATUS_AWAY: {
+            *out = TOX_USER_STATUS_AWAY;
+            return true;
+        }
+
+        case TOX_USER_STATUS_BUSY: {
+            *out = TOX_USER_STATUS_BUSY;
+            return true;
+        }
+
+        default: {
+            *out = TOX_USER_STATUS_NONE;
+            return false;
+        }
     }
 }
-bool tox_unpack_user_status(Bin_Unpack *bu, Tox_User_Status *val)
+
+bool tox_user_status_unpack(Bin_Unpack *bu, Tox_User_Status *val)
 {
     uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
-    }
-
-    *val = tox_user_status_from_int(u32);
-    return true;
+    return bin_unpack_u32(bu, &u32)
+           && tox_user_status_from_int(u32, val);
 }
 
-static Tox_Group_Privacy_State tox_group_privacy_state_from_int(uint32_t value)
+non_null()
+static bool tox_group_privacy_state_from_int(uint32_t value, Tox_Group_Privacy_State *out)
 {
-    switch (value) {
-        case 0:
-            return TOX_GROUP_PRIVACY_STATE_PUBLIC;
-        case 1:
-            return TOX_GROUP_PRIVACY_STATE_PRIVATE;
-        default:
-            return TOX_GROUP_PRIVACY_STATE_PRIVATE;
+  switch (value) {
+    case TOX_GROUP_PRIVACY_STATE_PUBLIC: {
+      *out = TOX_GROUP_PRIVACY_STATE_PUBLIC;
+      return true;
     }
-}
-bool tox_unpack_group_privacy_state(Bin_Unpack *bu, Tox_Group_Privacy_State *val)
-{
-    uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
+    case TOX_GROUP_PRIVACY_STATE_PRIVATE: {
+      *out = TOX_GROUP_PRIVACY_STATE_PRIVATE;
+      return true;
     }
-
-    *val = tox_group_privacy_state_from_int(u32);
-    return true;
-}
-static Tox_Group_Voice_State tox_group_voice_state_from_int(uint32_t value)
-{
-    switch (value) {
-        case 0:
-            return TOX_GROUP_VOICE_STATE_ALL;
-        case 1:
-            return TOX_GROUP_VOICE_STATE_MODERATOR;
-        case 2:
-            return TOX_GROUP_VOICE_STATE_FOUNDER;
-        default:
-            return TOX_GROUP_VOICE_STATE_FOUNDER;
+    default: {
+      *out = TOX_GROUP_PRIVACY_STATE_PUBLIC;
+      return false;
     }
+  }
 }
-bool tox_unpack_group_voice_state(Bin_Unpack *bu, Tox_Group_Voice_State *val)
+bool tox_group_privacy_state_unpack(Bin_Unpack *bu, Tox_Group_Privacy_State *val)
 {
     uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
-    }
-
-    *val = tox_group_voice_state_from_int(u32);
-    return true;
+    return bin_unpack_u32(bu, &u32)
+           && tox_group_privacy_state_from_int(u32, val);
 }
-
-static Tox_Group_Topic_Lock tox_group_topic_lock_from_int(uint32_t value)
+non_null()
+static bool tox_group_voice_state_from_int(uint32_t value, Tox_Group_Voice_State *out)
 {
-    switch (value) {
-        case 0:
-            return TOX_GROUP_TOPIC_LOCK_ENABLED;
-        case 1:
-            return TOX_GROUP_TOPIC_LOCK_DISABLED;
-        default:
-            return TOX_GROUP_TOPIC_LOCK_ENABLED;
+  switch (value) {
+    case TOX_GROUP_VOICE_STATE_ALL: {
+      *out = TOX_GROUP_VOICE_STATE_ALL;
+      return true;
     }
-}
-bool tox_unpack_group_topic_lock(Bin_Unpack *bu, Tox_Group_Topic_Lock *val)
-{
-    uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
+    case TOX_GROUP_VOICE_STATE_MODERATOR: {
+      *out = TOX_GROUP_VOICE_STATE_MODERATOR;
+      return true;
     }
-
-    *val = tox_group_topic_lock_from_int(u32);
-    return true;
-}
-
-static Tox_Group_Join_Fail tox_group_join_fail_from_int(uint32_t value)
-{
-    switch (value) {
-        case 0:
-            return TOX_GROUP_JOIN_FAIL_PEER_LIMIT;
-        case 1:
-            return TOX_GROUP_JOIN_FAIL_INVALID_PASSWORD;
-        case 2:
-            return TOX_GROUP_JOIN_FAIL_UNKNOWN;
-        default:
-            return TOX_GROUP_JOIN_FAIL_UNKNOWN;
+    case TOX_GROUP_VOICE_STATE_FOUNDER: {
+      *out = TOX_GROUP_VOICE_STATE_FOUNDER;
+      return true;
     }
+    default: {
+      *out = TOX_GROUP_VOICE_STATE_ALL;
+      return false;
+    }
+  }
 }
-bool tox_unpack_group_join_fail(Bin_Unpack *bu, Tox_Group_Join_Fail *val)
+bool tox_group_voice_state_unpack(Bin_Unpack *bu, Tox_Group_Voice_State *val)
 {
     uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
-    }
-
-    *val = tox_group_join_fail_from_int(u32);
-    return true;
+    return bin_unpack_u32(bu, &u32)
+           && tox_group_voice_state_from_int(u32, val);
 }
 
-static Tox_Group_Mod_Event tox_group_mod_event_from_int(uint32_t value)
+non_null()
+static bool tox_group_topic_lock_from_int(uint32_t value, Tox_Group_Topic_Lock *out)
 {
-    switch (value) {
-        case 0:
-            return TOX_GROUP_MOD_EVENT_KICK;
-        case 1:
-            return TOX_GROUP_MOD_EVENT_OBSERVER;
-        case 2:
-            return TOX_GROUP_MOD_EVENT_USER;
-        case 3:
-            return TOX_GROUP_MOD_EVENT_MODERATOR;
-        default:
-            return TOX_GROUP_MOD_EVENT_MODERATOR;
+  switch (value) {
+    case TOX_GROUP_TOPIC_LOCK_ENABLED: {
+      *out = TOX_GROUP_TOPIC_LOCK_ENABLED;
+      return true;
     }
+    case TOX_GROUP_TOPIC_LOCK_DISABLED: {
+      *out = TOX_GROUP_TOPIC_LOCK_DISABLED;
+      return true;
+    }
+    default: {
+      *out = TOX_GROUP_TOPIC_LOCK_ENABLED;
+      return false;
+    }
+  }
 }
-bool tox_unpack_group_mod_event(Bin_Unpack *bu, Tox_Group_Mod_Event *val)
+bool tox_group_topic_lock_unpack(Bin_Unpack *bu, Tox_Group_Topic_Lock *val)
 {
     uint32_t u32;
-
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
-    }
-
-    *val = tox_group_mod_event_from_int(u32);
-    return true;
+    return bin_unpack_u32(bu, &u32)
+           && tox_group_topic_lock_from_int(u32, val);
 }
 
-static Tox_Group_Exit_Type tox_group_exit_type_from_int(uint32_t value)
+non_null()
+static bool tox_group_join_fail_from_int(uint32_t value, Tox_Group_Join_Fail *out)
 {
-    switch (value) {
-        case 0:
-            return TOX_GROUP_EXIT_TYPE_QUIT;
-        case 1:
-            return TOX_GROUP_EXIT_TYPE_TIMEOUT;
-        case 2:
-            return TOX_GROUP_EXIT_TYPE_DISCONNECTED;
-        case 3:
-            return TOX_GROUP_EXIT_TYPE_SELF_DISCONNECTED;
-        case 4:
-            return TOX_GROUP_EXIT_TYPE_KICK;
-        case 5:
-            return TOX_GROUP_EXIT_TYPE_SYNC_ERROR;
-        default:
-            return TOX_GROUP_EXIT_TYPE_QUIT;
+  switch (value) {
+    case TOX_GROUP_JOIN_FAIL_PEER_LIMIT: {
+      *out = TOX_GROUP_JOIN_FAIL_PEER_LIMIT;
+      return true;
     }
+    case TOX_GROUP_JOIN_FAIL_INVALID_PASSWORD: {
+      *out = TOX_GROUP_JOIN_FAIL_INVALID_PASSWORD;
+      return true;
+    }
+    case TOX_GROUP_JOIN_FAIL_UNKNOWN: {
+      *out = TOX_GROUP_JOIN_FAIL_UNKNOWN;
+      return true;
+    }
+    default: {
+      *out = TOX_GROUP_JOIN_FAIL_PEER_LIMIT;
+      return false;
+    }
+  }
 }
-bool tox_unpack_group_exit_type(Bin_Unpack *bu, Tox_Group_Exit_Type *val)
+bool tox_group_join_fail_unpack(Bin_Unpack *bu, Tox_Group_Join_Fail *val)
 {
     uint32_t u32;
+    return bin_unpack_u32(bu, &u32)
+           && tox_group_join_fail_from_int(u32, val);
+}
 
-    if (!bin_unpack_u32(bu, &u32)) {
-        return false;
+non_null()
+static bool tox_group_mod_event_from_int(uint32_t value, Tox_Group_Mod_Event *out)
+{
+  switch (value) {
+    case TOX_GROUP_MOD_EVENT_KICK: {
+      *out = TOX_GROUP_MOD_EVENT_KICK;
+      return true;
     }
+    case TOX_GROUP_MOD_EVENT_OBSERVER: {
+      *out = TOX_GROUP_MOD_EVENT_OBSERVER;
+      return true;
+    }
+    case TOX_GROUP_MOD_EVENT_USER: {
+      *out = TOX_GROUP_MOD_EVENT_USER;
+      return true;
+    }
+    case TOX_GROUP_MOD_EVENT_MODERATOR: {
+      *out = TOX_GROUP_MOD_EVENT_MODERATOR;
+      return true;
+    }
+    default: {
+      *out = TOX_GROUP_MOD_EVENT_KICK;
+      return false;
+    }
+  }
+}
+bool tox_group_mod_event_unpack(Bin_Unpack *bu, Tox_Group_Mod_Event *val)
+{
+    uint32_t u32;
+    return bin_unpack_u32(bu, &u32)
+           && tox_group_mod_event_from_int(u32, val);
+}
 
-    *val = tox_group_exit_type_from_int(u32);
-    return true;
+non_null()
+static bool tox_group_exit_type_from_int(uint32_t value, Tox_Group_Exit_Type *out)
+{
+  switch (value) {
+    case TOX_GROUP_EXIT_TYPE_QUIT: {
+      *out = TOX_GROUP_EXIT_TYPE_QUIT;
+      return true;
+    }
+    case TOX_GROUP_EXIT_TYPE_TIMEOUT: {
+      *out = TOX_GROUP_EXIT_TYPE_TIMEOUT;
+      return true;
+    }
+    case TOX_GROUP_EXIT_TYPE_DISCONNECTED: {
+      *out = TOX_GROUP_EXIT_TYPE_DISCONNECTED;
+      return true;
+    }
+    case TOX_GROUP_EXIT_TYPE_SELF_DISCONNECTED: {
+      *out = TOX_GROUP_EXIT_TYPE_SELF_DISCONNECTED;
+      return true;
+    }
+    case TOX_GROUP_EXIT_TYPE_KICK: {
+      *out = TOX_GROUP_EXIT_TYPE_KICK;
+      return true;
+    }
+    case TOX_GROUP_EXIT_TYPE_SYNC_ERROR: {
+      *out = TOX_GROUP_EXIT_TYPE_SYNC_ERROR;
+      return true;
+    }
+    default: {
+      *out = TOX_GROUP_EXIT_TYPE_QUIT;
+      return false;
+    }
+  }
+}
+bool tox_group_exit_type_unpack(Bin_Unpack *bu, Tox_Group_Exit_Type *val)
+{
+    uint32_t u32;
+    return bin_unpack_u32(bu, &u32)
+           && tox_group_exit_type_from_int(u32, val);
 }

--- a/toxcore/tox_unpack.h
+++ b/toxcore/tox_unpack.h
@@ -9,16 +9,16 @@
 #include "bin_unpack.h"
 #include "tox.h"
 
-non_null() bool tox_unpack_conference_type(Bin_Unpack *bu, Tox_Conference_Type *val);
-non_null() bool tox_unpack_connection(Bin_Unpack *bu, Tox_Connection *val);
-non_null() bool tox_unpack_file_control(Bin_Unpack *bu, Tox_File_Control *val);
-non_null() bool tox_unpack_message_type(Bin_Unpack *bu, Tox_Message_Type *val);
-non_null() bool tox_unpack_user_status(Bin_Unpack *bu, Tox_User_Status *val);
-non_null() bool tox_unpack_group_privacy_state(Bin_Unpack *bu, Tox_Group_Privacy_State *val);
-non_null() bool tox_unpack_group_voice_state(Bin_Unpack *bu, Tox_Group_Voice_State *val);
-non_null() bool tox_unpack_group_topic_lock(Bin_Unpack *bu, Tox_Group_Topic_Lock *val);
-non_null() bool tox_unpack_group_join_fail(Bin_Unpack *bu, Tox_Group_Join_Fail *val);
-non_null() bool tox_unpack_group_mod_event(Bin_Unpack *bu, Tox_Group_Mod_Event *val);
-non_null() bool tox_unpack_group_exit_type(Bin_Unpack *bu, Tox_Group_Exit_Type *val);
+non_null() bool tox_conference_type_unpack(Bin_Unpack *bu, Tox_Conference_Type *val);
+non_null() bool tox_connection_unpack(Bin_Unpack *bu, Tox_Connection *val);
+non_null() bool tox_file_control_unpack(Bin_Unpack *bu, Tox_File_Control *val);
+non_null() bool tox_message_type_unpack(Bin_Unpack *bu, Tox_Message_Type *val);
+non_null() bool tox_user_status_unpack(Bin_Unpack *bu, Tox_User_Status *val);
+non_null() bool tox_group_privacy_state_unpack(Bin_Unpack *bu, Tox_Group_Privacy_State *val);
+non_null() bool tox_group_voice_state_unpack(Bin_Unpack *bu, Tox_Group_Voice_State *val);
+non_null() bool tox_group_topic_lock_unpack(Bin_Unpack *bu, Tox_Group_Topic_Lock *val);
+non_null() bool tox_group_join_fail_unpack(Bin_Unpack *bu, Tox_Group_Join_Fail *val);
+non_null() bool tox_group_mod_event_unpack(Bin_Unpack *bu, Tox_Group_Mod_Event *val);
+non_null() bool tox_group_exit_type_unpack(Bin_Unpack *bu, Tox_Group_Exit_Type *val);
 
 #endif  // C_TOXCORE_TOXCORE_TOX_UNPACK_H


### PR DESCRIPTION
These functions are a bit clearer and don't need to change if enum values change.

See https://github.com/TokTok/hs-tokstyle/pull/212 for the relevant linter implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2475)
<!-- Reviewable:end -->
