### PR TITLE
cleanup: Make TCP connection failures a warning instead of error.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-c93d2d972558f578c6893aa12c1dafadf8b3dbb959b68c22efbfe7ad00d20f88  /usr/local/bin/tox-bootstrapd
+7e935410e534383805cf9579f0f1855a31a034a9d04d498524ef5eb4bbabd496  /usr/local/bin/tox-bootstrapd

--- a/toxcore/ccompat.c
+++ b/toxcore/ccompat.c
@@ -3,4 +3,4 @@
  */
 #include "ccompat.h"
 
-static_assert(sizeof(int) >= 4, "toxcore does not support 16-bit platform");
+static_assert(sizeof(int) >= 4, "toxcore does not support 16-bit platforms");

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1753,8 +1753,8 @@ bool net_connect(const Memory *mem, const Logger *log, Socket sock, const IP_Por
         // Non-blocking socket: "Operation in progress" means it's connecting.
         if (!should_ignore_connect_error(error)) {
             char *net_strerror = net_new_strerror(error);
-            LOGGER_ERROR(log, "failed to connect to %s:%d: %d (%s)",
-                         net_ip_ntoa(&ip_port->ip, &ip_str), net_ntohs(ip_port->port), error, net_strerror);
+            LOGGER_WARNING(log, "failed to connect to %s:%d: %d (%s)",
+                           net_ip_ntoa(&ip_port->ip, &ip_str), net_ntohs(ip_port->port), error, net_strerror);
             net_kill_strerror(net_strerror);
             return false;
         }


### PR DESCRIPTION
It's not really bad, unless all connections fail. This is currently erroring on FreeBSD tests, making them fail needlessly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2506)
<!-- Reviewable:end -->
