### PR TITLE
refactor: Use `operator==` for equality tests of `Node_format`.

### DIFF
--- a/other/docker/windows/Dockerfile
+++ b/other/docker/windows/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye-slim
 
 # Build-time environment variables
 ARG VERSION_MSGPACK=4.0.0 \
-    VERSION_SODIUM=1.0.18 \
+    VERSION_SODIUM=1.0.19 \
     VERSION_OPUS=1.3.1 \
     VERSION_VPX=1.11.0 \
  \

--- a/other/docker/windows/build_dependencies.sh
+++ b/other/docker/windows/build_dependencies.sh
@@ -40,9 +40,9 @@ build() {
 
   echo
   echo "=== Building Sodium $VERSION_SODIUM $ARCH ==="
-  curl "${CURL_OPTIONS[@]}" -O "https://download.libsodium.org/libsodium/releases/libsodium-$VERSION_SODIUM.tar.gz"
+  curl "${CURL_OPTIONS[@]}" -O "https://github.com/jedisct1/libsodium/releases/download/$VERSION_SODIUM-RELEASE/libsodium-$VERSION_SODIUM.tar.gz"
   tar -xf "libsodium-$VERSION_SODIUM.tar.gz"
-  cd "libsodium-$VERSION_SODIUM"
+  cd "libsodium-stable"
   ./configure --host="$WINDOWS_TOOLCHAIN" --prefix="$PREFIX_DIR" --disable-shared --enable-static
   make
   make install

--- a/toxcore/DHT_test_util.cc
+++ b/toxcore/DHT_test_util.cc
@@ -17,7 +17,8 @@ Node_format random_node_format(const Random *rng)
 
 bool operator==(Node_format const &a, Node_format const &b)
 {
-    return std::memcmp(&a, &b, sizeof(Node_format)) == 0;
+    return std::memcmp(a.public_key, b.public_key, sizeof(a.public_key)) == 0
+        && a.ip_port == b.ip_port;
 }
 
 std::ostream &operator<<(std::ostream &out, Node_format const &v)

--- a/toxcore/network_test_util.cc
+++ b/toxcore/network_test_util.cc
@@ -27,6 +27,30 @@ IP_Port random_ip_port(const Random *rng)
     return ip_port;
 }
 
+bool operator==(Family const &a, Family const &b) { return a.value == b.value; }
+
+bool operator==(IP4 const &a, IP4 const &b) { return a.uint32 == b.uint32; }
+
+bool operator==(IP6 const &a, IP6 const &b)
+{
+    return a.uint64[0] == b.uint64[0] && a.uint64[1] == b.uint64[1];
+}
+
+bool operator==(IP const &a, IP const &b)
+{
+    if (!(a.family == b.family)) {
+        return false;
+    }
+
+    if (net_family_is_ipv4(a.family)) {
+        return a.ip.v4 == b.ip.v4;
+    } else {
+        return a.ip.v6 == b.ip.v6;
+    }
+}
+
+bool operator==(IP_Port const &a, IP_Port const &b) { return a.ip == b.ip && a.port == b.port; }
+
 std::ostream &operator<<(std::ostream &out, IP const &v)
 {
     Ip_Ntoa ip_str;

--- a/toxcore/network_test_util.hh
+++ b/toxcore/network_test_util.hh
@@ -26,6 +26,13 @@ public:
     IP_Port operator()();
 };
 
+bool operator==(Family const &a, Family const &b);
+
+bool operator==(IP4 const &a, IP4 const &b);
+bool operator==(IP6 const &a, IP6 const &b);
+bool operator==(IP const &a, IP const &b);
+bool operator==(IP_Port const &a, IP_Port const &b);
+
 std::ostream &operator<<(std::ostream &out, IP const &v);
 std::ostream &operator<<(std::ostream &out, IP_Port const &v);
 


### PR DESCRIPTION
It has padding bytes, so memcmp isn't necessarily safe. It is definitely unsafe for fuzzed node formats.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2545)
<!-- Reviewable:end -->
