### PR TITLE
refactor: Minor refactoring of get_close_nodes functions.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-a8e6d6d075090f4e6d27f59dd2e859a152948b3fac7f0b073386172339ec5d8d  /usr/local/bin/tox-bootstrapd
+7e86d4f1c4aadce01a03153f2101ac1486f6de65f824b7b0cccbbfbf832c180a  /usr/local/bin/tox-bootstrapd

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -384,18 +384,20 @@ void set_announce_node(DHT *dht, const uint8_t *public_key);
 #endif
 
 /**
- * Get the (maximum MAX_SENT_NODES) closest nodes to public_key we know
+ * @brief Get the (maximum MAX_SENT_NODES) closest nodes to public_key we know
  * and put them in nodes_list (must be MAX_SENT_NODES big).
  *
- * sa_family = family (IPv4 or IPv6) (0 if we don't care)?
- * is_LAN = return some LAN ips (true or false)
- * want_announce: return only nodes which implement the dht announcements protocol.
+ * @param sa_family family (IPv4 or IPv6) (0 if we don't care)?
+ * @param is_lan return some LAN ips (true or false).
+ * @param want_announce return only nodes which implement the dht announcements protocol.
  *
  * @return the number of nodes returned.
  */
 non_null()
-int get_close_nodes(const DHT *dht, const uint8_t *public_key, Node_format *nodes_list, Family sa_family,
-                    bool is_lan, bool want_announce);
+int get_close_nodes(
+        const DHT *dht, const uint8_t *public_key,
+        Node_format *nodes_list, Family sa_family,
+        bool is_lan, bool want_announce);
 
 
 /** @brief Put up to max_num nodes in nodes from the random friends.

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -92,6 +92,9 @@ struct TCP_Server {
     BS_List accepted_key_list;
 };
 
+static_assert(sizeof(TCP_Server) < 7 * 1024 * 1024,
+              "TCP_Server struct should not grow more; it's already 6MB");
+
 const uint8_t *tcp_server_public_key(const TCP_Server *tcp_server)
 {
     return tcp_server->public_key;


### PR DESCRIPTION
Avoiding passing down the entire DHT struct pointer to the inner functions makes it possible in the future to write unit tests without having to construct a full DHT object.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2539)
<!-- Reviewable:end -->
