### PR TITLE
cleanup: Add Toxav alias for ToxAV.

### DIFF
--- a/toxav/toxav.h
+++ b/toxav/toxav.h
@@ -843,6 +843,7 @@ bool toxav_groupchat_av_enabled(Tox *tox, uint32_t groupnumber);
 //!TOKSTYLE-
 #ifndef DOXYGEN_IGNORE
 
+typedef ToxAV Toxav;
 typedef Toxav_Err_Call TOXAV_ERR_CALL;
 typedef Toxav_Err_New TOXAV_ERR_NEW;
 typedef Toxav_Err_Answer TOXAV_ERR_ANSWER;


### PR DESCRIPTION
ToxAV does not comply with naming standards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2527)
<!-- Reviewable:end -->
