### PR TITLE
refactor: remove base_time from mono_clock

### DIFF
--- a/toxcore/mono_time.h
+++ b/toxcore/mono_time.h
@@ -63,14 +63,14 @@ void mono_time_update(Mono_Time *mono_time);
 
 /** @brief Return current monotonic time in milliseconds (ms).
  *
- * The starting point is UNIX epoch as measured by `time()` in `mono_time_new()`.
+ * The starting point is implementation defined.
  */
 non_null()
 uint64_t mono_time_get_ms(const Mono_Time *mono_time);
 
 /** @brief Return a monotonically increasing time in seconds.
  *
- * The starting point is UNIX epoch as measured by `time()` in `mono_time_new()`.
+ * The starting point is implementation defined.
  */
 non_null()
 uint64_t mono_time_get(const Mono_Time *mono_time);
@@ -85,6 +85,9 @@ bool mono_time_is_timeout(const Mono_Time *mono_time, uint64_t timestamp, uint64
  *
  * The starting point is unspecified and in particular is likely not comparable
  * to the return value of `mono_time_get_ms()`.
+ *
+ * TODO(Green-Sky): Get rid of this from the api.
+ *                  The only user seems to be net_crypt and for no good reason.
  */
 non_null()
 uint64_t current_time_monotonic(Mono_Time *mono_time);


### PR DESCRIPTION
The unix time offset is not used anywhere and was causing issues on windows.

Please everyone check, I might have overlooked a "unix time" usage.

Also, I not that the function `current_time_monotonic()` should probably be removed and the only user seems to be net_crypto. This would remove the extra lock from the windows code path and clean up the code alot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2492)
<!-- Reviewable:end -->
