### PR TITLE
cleanup: Move all vptr-to-ptr casts to the beginning of a function.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-7e935410e534383805cf9579f0f1855a31a034a9d04d498524ef5eb4bbabd496  /usr/local/bin/tox-bootstrapd
+85e90cc6f62d43a137d3665dc307c95e0560599b7200218ae52b76fa4eb286f8  /usr/local/bin/tox-bootstrapd

--- a/other/docker/coverage/Dockerfile
+++ b/other/docker/coverage/Dockerfile
@@ -19,11 +19,14 @@ RUN apt-get update && \
  make \
  ninja-build \
  pkg-config \
+ python3-lxml \
  python3-pip \
  python3-pygments \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install --no-cache-dir gcovr
+# strip gtest so it doesn't end up in stack traces. This speeds up the
+# mallocfail run below by a lot.
 RUN ["strip", "-g",\
  "/usr/lib/x86_64-linux-gnu/libgtest.a",\
  "/usr/lib/x86_64-linux-gnu/libgtest_main.a"]

--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -196,12 +196,12 @@ void ac_iterate(ACSession *ac)
 
 int ac_queue_message(Mono_Time *mono_time, void *acp, struct RTPMessage *msg)
 {
-    if (acp == nullptr || msg == nullptr) {
+    ACSession *ac = (ACSession *)acp;
+
+    if (ac == nullptr || msg == nullptr) {
         free(msg);
         return -1;
     }
-
-    ACSession *ac = (ACSession *)acp;
 
     if ((msg->header.pt & 0x7f) == (RTP_TYPE_AUDIO + 2) % 128) {
         LOGGER_WARNING(ac->log, "Got dummy!");

--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -208,6 +208,8 @@ static int bwc_send_custom_lossy_packet(Tox *tox, int32_t friendnumber, const ui
 
 static int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length, void *object)
 {
+    BWController *bwc = (BWController *)object;
+
     if (length - 1 != sizeof(struct BWCMessage)) {
         return -1;
     }
@@ -218,5 +220,5 @@ static int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *d
     offset += net_unpack_u32(data + offset, &msg.recv);
     assert(offset == length);
 
-    return on_update((BWController *)object, &msg);
+    return on_update(bwc, &msg);
 }

--- a/toxav/groupav.c
+++ b/toxav/groupav.c
@@ -290,8 +290,9 @@ static void group_av_peer_delete(void *object, uint32_t groupnumber, void *peer_
 
 static void group_av_groupchat_delete(void *object, uint32_t groupnumber)
 {
-    if (object != nullptr) {
-        kill_group_av((Group_AV *)object);
+    Group_AV *group_av = (Group_AV *)object;
+    if (group_av != nullptr) {
+        kill_group_av(group_av);
     }
 }
 
@@ -404,11 +405,12 @@ static int decode_audio_packet(Group_AV *group_av, Group_Peer_AV *peer_av, uint3
 static int handle_group_audio_packet(void *object, uint32_t groupnumber, uint32_t friendgroupnumber, void *peer_object,
                                      const uint8_t *packet, uint16_t length)
 {
-    if (peer_object == nullptr || object == nullptr || length <= sizeof(uint16_t)) {
+    Group_AV *group_av = (Group_AV *)object;
+    Group_Peer_AV *peer_av = (Group_Peer_AV *)peer_object;
+
+    if (group_av == nullptr || peer_av == nullptr || length <= sizeof(uint16_t)) {
         return -1;
     }
-
-    Group_Peer_AV *peer_av = (Group_Peer_AV *)peer_object;
 
     Group_Audio_Packet *pk = (Group_Audio_Packet *)calloc(1, sizeof(Group_Audio_Packet));
 
@@ -433,7 +435,7 @@ static int handle_group_audio_packet(void *object, uint32_t groupnumber, uint32_
         return -1;
     }
 
-    while (decode_audio_packet((Group_AV *)object, peer_av, groupnumber, friendgroupnumber) == 0) {
+    while (decode_audio_packet(group_av, peer_av, groupnumber, friendgroupnumber) == 0) {
         /* Continue. */
     }
 

--- a/toxav/video.c
+++ b/toxav/video.c
@@ -345,17 +345,18 @@ void vc_iterate(VCSession *vc)
 
 int vc_queue_message(Mono_Time *mono_time, void *vcp, struct RTPMessage *msg)
 {
+    VCSession *vc = (VCSession *)vcp;
+
     /* This function is called with complete messages
      * they have already been assembled.
      * this function gets called from handle_rtp_packet() and handle_rtp_packet_v3()
      */
-    if (vcp == nullptr || msg == nullptr) {
+    if (vc == nullptr || msg == nullptr) {
         free(msg);
 
         return -1;
     }
 
-    VCSession *vc = (VCSession *)vcp;
     const struct RTPHeader *const header = &msg->header;
 
     if (msg->header.pt == (RTP_TYPE_VIDEO + 2) % 128) {

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -422,7 +422,8 @@ static bool bin_pack_ip_port(Bin_Pack *bp, const Logger *logger, const IP_Port *
 non_null()
 static bool bin_pack_ip_port_handler(Bin_Pack *bp, const Logger *logger, const void *obj)
 {
-    return bin_pack_ip_port(bp, logger, (const IP_Port *)obj);
+    const IP_Port *ip_port = (const IP_Port *)obj;
+    return bin_pack_ip_port(bp, logger, ip_port);
 }
 
 int pack_ip_port(const Logger *logger, uint8_t *data, uint16_t length, const IP_Port *ip_port)
@@ -1479,11 +1480,11 @@ static int sendnodes_ipv6(const DHT *dht, const IP_Port *ip_port, const uint8_t 
 non_null()
 static int handle_getnodes(void *object, const IP_Port *source, const uint8_t *packet, uint16_t length, void *userdata)
 {
+    DHT *const dht = (DHT *)object;
+
     if (length != (CRYPTO_SIZE + CRYPTO_MAC_SIZE + sizeof(uint64_t))) {
         return 1;
     }
-
-    DHT *const dht = (DHT *)object;
 
     /* Check if packet is from ourself. */
     if (pk_equal(packet + 1, dht->self_public_key)) {
@@ -2265,11 +2266,12 @@ non_null()
 static int handle_nat_ping(void *object, const IP_Port *source, const uint8_t *source_pubkey, const uint8_t *packet,
                            uint16_t length, void *userdata)
 {
+    DHT *const dht = (DHT *)object;
+
     if (length != sizeof(uint64_t) + 1) {
         return 1;
     }
 
-    DHT *const dht = (DHT *)object;
     uint64_t ping_id;
     memcpy(&ping_id, packet + 1, sizeof(uint64_t));
 

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2401,11 +2401,12 @@ static int m_handle_packet_invite_groupchat(Messenger *m, const int i, const uin
 non_null(1, 3) nullable(5)
 static int m_handle_packet(void *object, int i, const uint8_t *temp, uint16_t len, void *userdata)
 {
+    Messenger *m = (Messenger *)object;
+
     if (len == 0) {
         return -1;
     }
 
-    Messenger *m = (Messenger *)object;
     const uint8_t packet_id = temp[0];
     const uint8_t *data = temp + 1;
     const uint16_t data_length = len - 1;
@@ -3192,7 +3193,8 @@ static void pack_groupchats(const GC_Session *c, Bin_Pack *bp)
 non_null()
 static bool pack_groupchats_handler(Bin_Pack *bp, const Logger *log, const void *obj)
 {
-    pack_groupchats((const GC_Session *)obj, bp);
+    const GC_Session *session = (const GC_Session *)obj;
+    pack_groupchats(session, bp);
     return true;  // TODO(iphydf): Return bool from pack functions.
 }
 

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -1138,11 +1138,12 @@ non_null(1, 4) nullable(6)
 static int tcp_conn_data_callback(void *object, uint32_t number, uint8_t connection_id, const uint8_t *data,
                                   uint16_t length, void *userdata)
 {
+    const TCP_Client_Connection *tcp_client_con = (TCP_Client_Connection *)object;
+
     if (length == 0) {
         return -1;
     }
 
-    const TCP_Client_Connection *tcp_client_con = (TCP_Client_Connection *)object;
     TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(tcp_client_con);
 
     const unsigned int tcp_connections_number = tcp_con_custom_uint(tcp_client_con);
@@ -1169,11 +1170,12 @@ non_null()
 static int tcp_conn_oob_callback(void *object, const uint8_t *public_key, const uint8_t *data, uint16_t length,
                                  void *userdata)
 {
+    const TCP_Client_Connection *tcp_client_con = (const TCP_Client_Connection *)object;
+
     if (length == 0) {
         return -1;
     }
 
-    const TCP_Client_Connection *tcp_client_con = (const TCP_Client_Connection *)object;
     TCP_Connections *tcp_c = (TCP_Connections *)tcp_con_custom_object(tcp_client_con);
 
     const unsigned int tcp_connections_number = tcp_con_custom_uint(tcp_client_con);

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -474,11 +474,12 @@ static void dht_pk_callback(void *object, int32_t number, const uint8_t *dht_pub
 non_null()
 static int handle_packet(void *object, int number, const uint8_t *data, uint16_t length, void *userdata)
 {
+    Friend_Connections *const fr_c = (Friend_Connections *)object;
+
     if (length == 0) {
         return -1;
     }
 
-    Friend_Connections *const fr_c = (Friend_Connections *)object;
     Friend_Conn *friend_con = get_conn(fr_c, number);
 
     if (friend_con == nullptr) {
@@ -533,11 +534,12 @@ static int handle_packet(void *object, int number, const uint8_t *data, uint16_t
 non_null()
 static int handle_lossy_packet(void *object, int number, const uint8_t *data, uint16_t length, void *userdata)
 {
+    const Friend_Connections *const fr_c = (const Friend_Connections *)object;
+
     if (length == 0) {
         return -1;
     }
 
-    const Friend_Connections *const fr_c = (const Friend_Connections *)object;
     const Friend_Conn *friend_con = get_conn(fr_c, number);
 
     if (friend_con == nullptr) {

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -341,10 +341,10 @@ non_null(1, 4) nullable(6)
 static void tox_friend_lossy_packet_handler(Messenger *m, uint32_t friend_number, uint8_t packet_id,
         const uint8_t *data, size_t length, void *user_data)
 {
+    struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
+
     assert(data != nullptr);
     assert(length > 0);
-
-    struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->friend_lossy_packet_callback_per_pktid[packet_id] != nullptr) {
         tox_data->tox->friend_lossy_packet_callback_per_pktid[packet_id](tox_data->tox, friend_number, data, length,
@@ -357,10 +357,10 @@ non_null(1, 4) nullable(6)
 static void tox_friend_lossless_packet_handler(Messenger *m, uint32_t friend_number, uint8_t packet_id,
         const uint8_t *data, size_t length, void *user_data)
 {
+    struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
+
     assert(data != nullptr);
     assert(length > 0);
-
-    struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->friend_lossless_packet_callback_per_pktid[packet_id] != nullptr) {
         tox_data->tox->friend_lossless_packet_callback_per_pktid[packet_id](tox_data->tox, friend_number, data, length,

--- a/toxcore/tox_events.c
+++ b/toxcore/tox_events.c
@@ -221,7 +221,8 @@ bool tox_events_unpack(Tox_Events *events, Bin_Unpack *bu)
 non_null(1) nullable(2, 3)
 static bool tox_events_bin_pack_handler(Bin_Pack *bp, const Logger *logger, const void *obj)
 {
-    return tox_events_pack((const Tox_Events *)obj, bp);
+    const Tox_Events *events = (const Tox_Events *)obj;
+    return tox_events_pack(events, bp);
 }
 
 uint32_t tox_events_bytes_size(const Tox_Events *events)


### PR DESCRIPTION
These casts are effectively part of the function type, so it makes sense to have them at the beginning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2512)
<!-- Reviewable:end -->
