### PR TITLE
fix: don't pass garbage data buffer to packet send functions

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-d5061af781d04d17bf26174c129b6149e0c8a120ef41133a51a8a7cc5e571e37  /usr/local/bin/tox-bootstrapd
+a8e6d6d075090f4e6d27f59dd2e859a152948b3fac7f0b073386172339ec5d8d  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -2107,16 +2107,17 @@ static int handle_gc_tcp_relays(GC_Chat *chat, GC_Connection *gconn, const uint8
 non_null()
 static bool send_gc_invite_request(const GC_Chat *chat, GC_Connection *gconn)
 {
-    uint16_t length = 0;
+    if (!chat_is_password_protected(chat)) {
+        return send_lossless_group_packet(chat, gconn, nullptr, 0, GP_INVITE_REQUEST);
+    }
+
     uint8_t data[sizeof(uint16_t) + MAX_GC_PASSWORD_SIZE];
 
-    if (chat_is_password_protected(chat)) {
-        net_pack_u16(data, chat->shared_state.password_length);
-        length += sizeof(uint16_t);
+    net_pack_u16(data, chat->shared_state.password_length);
+    uint16_t length = sizeof(uint16_t);
 
-        memcpy(data + length, chat->shared_state.password, MAX_GC_PASSWORD_SIZE);
-        length += MAX_GC_PASSWORD_SIZE;
-    }
+    memcpy(data + length, chat->shared_state.password, MAX_GC_PASSWORD_SIZE);
+    length += MAX_GC_PASSWORD_SIZE;
 
     return send_lossless_group_packet(chat, gconn, data, length, GP_INVITE_REQUEST);
 }


### PR DESCRIPTION
This garbage data was never looked at due to passing a zero length along with it, but it's still undesirable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2541)
<!-- Reviewable:end -->
