### PR TITLE
cleanup: Move `tox_get_system` out of the public API.

### DIFF
--- a/auto_tests/tox_dispatch_test.c
+++ b/auto_tests/tox_dispatch_test.c
@@ -10,6 +10,7 @@
 #include "../toxcore/tox.h"
 #include "../toxcore/tox_dispatch.h"
 #include "../toxcore/tox_events.h"
+#include "../toxcore/tox_private.h"
 #include "../toxcore/tox_unpack.h"
 #include "auto_test_support.h"
 #include "check_compat.h"

--- a/testing/fuzzing/protodump_reduce.cc
+++ b/testing/fuzzing/protodump_reduce.cc
@@ -4,6 +4,7 @@
 #include "../../toxcore/tox.h"
 #include "../../toxcore/tox_dispatch.h"
 #include "../../toxcore/tox_events.h"
+#include "../../toxcore/tox_private.h"
 #include "fuzz_support.h"
 #include "fuzz_tox.h"
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -922,8 +922,6 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error);
  */
 void tox_kill(Tox *tox);
 
-const Tox_System *tox_get_system(Tox *tox);
-
 /**
  * @brief Calculates the number of bytes required to store the tox instance with
  *   tox_get_savedata.

--- a/toxcore/tox_private.h
+++ b/toxcore/tox_private.h
@@ -31,6 +31,8 @@ Tox_System tox_default_system(void);
 void tox_lock(const Tox *tox);
 void tox_unlock(const Tox *tox);
 
+const Tox_System *tox_get_system(Tox *tox);
+
 /**
  * Set the callback for the `friend_lossy_packet` event for a specific packet ID.
  * Pass NULL to unset.


### PR DESCRIPTION
It's not released, yet, and this function is a pain. We don't want it going forward.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2523)
<!-- Reviewable:end -->
