### PR TITLE
fix: Remove fatal error for non-erroneous case

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-a6701e463517907cdb450f3210389633feb6c1cc3a1d3faec48c8b99a4aebf3c  /usr/local/bin/tox-bootstrapd
+398b0a1ffe8d4d76252964636e083c18ee08e9ceab58b3b377b61821ca04c17c  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -1442,6 +1442,9 @@ non_null(1, 2, 3, 5, 6) nullable(4)
 static int group_packet_unwrap(const Logger *log, const GC_Connection *gconn, uint8_t *data, uint64_t *message_id,
                                uint8_t *packet_type, const uint8_t *packet, uint16_t length)
 {
+    assert(data != nullptr);
+    assert(packet != nullptr);
+
     if (length <= CRYPTO_NONCE_SIZE) {
         LOGGER_FATAL(log, "Invalid packet length: %u", length);
         return -1;

--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -101,16 +101,12 @@ static bool create_array_entry(const Logger *log, const Mono_Time *mono_time, GC
     }
 
     if (length == 0) {
-        if (data != nullptr) {
-            LOGGER_FATAL(log, "Got non-null data with zero length (type %d)", packet_type); // should never happen
-            return false;
-        }
-
         array_entry->data = nullptr;
         array_entry->data_length = 0;
     } else {
-        if (data == nullptr) {
-            LOGGER_FATAL(log, "Got null data with non-zero length (type %u)", packet_type); // should never happen
+        if (data == nullptr) {  // should never happen
+            LOGGER_FATAL(log, "Got null data with non-zero length (length: %u, type %u)",
+                         length, packet_type);
             return false;
         }
 


### PR DESCRIPTION
We allow non-null data pointers to be passed to functions alongside 0-length data. For example when creating a data buffer that has room for the entire packet, including ignored header data.

This error broke a rare but legitimate case where we miss packets during a handshake attempt and need to store empty handshake packets in the packet array.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2555)
<!-- Reviewable:end -->
