### PR TITLE
refactor: packet broadcast functions now return errors

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-7e86d4f1c4aadce01a03153f2101ac1486f6de65f824b7b0cccbbfbf832c180a  /usr/local/bin/tox-bootstrapd
+423687bc6adc323174a2ab4e2ee8443e6c21c4d6509942af469b4bc16db6bfa4  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -190,6 +190,7 @@ int gc_send_private_message(const GC_Chat *chat, uint32_t peer_id, uint8_t type,
  * Returns -1 if the message is too long.
  * Returns -2 if the message pointer is NULL or length is zero.
  * Returns -3 if the sender has the observer role.
+ * Returns -4 if the packet did not successfully send to any peer.
  */
 non_null()
 int gc_send_custom_packet(const GC_Chat *chat, bool lossless, const uint8_t *data, uint16_t length);

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -4021,6 +4021,11 @@ bool tox_group_send_custom_packet(const Tox *tox, uint32_t group_number, bool lo
             SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SEND_CUSTOM_PACKET_PERMISSIONS);
             return false;
         }
+
+        case -4: {
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SEND_CUSTOM_PACKET_FAIL_SEND);
+            return false;
+        }
     }
 
     /* can't happen */

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -4736,6 +4736,12 @@ typedef enum Tox_Err_Group_Send_Custom_Packet {
      */
     TOX_ERR_GROUP_SEND_CUSTOM_PACKET_DISCONNECTED,
 
+    /**
+     * The packet did not successfully send to any peer. This often indicates
+     * a connection issue on the sender's side.
+     */
+    TOX_ERR_GROUP_SEND_CUSTOM_PACKET_FAIL_SEND,
+
 } Tox_Err_Group_Send_Custom_Packet;
 
 const char *tox_err_group_send_custom_packet_to_string(Tox_Err_Group_Send_Custom_Packet value);

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -1259,6 +1259,9 @@ const char *tox_err_group_send_custom_packet_to_string(Tox_Err_Group_Send_Custom
 
         case TOX_ERR_GROUP_SEND_CUSTOM_PACKET_DISCONNECTED:
             return "TOX_ERR_GROUP_SEND_CUSTOM_PACKET_DISCONNECTED";
+
+        case TOX_ERR_GROUP_SEND_CUSTOM_PACKET_FAIL_SEND:
+            return "TOX_ERR_GROUP_SEND_CUSTOM_PACKET_FAIL_SEND";
     }
 
     return "<invalid Tox_Err_Group_Send_Custom_Packet>";


### PR DESCRIPTION
We now return an error if our broadcast packets fail to send for every peer in the group.

This introduces an API change via an additional error case for custom group packets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2542)
<!-- Reviewable:end -->
