### PR TITLE
chore: Add fetch-sha256 script to update bootstrap node hash.

### DIFF
--- a/.github/scripts/tox-bootstrapd-docker
+++ b/.github/scripts/tox-bootstrapd-docker
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-set -exu
+set -exu -o pipefail
 
 LOCAL="${1:-}"
 
 readarray -t FILES <<<"$(git ls-files)"
 
-tar c "${FILES[@]}" | docker build -f other/bootstrap_daemon/docker/Dockerfile -t toxchat/bootstrap-node -
+if ! tar c "${FILES[@]}" | docker build -f other/bootstrap_daemon/docker/Dockerfile -t toxchat/bootstrap-node - 2>&1 | tee docker-build.log; then
+  grep -o "::error.*::[a-f0-9]*  /usr/local/bin/tox-bootstrapd" docker-build.log
+  false
+fi
 docker tag toxchat/bootstrap-node:latest toxchat/bootstrap-node:"$(other/print-version)"
 
 sudo useradd \

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -12,8 +12,7 @@ RUN ["apk", "--no-cache", "add",\
  "libsodium-static",\
  "musl-dev",\
  "ninja",\
- "python3"\
-]
+ "python3"]
 
 WORKDIR /src/c-toxcore
 
@@ -49,8 +48,10 @@ RUN CC=clang cmake -B_build -H. \
 # Verify checksum from dev-built binary, so we can be sure Docker Hub doesn't
 # mess with your binaries.
 COPY other/bootstrap_daemon/docker/tox-bootstrapd.sha256 other/bootstrap_daemon/docker/
-RUN sha256sum /usr/local/bin/tox-bootstrapd && \
-    sha256sum -c other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+RUN SHA256="$(sha256sum /usr/local/bin/tox-bootstrapd)" && \
+    (sha256sum -c other/bootstrap_daemon/docker/tox-bootstrapd.sha256 || \
+    (echo "::error file=other/bootstrap_daemon/docker/tox-bootstrapd.sha256,line=1::$SHA256" && \
+     false))
 
 # Remove all the example bootstrap nodes from the config file.
 COPY other/bootstrap_daemon/tox-bootstrapd.conf other/bootstrap_daemon/

--- a/other/bootstrap_daemon/docker/fetch-sha256
+++ b/other/bootstrap_daemon/docker/fetch-sha256
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import json
+import os
+import pprint
+import subprocess
+import sys
+import urllib.request
+from typing import Any
+
+SHA256_FILE = "other/bootstrap_daemon/docker/tox-bootstrapd.sha256"
+
+with open(f"{os.environ['HOME']}/.github-token") as fh:
+    token = fh.read().strip()
+
+head_sha = (subprocess.run(["git", "rev-parse", "HEAD"],
+                           capture_output=True,
+                           check=True).stdout.decode("utf-8").strip())
+
+
+def request(url: str) -> Any:
+    return json.loads(
+        urllib.request.urlopen(
+            urllib.request.Request(
+                url,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": "Bearer " + token,
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )).read())
+
+
+pp = pprint.PrettyPrinter(indent=2, compact=True)
+annots = [
+    a for r in request(
+        f"https://api.github.com/repos/TokTok/c-toxcore/commits/{head_sha}/check-runs?per_page=100"
+    )["check_runs"] if r["name"] == "docker-bootstrap-node"
+    for a in request(r["output"]["annotations_url"])
+    if a["path"] == SHA256_FILE
+]
+if not annots:
+    print("could not find sha256sum output")
+    sys.exit(1)
+with open(SHA256_FILE, "w") as fh:
+    fh.write(annots[0]["message"] + "\n")
+    print(f"updated {SHA256_FILE}")


### PR DESCRIPTION
This fetches it from github, so we don't need to build it locally.

Not super ideal, because devs are supposed to build it locally to prove reproducibility, but we can keep that diligence on the dev to do once when actually merging the PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2513)
<!-- Reviewable:end -->
