### PR TITLE
cleanup: Make group packet entry creation less error-prone

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-423687bc6adc323174a2ab4e2ee8443e6c21c4d6509942af469b4bc16db6bfa4  /usr/local/bin/tox-bootstrapd
+c98b35f18f351c9a3a05137e69a43e634ab5963d364b9337e89ad89469ebd8c2  /usr/local/bin/tox-bootstrapd


### PR DESCRIPTION
We always assumed that create_array_entry() would only be called with an empty array entry and wouldn't modify entries on error. We now explicitly require both conditions, and also give an error in the case of a non-null data pointer with a zero length field, as this indicates a logic error.

Checks for an empty array entry that precede a call to create_array_entry() are now redundant. It should be noted that a non-empty entry doesn't necessarily indicate an error. This condition can be triggered if packets are being sent or received faster than they can be processed/acknowledged, which is common when spamming messages on poor connections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2540)
<!-- Reviewable:end -->
