### PR TITLE
cleanup: Mark arrays in the tox API as `[]` instead of `*`.

### DIFF
--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -752,7 +752,7 @@ void tox_options_set_savedata_type(struct Tox_Options *options, Tox_Savedata_Typ
 
 const uint8_t *tox_options_get_savedata_data(const struct Tox_Options *options);
 
-void tox_options_set_savedata_data(struct Tox_Options *options, const uint8_t *data, size_t length);
+void tox_options_set_savedata_data(struct Tox_Options *options, const uint8_t data[], size_t length);
 
 size_t tox_options_get_savedata_length(const struct Tox_Options *options);
 
@@ -941,7 +941,7 @@ size_t tox_get_savedata_size(const Tox *tox);
  *   data. Call tox_get_savedata_size to find the number of bytes required. If this parameter
  *   is NULL, this function has no effect.
  */
-void tox_get_savedata(const Tox *tox, uint8_t *savedata);
+void tox_get_savedata(const Tox *tox, uint8_t savedata[]);
 
 /** @} */
 
@@ -1187,7 +1187,7 @@ const char *tox_err_set_info_to_string(Tox_Err_Set_Info value);
  *
  * @return true on success.
  */
-bool tox_self_set_name(Tox *tox, const uint8_t *name, size_t length, Tox_Err_Set_Info *error);
+bool tox_self_set_name(Tox *tox, const uint8_t name[], size_t length, Tox_Err_Set_Info *error);
 
 /**
  * @brief Return the length of the current nickname as passed to tox_self_set_name.
@@ -1211,7 +1211,7 @@ size_t tox_self_get_name_size(const Tox *tox);
  * @param name A valid memory location large enough to hold the nickname.
  *   If this parameter is NULL, the function has no effect.
  */
-void tox_self_get_name(const Tox *tox, uint8_t *name);
+void tox_self_get_name(const Tox *tox, uint8_t name[]);
 
 /**
  * @brief Set the client's status message.
@@ -1221,7 +1221,7 @@ void tox_self_get_name(const Tox *tox, uint8_t *name);
  * user status is set back to empty.
  */
 bool tox_self_set_status_message(
-        Tox *tox, const uint8_t *status_message, size_t length, Tox_Err_Set_Info *error);
+        Tox *tox, const uint8_t status_message[], size_t length, Tox_Err_Set_Info *error);
 
 /**
  * @brief Return the length of the current status message as passed to tox_self_set_status_message.
@@ -1245,7 +1245,7 @@ size_t tox_self_get_status_message_size(const Tox *tox);
  * @param status_message A valid memory location large enough to hold the
  *   status message. If this parameter is NULL, the function has no effect.
  */
-void tox_self_get_status_message(const Tox *tox, uint8_t *status_message);
+void tox_self_get_status_message(const Tox *tox, uint8_t status_message[]);
 
 /**
  * @brief Set the client's user status.
@@ -1348,7 +1348,7 @@ const char *tox_err_friend_add_to_string(Tox_Err_Friend_Add value);
  */
 Tox_Friend_Number tox_friend_add(
         Tox *tox, const uint8_t address[TOX_ADDRESS_SIZE],
-        const uint8_t *message, size_t length,
+        const uint8_t message[], size_t length,
         Tox_Err_Friend_Add *error);
 
 /**
@@ -1461,7 +1461,7 @@ size_t tox_self_get_friend_list_size(const Tox *tox);
  * @param friend_list A memory region with enough space to hold the friend
  *   list. If this parameter is NULL, this function has no effect.
  */
