### PR TITLE
refactor: Align group message sending with other send functions.

### DIFF
--- a/auto_tests/group_message_test.c
+++ b/auto_tests/group_message_test.c
@@ -395,8 +395,9 @@ static void group_message_test(AutoTox *autotoxes)
         iterate_all_wait(autotoxes, NUM_GROUP_TOXES, ITERATION_INTERVAL);
 
         if (state1->peer_joined && !state1->message_sent) {
-            tox_group_send_message(tox1, group_number, TOX_MESSAGE_TYPE_NORMAL, (const uint8_t *)TEST_MESSAGE,
-                                   TEST_MESSAGE_LEN, &state1->pseudo_msg_id, &err_send);
+            state1->pseudo_msg_id = tox_group_send_message(
+                    tox1, group_number, TOX_MESSAGE_TYPE_NORMAL, (const uint8_t *)TEST_MESSAGE,
+                    TEST_MESSAGE_LEN, &err_send);
             ck_assert(err_send == TOX_ERR_GROUP_SEND_MESSAGE_OK);
             state1->message_sent = true;
         }
@@ -419,7 +420,7 @@ static void group_message_test(AutoTox *autotoxes)
 
     // tox1 sends group a message which should not be seen by tox0's message handler
     tox_group_send_message(tox1, group_number, TOX_MESSAGE_TYPE_NORMAL, (const uint8_t *)IGNORE_MESSAGE,
-                           IGNORE_MESSAGE_LEN, nullptr, &err_send);
+                           IGNORE_MESSAGE_LEN, &err_send);
 
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, ITERATION_INTERVAL);
 
@@ -506,7 +507,7 @@ static void group_message_test(AutoTox *autotoxes)
 
         memcpy(m + 2, &checksum, sizeof(uint16_t));
 
-        tox_group_send_message(tox0, group_number, TOX_MESSAGE_TYPE_NORMAL, (const uint8_t *)m, message_size, nullptr, &err_send);
+        tox_group_send_message(tox0, group_number, TOX_MESSAGE_TYPE_NORMAL, (const uint8_t *)m, message_size, &err_send);
 
         ck_assert(err_send == TOX_ERR_GROUP_SEND_MESSAGE_OK);
     }
@@ -528,7 +529,7 @@ static void group_message_test(AutoTox *autotoxes)
 
         memcpy(m, &i, sizeof(uint16_t));
 
-        tox_group_send_message(tox0, group_number, TOX_MESSAGE_TYPE_NORMAL, (const uint8_t *)m, 2, nullptr, &err_send);
+        tox_group_send_message(tox0, group_number, TOX_MESSAGE_TYPE_NORMAL, (const uint8_t *)m, 2, &err_send);
         ck_assert(err_send == TOX_ERR_GROUP_SEND_MESSAGE_OK);
     }
 

