### PR TITLE
fix: issues with packet broadcast error reporting

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-c98b35f18f351c9a3a05137e69a43e634ab5963d364b9337e89ad89469ebd8c2  /usr/local/bin/tox-bootstrapd
+a6701e463517907cdb450f3210389633feb6c1cc3a1d3faec48c8b99a4aebf3c  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -143,11 +143,11 @@ bool gcc_send_packet(const GC_Chat *chat, const GC_Connection *gconn, const uint
 /** @brief Sends a lossless packet to `gconn` comprised of `data` of size `length`.
  *
  * This function will add the packet to the lossless send array, encrypt/wrap it using the
- * shared key associated with `gconn`, and send it over the wire.
+ * shared key associated with `gconn`, and try to send it over the wire.
  *
- * Return 0 on success.
+ * Return 0 if the packet was successfully encrypted and added to the send array.
  * Return -1 if the packet couldn't be added to the send array.
- * Return -2 if the packet failed to be encrypted or failed to send.
+ * Return -2 if the packet failed to be wrapped or encrypted.
  */
 non_null(1, 2) nullable(3)
 int gcc_send_lossless_packet(const GC_Chat *chat, GC_Connection *gconn, const uint8_t *data, uint16_t length,
@@ -172,11 +172,13 @@ bool gcc_send_lossless_packet_fragments(const GC_Chat *chat, GC_Connection *gcon
  *
  * This function does not add the packet to the send array.
  *
- * Return true on success.
+ * Return 0 on success.
+ * Return -1 if packet wrapping and encryption fails.
+ * Return -2 if the packet fails to send.
  */
 non_null(1, 2) nullable(3)
-bool gcc_encrypt_and_send_lossless_packet(const GC_Chat *chat, const GC_Connection *gconn, const uint8_t *data,
-        uint16_t length, uint64_t message_id, uint8_t packet_type);
+int gcc_encrypt_and_send_lossless_packet(const GC_Chat *chat, const GC_Connection *gconn, const uint8_t *data,
+       uint16_t length, uint64_t message_id, uint8_t packet_type);
 
 /** @brief Called when a peer leaves the group. */
 non_null()


### PR DESCRIPTION
commit 5b9c420c introduced some undesirable behaviour with packet send functions returning error when they shouldn't. We now only return an error if the packet fails to be added to the send queue or cannot be wrapped/encrypted. We no longer error if we fail to send the packet over the wire, because toxcore will keep trying to re-send the packet until the connection times out.

Additionally, we now make sure that our packet broadcast functions aren't returning an error when failing to send packets to peers that we have not successfully handshaked with yet, since this is expected behaviour.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2549)
<!-- Reviewable:end -->