-void tox_self_get_friend_list(const Tox *tox, Tox_Friend_Number *friend_list);
+void tox_self_get_friend_list(const Tox *tox, Tox_Friend_Number friend_list[]);
 
 typedef enum Tox_Err_Friend_Get_Public_Key {
 
@@ -1581,7 +1581,7 @@ size_t tox_friend_get_name_size(
  * @return true on success.
  */
 bool tox_friend_get_name(
-        const Tox *tox, Tox_Friend_Number friend_number, uint8_t *name, Tox_Err_Friend_Query *error);
+        const Tox *tox, Tox_Friend_Number friend_number, uint8_t name[], Tox_Err_Friend_Query *error);
 
 /**
  * @param friend_number The friend number of the friend whose name changed.
@@ -1592,7 +1592,7 @@ bool tox_friend_get_name(
  */
 typedef void tox_friend_name_cb(
         Tox *tox, Tox_Friend_Number friend_number,
-        const uint8_t *name, size_t length, void *user_data);
+        const uint8_t name[], size_t length, void *user_data);
 
 
 /**
@@ -1625,7 +1625,7 @@ size_t tox_friend_get_status_message_size(
  * @param status_message A valid memory region large enough to store the friend's status message.
  */
 bool tox_friend_get_status_message(
-        const Tox *tox, Tox_Friend_Number friend_number, uint8_t *status_message,
+        const Tox *tox, Tox_Friend_Number friend_number, uint8_t status_message[],
         Tox_Err_Friend_Query *error);
 
 /**
@@ -1638,7 +1638,7 @@ bool tox_friend_get_status_message(
  */
 typedef void tox_friend_status_message_cb(
         Tox *tox, Tox_Friend_Number friend_number,
-        const uint8_t *message, size_t length, void *user_data);
+        const uint8_t message[], size_t length, void *user_data);
 
 
 /**
@@ -1862,7 +1862,7 @@ typedef uint32_t Tox_Friend_Message_Id;
  */
 Tox_Friend_Message_Id tox_friend_send_message(
         Tox *tox, Tox_Friend_Number friend_number, Tox_Message_Type type,
-        const uint8_t *message, size_t length, Tox_Err_Friend_Send_Message *error);
+        const uint8_t message[], size_t length, Tox_Err_Friend_Send_Message *error);
 
 /**
  * @param friend_number The friend number of the friend who received the message.
@@ -1897,7 +1897,7 @@ void tox_callback_friend_read_receipt(Tox *tox, tox_friend_read_receipt_cb *call
  */
 typedef void tox_friend_request_cb(
         Tox *tox, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
-        const uint8_t *message, size_t length,
+        const uint8_t message[], size_t length,
         void *user_data);
 
 
@@ -1917,7 +1917,7 @@ void tox_callback_friend_request(Tox *tox, tox_friend_request_cb *callback);
  */
 typedef void tox_friend_message_cb(
         Tox *tox, Tox_Friend_Number friend_number, Tox_Message_Type type,
-        const uint8_t *message, size_t length, void *user_data);
+        const uint8_t message[], size_t length, void *user_data);
 
 
 /**
@@ -1957,7 +1957,7 @@ typedef uint32_t Tox_File_Number;
  *
  * @return true if hash was not NULL.
  */
