### PR TITLE
refactor: Change all enum-like `#define` sequences into enums.

### DIFF
--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -185,14 +185,16 @@ static int proxy_http_read_connection_response(const Logger *logger, const TCP_C
     return -1;
 }
 
-#define TCP_SOCKS5_PROXY_HS_VERSION_SOCKS5 0x05
-#define TCP_SOCKS5_PROXY_HS_COMM_ESTABLISH_REQUEST 0x01
-#define TCP_SOCKS5_PROXY_HS_COMM_REQUEST_GRANTED 0x00
-#define TCP_SOCKS5_PROXY_HS_AUTH_METHODS_SUPPORTED 0x01
-#define TCP_SOCKS5_PROXY_HS_NO_AUTH 0x00
-#define TCP_SOCKS5_PROXY_HS_RESERVED 0x00
-#define TCP_SOCKS5_PROXY_HS_ADDR_TYPE_IPV4 0x01
-#define TCP_SOCKS5_PROXY_HS_ADDR_TYPE_IPV6 0x04
+enum Tcp_Socks5_Proxy_Hs {
+    TCP_SOCKS5_PROXY_HS_VERSION_SOCKS5          = 0x05,
+    TCP_SOCKS5_PROXY_HS_COMM_ESTABLISH_REQUEST  = 0x01,
+    TCP_SOCKS5_PROXY_HS_COMM_REQUEST_GRANTED    = 0x00,
+    TCP_SOCKS5_PROXY_HS_AUTH_METHODS_SUPPORTED  = 0x01,
+    TCP_SOCKS5_PROXY_HS_NO_AUTH                 = 0x00,
+    TCP_SOCKS5_PROXY_HS_RESERVED                = 0x00,
+    TCP_SOCKS5_PROXY_HS_ADDR_TYPE_IPV4          = 0x01,
+    TCP_SOCKS5_PROXY_HS_ADDR_TYPE_IPV6          = 0x04,
+};
 
 non_null()
 static void proxy_socks5_generate_greetings(TCP_Client_Connection *tcp_conn)

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -43,29 +43,31 @@
 
 /*** Messages. */
 
-#define PACKET_ID_PADDING 0 // Denotes padding
-#define PACKET_ID_REQUEST 1 // Used to request unreceived packets
-#define PACKET_ID_KILL    2 // Used to kill connection
+typedef enum Packet_Id {
+    PACKET_ID_PADDING            = 0, // Denotes padding
+    PACKET_ID_REQUEST            = 1, // Used to request unreceived packets
+    PACKET_ID_KILL               = 2, // Used to kill connection
 
-#define PACKET_ID_ONLINE 24
-#define PACKET_ID_OFFLINE 25
-#define PACKET_ID_NICKNAME 48
-#define PACKET_ID_STATUSMESSAGE 49
-#define PACKET_ID_USERSTATUS 50
-#define PACKET_ID_TYPING 51
-#define PACKET_ID_MESSAGE 64
-#define PACKET_ID_ACTION 65 // PACKET_ID_MESSAGE + MESSAGE_ACTION
-#define PACKET_ID_MSI 69    // Used by AV to setup calls and etc
-#define PACKET_ID_FILE_SENDREQUEST 80
-#define PACKET_ID_FILE_CONTROL 81
-#define PACKET_ID_FILE_DATA 82
-#define PACKET_ID_INVITE_GROUPCHAT 95
-#define PACKET_ID_INVITE_CONFERENCE 96
-#define PACKET_ID_ONLINE_PACKET 97
-#define PACKET_ID_DIRECT_CONFERENCE 98
-#define PACKET_ID_MESSAGE_CONFERENCE 99
-#define PACKET_ID_REJOIN_CONFERENCE 100
-#define PACKET_ID_LOSSY_CONFERENCE 199
+    PACKET_ID_ONLINE             = 24,
+    PACKET_ID_OFFLINE            = 25,
+    PACKET_ID_NICKNAME           = 48,
+    PACKET_ID_STATUSMESSAGE      = 49,
+    PACKET_ID_USERSTATUS         = 50,
+    PACKET_ID_TYPING             = 51,
+    PACKET_ID_MESSAGE            = 64,
+    PACKET_ID_ACTION             = 65, // PACKET_ID_MESSAGE + MESSAGE_ACTION
+    PACKET_ID_MSI                = 69, // Used by AV to setup calls and etc
+    PACKET_ID_FILE_SENDREQUEST   = 80,
+    PACKET_ID_FILE_CONTROL       = 81,
+    PACKET_ID_FILE_DATA          = 82,
+    PACKET_ID_INVITE_GROUPCHAT   = 95,
+    PACKET_ID_INVITE_CONFERENCE  = 96,
+    PACKET_ID_ONLINE_PACKET      = 97,
+    PACKET_ID_DIRECT_CONFERENCE  = 98,
+    PACKET_ID_MESSAGE_CONFERENCE = 99,
+    PACKET_ID_REJOIN_CONFERENCE  = 100,
+    PACKET_ID_LOSSY_CONFERENCE   = 199,
+} Packet_Id;
 
 /** Maximum size of receiving and sending packet buffers. */
 #define CRYPTO_PACKET_BUFFER_SIZE 32768 // Must be a power of 2


### PR DESCRIPTION
The only one I'm not so sure about is `Tcp_Socks5_Proxy_Hs`, which has repeats. Should we ignore repeats?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2487)
<!-- Reviewable:end -->
