### PR TITLE
chore: Add `net_(new|kill)_strerror` to cppcheck's allocators.

### DIFF
--- a/other/docker/cppcheck/toxcore.cfg
+++ b/other/docker/cppcheck/toxcore.cfg
@@ -93,6 +93,10 @@
     <dealloc arg="1">kill_networking</dealloc>
   </resource>
   <resource>
+    <alloc init="true">net_new_strerror</alloc>
+    <dealloc arg="1">net_kill_strerror</dealloc>
+  </resource>
+  <resource>
     <alloc init="true">new_onion</alloc>
     <dealloc arg="1">kill_onion</dealloc>
   </resource>


### PR DESCRIPTION
This helps ensure strerrors are cleaned up everywhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2508)
<!-- Reviewable:end -->