--- a/auto_tests/group_moderation_test.c
+++ b/auto_tests/group_moderation_test.c
@@ -334,21 +334,21 @@ static void voice_state_message_test(AutoTox *autotox, Tox_Group_Voice_State voi
     ck_assert(sq_err == TOX_ERR_GROUP_SELF_QUERY_OK);
 
     Tox_Err_Group_Send_Message msg_err;
-    bool send_ret = tox_group_send_message(autotox->tox, state->group_number, TOX_MESSAGE_TYPE_NORMAL,
-                                           (const uint8_t *)"test", 4, nullptr, &msg_err);
+    tox_group_send_message(autotox->tox, state->group_number, TOX_MESSAGE_TYPE_NORMAL,
+                           (const uint8_t *)"test", 4, &msg_err);
 
     switch (self_role) {
         case TOX_GROUP_ROLE_OBSERVER: {
-            ck_assert(!send_ret && msg_err == TOX_ERR_GROUP_SEND_MESSAGE_PERMISSIONS);
+            ck_assert(msg_err == TOX_ERR_GROUP_SEND_MESSAGE_PERMISSIONS);
             break;
         }
 
         case TOX_GROUP_ROLE_USER: {
             if (voice_state != TOX_GROUP_VOICE_STATE_ALL) {
-                ck_assert_msg(!send_ret && msg_err == TOX_ERR_GROUP_SEND_MESSAGE_PERMISSIONS,
-                              "%d, %d", send_ret, msg_err);
+                ck_assert_msg(msg_err == TOX_ERR_GROUP_SEND_MESSAGE_PERMISSIONS,
+                              "%d", msg_err);
             } else {
-                ck_assert(send_ret && msg_err == TOX_ERR_GROUP_SEND_MESSAGE_OK);
+                ck_assert(msg_err == TOX_ERR_GROUP_SEND_MESSAGE_OK);
             }
 
             break;
@@ -356,16 +356,16 @@ static void voice_state_message_test(AutoTox *autotox, Tox_Group_Voice_State voi
 
         case TOX_GROUP_ROLE_MODERATOR: {
             if (voice_state != TOX_GROUP_VOICE_STATE_FOUNDER) {
-                ck_assert(send_ret && msg_err == TOX_ERR_GROUP_SEND_MESSAGE_OK);
+                ck_assert(msg_err == TOX_ERR_GROUP_SEND_MESSAGE_OK);
             } else {
-                ck_assert(!send_ret && msg_err == TOX_ERR_GROUP_SEND_MESSAGE_PERMISSIONS);
+                ck_assert(msg_err == TOX_ERR_GROUP_SEND_MESSAGE_PERMISSIONS);
             }
 
             break;
         }
 
         case TOX_GROUP_ROLE_FOUNDER: {
-            ck_assert(send_ret && msg_err == TOX_ERR_GROUP_SEND_MESSAGE_OK);
+            ck_assert(msg_err == TOX_ERR_GROUP_SEND_MESSAGE_OK);
             break;
         }
     }

--- a/auto_tests/group_tcp_test.c
+++ b/auto_tests/group_tcp_test.c
@@ -206,7 +206,7 @@ static void group_tcp_test(AutoTox *autotoxes)
 
     Tox_Err_Group_Send_Message merr;
     tox_group_send_message(autotoxes[0].tox, groupnumber, TOX_MESSAGE_TYPE_NORMAL,
-                           (const uint8_t *)CODEWORD, CODEWORD_LEN, nullptr, &merr);
+                           (const uint8_t *)CODEWORD, CODEWORD_LEN, &merr);
     ck_assert(merr == TOX_ERR_GROUP_SEND_MESSAGE_OK);
 
     while (!state1->got_second_code) {

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-0030bf6448655c3299a8f0552cae1f78340db9cec33e2e479aad497ec3c03de4  /usr/local/bin/tox-bootstrapd
+0ac3f502265ed3c2a4fb2971d1f7b92ad20f900b8daa64b828fd5994c3d4af9d  /usr/local/bin/tox-bootstrapd

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -4619,15 +4619,13 @@ const char *tox_err_group_send_message_to_string(Tox_Err_Group_Send_Message valu
  * @param message A non-NULL pointer to the first element of a byte array
  *   containing the message text.
  * @param length Length of the message to be sent.
- * @param message_id A pointer to a Tox_Group_Message_Id. The message_id of this message will be returned
- *   unless the parameter is NULL, in which case the returned parameter value will be undefined.
- *   If this function returns false the returned parameter `message_id` value will also be undefined.
  *
- * @return true on success.
+ * @return The message_id of this message. If this function has an error, the
+ *   returned message ID value will be undefined.
  */
-bool tox_group_send_message(
+Tox_Group_Message_Id tox_group_send_message(
         const Tox *tox, Tox_Group_Number group_number, Tox_Message_Type type,
-        const uint8_t message[], size_t length, Tox_Group_Message_Id *message_id,
+        const uint8_t message[], size_t length,
         Tox_Err_Group_Send_Message *error);
 
 typedef enum Tox_Err_Group_Send_Private_Message {


### PR DESCRIPTION
None of the others use out parameters. Also no toxcore function uses out parameters for anything other than arrays and errors. This would be a first, for no good reason.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2519)
<!-- Reviewable:end -->
