### PR TITLE
fix: Use QueryPerformanceCounter on windows for monotonic time.

### DIFF
--- a/auto_tests/auto_test_support.c
+++ b/auto_tests/auto_test_support.c
@@ -149,6 +149,8 @@ void set_mono_time_callback(AutoTox *autotox)
     Mono_Time *mono_time = autotox->tox->mono_time;
 
     autotox->clock = current_time_monotonic(mono_time);
+    ck_assert_msg(autotox->clock >= 1000,
+                  "clock is too low (not initialised?): %lu", (unsigned long)autotox->clock);
     mono_time_set_current_time_callback(mono_time, nullptr, nullptr);  // set to default first
     mono_time_set_current_time_callback(mono_time, get_state_clock_callback, &autotox->clock);
 }

--- a/toxcore/group_announce_test.cc
+++ b/toxcore/group_announce_test.cc
@@ -9,7 +9,7 @@ namespace {
 struct Announces : ::testing::Test {
 protected:
     const Memory *mem_ = system_memory();
-    uint64_t clock_ = 0;
+    uint64_t clock_ = 1000;
     Mono_Time *mono_time_ = nullptr;
     GC_Announces_List *gca_ = nullptr;
     GC_Announce _ann1;

--- a/toxcore/mono_time_test.cc
+++ b/toxcore/mono_time_test.cc
@@ -53,11 +53,14 @@ TEST(MonoTime, IsTimeoutReal)
     uint64_t const start = mono_time_get(mono_time);
     EXPECT_FALSE(mono_time_is_timeout(mono_time, start, 5));
 
+    const uint64_t before_sleep = mono_time_get(mono_time);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     mono_time_update(mono_time);
+    const uint64_t after_sleep = mono_time_get(mono_time);
 
     // should still not have timed out (5sec) after sleeping ~100ms
-    EXPECT_FALSE(mono_time_is_timeout(mono_time, start, 5));
+    EXPECT_FALSE(mono_time_is_timeout(mono_time, start, 5))
+        << "before sleep: " << before_sleep << ", after sleep: " << after_sleep;
 
     mono_time_free(mem, mono_time);
 }


### PR DESCRIPTION
This fixes time resolution issues and simplifies the code a bit. QPC can in theory jump forward in time, but in practice not by enough to matter in our use case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2509)
<!-- Reviewable:end -->