-bool tox_hash(uint8_t hash[TOX_HASH_LENGTH], const uint8_t *data, size_t length);
+bool tox_hash(uint8_t hash[TOX_HASH_LENGTH], const uint8_t data[], size_t length);
 
 /**
  * @brief A list of pre-defined file kinds.
@@ -2318,7 +2318,7 @@ const char *tox_err_file_send_to_string(Tox_Err_File_Send value);
  */
 Tox_File_Number tox_file_send(
         Tox *tox, Tox_Friend_Number friend_number, uint32_t kind, uint64_t file_size,
-        const uint8_t file_id[TOX_FILE_ID_LENGTH], const uint8_t *filename, size_t filename_length,
+        const uint8_t file_id[TOX_FILE_ID_LENGTH], const uint8_t filename[], size_t filename_length,
         Tox_Err_File_Send *error);
 
 typedef enum Tox_Err_File_Send_Chunk {
@@ -2394,7 +2394,7 @@ const char *tox_err_file_send_chunk_to_string(Tox_Err_File_Send_Chunk value);
  */
 bool tox_file_send_chunk(
         Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint64_t position,
-        const uint8_t *data, size_t length, Tox_Err_File_Send_Chunk *error);
+        const uint8_t data[], size_t length, Tox_Err_File_Send_Chunk *error);
 
 /**
  * If the length parameter is 0, the file transfer is finished, and the client's
@@ -2459,7 +2459,7 @@ void tox_callback_file_chunk_request(Tox *tox, tox_file_chunk_request_cb *callba
  */
 typedef void tox_file_recv_cb(
         Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint32_t kind, uint64_t file_size,
-        const uint8_t *filename, size_t filename_length, void *user_data);
+        const uint8_t filename[], size_t filename_length, void *user_data);
 
 
 /**
@@ -2489,7 +2489,7 @@ void tox_callback_file_recv(Tox *tox, tox_file_recv_cb *callback);
  */
 typedef void tox_file_recv_chunk_cb(
         Tox *tox, Tox_Friend_Number friend_number, Tox_File_Number file_number, uint64_t position,
-        const uint8_t *data, size_t length, void *user_data);
+        const uint8_t data[], size_t length, void *user_data);
 
 
 /**
@@ -2544,7 +2544,7 @@ const char *tox_conference_type_to_string(Tox_Conference_Type value);
  */
 typedef void tox_conference_invite_cb(
         Tox *tox, Tox_Friend_Number friend_number, Tox_Conference_Type type,
-        const uint8_t *cookie, size_t length, void *user_data);
+        const uint8_t cookie[], size_t length, void *user_data);
 
 
 /**
@@ -2582,7 +2582,7 @@ void tox_callback_conference_connected(Tox *tox, tox_conference_connected_cb *ca
  */
 typedef void tox_conference_message_cb(
         Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
-        Tox_Message_Type type, const uint8_t *message, size_t length, void *user_data);
+        Tox_Message_Type type, const uint8_t message[], size_t length, void *user_data);
 
 
 /**
@@ -2603,7 +2603,7 @@ void tox_callback_conference_message(Tox *tox, tox_conference_message_cb *callba
  */
 typedef void tox_conference_title_cb(
         Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
-        const uint8_t *title, size_t length, void *user_data);
+        const uint8_t title[], size_t length, void *user_data);
 
 
 /**
@@ -2626,7 +2626,7 @@ void tox_callback_conference_title(Tox *tox, tox_conference_title_cb *callback);
  */
 typedef void tox_conference_peer_name_cb(
         Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
-        const uint8_t *name, size_t length, void *user_data);
+        const uint8_t name[], size_t length, void *user_data);
 
 
 /**
@@ -2768,7 +2768,7 @@ size_t tox_conference_peer_get_name_size(
  */
 bool tox_conference_peer_get_name(
         const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number peer_number,
-        uint8_t *name, Tox_Err_Conference_Peer_Query *error);
+        uint8_t name[], Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Copy the public key of peer_number who is in conference_number to public_key.
@@ -2821,7 +2821,7 @@ size_t tox_conference_offline_peer_get_name_size(
  */
 bool tox_conference_offline_peer_get_name(
         const Tox *tox, Tox_Conference_Number conference_number, Tox_Conference_Peer_Number offline_peer_number,
-        uint8_t *name, Tox_Err_Conference_Peer_Query *error);
+        uint8_t name[], Tox_Err_Conference_Peer_Query *error);
 
 /**
  * @brief Copy the public key of offline_peer_number who is in conference_number to public_key.
@@ -2965,7 +2965,7 @@ const char *tox_err_conference_join_to_string(Tox_Err_Conference_Join value);
  */
 Tox_Conference_Number tox_conference_join(
         Tox *tox, Tox_Friend_Number friend_number,
-        const uint8_t *cookie, size_t length,
+        const uint8_t cookie[], size_t length,
         Tox_Err_Conference_Join *error);
 
 typedef enum Tox_Err_Conference_Send_Message {
@@ -3021,7 +3021,7 @@ const char *tox_err_conference_send_message_to_string(Tox_Err_Conference_Send_Me
  */
 bool tox_conference_send_message(
         Tox *tox, Tox_Conference_Number conference_number, Tox_Message_Type type,
-        const uint8_t *message, size_t length,
+        const uint8_t message[], size_t length,
         Tox_Err_Conference_Send_Message *error);
 
 typedef enum Tox_Err_Conference_Title {
@@ -3077,7 +3077,7 @@ size_t tox_conference_get_title_size(
  */
 bool tox_conference_get_title(
         const Tox *tox, Tox_Conference_Number conference_number,
-        uint8_t *title,
+        uint8_t title[],
         Tox_Err_Conference_Title *error);
 
 /**
@@ -3089,7 +3089,7 @@ bool tox_conference_get_title(
  */
 bool tox_conference_set_title(
         Tox *tox, Tox_Conference_Number conference_number,
-        const uint8_t *title, size_t length,
+        const uint8_t title[], size_t length,
         Tox_Err_Conference_Title *error);
 
 /**
@@ -3113,7 +3113,7 @@ size_t tox_conference_get_chatlist_size(const Tox *tox);
  * The conference number of a loaded conference may differ from the conference
  * number it had when it was saved.
  */
-void tox_conference_get_chatlist(const Tox *tox, Tox_Conference_Number *chatlist);
+void tox_conference_get_chatlist(const Tox *tox, Tox_Conference_Number chatlist[]);
 
 /**
  * @brief Returns the type of conference (Tox_Conference_Type) that conference_number is.
@@ -3311,7 +3311,7 @@ const char *tox_err_friend_custom_packet_to_string(Tox_Err_Friend_Custom_Packet 
  */
 bool tox_friend_send_lossy_packet(
         Tox *tox, Tox_Friend_Number friend_number,
-        const uint8_t *data, size_t length,
+        const uint8_t data[], size_t length,
         Tox_Err_Friend_Custom_Packet *error);
 
 /**
@@ -3332,7 +3332,7 @@ bool tox_friend_send_lossy_packet(
  */
 bool tox_friend_send_lossless_packet(
         Tox *tox, Tox_Friend_Number friend_number,
-        const uint8_t *data, size_t length,
+        const uint8_t data[], size_t length,
         Tox_Err_Friend_Custom_Packet *error);
 
 /**
@@ -3342,7 +3342,7 @@ bool tox_friend_send_lossless_packet(
  */
 typedef void tox_friend_lossy_packet_cb(
         Tox *tox, Tox_Friend_Number friend_number,
-        const uint8_t *data, size_t length,
+        const uint8_t data[], size_t length,
         void *user_data);
 
 
@@ -3360,7 +3360,7 @@ void tox_callback_friend_lossy_packet(Tox *tox, tox_friend_lossy_packet_cb *call
  */
 typedef void tox_friend_lossless_packet_cb(
         Tox *tox, Tox_Friend_Number friend_number,
-        const uint8_t *data, size_t length,
+        const uint8_t data[], size_t length,
         void *user_data);
 
 
@@ -3691,8 +3691,8 @@ const char *tox_err_group_new_to_string(Tox_Err_Group_New value);
  */
 Tox_Group_Number tox_group_new(
         Tox *tox, Tox_Group_Privacy_State privacy_state,
-        const uint8_t *group_name, size_t group_name_length,
-        const uint8_t *name, size_t name_length, Tox_Err_Group_New *error);
+        const uint8_t group_name[], size_t group_name_length,
+        const uint8_t name[], size_t name_length, Tox_Err_Group_New *error);
 
 typedef enum Tox_Err_Group_Join {
 
@@ -3756,8 +3756,8 @@ const char *tox_err_group_join_to_string(Tox_Err_Group_Join value);
  */
 Tox_Group_Number tox_group_join(
         Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
-        const uint8_t *name, size_t name_length,
-        const uint8_t *password, size_t password_length,
+        const uint8_t name[], size_t name_length,
+        const uint8_t password[], size_t password_length,
         Tox_Err_Group_Join *error);
 
 typedef enum Tox_Err_Group_Is_Connected {
@@ -3891,7 +3891,7 @@ const char *tox_err_group_leave_to_string(Tox_Err_Group_Leave value);
  */
 bool tox_group_leave(
         Tox *tox, Tox_Group_Number group_number,
-        const uint8_t *part_message, size_t length,
+        const uint8_t part_message[], size_t length,
         Tox_Err_Group_Leave *error);
 
 
@@ -3971,7 +3971,7 @@ const char *tox_err_group_self_name_set_to_string(Tox_Err_Group_Self_Name_Set va
  */
 bool tox_group_self_set_name(
         const Tox *tox, Tox_Group_Number group_number,
-        const uint8_t *name, size_t length,
+        const uint8_t name[], size_t length,
         Tox_Err_Group_Self_Name_Set *error);
 
 /**
@@ -4000,7 +4000,7 @@ size_t tox_group_self_get_name_size(const Tox *tox, Tox_Group_Number group_numbe
  */
 bool tox_group_self_get_name(
         const Tox *tox, Tox_Group_Number group_number,
-        uint8_t *name, Tox_Err_Group_Self_Query *error);
+        uint8_t name[], Tox_Err_Group_Self_Query *error);
 
 /**
  * Error codes for self status setting.
@@ -4134,7 +4134,7 @@ size_t tox_group_peer_get_name_size(const Tox *tox, Tox_Group_Number group_numbe
  */
 bool tox_group_peer_get_name(
         const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
-        uint8_t *name, Tox_Err_Group_Peer_Query *error);
+        uint8_t name[], Tox_Err_Group_Peer_Query *error);
 
 /**
  * Return the peer's user status (away/busy/...). If the ID or group number is
@@ -4202,7 +4202,7 @@ bool tox_group_peer_get_public_key(
  */
 typedef void tox_group_peer_name_cb(
         Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
-        const uint8_t *name, size_t length, void *user_data);
+        const uint8_t name[], size_t length, void *user_data);
 
 
 /**
@@ -4312,7 +4312,7 @@ const char *tox_err_group_topic_set_to_string(Tox_Err_Group_Topic_Set value);
  */
 bool tox_group_set_topic(
         const Tox *tox, Tox_Group_Number group_number,
-        const uint8_t *topic, size_t length,
+        const uint8_t topic[], size_t length,
         Tox_Err_Group_Topic_Set *error);
 
 /**
@@ -4339,7 +4339,7 @@ size_t tox_group_get_topic_size(const Tox *tox, Tox_Group_Number group_number, T
  */
 bool tox_group_get_topic(
         const Tox *tox, Tox_Group_Number group_number,
-        uint8_t *topic, Tox_Err_Group_State_Queries *error);
+        uint8_t topic[], Tox_Err_Group_State_Queries *error);
 
 /**
  * @param group_number The group number of the group the topic change is intended for.
@@ -4350,7 +4350,7 @@ bool tox_group_get_topic(
  */
 typedef void tox_group_topic_cb(
         Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
-        const uint8_t *topic, size_t length,
+        const uint8_t topic[], size_t length,
         void *user_data);
 
 
@@ -4379,7 +4379,7 @@ size_t tox_group_get_name_size(const Tox *tox, Tox_Group_Number group_number, To
  */
 bool tox_group_get_name(
         const Tox *tox, Tox_Group_Number group_number,
-        uint8_t *group_name, Tox_Err_Group_State_Queries *error);
+        uint8_t group_name[], Tox_Err_Group_State_Queries *error);
 
 /**
  * Write the Chat ID designated by the given group number to a byte array.
@@ -4527,7 +4527,7 @@ size_t tox_group_get_password_size(const Tox *tox, Tox_Group_Number group_number
  * @return true on success.
  */
 bool tox_group_get_password(
-        const Tox *tox, Tox_Group_Number group_number, uint8_t *password,
+        const Tox *tox, Tox_Group_Number group_number, uint8_t password[],
         Tox_Err_Group_State_Queries *error);
 
 /**
@@ -4537,7 +4537,7 @@ bool tox_group_get_password(
  */
 typedef void tox_group_password_cb(
         Tox *tox, Tox_Group_Number group_number,
-        const uint8_t *password, size_t length,
+        const uint8_t password[], size_t length,
         void *user_data);
 
 
@@ -4627,7 +4627,7 @@ const char *tox_err_group_send_message_to_string(Tox_Err_Group_Send_Message valu
  */
 bool tox_group_send_message(
         const Tox *tox, Tox_Group_Number group_number, Tox_Message_Type type,
-        const uint8_t *message, size_t length, Tox_Group_Message_Id *message_id,
+        const uint8_t message[], size_t length, Tox_Group_Message_Id *message_id,
         Tox_Err_Group_Send_Message *error);
 
 typedef enum Tox_Err_Group_Send_Private_Message {
@@ -4702,7 +4702,7 @@ const char *tox_err_group_send_private_message_to_string(Tox_Err_Group_Send_Priv
  */
 bool tox_group_send_private_message(
         const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
-        const uint8_t *message, size_t length,
+        const uint8_t message[], size_t length,
         Tox_Err_Group_Send_Private_Message *error);
 
 typedef enum Tox_Err_Group_Send_Custom_Packet {
@@ -4770,7 +4770,7 @@ const char *tox_err_group_send_custom_packet_to_string(Tox_Err_Group_Send_Custom
  */
 bool tox_group_send_custom_packet(
         const Tox *tox, Tox_Group_Number group_number, bool lossless,
-        const uint8_t *data, size_t length,
+        const uint8_t data[], size_t length,
         Tox_Err_Group_Send_Custom_Packet *error);
 
 
@@ -4848,7 +4848,7 @@ const char *tox_err_group_send_custom_private_packet_to_string(Tox_Err_Group_Sen
  * @return true on success.
  */
 bool tox_group_send_custom_private_packet(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, bool lossless,
-        const uint8_t *data, size_t length,
+        const uint8_t data[], size_t length,
         Tox_Err_Group_Send_Custom_Private_Packet *error);
 
 
@@ -4870,7 +4870,7 @@ bool tox_group_send_custom_private_packet(const Tox *tox, Tox_Group_Number group
  */
 typedef void tox_group_message_cb(
         Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
-        const uint8_t *message, size_t length, Tox_Group_Message_Id message_id, void *user_data);
+        const uint8_t message[], size_t length, Tox_Group_Message_Id message_id, void *user_data);
 
 
 /**
@@ -4888,7 +4888,7 @@ void tox_callback_group_message(Tox *tox, tox_group_message_cb *callback);
  */
 typedef void tox_group_private_message_cb(
         Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
-        const uint8_t *message, size_t length, void *user_data);
+        const uint8_t message[], size_t length, void *user_data);
 
 
 /**
@@ -4906,7 +4906,7 @@ void tox_callback_group_private_message(Tox *tox, tox_group_private_message_cb *
  */
 typedef void tox_group_custom_packet_cb(
         Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
-        const uint8_t *data, size_t length, void *user_data);
+        const uint8_t data[], size_t length, void *user_data);
 
 
 /**
@@ -4924,7 +4924,7 @@ void tox_callback_group_custom_packet(Tox *tox, tox_group_custom_packet_cb *call
  */
 typedef void tox_group_custom_private_packet_cb(
         Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
-        const uint8_t *data, size_t length, void *user_data);
+        const uint8_t data[], size_t length, void *user_data);
 
 
 /**
@@ -5058,9 +5058,9 @@ const char *tox_err_group_invite_accept_to_string(Tox_Err_Group_Invite_Accept va
  */
 Tox_Group_Number tox_group_invite_accept(
         Tox *tox, Tox_Friend_Number friend_number,
-        const uint8_t *invite_data, size_t length,
-        const uint8_t *name, size_t name_length,
-        const uint8_t *password, size_t password_length,
+        const uint8_t invite_data[], size_t length,
+        const uint8_t name[], size_t name_length,
+        const uint8_t password[], size_t password_length,
         Tox_Err_Group_Invite_Accept *error);
 
 /**
@@ -5070,8 +5070,8 @@ Tox_Group_Number tox_group_invite_accept(
  */
 typedef void tox_group_invite_cb(
         Tox *tox, Tox_Friend_Number friend_number,
-        const uint8_t *invite_data, size_t length,
-        const uint8_t *group_name, size_t group_name_length,
+        const uint8_t invite_data[], size_t length,
+        const uint8_t group_name[], size_t group_name_length,
         void *user_data);
 
 
@@ -5151,8 +5151,8 @@ const char *tox_group_exit_type_to_string(Tox_Group_Exit_Type value);
  */
 typedef void tox_group_peer_exit_cb(
         Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Group_Exit_Type exit_type,
-        const uint8_t *name, size_t name_length,
-        const uint8_t *part_message, size_t part_message_length, void *user_data);
+        const uint8_t name[], size_t name_length,
+        const uint8_t part_message[], size_t part_message_length, void *user_data);
 
 
 /**
@@ -5282,7 +5282,7 @@ const char *tox_err_group_founder_set_password_to_string(Tox_Err_Group_Founder_S
  */
 bool tox_group_founder_set_password(
         const Tox *tox, Tox_Group_Number group_number,
-        const uint8_t *password, size_t length,
+        const uint8_t password[], size_t length,
         Tox_Err_Group_Founder_Set_Password *error);
 
 typedef enum Tox_Err_Group_Founder_Set_Topic_Lock {


### PR DESCRIPTION
This makes it clearer what is actually a pointer (i.e. the `this` pointer or the `error` pointer) vs. what is an array.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2520)
<!-- Reviewable:end -->
