### PR TITLE
cleanup: Add typedefs for public API int identifiers.

### DIFF
--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -171,7 +171,7 @@ static void tox_friend_read_receipt_handler(Messenger *m, uint32_t friend_number
 
 static m_friend_request_cb tox_friend_request_handler;
 non_null(1, 2, 3) nullable(5)
-static void tox_friend_request_handler(Messenger *m, const uint8_t *public_key, const uint8_t *message, size_t length,
+static void tox_friend_request_handler(Messenger *m, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE], const uint8_t *message, size_t length,
                                        void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
@@ -1013,7 +1013,7 @@ void tox_get_savedata(const Tox *tox, uint8_t *savedata)
 }
 
 non_null(5) nullable(1, 2, 4, 6)
-static int32_t resolve_bootstrap_node(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key,
+static int32_t resolve_bootstrap_node(Tox *tox, const char *host, uint16_t port, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
                                       IP_Port **root, Tox_Err_Bootstrap *error)
 {
     assert(tox != nullptr);
@@ -1042,7 +1042,7 @@ static int32_t resolve_bootstrap_node(Tox *tox, const char *host, uint16_t port,
     return count;
 }
 
-bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key, Tox_Err_Bootstrap *error)
+bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Bootstrap *error)
 {
     IP_Port *root;
     const int32_t count = resolve_bootstrap_node(tox, host, port, public_key, &root, error);
@@ -1093,7 +1093,7 @@ bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t *pub
     return true;
 }
 
-bool tox_add_tcp_relay(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key,
+bool tox_add_tcp_relay(Tox *tox, const char *host, uint16_t port, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
                        Tox_Err_Bootstrap *error)
 {
     IP_Port *root;
@@ -1182,7 +1182,7 @@ void tox_iterate(Tox *tox, void *user_data)
     tox_unlock(tox);
 }
 
-void tox_self_get_address(const Tox *tox, uint8_t *address)
+void tox_self_get_address(const Tox *tox, uint8_t address[TOX_ADDRESS_SIZE])
 {
     assert(tox != nullptr);
 
@@ -1210,7 +1210,7 @@ uint32_t tox_self_get_nospam(const Tox *tox)
     return ret;
 }
 
-void tox_self_get_public_key(const Tox *tox, uint8_t *public_key)
+void tox_self_get_public_key(const Tox *tox, uint8_t public_key[TOX_PUBLIC_KEY_SIZE])
 {
     assert(tox != nullptr);
 
@@ -1221,7 +1221,7 @@ void tox_self_get_public_key(const Tox *tox, uint8_t *public_key)
     }
 }
 
-void tox_self_get_secret_key(const Tox *tox, uint8_t *secret_key)
+void tox_self_get_secret_key(const Tox *tox, uint8_t secret_key[TOX_SECRET_KEY_SIZE])
 {
     assert(tox != nullptr);
 
@@ -1382,7 +1382,7 @@ static void set_friend_error(const Logger *log, int32_t ret, Tox_Err_Friend_Add 
     }
 }
 
-uint32_t tox_friend_add(Tox *tox, const uint8_t *address, const uint8_t *message, size_t length,
+uint32_t tox_friend_add(Tox *tox, const uint8_t address[TOX_ADDRESS_SIZE], const uint8_t *message, size_t length,
                         Tox_Err_Friend_Add *error)
 {
     assert(tox != nullptr);
@@ -1406,7 +1406,7 @@ uint32_t tox_friend_add(Tox *tox, const uint8_t *address, const uint8_t *message
     return UINT32_MAX;
 }
 
-uint32_t tox_friend_add_norequest(Tox *tox, const uint8_t *public_key, Tox_Err_Friend_Add *error)
+uint32_t tox_friend_add_norequest(Tox *tox, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Friend_Add *error)
 {
     assert(tox != nullptr);
 
@@ -1446,7 +1446,7 @@ bool tox_friend_delete(Tox *tox, uint32_t friend_number, Tox_Err_Friend_Delete *
     return true;
 }
 
-uint32_t tox_friend_by_public_key(const Tox *tox, const uint8_t *public_key, Tox_Err_Friend_By_Public_Key *error)
+uint32_t tox_friend_by_public_key(const Tox *tox, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Friend_By_Public_Key *error)
 {
     assert(tox != nullptr);
 
@@ -1469,7 +1469,7 @@ uint32_t tox_friend_by_public_key(const Tox *tox, const uint8_t *public_key, Tox
     return (uint32_t)ret;
 }
 
-bool tox_friend_get_public_key(const Tox *tox, uint32_t friend_number, uint8_t *public_key,
+bool tox_friend_get_public_key(const Tox *tox, uint32_t friend_number, uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
                                Tox_Err_Friend_Get_Public_Key *error)
 {
     assert(tox != nullptr);
@@ -1795,7 +1795,7 @@ void tox_callback_friend_message(Tox *tox, tox_friend_message_cb *callback)
     tox->friend_message_callback = callback;
 }
 
-bool tox_hash(uint8_t *hash, const uint8_t *data, size_t length)
+bool tox_hash(uint8_t hash[TOX_HASH_LENGTH], const uint8_t *data, size_t length)
 {
     if (hash == nullptr || (data == nullptr && length != 0)) {
         return false;
@@ -1925,7 +1925,7 @@ void tox_callback_file_recv_control(Tox *tox, tox_file_recv_control_cb *callback
     tox->file_recv_control_callback = callback;
 }
 
-bool tox_file_get_file_id(const Tox *tox, uint32_t friend_number, uint32_t file_number, uint8_t *file_id,
+bool tox_file_get_file_id(const Tox *tox, uint32_t friend_number, uint32_t file_number, uint8_t file_id[TOX_FILE_ID_LENGTH],
                           Tox_Err_File_Get *error)
 {
     assert(tox != nullptr);
@@ -1953,7 +1953,7 @@ bool tox_file_get_file_id(const Tox *tox, uint32_t friend_number, uint32_t file_
     return false;
 }
 
-uint32_t tox_file_send(Tox *tox, uint32_t friend_number, uint32_t kind, uint64_t file_size, const uint8_t *file_id,
+uint32_t tox_file_send(Tox *tox, uint32_t friend_number, uint32_t kind, uint64_t file_size, const uint8_t file_id[TOX_FILE_ID_LENGTH],
                        const uint8_t *filename, size_t filename_length, Tox_Err_File_Send *error)
 {
     assert(tox != nullptr);
@@ -2215,7 +2215,7 @@ bool tox_conference_peer_get_name(const Tox *tox, uint32_t conference_number, ui
 }
 
 bool tox_conference_peer_get_public_key(const Tox *tox, uint32_t conference_number, uint32_t peer_number,
-                                        uint8_t *public_key, Tox_Err_Conference_Peer_Query *error)
+                                        uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Conference_Peer_Query *error)
 {
     assert(tox != nullptr);
     tox_lock(tox);
@@ -2336,7 +2336,7 @@ bool tox_conference_offline_peer_get_name(const Tox *tox, uint32_t conference_nu
 
 bool tox_conference_offline_peer_get_public_key(const Tox *tox, uint32_t conference_number,
         uint32_t offline_peer_number,
-        uint8_t *public_key, Tox_Err_Conference_Peer_Query *error)
+        uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Conference_Peer_Query *error)
 {
     assert(tox != nullptr);
     tox_lock(tox);
@@ -2629,7 +2629,7 @@ Tox_Conference_Type tox_conference_get_type(const Tox *tox, uint32_t conference_
     return (Tox_Conference_Type)ret;
 }
 
-bool tox_conference_get_id(const Tox *tox, uint32_t conference_number, uint8_t *id)
+bool tox_conference_get_id(const Tox *tox, uint32_t conference_number, uint8_t id[TOX_CONFERENCE_ID_SIZE])
 {
     assert(tox != nullptr);
     tox_lock(tox);
@@ -2639,13 +2639,13 @@ bool tox_conference_get_id(const Tox *tox, uint32_t conference_number, uint8_t *
 }
 
 // TODO(iphydf): Delete in 0.3.0.
-bool tox_conference_get_uid(const Tox *tox, uint32_t conference_number, uint8_t *uid)
+bool tox_conference_get_uid(const Tox *tox, uint32_t conference_number, uint8_t uid[TOX_CONFERENCE_UID_SIZE])
 {
     assert(tox != nullptr);
     return tox_conference_get_id(tox, conference_number, uid);
 }
 
-uint32_t tox_conference_by_id(const Tox *tox, const uint8_t *id, Tox_Err_Conference_By_Id *error)
+uint32_t tox_conference_by_id(const Tox *tox, const uint8_t id[TOX_CONFERENCE_ID_SIZE], Tox_Err_Conference_By_Id *error)
 {
     assert(tox != nullptr);
 
@@ -2669,7 +2669,7 @@ uint32_t tox_conference_by_id(const Tox *tox, const uint8_t *id, Tox_Err_Confere
 }
 
 // TODO(iphydf): Delete in 0.3.0.
-uint32_t tox_conference_by_uid(const Tox *tox, const uint8_t *uid, Tox_Err_Conference_By_Uid *error)
+uint32_t tox_conference_by_uid(const Tox *tox, const uint8_t uid[TOX_CONFERENCE_UID_SIZE], Tox_Err_Conference_By_Uid *error)
 {
     assert(tox != nullptr);
     Tox_Err_Conference_By_Id id_error;
@@ -2805,7 +2805,7 @@ void tox_callback_friend_lossless_packet(Tox *tox, tox_friend_lossless_packet_cb
     }
 }
 
-void tox_self_get_dht_id(const Tox *tox, uint8_t *dht_id)
+void tox_self_get_dht_id(const Tox *tox, uint8_t dht_id[TOX_PUBLIC_KEY_SIZE])
 {
     assert(tox != nullptr);
 
@@ -3007,7 +3007,7 @@ uint32_t tox_group_new(Tox *tox, Tox_Group_Privacy_State privacy_state, const ui
     return UINT32_MAX;
 }
 
-uint32_t tox_group_join(Tox *tox, const uint8_t *chat_id, const uint8_t *name, size_t name_length,
+uint32_t tox_group_join(Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t *name, size_t name_length,
                         const uint8_t *password, size_t password_length, Tox_Err_Group_Join *error)
 {
     assert(tox != nullptr);
@@ -3372,7 +3372,7 @@ uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_E
     return ret;
 }
 
-bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
+bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
                                    Tox_Err_Group_Self_Query *error)
 {
     assert(tox != nullptr);
@@ -3498,7 +3498,7 @@ Tox_Group_Role tox_group_peer_get_role(const Tox *tox, uint32_t group_number, ui
     return (Tox_Group_Role)ret;
 }
 
-bool tox_group_peer_get_public_key(const Tox *tox, uint32_t group_number, uint32_t peer_id, uint8_t *public_key,
+bool tox_group_peer_get_public_key(const Tox *tox, uint32_t group_number, uint32_t peer_id, uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
                                    Tox_Err_Group_Peer_Query *error)
 {
     assert(tox != nullptr);
@@ -3689,7 +3689,7 @@ bool tox_group_get_name(const Tox *tox, uint32_t group_number, uint8_t *group_na
     return true;
 }
 
-bool tox_group_get_chat_id(const Tox *tox, uint32_t group_number, uint8_t *chat_id, Tox_Err_Group_State_Queries *error)
+bool tox_group_get_chat_id(const Tox *tox, uint32_t group_number, uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], Tox_Err_Group_State_Queries *error)
 {
     assert(tox != nullptr);
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -1265,6 +1265,8 @@ Tox_User_Status tox_self_get_status(const Tox *tox);
  * @name Friend list management
  */
 
+typedef uint32_t Tox_Friend_Number;
+
 typedef enum Tox_Err_Friend_Add {
 
     /**
@@ -1343,8 +1345,9 @@ const char *tox_err_friend_add_to_string(Tox_Err_Friend_Add value);
  *
  * @return the friend number on success, an unspecified value on failure.
  */
-uint32_t tox_friend_add(Tox *tox, const uint8_t *address, const uint8_t *message, size_t length,
-                        Tox_Err_Friend_Add *error);
+Tox_Friend_Number tox_friend_add(
+        Tox *tox, const uint8_t *address, const uint8_t *message, size_t length,
+        Tox_Err_Friend_Add *error);
 
 /**
  * @brief Add a friend without sending a friend request.
@@ -1364,7 +1367,8 @@ uint32_t tox_friend_add(Tox *tox, const uint8_t *address, const uint8_t *message
  * @return the friend number on success, an unspecified value on failure.
  * @see tox_friend_add for a more detailed description of friend numbers.
  */
-uint32_t tox_friend_add_norequest(Tox *tox, const uint8_t *public_key, Tox_Err_Friend_Add *error);
+Tox_Friend_Number tox_friend_add_norequest(
+        Tox *tox, const uint8_t *public_key, Tox_Err_Friend_Add *error);
 
 typedef enum Tox_Err_Friend_Delete {
 
@@ -1394,7 +1398,7 @@ const char *tox_err_friend_delete_to_string(Tox_Err_Friend_Delete value);
  *
  * @return true on success.
  */
-bool tox_friend_delete(Tox *tox, uint32_t friend_number, Tox_Err_Friend_Delete *error);
+bool tox_friend_delete(Tox *tox, Tox_Friend_Number friend_number, Tox_Err_Friend_Delete *error);
 
 /** @} */
 
@@ -1431,13 +1435,13 @@ const char *tox_err_friend_by_public_key_to_string(Tox_Err_Friend_By_Public_Key 
  * @return the friend number on success, an unspecified value on failure.
  * @param public_key A byte array containing the Public Key.
  */
-uint32_t tox_friend_by_public_key(const Tox *tox, const uint8_t *public_key, Tox_Err_Friend_By_Public_Key *error);
+Tox_Friend_Number tox_friend_by_public_key(const Tox *tox, const uint8_t *public_key, Tox_Err_Friend_By_Public_Key *error);
 
 /**
  * @brief Checks if a friend with the given friend number exists and returns true if
  * it does.
  */
-bool tox_friend_exists(const Tox *tox, uint32_t friend_number);
+bool tox_friend_exists(const Tox *tox, Tox_Friend_Number friend_number);
 
 /**
  * @brief Return the number of friends on the friend list.
@@ -1455,7 +1459,7 @@ size_t tox_self_get_friend_list_size(const Tox *tox);
  * @param friend_list A memory region with enough space to hold the friend
  *   list. If this parameter is NULL, this function has no effect.
  */
-void tox_self_get_friend_list(const Tox *tox, uint32_t *friend_list);
+void tox_self_get_friend_list(const Tox *tox, Tox_Friend_Number *friend_list);
 
 typedef enum Tox_Err_Friend_Get_Public_Key {
 
@@ -1483,8 +1487,9 @@ const char *tox_err_friend_get_public_key_to_string(Tox_Err_Friend_Get_Public_Ke
  *
  * @return true on success.
  */
-bool tox_friend_get_public_key(const Tox *tox, uint32_t friend_number, uint8_t *public_key,
-                               Tox_Err_Friend_Get_Public_Key *error);
+bool tox_friend_get_public_key(
+        const Tox *tox, Tox_Friend_Number friend_number, uint8_t *public_key,
+        Tox_Err_Friend_Get_Public_Key *error);
 
 typedef enum Tox_Err_Friend_Get_Last_Online {
 
@@ -1511,7 +1516,8 @@ const char *tox_err_friend_get_last_online_to_string(Tox_Err_Friend_Get_Last_Onl
  *
  * @param friend_number The friend number you want to query.
  */
-uint64_t tox_friend_get_last_online(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Get_Last_Online *error);
+uint64_t tox_friend_get_last_online(
+        const Tox *tox, Tox_Friend_Number friend_number, Tox_Err_Friend_Get_Last_Online *error);
 
 /** @} */
 
@@ -1555,7 +1561,8 @@ const char *tox_err_friend_query_to_string(Tox_Err_Friend_Query value);
  * The return value is equal to the `length` argument received by the last
  * `friend_name` callback.
  */
-size_t tox_friend_get_name_size(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error);
+size_t tox_friend_get_name_size(
+        const Tox *tox, Tox_Friend_Number friend_number, Tox_Err_Friend_Query *error);
 
 /**
  * @brief Write the name of the friend designated by the given friend number to a byte
@@ -1571,7 +1578,8 @@ size_t tox_friend_get_name_size(const Tox *tox, uint32_t friend_number, Tox_Err_
  *
  * @return true on success.
  */
-bool tox_friend_get_name(const Tox *tox, uint32_t friend_number, uint8_t *name, Tox_Err_Friend_Query *error);
+bool tox_friend_get_name(
+        const Tox *tox, Tox_Friend_Number friend_number, uint8_t *name, Tox_Err_Friend_Query *error);
 
 /**
  * @param friend_number The friend number of the friend whose name changed.
@@ -1580,7 +1588,8 @@ bool tox_friend_get_name(const Tox *tox, uint32_t friend_number, uint8_t *name, 
  * @param length A value equal to the return value of
  *   tox_friend_get_name_size.
  */
-typedef void tox_friend_name_cb(Tox *tox, uint32_t friend_number, const uint8_t *name, size_t length, void *user_data);
+typedef void tox_friend_name_cb(
+        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *name, size_t length, void *user_data);
 
 
 /**
@@ -1597,7 +1606,8 @@ void tox_callback_friend_name(Tox *tox, tox_friend_name_cb *callback);
  *
  * If the friend number isinvalid, the return value is SIZE_MAX.
  */
-size_t tox_friend_get_status_message_size(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error);
+size_t tox_friend_get_status_message_size(
+        const Tox *tox, Tox_Friend_Number friend_number, Tox_Err_Friend_Query *error);
 
 /**
  * @brief Write the status message of the friend designated by the given friend number to a byte
@@ -1611,8 +1621,9 @@ size_t tox_friend_get_status_message_size(const Tox *tox, uint32_t friend_number
  *
  * @param status_message A valid memory region large enough to store the friend's status message.
  */
-bool tox_friend_get_status_message(const Tox *tox, uint32_t friend_number, uint8_t *status_message,
-                                   Tox_Err_Friend_Query *error);
+bool tox_friend_get_status_message(
+        const Tox *tox, Tox_Friend_Number friend_number, uint8_t *status_message,
+        Tox_Err_Friend_Query *error);
 
 /**
  * @param friend_number The friend number of the friend whose status message
@@ -1622,8 +1633,8 @@ bool tox_friend_get_status_message(const Tox *tox, uint32_t friend_number, uint8
  * @param length A value equal to the return value of
  *   tox_friend_get_status_message_size.
  */
-typedef void tox_friend_status_message_cb(Tox *tox, uint32_t friend_number, const uint8_t *message, size_t length,
-        void *user_data);
+typedef void tox_friend_status_message_cb(
+        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *message, size_t length, void *user_data);
 
 
 /**
@@ -1646,14 +1657,16 @@ void tox_callback_friend_status_message(Tox *tox, tox_friend_status_message_cb *
  * @deprecated This getter is deprecated. Use the event and store the status
  *   in the client state.
  */
-Tox_User_Status tox_friend_get_status(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error);
+Tox_User_Status tox_friend_get_status(
+        const Tox *tox, Tox_Friend_Number friend_number, Tox_Err_Friend_Query *error);
 
 /**
  * @param friend_number The friend number of the friend whose user status
  *   changed.
  * @param status The new user status.
  */
-typedef void tox_friend_status_cb(Tox *tox, uint32_t friend_number, Tox_User_Status status, void *user_data);
+typedef void tox_friend_status_cb(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_User_Status status, void *user_data);
 
 
 /**
@@ -1680,7 +1693,8 @@ void tox_callback_friend_status(Tox *tox, tox_friend_status_cb *callback);
  * @deprecated This getter is deprecated. Use the event and store the status
  *   in the client state.
  */
-Tox_Connection tox_friend_get_connection_status(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error);
+Tox_Connection tox_friend_get_connection_status(
+        const Tox *tox, Tox_Friend_Number friend_number, Tox_Err_Friend_Query *error);
 
 /**
  * @param friend_number The friend number of the friend whose connection status
@@ -1688,8 +1702,8 @@ Tox_Connection tox_friend_get_connection_status(const Tox *tox, uint32_t friend_
  * @param connection_status The result of calling
  *   tox_friend_get_connection_status on the passed friend_number.
  */
-typedef void tox_friend_connection_status_cb(Tox *tox, uint32_t friend_number, Tox_Connection connection_status,
-        void *user_data);
+typedef void tox_friend_connection_status_cb(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_Connection connection_status, void *user_data);
 
 
 /**
@@ -1717,7 +1731,8 @@ void tox_callback_friend_connection_status(Tox *tox, tox_friend_connection_statu
  * @deprecated This getter is deprecated. Use the event and store the status
  *   in the client state.
  */
-bool tox_friend_get_typing(const Tox *tox, uint32_t friend_number, Tox_Err_Friend_Query *error);
+bool tox_friend_get_typing(
+        const Tox *tox, Tox_Friend_Number friend_number, Tox_Err_Friend_Query *error);
 
 /**
  * @param friend_number The friend number of the friend who started or stopped
@@ -1725,7 +1740,8 @@ bool tox_friend_get_typing(const Tox *tox, uint32_t friend_number, Tox_Err_Frien
  * @param typing The result of calling tox_friend_get_typing on the passed
  *   friend_number.
  */
-typedef void tox_friend_typing_cb(Tox *tox, uint32_t friend_number, bool typing, void *user_data);
+typedef void tox_friend_typing_cb(
+        Tox *tox, Tox_Friend_Number friend_number, bool typing, void *user_data);
 
 
 /**
@@ -1771,7 +1787,8 @@ const char *tox_err_set_typing_to_string(Tox_Err_Set_Typing value);
  *
  * @return true on success.
  */
-bool tox_self_set_typing(Tox *tox, uint32_t friend_number, bool typing, Tox_Err_Set_Typing *error);
+bool tox_self_set_typing(
+        Tox *tox, Tox_Friend_Number friend_number, bool typing, Tox_Err_Set_Typing *error);
 
 typedef enum Tox_Err_Friend_Send_Message {
 
@@ -1814,6 +1831,7 @@ typedef enum Tox_Err_Friend_Send_Message {
 
 const char *tox_err_friend_send_message_to_string(Tox_Err_Friend_Send_Message value);
 
+typedef uint32_t Tox_Friend_Message_Id;
 
 /**
  * @brief Send a text chat message to an online friend.
@@ -1838,15 +1856,17 @@ const char *tox_err_friend_send_message_to_string(Tox_Err_Friend_Send_Message va
  *   containing the message text.
  * @param length Length of the message to be sent.
  */
-uint32_t tox_friend_send_message(Tox *tox, uint32_t friend_number, Tox_Message_Type type, const uint8_t *message,
-                                 size_t length, Tox_Err_Friend_Send_Message *error);
+Tox_Friend_Message_Id tox_friend_send_message(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_Message_Type type, const uint8_t *message,
+        size_t length, Tox_Err_Friend_Send_Message *error);
 
 /**
  * @param friend_number The friend number of the friend who received the message.
  * @param message_id The message ID as returned from tox_friend_send_message
  *   corresponding to the message sent.
  */
-typedef void tox_friend_read_receipt_cb(Tox *tox, uint32_t friend_number, uint32_t message_id, void *user_data);
+typedef void tox_friend_read_receipt_cb(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_Friend_Message_Id message_id, void *user_data);
 
 
 /**
@@ -1889,8 +1909,9 @@ void tox_callback_friend_request(Tox *tox, tox_friend_request_cb *callback);
  * @param message The message data they sent.
  * @param length The size of the message byte array.
  */
-typedef void tox_friend_message_cb(Tox *tox, uint32_t friend_number, Tox_Message_Type type, const uint8_t *message,
-                                   size_t length, void *user_data);
+typedef void tox_friend_message_cb(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_Message_Type type, const uint8_t *message,
+        size_t length, void *user_data);
 
 
 /**
@@ -1908,6 +1929,8 @@ void tox_callback_friend_message(Tox *tox, tox_friend_message_cb *callback);
 /** @{
  * @name File transmission: common between sending and receiving
  */
+
+typedef uint32_t Tox_File_Number;
 
 /**
  * @brief Generates a cryptographic hash of the given data.
@@ -2057,8 +2080,9 @@ const char *tox_err_file_control_to_string(Tox_Err_File_Control value);
  *
  * @return true on success.
  */
-bool tox_file_control(Tox *tox, uint32_t friend_number, uint32_t file_number, Tox_File_Control control,
-                      Tox_Err_File_Control *error);
+bool tox_file_control(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, Tox_File_Control control,
+        Tox_Err_File_Control *error);
 
 /**
  * @brief When receiving TOX_FILE_CONTROL_CANCEL, the client should release the
@@ -2069,8 +2093,9 @@ bool tox_file_control(Tox *tox, uint32_t friend_number, uint32_t file_number, To
  *   associated with.
  * @param control The file control command received.
  */
-typedef void tox_file_recv_control_cb(Tox *tox, uint32_t friend_number, uint32_t file_number, Tox_File_Control control,
-                                      void *user_data);
+typedef void tox_file_recv_control_cb(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, Tox_File_Control control,
+        void *user_data);
 
 
 /**
@@ -2136,7 +2161,8 @@ const char *tox_err_file_seek_to_string(Tox_Err_File_Seek value);
  * @param file_number The friend-specific identifier for the file transfer.
  * @param position The position that the file should be seeked to.
  */
-bool tox_file_seek(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, Tox_Err_File_Seek *error);
+bool tox_file_seek(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint64_t position, Tox_Err_File_Seek *error);
 
 typedef enum Tox_Err_File_Get {
 
@@ -2176,8 +2202,9 @@ const char *tox_err_file_get_to_string(Tox_Err_File_Get value);
  *
  * @return true on success.
  */
-bool tox_file_get_file_id(const Tox *tox, uint32_t friend_number, uint32_t file_number, uint8_t *file_id,
-                          Tox_Err_File_Get *error);
+bool tox_file_get_file_id(
+        const Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint8_t *file_id,
+        Tox_Err_File_Get *error);
 
 /** @} */
 
@@ -2282,8 +2309,9 @@ const char *tox_err_file_send_to_string(Tox_Err_File_Send value);
  *   On failure, this function returns an unspecified value. Any pattern in file numbers
  *   should not be relied on.
  */
-uint32_t tox_file_send(Tox *tox, uint32_t friend_number, uint32_t kind, uint64_t file_size, const uint8_t *file_id,
-                       const uint8_t *filename, size_t filename_length, Tox_Err_File_Send *error);
+Tox_File_Number tox_file_send(
+        Tox *tox, Tox_Friend_Number friend_number, uint32_t kind, uint64_t file_size, const uint8_t *file_id,
+        const uint8_t *filename, size_t filename_length, Tox_Err_File_Send *error);
 
 typedef enum Tox_Err_File_Send_Chunk {
 
@@ -2356,8 +2384,9 @@ const char *tox_err_file_send_chunk_to_string(Tox_Err_File_Send_Chunk value);
  * @param position The file or stream position from which to continue reading.
  * @return true on success.
  */
-bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, const uint8_t *data,
-                         size_t length, Tox_Err_File_Send_Chunk *error);
+bool tox_file_send_chunk(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint64_t position, const uint8_t *data,
+        size_t length, Tox_Err_File_Send_Chunk *error);
 
 /**
  * If the length parameter is 0, the file transfer is finished, and the client's
@@ -2381,8 +2410,9 @@ bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number,
  * @param position The file or stream position from which to continue reading.
  * @param length The number of bytes requested for the current chunk.
  */
-typedef void tox_file_chunk_request_cb(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position,
-                                       size_t length, void *user_data);
+typedef void tox_file_chunk_request_cb(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint64_t position,
+        size_t length, void *user_data);
 
 
 /**
@@ -2419,8 +2449,9 @@ void tox_callback_file_chunk_request(Tox *tox, tox_file_chunk_request_cb *callba
  *   name will be sent along with the file send request.
  * @param filename_length Size in bytes of the filename.
  */
-typedef void tox_file_recv_cb(Tox *tox, uint32_t friend_number, uint32_t file_number, uint32_t kind, uint64_t file_size,
-                              const uint8_t *filename, size_t filename_length, void *user_data);
+typedef void tox_file_recv_cb(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint32_t kind, uint64_t file_size,
+        const uint8_t *filename, size_t filename_length, void *user_data);
 
 
 /**
@@ -2448,8 +2479,9 @@ void tox_callback_file_recv(Tox *tox, tox_file_recv_cb *callback);
  * @param data A byte array containing the received chunk.
  * @param length The length of the received chunk.
  */
-typedef void tox_file_recv_chunk_cb(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position,
-                                    const uint8_t *data, size_t length, void *user_data);
+typedef void tox_file_recv_chunk_cb(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint64_t position,
+        const uint8_t *data, size_t length, void *user_data);
 
 
 /**
@@ -2468,6 +2500,9 @@ void tox_callback_file_recv_chunk(Tox *tox, tox_file_recv_chunk_cb *callback);
 /** @{
  * @name Conference management
  */
+
+typedef uint32_t Tox_Conference_Number;
+typedef uint32_t Tox_Conference_Peer_Number;
 
 /**
  * @brief Conference types for the conference_invite event.
@@ -2499,8 +2534,9 @@ const char *tox_conference_type_to_string(Tox_Conference_Type value);
  *   conference.
  * @param length The length of the cookie.
  */
-typedef void tox_conference_invite_cb(Tox *tox, uint32_t friend_number, Tox_Conference_Type type, const uint8_t *cookie,
-                                      size_t length, void *user_data);
+typedef void tox_conference_invite_cb(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_Conference_Type type, const uint8_t *cookie,
+        size_t length, void *user_data);
 
 
 /**
@@ -2515,7 +2551,7 @@ void tox_callback_conference_invite(Tox *tox, tox_conference_invite_cb *callback
 /**
  * @param conference_number The conference number of the conference to which we have connected.
  */
-typedef void tox_conference_connected_cb(Tox *tox, uint32_t conference_number, void *user_data);
+typedef void tox_conference_connected_cb(Tox *tox, Tox_Conference_Number conference_number, void *user_data);
 
 
 /**
@@ -2536,8 +2572,9 @@ void tox_callback_conference_connected(Tox *tox, tox_conference_connected_cb *ca
  * @param message The message data.
  * @param length The length of the message.
  */
-typedef void tox_conference_message_cb(Tox *tox, uint32_t conference_number, uint32_t peer_number,
-                                       Tox_Message_Type type, const uint8_t *message, size_t length, void *user_data);
+typedef void tox_conference_message_cb(
+        Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
+        Tox_Message_Type type, const uint8_t *message, size_t length, void *user_data);
 
 
 /**
@@ -2556,8 +2593,9 @@ void tox_callback_conference_message(Tox *tox, tox_conference_message_cb *callba
  * @param title The title data.
  * @param length The title length.
  */
-typedef void tox_conference_title_cb(Tox *tox, uint32_t conference_number, uint32_t peer_number, const uint8_t *title,
-                                     size_t length, void *user_data);
+typedef void tox_conference_title_cb(
+        Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number, const uint8_t *title,
+        size_t length, void *user_data);
 
 
 /**
@@ -2578,7 +2616,8 @@ void tox_callback_conference_title(Tox *tox, tox_conference_title_cb *callback);
  * @param name A byte array containing the new nickname.
  * @param length The size of the name byte array.
  */
-typedef void tox_conference_peer_name_cb(Tox *tox, uint32_t conference_number, uint32_t peer_number,
+typedef void tox_conference_peer_name_cb(
+        Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
         const uint8_t *name, size_t length, void *user_data);
 
 
@@ -2595,7 +2634,7 @@ void tox_callback_conference_peer_name(Tox *tox, tox_conference_peer_name_cb *ca
  * @param conference_number The conference number of the conference the
  *   peer is in.
  */
-typedef void tox_conference_peer_list_changed_cb(Tox *tox, uint32_t conference_number, void *user_data);
+typedef void tox_conference_peer_list_changed_cb(Tox *tox, Tox_Conference_Number conference_number, void *user_data);
 
 
 /**
@@ -2633,7 +2672,7 @@ const char *tox_err_conference_new_to_string(Tox_Err_Conference_New value);
  *   - conference number on success
  *   - an unspecified value on failure
  */
-uint32_t tox_conference_new(Tox *tox, Tox_Err_Conference_New *error);
+Tox_Conference_Number tox_conference_new(Tox *tox, Tox_Err_Conference_New *error);
 
 typedef enum Tox_Err_Conference_Delete {
 
@@ -2659,7 +2698,7 @@ const char *tox_err_conference_delete_to_string(Tox_Err_Conference_Delete value)
  *
  * @return true on success.
  */
-bool tox_conference_delete(Tox *tox, uint32_t conference_number, Tox_Err_Conference_Delete *error);
+bool tox_conference_delete(Tox *tox, Tox_Conference_Number conference_number, Tox_Err_Conference_Delete *error);
 
 /**
  * @brief Error codes for peer info queries.
@@ -2698,14 +2737,16 @@ const char *tox_err_conference_peer_query_to_string(Tox_Err_Conference_Peer_Quer
  * peer_number for the functions querying these peers. Return value is
  * unspecified on failure.
  */
-uint32_t tox_conference_peer_count(const Tox *tox, uint32_t conference_number, Tox_Err_Conference_Peer_Query *error);
+Tox_Conference_Peer_Number tox_conference_peer_count(
+        const Tox *tox, Tox_Conference_Number conference_number, Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Return the length of the peer's name.
  *
  * Return value is unspecified on failure.
  */
-size_t tox_conference_peer_get_name_size(const Tox *tox, uint32_t conference_number, uint32_t peer_number,
+size_t tox_conference_peer_get_name_size(
+        const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
         Tox_Err_Conference_Peer_Query *error);
 
 /**
@@ -2717,8 +2758,9 @@ size_t tox_conference_peer_get_name_size(const Tox *tox, uint32_t conference_num
  *
  * @return true on success.
  */
-bool tox_conference_peer_get_name(const Tox *tox, uint32_t conference_number, uint32_t peer_number, uint8_t *name,
-                                  Tox_Err_Conference_Peer_Query *error);
+bool tox_conference_peer_get_name(
+        const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number, uint8_t *name,
+        Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Copy the public key of peer_number who is in conference_number to public_key.
@@ -2727,14 +2769,16 @@ bool tox_conference_peer_get_name(const Tox *tox, uint32_t conference_number, ui
  *
  * @return true on success.
  */
-bool tox_conference_peer_get_public_key(const Tox *tox, uint32_t conference_number, uint32_t peer_number,
-                                        uint8_t *public_key, Tox_Err_Conference_Peer_Query *error);
+bool tox_conference_peer_get_public_key(
+        const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
+        uint8_t *public_key, Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Return true if passed peer_number corresponds to our own.
  */
-bool tox_conference_peer_number_is_ours(const Tox *tox, uint32_t conference_number, uint32_t peer_number,
-                                        Tox_Err_Conference_Peer_Query *error);
+bool tox_conference_peer_number_is_ours(
+        const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
+        Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Return the number of offline peers in the conference.
@@ -2744,7 +2788,8 @@ bool tox_conference_peer_number_is_ours(const Tox *tox, uint32_t conference_numb
  *
  * Return value is unspecified on failure.
  */
-uint32_t tox_conference_offline_peer_count(const Tox *tox, uint32_t conference_number,
+uint32_t tox_conference_offline_peer_count(
+        const Tox *tox, Tox_Conference_Number conference_number,
         Tox_Err_Conference_Peer_Query *error);
 
 /**
@@ -2752,8 +2797,9 @@ uint32_t tox_conference_offline_peer_count(const Tox *tox, uint32_t conference_n
  *
  * Return value is unspecified on failure.
  */
-size_t tox_conference_offline_peer_get_name_size(const Tox *tox, uint32_t conference_number,
-        uint32_t offline_peer_number, Tox_Err_Conference_Peer_Query *error);
+size_t tox_conference_offline_peer_get_name_size(
+        const Tox *tox, Tox_Conference_Number conference_number,
+        Tox_Conference_Peer_Number offline_peer_number, Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Copy the name of offline_peer_number who is in conference_number to name.
@@ -2765,7 +2811,8 @@ size_t tox_conference_offline_peer_get_name_size(const Tox *tox, uint32_t confer
  *
  * @return true on success.
  */
-bool tox_conference_offline_peer_get_name(const Tox *tox, uint32_t conference_number, uint32_t offline_peer_number,
+bool tox_conference_offline_peer_get_name(
+        const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number offline_peer_number,
         uint8_t *name, Tox_Err_Conference_Peer_Query *error);
 
 /**
@@ -2775,14 +2822,16 @@ bool tox_conference_offline_peer_get_name(const Tox *tox, uint32_t conference_nu
  *
  * @return true on success.
  */
-bool tox_conference_offline_peer_get_public_key(const Tox *tox, uint32_t conference_number,
-        uint32_t offline_peer_number, uint8_t *public_key, Tox_Err_Conference_Peer_Query *error);
+bool tox_conference_offline_peer_get_public_key(
+        const Tox *tox, Tox_Conference_Number conference_number,
+        Tox_Conference_Peer_Number offline_peer_number, uint8_t *public_key, Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Return a unix-time timestamp of the last time offline_peer_number was seen to be active.
  */
-uint64_t tox_conference_offline_peer_get_last_active(const Tox *tox, uint32_t conference_number,
-        uint32_t offline_peer_number, Tox_Err_Conference_Peer_Query *error);
+uint64_t tox_conference_offline_peer_get_last_active(
+        const Tox *tox, Tox_Conference_Number conference_number,
+        Tox_Conference_Peer_Number offline_peer_number, Tox_Err_Conference_Peer_Query *error);
 
 typedef enum Tox_Err_Conference_Set_Max_Offline {
 
@@ -2804,8 +2853,9 @@ const char *tox_err_conference_set_max_offline_to_string(Tox_Err_Conference_Set_
 /**
  * @brief Set maximum number of offline peers to store, overriding the default.
  */
-bool tox_conference_set_max_offline(Tox *tox, uint32_t conference_number, uint32_t max_offline_peers,
-                                    Tox_Err_Conference_Set_Max_Offline *error);
+bool tox_conference_set_max_offline(
+        Tox *tox, Tox_Conference_Number conference_number, uint32_t max_offline_peers,
+        Tox_Err_Conference_Set_Max_Offline *error);
 
 typedef enum Tox_Err_Conference_Invite {
 
@@ -2842,8 +2892,9 @@ const char *tox_err_conference_invite_to_string(Tox_Err_Conference_Invite value)
  *
  * @return true on success.
  */
-bool tox_conference_invite(Tox *tox, uint32_t friend_number, uint32_t conference_number,
-                           Tox_Err_Conference_Invite *error);
+bool tox_conference_invite(
+        Tox *tox, Tox_Friend_Number friend_number, Tox_Conference_Number conference_number,
+        Tox_Err_Conference_Invite *error);
 
 typedef enum Tox_Err_Conference_Join {
 
@@ -2904,8 +2955,9 @@ const char *tox_err_conference_join_to_string(Tox_Err_Conference_Join value);
  *
  * @return conference number on success, an unspecified value on failure.
  */
-uint32_t tox_conference_join(Tox *tox, uint32_t friend_number, const uint8_t *cookie, size_t length,
-                             Tox_Err_Conference_Join *error);
+Tox_Conference_Number tox_conference_join(
+        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *cookie, size_t length,
+        Tox_Err_Conference_Join *error);
 
 typedef enum Tox_Err_Conference_Send_Message {
 
@@ -2958,8 +3010,9 @@ const char *tox_err_conference_send_message_to_string(Tox_Err_Conference_Send_Me
  *
  * @return true on success.
  */
-bool tox_conference_send_message(Tox *tox, uint32_t conference_number, Tox_Message_Type type, const uint8_t *message,
-                                 size_t length, Tox_Err_Conference_Send_Message *error);
+bool tox_conference_send_message(
+        Tox *tox, Tox_Conference_Number conference_number, Tox_Message_Type type, const uint8_t *message,
+        size_t length, Tox_Err_Conference_Send_Message *error);
 
 typedef enum Tox_Err_Conference_Title {
 
@@ -2996,7 +3049,8 @@ const char *tox_err_conference_title_to_string(Tox_Err_Conference_Title value);
  * The return value is equal to the `length` argument received by the last
  * `conference_title` callback.
  */
-size_t tox_conference_get_title_size(const Tox *tox, uint32_t conference_number, Tox_Err_Conference_Title *error);
+size_t tox_conference_get_title_size(
+        const Tox *tox, Tox_Conference_Number conference_number, Tox_Err_Conference_Title *error);
 
 /**
  * @brief Write the title designated by the given conference number to a byte array.
@@ -3011,8 +3065,9 @@ size_t tox_conference_get_title_size(const Tox *tox, uint32_t conference_number,
  *
  * @return true on success.
  */
-bool tox_conference_get_title(const Tox *tox, uint32_t conference_number, uint8_t *title,
-                              Tox_Err_Conference_Title *error);
+bool tox_conference_get_title(
+        const Tox *tox, Tox_Conference_Number conference_number, uint8_t *title,
+        Tox_Err_Conference_Title *error);
 
 /**
  * @brief Set the conference title and broadcast it to the rest of the conference.
@@ -3021,8 +3076,9 @@ bool tox_conference_get_title(const Tox *tox, uint32_t conference_number, uint8_
  *
  * @return true on success.
  */
-bool tox_conference_set_title(Tox *tox, uint32_t conference_number, const uint8_t *title, size_t length,
-                              Tox_Err_Conference_Title *error);
+bool tox_conference_set_title(
+        Tox *tox, Tox_Conference_Number conference_number, const uint8_t *title, size_t length,
+        Tox_Err_Conference_Title *error);
 
 /**
  * @brief Return the number of conferences in the Tox instance.
@@ -3045,7 +3101,7 @@ size_t tox_conference_get_chatlist_size(const Tox *tox);
  * The conference number of a loaded conference may differ from the conference
  * number it had when it was saved.
  */
-void tox_conference_get_chatlist(const Tox *tox, uint32_t *chatlist);
+void tox_conference_get_chatlist(const Tox *tox, Tox_Conference_Number *chatlist);
 
 /**
  * @brief Returns the type of conference (Tox_Conference_Type) that conference_number is.
@@ -3072,7 +3128,8 @@ const char *tox_err_conference_get_type_to_string(Tox_Err_Conference_Get_Type va
 /**
  * @brief Get the type (text or A/V) for the conference.
  */
-Tox_Conference_Type tox_conference_get_type(const Tox *tox, uint32_t conference_number,
+Tox_Conference_Type tox_conference_get_type(
+        const Tox *tox, Tox_Conference_Number conference_number,
         Tox_Err_Conference_Get_Type *error);
 
 /**
@@ -3084,7 +3141,7 @@ Tox_Conference_Type tox_conference_get_type(const Tox *tox, uint32_t conference_
  *
  * @return true on success.
  */
-bool tox_conference_get_id(const Tox *tox, uint32_t conference_number, uint8_t *id);
+bool tox_conference_get_id(const Tox *tox, Tox_Conference_Number conference_number, uint8_t *id);
 
 typedef enum Tox_Err_Conference_By_Id {
 
@@ -3115,7 +3172,7 @@ const char *tox_err_conference_by_id_to_string(Tox_Err_Conference_By_Id value);
  *
  * @return the conference number on success, an unspecified value on failure.
  */
-uint32_t tox_conference_by_id(const Tox *tox, const uint8_t *id, Tox_Err_Conference_By_Id *error);
+Tox_Conference_Number tox_conference_by_id(const Tox *tox, const uint8_t *id, Tox_Err_Conference_By_Id *error);
 
 /**
  * @brief Get the conference unique ID.
@@ -3127,7 +3184,7 @@ uint32_t tox_conference_by_id(const Tox *tox, const uint8_t *id, Tox_Err_Confere
  * @return true on success.
  * @deprecated use tox_conference_get_id instead (exactly the same function, just renamed).
  */
-bool tox_conference_get_uid(const Tox *tox, uint32_t conference_number, uint8_t *uid);
+bool tox_conference_get_uid(const Tox *tox, Tox_Conference_Number conference_number, uint8_t *uid);
 
 typedef enum Tox_Err_Conference_By_Uid {
 
@@ -3159,7 +3216,7 @@ const char *tox_err_conference_by_uid_to_string(Tox_Err_Conference_By_Uid value)
  * @return the conference number on success, an unspecified value on failure.
  * @deprecated use tox_conference_by_id instead (exactly the same function, just renamed).
  */
-uint32_t tox_conference_by_uid(const Tox *tox, const uint8_t *uid, Tox_Err_Conference_By_Uid *error);
+Tox_Conference_Number tox_conference_by_uid(const Tox *tox, const uint8_t *uid, Tox_Err_Conference_By_Uid *error);
 
 /** @} */
 
@@ -3236,8 +3293,9 @@ const char *tox_err_friend_custom_packet_to_string(Tox_Err_Friend_Custom_Packet 
  *
  * @return true on success.
  */
-bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
-                                  Tox_Err_Friend_Custom_Packet *error);
+bool tox_friend_send_lossy_packet(
+        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length,
+        Tox_Err_Friend_Custom_Packet *error);
 
 /**
  * @brief Send a custom lossless packet to a friend.
@@ -3255,16 +3313,18 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
  *
  * @return true on success.
  */
-bool tox_friend_send_lossless_packet(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
-                                     Tox_Err_Friend_Custom_Packet *error);
+bool tox_friend_send_lossless_packet(
+        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length,
+        Tox_Err_Friend_Custom_Packet *error);
 
 /**
  * @param friend_number The friend number of the friend who sent a lossy packet.
  * @param data A byte array containing the received packet data.
  * @param length The length of the packet data byte array.
  */
-typedef void tox_friend_lossy_packet_cb(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
-                                        void *user_data);
+typedef void tox_friend_lossy_packet_cb(
+        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length,
+        void *user_data);
 
 
 /**
@@ -3279,7 +3339,8 @@ void tox_callback_friend_lossy_packet(Tox *tox, tox_friend_lossy_packet_cb *call
  * @param data A byte array containing the received packet data.
  * @param length The length of the packet data byte array.
  */
-typedef void tox_friend_lossless_packet_cb(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
+typedef void tox_friend_lossless_packet_cb(
+        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length,
         void *user_data);
 
 
@@ -3342,12 +3403,13 @@ uint16_t tox_self_get_tcp_port(const Tox *tox, Tox_Err_Get_Port *error);
 
 /** @} */
 
-/*******************************************************************************
- *
- * :: Group chats
- *
- ******************************************************************************/
+/** @{
+ * @name Group chats
+ */
 
+typedef uint32_t Tox_Group_Number;
+typedef uint32_t Tox_Group_Peer_Number;
+typedef uint32_t Tox_Group_Message_Id;
 
 
 
@@ -3359,7 +3421,7 @@ uint16_t tox_self_get_tcp_port(const Tox *tox, Tox_Err_Get_Port *error);
 
 
 
-/** @{
+/**
  * Maximum length of a group topic.
  */
 #define TOX_GROUP_MAX_TOPIC_LENGTH     512
@@ -3607,8 +3669,9 @@ const char *tox_err_group_new_to_string(Tox_Err_Group_New value);
  *
  * @return group_number on success, UINT32_MAX on failure.
  */
-uint32_t tox_group_new(Tox *tox, Tox_Group_Privacy_State privacy_state, const uint8_t *group_name,
-                       size_t group_name_length, const uint8_t *name, size_t name_length, Tox_Err_Group_New *error);
+Tox_Group_Number tox_group_new(
+        Tox *tox, Tox_Group_Privacy_State privacy_state, const uint8_t *group_name,
+        size_t group_name_length, const uint8_t *name, size_t name_length, Tox_Err_Group_New *error);
 
 typedef enum Tox_Err_Group_Join {
 
@@ -3670,8 +3733,9 @@ const char *tox_err_group_join_to_string(Tox_Err_Group_Join value);
  *
  * @return group_number on success, UINT32_MAX on failure.
  */
-uint32_t tox_group_join(Tox *tox, const uint8_t *chat_id, const uint8_t *name, size_t name_length,
-                        const uint8_t *password, size_t password_length, Tox_Err_Group_Join *error);
+Tox_Group_Number tox_group_join(
+        Tox *tox, const uint8_t *chat_id, const uint8_t *name, size_t name_length,
+        const uint8_t *password, size_t password_length, Tox_Err_Group_Join *error);
 
 typedef enum Tox_Err_Group_Is_Connected {
 
@@ -3696,7 +3760,7 @@ const char *tox_err_group_is_connected_to_string(Tox_Err_Group_Is_Connected valu
  *
  * @param group_number The group number of the designated group.
  */
-bool tox_group_is_connected(const Tox *tox, uint32_t group_number, Tox_Err_Group_Is_Connected *error);
+bool tox_group_is_connected(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_Is_Connected *error);
 
 typedef enum Tox_Err_Group_Disconnect {
 
@@ -3726,7 +3790,7 @@ const char *tox_err_group_disconnect_to_string(Tox_Err_Group_Disconnect value);
  *
  * @param group_number The group number of the designated group.
  */
-bool tox_group_disconnect(const Tox *tox, uint32_t group_number, Tox_Err_Group_Disconnect *error);
+bool tox_group_disconnect(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_Disconnect *error);
 
 typedef enum Tox_Err_Group_Reconnect {
 
@@ -3760,7 +3824,7 @@ const char *tox_err_group_reconnect_to_string(Tox_Err_Group_Reconnect value);
  *
  * @return true on success.
  */
-bool tox_group_reconnect(Tox *tox, uint32_t group_number, Tox_Err_Group_Reconnect *error);
+bool tox_group_reconnect(Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_Reconnect *error);
 
 typedef enum Tox_Err_Group_Leave {
 
@@ -3802,7 +3866,7 @@ const char *tox_err_group_leave_to_string(Tox_Err_Group_Leave value);
  *
  * @return true if the group chat instance is successfully deleted.
  */
-bool tox_group_leave(Tox *tox, uint32_t group_number, const uint8_t *part_message, size_t length,
+bool tox_group_leave(Tox *tox, Tox_Group_Number group_number, const uint8_t *part_message, size_t length,
                      Tox_Err_Group_Leave *error);
 
 
@@ -3880,7 +3944,7 @@ const char *tox_err_group_self_name_set_to_string(Tox_Err_Group_Self_Name_Set va
  *
  * @return true on success.
  */
-bool tox_group_self_set_name(const Tox *tox, uint32_t group_number, const uint8_t *name, size_t length,
+bool tox_group_self_set_name(const Tox *tox, Tox_Group_Number group_number, const uint8_t *name, size_t length,
                              Tox_Err_Group_Self_Name_Set *error);
 
 /**
@@ -3892,7 +3956,7 @@ bool tox_group_self_set_name(const Tox *tox, uint32_t group_number, const uint8_
  *
  * @see threading for concurrency implications.
  */
-size_t tox_group_self_get_name_size(const Tox *tox, uint32_t group_number, Tox_Err_Group_Self_Query *error);
+size_t tox_group_self_get_name_size(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_Self_Query *error);
 
 /**
  * Write the nickname set by tox_group_self_set_name to a byte array.
@@ -3907,7 +3971,7 @@ size_t tox_group_self_get_name_size(const Tox *tox, uint32_t group_number, Tox_E
  *
  * @return true on success.
  */
-bool tox_group_self_get_name(const Tox *tox, uint32_t group_number, uint8_t *name, Tox_Err_Group_Self_Query *error);
+bool tox_group_self_get_name(const Tox *tox, Tox_Group_Number group_number, uint8_t *name, Tox_Err_Group_Self_Query *error);
 
 /**
  * Error codes for self status setting.
@@ -3939,26 +4003,26 @@ const char *tox_err_group_self_status_set_to_string(Tox_Err_Group_Self_Status_Se
  *
  * @return true on success.
  */
-bool tox_group_self_set_status(const Tox *tox, uint32_t group_number, Tox_User_Status status,
+bool tox_group_self_set_status(const Tox *tox, Tox_Group_Number group_number, Tox_User_Status status,
                                Tox_Err_Group_Self_Status_Set *error);
 
 /**
  * returns the client's status for the group instance on success.
  * return value is unspecified on failure.
  */
-Tox_User_Status tox_group_self_get_status(const Tox *tox, uint32_t group_number, Tox_Err_Group_Self_Query *error);
+Tox_User_Status tox_group_self_get_status(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_Self_Query *error);
 
 /**
  * returns the client's role for the group instance on success.
  * return value is unspecified on failure.
  */
-Tox_Group_Role tox_group_self_get_role(const Tox *tox, uint32_t group_number, Tox_Err_Group_Self_Query *error);
+Tox_Group_Role tox_group_self_get_role(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_Self_Query *error);
 
 /**
  * returns the client's peer id for the group instance on success.
  * return value is unspecified on failure.
  */
-uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_Err_Group_Self_Query *error);
+Tox_Group_Peer_Number tox_group_self_get_peer_id(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_Self_Query *error);
 
 /**
  * Write the client's group public key designated by the given group number to a byte array.
@@ -3974,7 +4038,7 @@ uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_E
  *
  * @return true on success.
  */
-bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
+bool tox_group_self_get_public_key(const Tox *tox, Tox_Group_Number group_number, uint8_t *public_key,
                                    Tox_Err_Group_Self_Query *error);
 
 
@@ -4021,7 +4085,7 @@ const char *tox_err_group_peer_query_to_string(Tox_Err_Group_Peer_Query value);
  * The return value is equal to the `length` argument received by the last
  * `group_peer_name` callback.
  */
-size_t tox_group_peer_get_name_size(const Tox *tox, uint32_t group_number, uint32_t peer_id,
+size_t tox_group_peer_get_name_size(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
                                     Tox_Err_Group_Peer_Query *error);
 
 /**
@@ -4039,7 +4103,7 @@ size_t tox_group_peer_get_name_size(const Tox *tox, uint32_t group_number, uint3
  *
  * @return true on success.
  */
-bool tox_group_peer_get_name(const Tox *tox, uint32_t group_number, uint32_t peer_id, uint8_t *name,
+bool tox_group_peer_get_name(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, uint8_t *name,
                              Tox_Err_Group_Peer_Query *error);
 
 /**
@@ -4052,7 +4116,7 @@ bool tox_group_peer_get_name(const Tox *tox, uint32_t group_number, uint32_t pee
  * The status returned is equal to the last status received through the
  * `group_peer_status` callback.
  */
-Tox_User_Status tox_group_peer_get_status(const Tox *tox, uint32_t group_number, uint32_t peer_id,
+Tox_User_Status tox_group_peer_get_status(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
         Tox_Err_Group_Peer_Query *error);
 
 /**
@@ -4065,7 +4129,7 @@ Tox_User_Status tox_group_peer_get_status(const Tox *tox, uint32_t group_number,
  * The role returned is equal to the last role received through the
  * `group_moderation` callback.
  */
-Tox_Group_Role tox_group_peer_get_role(const Tox *tox, uint32_t group_number, uint32_t peer_id,
+Tox_Group_Role tox_group_peer_get_role(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
                                        Tox_Err_Group_Peer_Query *error);
 
 /**
@@ -4077,7 +4141,7 @@ Tox_Group_Role tox_group_peer_get_role(const Tox *tox, uint32_t group_number, ui
  * @param group_number The group number of the group we wish to query.
  * @param peer_id The ID of the peer whose connection status we wish to query.
  */
-Tox_Connection tox_group_peer_get_connection_status(const Tox *tox, uint32_t group_number, uint32_t peer_id,
+Tox_Connection tox_group_peer_get_connection_status(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
         Tox_Err_Group_Peer_Query *error);
 
 /**
@@ -4096,7 +4160,7 @@ Tox_Connection tox_group_peer_get_connection_status(const Tox *tox, uint32_t gro
  *
  * @return true on success.
  */
-bool tox_group_peer_get_public_key(const Tox *tox, uint32_t group_number, uint32_t peer_id, uint8_t *public_key,
+bool tox_group_peer_get_public_key(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, uint8_t *public_key,
                                    Tox_Err_Group_Peer_Query *error);
 
 /**
@@ -4105,7 +4169,7 @@ bool tox_group_peer_get_public_key(const Tox *tox, uint32_t group_number, uint32
  * @param name The name data.
  * @param length The length of the name.
  */
-typedef void tox_group_peer_name_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *name,
+typedef void tox_group_peer_name_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, const uint8_t *name,
                                     size_t length, void *user_data);
 
 
@@ -4121,7 +4185,7 @@ void tox_callback_group_peer_name(Tox *tox, tox_group_peer_name_cb *callback);
  * @param peer_id The ID of the peer who has changed their status.
  * @param status The new status of the peer.
  */
-typedef void tox_group_peer_status_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_User_Status status,
+typedef void tox_group_peer_status_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_User_Status status,
                                       void *user_data);
 
 
@@ -4214,7 +4278,7 @@ const char *tox_err_group_topic_set_to_string(Tox_Err_Group_Topic_Set value);
  *
  * @return true on success.
  */
-bool tox_group_set_topic(const Tox *tox, uint32_t group_number, const uint8_t *topic, size_t length,
+bool tox_group_set_topic(const Tox *tox, Tox_Group_Number group_number, const uint8_t *topic, size_t length,
                          Tox_Err_Group_Topic_Set *error);
 
 /**
@@ -4224,7 +4288,7 @@ bool tox_group_set_topic(const Tox *tox, uint32_t group_number, const uint8_t *t
  * The return value is equal to the `length` argument received by the last
  * `group_topic` callback.
  */
-size_t tox_group_get_topic_size(const Tox *tox, uint32_t group_number, Tox_Err_Group_State_Queries *error);
+size_t tox_group_get_topic_size(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_State_Queries *error);
 
 /**
  * Write the topic designated by the given group number to a byte array.
@@ -4239,7 +4303,7 @@ size_t tox_group_get_topic_size(const Tox *tox, uint32_t group_number, Tox_Err_G
  *
  * @return true on success.
  */
-bool tox_group_get_topic(const Tox *tox, uint32_t group_number, uint8_t *topic, Tox_Err_Group_State_Queries *error);
+bool tox_group_get_topic(const Tox *tox, Tox_Group_Number group_number, uint8_t *topic, Tox_Err_Group_State_Queries *error);
 
 /**
  * @param group_number The group number of the group the topic change is intended for.
@@ -4248,7 +4312,7 @@ bool tox_group_get_topic(const Tox *tox, uint32_t group_number, uint8_t *topic, 
  * @param topic The topic data.
  * @param length The topic length.
  */
-typedef void tox_group_topic_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *topic, size_t length,
+typedef void tox_group_topic_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, const uint8_t *topic, size_t length,
                                 void *user_data);
 
 
@@ -4263,7 +4327,7 @@ void tox_callback_group_topic(Tox *tox, tox_group_topic_cb *callback);
  * Return the length of the group name. If the group number is invalid, the
  * return value is unspecified.
  */
-size_t tox_group_get_name_size(const Tox *tox, uint32_t group_number, Tox_Err_Group_State_Queries *error);
+size_t tox_group_get_name_size(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_State_Queries *error);
 
 /**
  * Write the name of the group designated by the given group number to a byte array.
@@ -4275,7 +4339,7 @@ size_t tox_group_get_name_size(const Tox *tox, uint32_t group_number, Tox_Err_Gr
  *
  * @return true on success.
  */
-bool tox_group_get_name(const Tox *tox, uint32_t group_number, uint8_t *group_name, Tox_Err_Group_State_Queries *error);
+bool tox_group_get_name(const Tox *tox, Tox_Group_Number group_number, uint8_t *group_name, Tox_Err_Group_State_Queries *error);
 
 /**
  * Write the Chat ID designated by the given group number to a byte array.
@@ -4287,7 +4351,7 @@ bool tox_group_get_name(const Tox *tox, uint32_t group_number, uint8_t *group_na
  *
  * @return true on success.
  */
-bool tox_group_get_chat_id(const Tox *tox, uint32_t group_number, uint8_t *chat_id, Tox_Err_Group_State_Queries *error);
+bool tox_group_get_chat_id(const Tox *tox, Tox_Group_Number group_number, uint8_t *chat_id, Tox_Err_Group_State_Queries *error);
 
 /**
  * Return the number of groups in the Tox chats array.
@@ -4303,14 +4367,14 @@ uint32_t tox_group_get_number_groups(const Tox *tox);
  *
  * @see the `Group chat founder controls` section for the respective set function.
  */
-Tox_Group_Privacy_State tox_group_get_privacy_state(const Tox *tox, uint32_t group_number,
+Tox_Group_Privacy_State tox_group_get_privacy_state(const Tox *tox, Tox_Group_Number group_number,
         Tox_Err_Group_State_Queries *error);
 
 /**
  * @param group_number The group number of the group the privacy state is intended for.
  * @param privacy_state The new privacy state.
  */
-typedef void tox_group_privacy_state_cb(Tox *tox, uint32_t group_number, Tox_Group_Privacy_State privacy_state,
+typedef void tox_group_privacy_state_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Privacy_State privacy_state,
                                         void *user_data);
 
 
@@ -4329,14 +4393,14 @@ void tox_callback_group_privacy_state(Tox *tox, tox_group_privacy_state_cb *call
  *
  * @see the `Group chat founder controls` section for the respective set function.
  */
-Tox_Group_Voice_State tox_group_get_voice_state(const Tox *tox, uint32_t group_number,
+Tox_Group_Voice_State tox_group_get_voice_state(const Tox *tox, Tox_Group_Number group_number,
         Tox_Err_Group_State_Queries *error);
 
 /**
  * @param group_number The group number of the group the voice state change is intended for.
  * @param voice_state The new voice state.
  */
-typedef void tox_group_voice_state_cb(Tox *tox, uint32_t group_number, Tox_Group_Voice_State voice_state,
+typedef void tox_group_voice_state_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Voice_State voice_state,
                                       void *user_data);
 
 
@@ -4356,14 +4420,14 @@ void tox_callback_group_voice_state(Tox *tox, tox_group_voice_state_cb *callback
  *
  * @see the `Group chat founder contols` section for the respective set function.
  */
-Tox_Group_Topic_Lock tox_group_get_topic_lock(const Tox *tox, uint32_t group_number,
+Tox_Group_Topic_Lock tox_group_get_topic_lock(const Tox *tox, Tox_Group_Number group_number,
         Tox_Err_Group_State_Queries *error);
 
 /**
  * @param group_number The group number of the group for which the topic lock has changed.
  * @param topic_lock The new topic lock state.
  */
-typedef void tox_group_topic_lock_cb(Tox *tox, uint32_t group_number, Tox_Group_Topic_Lock topic_lock, void *user_data);
+typedef void tox_group_topic_lock_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Topic_Lock topic_lock, void *user_data);
 
 
 
@@ -4383,13 +4447,13 @@ void tox_callback_group_topic_lock(Tox *tox, tox_group_topic_lock_cb *callback);
  *
  * @see the `Group chat founder controls` section for the respective set function.
  */
-uint16_t tox_group_get_peer_limit(const Tox *tox, uint32_t group_number, Tox_Err_Group_State_Queries *error);
+uint16_t tox_group_get_peer_limit(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_State_Queries *error);
 
 /**
  * @param group_number The group number of the group for which the peer limit has changed.
  * @param peer_limit The new peer limit for the group.
  */
-typedef void tox_group_peer_limit_cb(Tox *tox, uint32_t group_number, uint32_t peer_limit, void *user_data);
+typedef void tox_group_peer_limit_cb(Tox *tox, Tox_Group_Number group_number, uint32_t peer_limit, void *user_data);
 
 
 /**
@@ -4403,7 +4467,7 @@ void tox_callback_group_peer_limit(Tox *tox, tox_group_peer_limit_cb *callback);
  * Return the length of the group password. If the group number is invalid, the
  * return value is unspecified.
  */
-size_t tox_group_get_password_size(const Tox *tox, uint32_t group_number, Tox_Err_Group_State_Queries *error);
+size_t tox_group_get_password_size(const Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_State_Queries *error);
 
 /**
  * Write the password for the group designated by the given group number to a byte array.
@@ -4420,7 +4484,7 @@ size_t tox_group_get_password_size(const Tox *tox, uint32_t group_number, Tox_Er
  *
  * @return true on success.
  */
-bool tox_group_get_password(const Tox *tox, uint32_t group_number, uint8_t *password,
+bool tox_group_get_password(const Tox *tox, Tox_Group_Number group_number, uint8_t *password,
                             Tox_Err_Group_State_Queries *error);
 
 /**
@@ -4428,7 +4492,7 @@ bool tox_group_get_password(const Tox *tox, uint32_t group_number, uint8_t *pass
  * @param password The new group password.
  * @param length The length of the password.
  */
-typedef void tox_group_password_cb(Tox *tox, uint32_t group_number, const uint8_t *password, size_t length,
+typedef void tox_group_password_cb(Tox *tox, Tox_Group_Number group_number, const uint8_t *password, size_t length,
                                    void *user_data);
 
 
@@ -4510,14 +4574,14 @@ const char *tox_err_group_send_message_to_string(Tox_Err_Group_Send_Message valu
  * @param message A non-NULL pointer to the first element of a byte array
  *   containing the message text.
  * @param length Length of the message to be sent.
- * @param message_id A pointer to a uint32_t. The message_id of this message will be returned
+ * @param message_id A pointer to a Tox_Group_Message_Id. The message_id of this message will be returned
  *   unless the parameter is NULL, in which case the returned parameter value will be undefined.
  *   If this function returns false the returned parameter `message_id` value will also be undefined.
  *
  * @return true on success.
  */
-bool tox_group_send_message(const Tox *tox, uint32_t group_number, Tox_Message_Type type, const uint8_t *message,
-                            size_t length, uint32_t *message_id, Tox_Err_Group_Send_Message *error);
+bool tox_group_send_message(const Tox *tox, Tox_Group_Number group_number, Tox_Message_Type type, const uint8_t *message,
+                            size_t length, Tox_Group_Message_Id *message_id, Tox_Err_Group_Send_Message *error);
 
 typedef enum Tox_Err_Group_Send_Private_Message {
 
@@ -4589,7 +4653,7 @@ const char *tox_err_group_send_private_message_to_string(Tox_Err_Group_Send_Priv
  *
  * @return true on success.
  */
-bool tox_group_send_private_message(const Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Message_Type type,
+bool tox_group_send_private_message(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
                                     const uint8_t *message, size_t length, Tox_Err_Group_Send_Private_Message *error);
 
 typedef enum Tox_Err_Group_Send_Custom_Packet {
@@ -4655,7 +4719,7 @@ const char *tox_err_group_send_custom_packet_to_string(Tox_Err_Group_Send_Custom
  *
  * @return true on success.
  */
-bool tox_group_send_custom_packet(const Tox *tox, uint32_t group_number, bool lossless, const uint8_t *data,
+bool tox_group_send_custom_packet(const Tox *tox, Tox_Group_Number group_number, bool lossless, const uint8_t *data,
                                   size_t length,
                                   Tox_Err_Group_Send_Custom_Packet *error);
 
@@ -4733,7 +4797,7 @@ const char *tox_err_group_send_custom_private_packet_to_string(Tox_Err_Group_Sen
  *
  * @return true on success.
  */
-bool tox_group_send_custom_private_packet(const Tox *tox, uint32_t group_number, uint32_t peer_id, bool lossless,
+bool tox_group_send_custom_private_packet(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, bool lossless,
         const uint8_t *data, size_t length,
         Tox_Err_Group_Send_Custom_Private_Packet *error);
 
@@ -4754,8 +4818,8 @@ bool tox_group_send_custom_private_packet(const Tox *tox, uint32_t group_number,
  * @param message_id A pseudo message id that clients can use to uniquely identify this group message.
  * @param length The length of the message.
  */
-typedef void tox_group_message_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Message_Type type,
-                                  const uint8_t *message, size_t length, uint32_t message_id, void *user_data);
+typedef void tox_group_message_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
+                                  const uint8_t *message, size_t length, Tox_Group_Message_Id message_id, void *user_data);
 
 
 /**
@@ -4771,7 +4835,7 @@ void tox_callback_group_message(Tox *tox, tox_group_message_cb *callback);
  * @param message The message data.
  * @param length The length of the message.
  */
-typedef void tox_group_private_message_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Message_Type type,
+typedef void tox_group_private_message_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
         const uint8_t *message, size_t length, void *user_data);
 
 
@@ -4788,7 +4852,7 @@ void tox_callback_group_private_message(Tox *tox, tox_group_private_message_cb *
  * @param data The packet data.
  * @param length The length of the data.
  */
-typedef void tox_group_custom_packet_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data,
+typedef void tox_group_custom_packet_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, const uint8_t *data,
                                         size_t length, void *user_data);
 
 
@@ -4805,7 +4869,7 @@ void tox_callback_group_custom_packet(Tox *tox, tox_group_custom_packet_cb *call
  * @param data The packet data.
  * @param length The length of the data.
  */
-typedef void tox_group_custom_private_packet_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data,
+typedef void tox_group_custom_private_packet_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, const uint8_t *data,
         size_t length, void *user_data);
 
 
@@ -4872,8 +4936,9 @@ const char *tox_err_group_invite_friend_to_string(Tox_Err_Group_Invite_Friend va
  *
  * @return true on success.
  */
-bool tox_group_invite_friend(const Tox *tox, uint32_t group_number, uint32_t friend_number,
-                             Tox_Err_Group_Invite_Friend *error);
+bool tox_group_invite_friend(
+        const Tox *tox, Tox_Group_Number group_number, Tox_Friend_Number friend_number,
+        Tox_Err_Group_Invite_Friend *error);
 
 typedef enum Tox_Err_Group_Invite_Accept {
 
@@ -4937,17 +5002,19 @@ const char *tox_err_group_invite_accept_to_string(Tox_Err_Group_Invite_Accept va
  *
  * @return the group_number on success, UINT32_MAX on failure.
  */
-uint32_t tox_group_invite_accept(Tox *tox, uint32_t friend_number, const uint8_t *invite_data, size_t length,
-                                 const uint8_t *name, size_t name_length, const uint8_t *password, size_t password_length,
-                                 Tox_Err_Group_Invite_Accept *error);
+Tox_Group_Number tox_group_invite_accept(
+        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *invite_data, size_t length,
+        const uint8_t *name, size_t name_length, const uint8_t *password, size_t password_length,
+        Tox_Err_Group_Invite_Accept *error);
 
 /**
  * @param friend_number The friend number of the contact who sent the invite.
  * @param invite_data The invite data.
  * @param length The length of invite_data.
  */
-typedef void tox_group_invite_cb(Tox *tox, uint32_t friend_number, const uint8_t *invite_data, size_t length,
-                                 const uint8_t *group_name, size_t group_name_length, void *user_data);
+typedef void tox_group_invite_cb(
+        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *invite_data, size_t length,
+        const uint8_t *group_name, size_t group_name_length, void *user_data);
 
 
 /**
@@ -4963,7 +5030,7 @@ void tox_callback_group_invite(Tox *tox, tox_group_invite_cb *callback);
  * @param peer_id The permanent ID of the new peer. This id should not be relied on for
  * client behaviour and should be treated as a random value.
  */
-typedef void tox_group_peer_join_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, void *user_data);
+typedef void tox_group_peer_join_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, void *user_data);
 
 
 /**
@@ -5024,7 +5091,7 @@ const char *tox_group_exit_type_to_string(Tox_Group_Exit_Type value);
  * @param part_message The parting message data.
  * @param part_message_length The length of the parting message.
  */
-typedef void tox_group_peer_exit_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Group_Exit_Type exit_type,
+typedef void tox_group_peer_exit_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Group_Exit_Type exit_type,
                                     const uint8_t *name, size_t name_length, const uint8_t *part_message, size_t part_message_length, void *user_data);
 
 
@@ -5038,7 +5105,7 @@ void tox_callback_group_peer_exit(Tox *tox, tox_group_peer_exit_cb *callback);
 /**
  * @param group_number The group number of the group that the client has joined.
  */
-typedef void tox_group_self_join_cb(Tox *tox, uint32_t group_number, void *user_data);
+typedef void tox_group_self_join_cb(Tox *tox, Tox_Group_Number group_number, void *user_data);
 
 
 /**
@@ -5080,7 +5147,7 @@ const char *tox_group_join_fail_to_string(Tox_Group_Join_Fail value);
  * @param group_number The group number of the group for which the join has failed.
  * @param fail_type The type of group rejection.
  */
-typedef void tox_group_join_fail_cb(Tox *tox, uint32_t group_number, Tox_Group_Join_Fail fail_type, void *user_data);
+typedef void tox_group_join_fail_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Join_Fail fail_type, void *user_data);
 
 
 /**
@@ -5153,7 +5220,7 @@ const char *tox_err_group_founder_set_password_to_string(Tox_Err_Group_Founder_S
  *
  * @return true on success.
  */
-bool tox_group_founder_set_password(const Tox *tox, uint32_t group_number, const uint8_t *password, size_t length,
+bool tox_group_founder_set_password(const Tox *tox, Tox_Group_Number group_number, const uint8_t *password, size_t length,
                                     Tox_Err_Group_Founder_Set_Password *error);
 
 typedef enum Tox_Err_Group_Founder_Set_Topic_Lock {
@@ -5213,7 +5280,7 @@ const char *tox_err_group_founder_set_topic_lock_to_string(Tox_Err_Group_Founder
  *
  * @return true on success.
  */
-bool tox_group_founder_set_topic_lock(const Tox *tox, uint32_t group_number, Tox_Group_Topic_Lock topic_lock,
+bool tox_group_founder_set_topic_lock(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Topic_Lock topic_lock,
                                       Tox_Err_Group_Founder_Set_Topic_Lock *error);
 
 typedef enum Tox_Err_Group_Founder_Set_Voice_State {
@@ -5267,7 +5334,7 @@ const char *tox_err_group_founder_set_voice_state_to_string(Tox_Err_Group_Founde
  *
  * @return true on success.
  */
-bool tox_group_founder_set_voice_state(const Tox *tox, uint32_t group_number, Tox_Group_Voice_State voice_state,
+bool tox_group_founder_set_voice_state(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Voice_State voice_state,
                                        Tox_Err_Group_Founder_Set_Voice_State *error);
 
 typedef enum Tox_Err_Group_Founder_Set_Privacy_State {
@@ -5321,7 +5388,7 @@ const char *tox_err_group_founder_set_privacy_state_to_string(Tox_Err_Group_Foun
  *
  * @return true on success.
  */
-bool tox_group_founder_set_privacy_state(const Tox *tox, uint32_t group_number, Tox_Group_Privacy_State privacy_state,
+bool tox_group_founder_set_privacy_state(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Privacy_State privacy_state,
         Tox_Err_Group_Founder_Set_Privacy_State *error);
 
 typedef enum Tox_Err_Group_Founder_Set_Peer_Limit {
@@ -5373,7 +5440,7 @@ const char *tox_err_group_founder_set_peer_limit_to_string(Tox_Err_Group_Founder
  *
  * @return true on success.
  */
-bool tox_group_founder_set_peer_limit(const Tox *tox, uint32_t group_number, uint16_t max_peers,
+bool tox_group_founder_set_peer_limit(const Tox *tox, Tox_Group_Number group_number, uint16_t max_peers,
                                       Tox_Err_Group_Founder_Set_Peer_Limit *error);
 
 
@@ -5421,7 +5488,7 @@ const char *tox_err_group_set_ignore_to_string(Tox_Err_Group_Set_Ignore value);
  *
  * @return true on success.
  */
-bool tox_group_set_ignore(const Tox *tox, uint32_t group_number, uint32_t peer_id, bool ignore,
+bool tox_group_set_ignore(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, bool ignore,
                           Tox_Err_Group_Set_Ignore *error);
 
 typedef enum Tox_Err_Group_Mod_Set_Role {
@@ -5481,7 +5548,7 @@ const char *tox_err_group_mod_set_role_to_string(Tox_Err_Group_Mod_Set_Role valu
  *
  * @return true on success.
  */
-bool tox_group_mod_set_role(const Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Group_Role role,
+bool tox_group_mod_set_role(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Group_Role role,
                             Tox_Err_Group_Mod_Set_Role *error);
 
 typedef enum Tox_Err_Group_Mod_Kick_Peer {
@@ -5538,7 +5605,7 @@ const char *tox_err_group_mod_kick_peer_to_string(Tox_Err_Group_Mod_Kick_Peer va
  *
  * @return true on success.
  */
-bool tox_group_mod_kick_peer(const Tox *tox, uint32_t group_number, uint32_t peer_id,
+bool tox_group_mod_kick_peer(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
                              Tox_Err_Group_Mod_Kick_Peer *error);
 
 /**
@@ -5577,8 +5644,9 @@ const char *tox_group_mod_event_to_string(Tox_Group_Mod_Event value);
  * @param target_peer_id The ID of the peer who is the target of the event.
  * @param mod_type The type of event.
  */
-typedef void tox_group_moderation_cb(Tox *tox, uint32_t group_number, uint32_t source_peer_id, uint32_t target_peer_id,
-                                     Tox_Group_Mod_Event mod_type, void *user_data);
+typedef void tox_group_moderation_cb(
+        Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number source_peer_id, Tox_Group_Peer_Number target_peer_id,
+        Tox_Group_Mod_Event mod_type, void *user_data);
 
 
 /**

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -994,7 +994,7 @@ const char *tox_err_bootstrap_to_string(Tox_Err_Bootstrap value);
  *   (TOX_PUBLIC_KEY_SIZE bytes).
  * @return true on success.
  */
-bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key, Tox_Err_Bootstrap *error);
+bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Bootstrap *error);
 
 /**
  * @brief Adds additional host:port pair as TCP relay.
@@ -1010,7 +1010,7 @@ bool tox_bootstrap(Tox *tox, const char *host, uint16_t port, const uint8_t *pub
  *   (TOX_PUBLIC_KEY_SIZE bytes).
  * @return true on success.
  */
-bool tox_add_tcp_relay(Tox *tox, const char *host, uint16_t port, const uint8_t *public_key, Tox_Err_Bootstrap *error);
+bool tox_add_tcp_relay(Tox *tox, const char *host, uint16_t port, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Bootstrap *error);
 
 /**
  * @brief Protocols that can be used to connect to the network or friends.
@@ -1108,7 +1108,7 @@ void tox_iterate(Tox *tox, void *user_data);
  *   parameter is NULL, this function has no effect.
  * @see TOX_ADDRESS_SIZE for the address format.
  */
-void tox_self_get_address(const Tox *tox, uint8_t *address);
+void tox_self_get_address(const Tox *tox, uint8_t address[TOX_ADDRESS_SIZE]);
 
 /**
  * @brief Set the 4-byte nospam part of the address.
@@ -1133,7 +1133,7 @@ uint32_t tox_self_get_nospam(const Tox *tox);
  * @param public_key A memory region of at least TOX_PUBLIC_KEY_SIZE bytes. If
  *   this parameter is NULL, this function has no effect.
  */
-void tox_self_get_public_key(const Tox *tox, uint8_t *public_key);
+void tox_self_get_public_key(const Tox *tox, uint8_t public_key[TOX_PUBLIC_KEY_SIZE]);
 
 /**
  * @brief Copy the Tox Secret Key from the Tox object.
@@ -1141,7 +1141,7 @@ void tox_self_get_public_key(const Tox *tox, uint8_t *public_key);
  * @param secret_key A memory region of at least TOX_SECRET_KEY_SIZE bytes. If
  *   this parameter is NULL, this function has no effect.
  */
-void tox_self_get_secret_key(const Tox *tox, uint8_t *secret_key);
+void tox_self_get_secret_key(const Tox *tox, uint8_t secret_key[TOX_SECRET_KEY_SIZE]);
 
 /** @} */
 
@@ -1220,7 +1220,8 @@ void tox_self_get_name(const Tox *tox, uint8_t *name);
  * length is 0, the status parameter is ignored (it can be NULL), and the
  * user status is set back to empty.
  */
-bool tox_self_set_status_message(Tox *tox, const uint8_t *status_message, size_t length, Tox_Err_Set_Info *error);
+bool tox_self_set_status_message(
+        Tox *tox, const uint8_t *status_message, size_t length, Tox_Err_Set_Info *error);
 
 /**
  * @brief Return the length of the current status message as passed to tox_self_set_status_message.
@@ -1346,7 +1347,8 @@ const char *tox_err_friend_add_to_string(Tox_Err_Friend_Add value);
  * @return the friend number on success, an unspecified value on failure.
  */
 Tox_Friend_Number tox_friend_add(
-        Tox *tox, const uint8_t *address, const uint8_t *message, size_t length,
+        Tox *tox, const uint8_t address[TOX_ADDRESS_SIZE],
+        const uint8_t *message, size_t length,
         Tox_Err_Friend_Add *error);
 
 /**
@@ -1368,7 +1370,7 @@ Tox_Friend_Number tox_friend_add(
  * @see tox_friend_add for a more detailed description of friend numbers.
  */
 Tox_Friend_Number tox_friend_add_norequest(
-        Tox *tox, const uint8_t *public_key, Tox_Err_Friend_Add *error);
+        Tox *tox, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Friend_Add *error);
 
 typedef enum Tox_Err_Friend_Delete {
 
@@ -1435,7 +1437,7 @@ const char *tox_err_friend_by_public_key_to_string(Tox_Err_Friend_By_Public_Key 
  * @return the friend number on success, an unspecified value on failure.
  * @param public_key A byte array containing the Public Key.
  */
-Tox_Friend_Number tox_friend_by_public_key(const Tox *tox, const uint8_t *public_key, Tox_Err_Friend_By_Public_Key *error);
+Tox_Friend_Number tox_friend_by_public_key(const Tox *tox, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Friend_By_Public_Key *error);
 
 /**
  * @brief Checks if a friend with the given friend number exists and returns true if
@@ -1488,7 +1490,7 @@ const char *tox_err_friend_get_public_key_to_string(Tox_Err_Friend_Get_Public_Ke
  * @return true on success.
  */
 bool tox_friend_get_public_key(
-        const Tox *tox, Tox_Friend_Number friend_number, uint8_t *public_key,
+        const Tox *tox, Tox_Friend_Number friend_number, uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
         Tox_Err_Friend_Get_Public_Key *error);
 
 typedef enum Tox_Err_Friend_Get_Last_Online {
@@ -1589,7 +1591,8 @@ bool tox_friend_get_name(
  *   tox_friend_get_name_size.
  */
 typedef void tox_friend_name_cb(
-        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *name, size_t length, void *user_data);
+        Tox *tox, Tox_Friend_Number friend_number,
+        const uint8_t *name, size_t length, void *user_data);
 
 
 /**
@@ -1634,7 +1637,8 @@ bool tox_friend_get_status_message(
  *   tox_friend_get_status_message_size.
  */
 typedef void tox_friend_status_message_cb(
-        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *message, size_t length, void *user_data);
+        Tox *tox, Tox_Friend_Number friend_number,
+        const uint8_t *message, size_t length, void *user_data);
 
 
 /**
@@ -1857,8 +1861,8 @@ typedef uint32_t Tox_Friend_Message_Id;
  * @param length Length of the message to be sent.
  */
 Tox_Friend_Message_Id tox_friend_send_message(
-        Tox *tox, Tox_Friend_Number friend_number, Tox_Message_Type type, const uint8_t *message,
-        size_t length, Tox_Err_Friend_Send_Message *error);
+        Tox *tox, Tox_Friend_Number friend_number, Tox_Message_Type type,
+        const uint8_t *message, size_t length, Tox_Err_Friend_Send_Message *error);
 
 /**
  * @param friend_number The friend number of the friend who received the message.
@@ -1891,8 +1895,10 @@ void tox_callback_friend_read_receipt(Tox *tox, tox_friend_read_receipt_cb *call
  * @param message The message they sent along with the request.
  * @param length The size of the message byte array.
  */
-typedef void tox_friend_request_cb(Tox *tox, const uint8_t *public_key, const uint8_t *message, size_t length,
-                                   void *user_data);
+typedef void tox_friend_request_cb(
+        Tox *tox, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
+        const uint8_t *message, size_t length,
+        void *user_data);
 
 
 /**
@@ -1910,8 +1916,8 @@ void tox_callback_friend_request(Tox *tox, tox_friend_request_cb *callback);
  * @param length The size of the message byte array.
  */
 typedef void tox_friend_message_cb(
-        Tox *tox, Tox_Friend_Number friend_number, Tox_Message_Type type, const uint8_t *message,
-        size_t length, void *user_data);
+        Tox *tox, Tox_Friend_Number friend_number, Tox_Message_Type type,
+        const uint8_t *message, size_t length, void *user_data);
 
 
 /**
@@ -1951,7 +1957,7 @@ typedef uint32_t Tox_File_Number;
  *
  * @return true if hash was not NULL.
  */
-bool tox_hash(uint8_t *hash, const uint8_t *data, size_t length);
+bool tox_hash(uint8_t hash[TOX_HASH_LENGTH], const uint8_t *data, size_t length);
 
 /**
  * @brief A list of pre-defined file kinds.
@@ -2203,7 +2209,8 @@ const char *tox_err_file_get_to_string(Tox_Err_File_Get value);
  * @return true on success.
  */
 bool tox_file_get_file_id(
-        const Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint8_t *file_id,
+        const Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number,
+        uint8_t file_id[TOX_FILE_ID_LENGTH],
         Tox_Err_File_Get *error);
 
 /** @} */
@@ -2310,8 +2317,9 @@ const char *tox_err_file_send_to_string(Tox_Err_File_Send value);
  *   should not be relied on.
  */
 Tox_File_Number tox_file_send(
-        Tox *tox, Tox_Friend_Number friend_number, uint32_t kind, uint64_t file_size, const uint8_t *file_id,
-        const uint8_t *filename, size_t filename_length, Tox_Err_File_Send *error);
+        Tox *tox, Tox_Friend_Number friend_number, uint32_t kind, uint64_t file_size,
+        const uint8_t file_id[TOX_FILE_ID_LENGTH], const uint8_t *filename, size_t filename_length,
+        Tox_Err_File_Send *error);
 
 typedef enum Tox_Err_File_Send_Chunk {
 
@@ -2385,8 +2393,8 @@ const char *tox_err_file_send_chunk_to_string(Tox_Err_File_Send_Chunk value);
  * @return true on success.
  */
 bool tox_file_send_chunk(
-        Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint64_t position, const uint8_t *data,
-        size_t length, Tox_Err_File_Send_Chunk *error);
+        Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint64_t position,
+        const uint8_t *data, size_t length, Tox_Err_File_Send_Chunk *error);
 
 /**
  * If the length parameter is 0, the file transfer is finished, and the client's
@@ -2535,8 +2543,8 @@ const char *tox_conference_type_to_string(Tox_Conference_Type value);
  * @param length The length of the cookie.
  */
 typedef void tox_conference_invite_cb(
-        Tox *tox, Tox_Friend_Number friend_number, Tox_Conference_Type type, const uint8_t *cookie,
-        size_t length, void *user_data);
+        Tox *tox, Tox_Friend_Number friend_number, Tox_Conference_Type type,
+        const uint8_t *cookie, size_t length, void *user_data);
 
 
 /**
@@ -2594,8 +2602,8 @@ void tox_callback_conference_message(Tox *tox, tox_conference_message_cb *callba
  * @param length The title length.
  */
 typedef void tox_conference_title_cb(
-        Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number, const uint8_t *title,
-        size_t length, void *user_data);
+        Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
+        const uint8_t *title, size_t length, void *user_data);
 
 
 /**
@@ -2759,8 +2767,8 @@ size_t tox_conference_peer_get_name_size(
  * @return true on success.
  */
 bool tox_conference_peer_get_name(
-        const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number, uint8_t *name,
-        Tox_Err_Conference_Peer_Query *error);
+        const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
+        uint8_t *name, Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Copy the public key of peer_number who is in conference_number to public_key.
@@ -2771,7 +2779,7 @@ bool tox_conference_peer_get_name(
  */
 bool tox_conference_peer_get_public_key(
         const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
-        uint8_t *public_key, Tox_Err_Conference_Peer_Query *error);
+        uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Return true if passed peer_number corresponds to our own.
@@ -2824,7 +2832,7 @@ bool tox_conference_offline_peer_get_name(
  */
 bool tox_conference_offline_peer_get_public_key(
         const Tox *tox, Tox_Conference_Number conference_number,
-        Tox_Conference_Peer_Number offline_peer_number, uint8_t *public_key, Tox_Err_Conference_Peer_Query *error);
+        Tox_Conference_Peer_Number offline_peer_number, uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Return a unix-time timestamp of the last time offline_peer_number was seen to be active.
@@ -2956,7 +2964,8 @@ const char *tox_err_conference_join_to_string(Tox_Err_Conference_Join value);
  * @return conference number on success, an unspecified value on failure.
  */
 Tox_Conference_Number tox_conference_join(
-        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *cookie, size_t length,
+        Tox *tox, Tox_Friend_Number friend_number,
+        const uint8_t *cookie, size_t length,
         Tox_Err_Conference_Join *error);
 
 typedef enum Tox_Err_Conference_Send_Message {
@@ -3011,8 +3020,9 @@ const char *tox_err_conference_send_message_to_string(Tox_Err_Conference_Send_Me
  * @return true on success.
  */
 bool tox_conference_send_message(
-        Tox *tox, Tox_Conference_Number conference_number, Tox_Message_Type type, const uint8_t *message,
-        size_t length, Tox_Err_Conference_Send_Message *error);
+        Tox *tox, Tox_Conference_Number conference_number, Tox_Message_Type type,
+        const uint8_t *message, size_t length,
+        Tox_Err_Conference_Send_Message *error);
 
 typedef enum Tox_Err_Conference_Title {
 
@@ -3066,7 +3076,8 @@ size_t tox_conference_get_title_size(
  * @return true on success.
  */
 bool tox_conference_get_title(
-        const Tox *tox, Tox_Conference_Number conference_number, uint8_t *title,
+        const Tox *tox, Tox_Conference_Number conference_number,
+        uint8_t *title,
         Tox_Err_Conference_Title *error);
 
 /**
@@ -3077,7 +3088,8 @@ bool tox_conference_get_title(
  * @return true on success.
  */
 bool tox_conference_set_title(
-        Tox *tox, Tox_Conference_Number conference_number, const uint8_t *title, size_t length,
+        Tox *tox, Tox_Conference_Number conference_number,
+        const uint8_t *title, size_t length,
         Tox_Err_Conference_Title *error);
 
 /**
@@ -3141,7 +3153,8 @@ Tox_Conference_Type tox_conference_get_type(
  *
  * @return true on success.
  */
-bool tox_conference_get_id(const Tox *tox, Tox_Conference_Number conference_number, uint8_t *id);
+bool tox_conference_get_id(
+        const Tox *tox, Tox_Conference_Number conference_number, uint8_t id[TOX_CONFERENCE_ID_SIZE]);
 
 typedef enum Tox_Err_Conference_By_Id {
 
@@ -3172,7 +3185,8 @@ const char *tox_err_conference_by_id_to_string(Tox_Err_Conference_By_Id value);
  *
  * @return the conference number on success, an unspecified value on failure.
  */
-Tox_Conference_Number tox_conference_by_id(const Tox *tox, const uint8_t *id, Tox_Err_Conference_By_Id *error);
+Tox_Conference_Number tox_conference_by_id(
+        const Tox *tox, const uint8_t id[TOX_CONFERENCE_ID_SIZE], Tox_Err_Conference_By_Id *error);
 
 /**
  * @brief Get the conference unique ID.
@@ -3184,7 +3198,8 @@ Tox_Conference_Number tox_conference_by_id(const Tox *tox, const uint8_t *id, To
  * @return true on success.
  * @deprecated use tox_conference_get_id instead (exactly the same function, just renamed).
  */
-bool tox_conference_get_uid(const Tox *tox, Tox_Conference_Number conference_number, uint8_t *uid);
+bool tox_conference_get_uid(
+        const Tox *tox, Tox_Conference_Number conference_number, uint8_t uid[TOX_CONFERENCE_UID_SIZE]);
 
 typedef enum Tox_Err_Conference_By_Uid {
 
@@ -3216,7 +3231,8 @@ const char *tox_err_conference_by_uid_to_string(Tox_Err_Conference_By_Uid value)
  * @return the conference number on success, an unspecified value on failure.
  * @deprecated use tox_conference_by_id instead (exactly the same function, just renamed).
  */
-Tox_Conference_Number tox_conference_by_uid(const Tox *tox, const uint8_t *uid, Tox_Err_Conference_By_Uid *error);
+Tox_Conference_Number tox_conference_by_uid(
+        const Tox *tox, const uint8_t uid[TOX_CONFERENCE_UID_SIZE], Tox_Err_Conference_By_Uid *error);
 
 /** @} */
 
@@ -3294,7 +3310,8 @@ const char *tox_err_friend_custom_packet_to_string(Tox_Err_Friend_Custom_Packet 
  * @return true on success.
  */
 bool tox_friend_send_lossy_packet(
-        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length,
+        Tox *tox, Tox_Friend_Number friend_number,
+        const uint8_t *data, size_t length,
         Tox_Err_Friend_Custom_Packet *error);
 
 /**
@@ -3314,7 +3331,8 @@ bool tox_friend_send_lossy_packet(
  * @return true on success.
  */
 bool tox_friend_send_lossless_packet(
-        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length,
+        Tox *tox, Tox_Friend_Number friend_number,
+        const uint8_t *data, size_t length,
         Tox_Err_Friend_Custom_Packet *error);
 
 /**
@@ -3323,7 +3341,8 @@ bool tox_friend_send_lossless_packet(
  * @param length The length of the packet data byte array.
  */
 typedef void tox_friend_lossy_packet_cb(
-        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length,
+        Tox *tox, Tox_Friend_Number friend_number,
+        const uint8_t *data, size_t length,
         void *user_data);
 
 
@@ -3340,7 +3359,8 @@ void tox_callback_friend_lossy_packet(Tox *tox, tox_friend_lossy_packet_cb *call
  * @param length The length of the packet data byte array.
  */
 typedef void tox_friend_lossless_packet_cb(
-        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length,
+        Tox *tox, Tox_Friend_Number friend_number,
+        const uint8_t *data, size_t length,
         void *user_data);
 
 
@@ -3387,7 +3407,7 @@ const char *tox_err_get_port_to_string(Tox_Err_Get_Port value);
  * @param dht_id A memory region of at least TOX_PUBLIC_KEY_SIZE bytes. If this
  *   parameter is NULL, this function has no effect.
  */
-void tox_self_get_dht_id(const Tox *tox, uint8_t *dht_id);
+void tox_self_get_dht_id(const Tox *tox, uint8_t dht_id[TOX_PUBLIC_KEY_SIZE]);
 
 /**
  * @brief Return the UDP port this Tox instance is bound to.
@@ -3670,8 +3690,9 @@ const char *tox_err_group_new_to_string(Tox_Err_Group_New value);
  * @return group_number on success, UINT32_MAX on failure.
  */
 Tox_Group_Number tox_group_new(
-        Tox *tox, Tox_Group_Privacy_State privacy_state, const uint8_t *group_name,
-        size_t group_name_length, const uint8_t *name, size_t name_length, Tox_Err_Group_New *error);
+        Tox *tox, Tox_Group_Privacy_State privacy_state,
+        const uint8_t *group_name, size_t group_name_length,
+        const uint8_t *name, size_t name_length, Tox_Err_Group_New *error);
 
 typedef enum Tox_Err_Group_Join {
 
@@ -3734,8 +3755,10 @@ const char *tox_err_group_join_to_string(Tox_Err_Group_Join value);
  * @return group_number on success, UINT32_MAX on failure.
  */
 Tox_Group_Number tox_group_join(
-        Tox *tox, const uint8_t *chat_id, const uint8_t *name, size_t name_length,
-        const uint8_t *password, size_t password_length, Tox_Err_Group_Join *error);
+        Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+        const uint8_t *name, size_t name_length,
+        const uint8_t *password, size_t password_length,
+        Tox_Err_Group_Join *error);
 
 typedef enum Tox_Err_Group_Is_Connected {
 
@@ -3866,8 +3889,10 @@ const char *tox_err_group_leave_to_string(Tox_Err_Group_Leave value);
  *
  * @return true if the group chat instance is successfully deleted.
  */
-bool tox_group_leave(Tox *tox, Tox_Group_Number group_number, const uint8_t *part_message, size_t length,
-                     Tox_Err_Group_Leave *error);
+bool tox_group_leave(
+        Tox *tox, Tox_Group_Number group_number,
+        const uint8_t *part_message, size_t length,
+        Tox_Err_Group_Leave *error);
 
 
 /*******************************************************************************
@@ -3944,8 +3969,10 @@ const char *tox_err_group_self_name_set_to_string(Tox_Err_Group_Self_Name_Set va
  *
  * @return true on success.
  */
-bool tox_group_self_set_name(const Tox *tox, Tox_Group_Number group_number, const uint8_t *name, size_t length,
-                             Tox_Err_Group_Self_Name_Set *error);
+bool tox_group_self_set_name(
+        const Tox *tox, Tox_Group_Number group_number,
+        const uint8_t *name, size_t length,
+        Tox_Err_Group_Self_Name_Set *error);
 
 /**
  * Return the length of the client's current nickname for the group instance designated
@@ -3971,7 +3998,9 @@ size_t tox_group_self_get_name_size(const Tox *tox, Tox_Group_Number group_numbe
  *
  * @return true on success.
  */
-bool tox_group_self_get_name(const Tox *tox, Tox_Group_Number group_number, uint8_t *name, Tox_Err_Group_Self_Query *error);
+bool tox_group_self_get_name(
+        const Tox *tox, Tox_Group_Number group_number,
+        uint8_t *name, Tox_Err_Group_Self_Query *error);
 
 /**
  * Error codes for self status setting.
@@ -4038,7 +4067,7 @@ Tox_Group_Peer_Number tox_group_self_get_peer_id(const Tox *tox, Tox_Group_Numbe
  *
  * @return true on success.
  */
-bool tox_group_self_get_public_key(const Tox *tox, Tox_Group_Number group_number, uint8_t *public_key,
+bool tox_group_self_get_public_key(const Tox *tox, Tox_Group_Number group_number, uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
                                    Tox_Err_Group_Self_Query *error);
 
 
@@ -4103,8 +4132,9 @@ size_t tox_group_peer_get_name_size(const Tox *tox, Tox_Group_Number group_numbe
  *
  * @return true on success.
  */
-bool tox_group_peer_get_name(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, uint8_t *name,
-                             Tox_Err_Group_Peer_Query *error);
+bool tox_group_peer_get_name(
+        const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
+        uint8_t *name, Tox_Err_Group_Peer_Query *error);
 
 /**
  * Return the peer's user status (away/busy/...). If the ID or group number is
@@ -4160,8 +4190,9 @@ Tox_Connection tox_group_peer_get_connection_status(const Tox *tox, Tox_Group_Nu
  *
  * @return true on success.
  */
-bool tox_group_peer_get_public_key(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, uint8_t *public_key,
-                                   Tox_Err_Group_Peer_Query *error);
+bool tox_group_peer_get_public_key(
+        const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
+        uint8_t public_key[TOX_PUBLIC_KEY_SIZE], Tox_Err_Group_Peer_Query *error);
 
 /**
  * @param group_number The group number of the group the name change is intended for.
@@ -4169,8 +4200,9 @@ bool tox_group_peer_get_public_key(const Tox *tox, Tox_Group_Number group_number
  * @param name The name data.
  * @param length The length of the name.
  */
-typedef void tox_group_peer_name_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, const uint8_t *name,
-                                    size_t length, void *user_data);
+typedef void tox_group_peer_name_cb(
+        Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
+        const uint8_t *name, size_t length, void *user_data);
 
 
 /**
@@ -4278,8 +4310,10 @@ const char *tox_err_group_topic_set_to_string(Tox_Err_Group_Topic_Set value);
  *
  * @return true on success.
  */
-bool tox_group_set_topic(const Tox *tox, Tox_Group_Number group_number, const uint8_t *topic, size_t length,
-                         Tox_Err_Group_Topic_Set *error);
+bool tox_group_set_topic(
+        const Tox *tox, Tox_Group_Number group_number,
+        const uint8_t *topic, size_t length,
+        Tox_Err_Group_Topic_Set *error);
 
 /**
  * Return the length of the group topic. If the group number is invalid, the
@@ -4303,7 +4337,9 @@ size_t tox_group_get_topic_size(const Tox *tox, Tox_Group_Number group_number, T
  *
  * @return true on success.
  */
-bool tox_group_get_topic(const Tox *tox, Tox_Group_Number group_number, uint8_t *topic, Tox_Err_Group_State_Queries *error);
+bool tox_group_get_topic(
+        const Tox *tox, Tox_Group_Number group_number,
+        uint8_t *topic, Tox_Err_Group_State_Queries *error);
 
 /**
  * @param group_number The group number of the group the topic change is intended for.
@@ -4312,8 +4348,10 @@ bool tox_group_get_topic(const Tox *tox, Tox_Group_Number group_number, uint8_t 
  * @param topic The topic data.
  * @param length The topic length.
  */
-typedef void tox_group_topic_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, const uint8_t *topic, size_t length,
-                                void *user_data);
+typedef void tox_group_topic_cb(
+        Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
+        const uint8_t *topic, size_t length,
+        void *user_data);
 
 
 /**
@@ -4339,7 +4377,9 @@ size_t tox_group_get_name_size(const Tox *tox, Tox_Group_Number group_number, To
  *
  * @return true on success.
  */
-bool tox_group_get_name(const Tox *tox, Tox_Group_Number group_number, uint8_t *group_name, Tox_Err_Group_State_Queries *error);
+bool tox_group_get_name(
+        const Tox *tox, Tox_Group_Number group_number,
+        uint8_t *group_name, Tox_Err_Group_State_Queries *error);
 
 /**
  * Write the Chat ID designated by the given group number to a byte array.
@@ -4351,7 +4391,9 @@ bool tox_group_get_name(const Tox *tox, Tox_Group_Number group_number, uint8_t *
  *
  * @return true on success.
  */
-bool tox_group_get_chat_id(const Tox *tox, Tox_Group_Number group_number, uint8_t *chat_id, Tox_Err_Group_State_Queries *error);
+bool tox_group_get_chat_id(
+        const Tox *tox, Tox_Group_Number group_number, uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+        Tox_Err_Group_State_Queries *error);
 
 /**
  * Return the number of groups in the Tox chats array.
@@ -4484,16 +4526,19 @@ size_t tox_group_get_password_size(const Tox *tox, Tox_Group_Number group_number
  *
  * @return true on success.
  */
-bool tox_group_get_password(const Tox *tox, Tox_Group_Number group_number, uint8_t *password,
-                            Tox_Err_Group_State_Queries *error);
+bool tox_group_get_password(
+        const Tox *tox, Tox_Group_Number group_number, uint8_t *password,
+        Tox_Err_Group_State_Queries *error);
 
 /**
  * @param group_number The group number of the group for which the password has changed.
  * @param password The new group password.
  * @param length The length of the password.
  */
-typedef void tox_group_password_cb(Tox *tox, Tox_Group_Number group_number, const uint8_t *password, size_t length,
-                                   void *user_data);
+typedef void tox_group_password_cb(
+        Tox *tox, Tox_Group_Number group_number,
+        const uint8_t *password, size_t length,
+        void *user_data);
 
 
 /**
@@ -4580,8 +4625,10 @@ const char *tox_err_group_send_message_to_string(Tox_Err_Group_Send_Message valu
  *
  * @return true on success.
  */
-bool tox_group_send_message(const Tox *tox, Tox_Group_Number group_number, Tox_Message_Type type, const uint8_t *message,
-                            size_t length, Tox_Group_Message_Id *message_id, Tox_Err_Group_Send_Message *error);
+bool tox_group_send_message(
+        const Tox *tox, Tox_Group_Number group_number, Tox_Message_Type type,
+        const uint8_t *message, size_t length, Tox_Group_Message_Id *message_id,
+        Tox_Err_Group_Send_Message *error);
 
 typedef enum Tox_Err_Group_Send_Private_Message {
 
@@ -4653,8 +4700,10 @@ const char *tox_err_group_send_private_message_to_string(Tox_Err_Group_Send_Priv
  *
  * @return true on success.
  */
-bool tox_group_send_private_message(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
-                                    const uint8_t *message, size_t length, Tox_Err_Group_Send_Private_Message *error);
+bool tox_group_send_private_message(
+        const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
+        const uint8_t *message, size_t length,
+        Tox_Err_Group_Send_Private_Message *error);
 
 typedef enum Tox_Err_Group_Send_Custom_Packet {
 
@@ -4719,9 +4768,10 @@ const char *tox_err_group_send_custom_packet_to_string(Tox_Err_Group_Send_Custom
  *
  * @return true on success.
  */
-bool tox_group_send_custom_packet(const Tox *tox, Tox_Group_Number group_number, bool lossless, const uint8_t *data,
-                                  size_t length,
-                                  Tox_Err_Group_Send_Custom_Packet *error);
+bool tox_group_send_custom_packet(
+        const Tox *tox, Tox_Group_Number group_number, bool lossless,
+        const uint8_t *data, size_t length,
+        Tox_Err_Group_Send_Custom_Packet *error);
 
 
 typedef enum Tox_Err_Group_Send_Custom_Private_Packet {
@@ -4818,8 +4868,9 @@ bool tox_group_send_custom_private_packet(const Tox *tox, Tox_Group_Number group
  * @param message_id A pseudo message id that clients can use to uniquely identify this group message.
  * @param length The length of the message.
  */
-typedef void tox_group_message_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
-                                  const uint8_t *message, size_t length, Tox_Group_Message_Id message_id, void *user_data);
+typedef void tox_group_message_cb(
+        Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
+        const uint8_t *message, size_t length, Tox_Group_Message_Id message_id, void *user_data);
 
 
 /**
@@ -4835,7 +4886,8 @@ void tox_callback_group_message(Tox *tox, tox_group_message_cb *callback);
  * @param message The message data.
  * @param length The length of the message.
  */
-typedef void tox_group_private_message_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
+typedef void tox_group_private_message_cb(
+        Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
         const uint8_t *message, size_t length, void *user_data);
 
 
@@ -4852,8 +4904,9 @@ void tox_callback_group_private_message(Tox *tox, tox_group_private_message_cb *
  * @param data The packet data.
  * @param length The length of the data.
  */
-typedef void tox_group_custom_packet_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, const uint8_t *data,
-                                        size_t length, void *user_data);
+typedef void tox_group_custom_packet_cb(
+        Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
+        const uint8_t *data, size_t length, void *user_data);
 
 
 /**
@@ -4869,8 +4922,9 @@ void tox_callback_group_custom_packet(Tox *tox, tox_group_custom_packet_cb *call
  * @param data The packet data.
  * @param length The length of the data.
  */
-typedef void tox_group_custom_private_packet_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, const uint8_t *data,
-        size_t length, void *user_data);
+typedef void tox_group_custom_private_packet_cb(
+        Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
+        const uint8_t *data, size_t length, void *user_data);
 
 
 /**
@@ -5003,8 +5057,10 @@ const char *tox_err_group_invite_accept_to_string(Tox_Err_Group_Invite_Accept va
  * @return the group_number on success, UINT32_MAX on failure.
  */
 Tox_Group_Number tox_group_invite_accept(
-        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *invite_data, size_t length,
-        const uint8_t *name, size_t name_length, const uint8_t *password, size_t password_length,
+        Tox *tox, Tox_Friend_Number friend_number,
+        const uint8_t *invite_data, size_t length,
+        const uint8_t *name, size_t name_length,
+        const uint8_t *password, size_t password_length,
         Tox_Err_Group_Invite_Accept *error);
 
 /**
@@ -5013,8 +5069,10 @@ Tox_Group_Number tox_group_invite_accept(
  * @param length The length of invite_data.
  */
 typedef void tox_group_invite_cb(
-        Tox *tox, Tox_Friend_Number friend_number, const uint8_t *invite_data, size_t length,
-        const uint8_t *group_name, size_t group_name_length, void *user_data);
+        Tox *tox, Tox_Friend_Number friend_number,
+        const uint8_t *invite_data, size_t length,
+        const uint8_t *group_name, size_t group_name_length,
+        void *user_data);
 
 
 /**
@@ -5091,8 +5149,10 @@ const char *tox_group_exit_type_to_string(Tox_Group_Exit_Type value);
  * @param part_message The parting message data.
  * @param part_message_length The length of the parting message.
  */
-typedef void tox_group_peer_exit_cb(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Group_Exit_Type exit_type,
-                                    const uint8_t *name, size_t name_length, const uint8_t *part_message, size_t part_message_length, void *user_data);
+typedef void tox_group_peer_exit_cb(
+        Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Group_Exit_Type exit_type,
+        const uint8_t *name, size_t name_length,
+        const uint8_t *part_message, size_t part_message_length, void *user_data);
 
 
 /**
@@ -5220,8 +5280,10 @@ const char *tox_err_group_founder_set_password_to_string(Tox_Err_Group_Founder_S
  *
  * @return true on success.
  */
-bool tox_group_founder_set_password(const Tox *tox, Tox_Group_Number group_number, const uint8_t *password, size_t length,
-                                    Tox_Err_Group_Founder_Set_Password *error);
+bool tox_group_founder_set_password(
+        const Tox *tox, Tox_Group_Number group_number,
+        const uint8_t *password, size_t length,
+        Tox_Err_Group_Founder_Set_Password *error);
 
 typedef enum Tox_Err_Group_Founder_Set_Topic_Lock {
 


### PR DESCRIPTION
These make it clearer which kinds of `uint32_t` can fit in which functions. It also makes it easier to generate higher level bindings without doing a lot of inference/heuristics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2518)
<!-- Reviewable:end -->
