### PR TITLE
cleanup: Move the 2-element array pack out of individual events.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-0eb835fe755f1162748029660f46717952f33775e7a845c389ecb4b4e3fbb998  /usr/local/bin/tox-bootstrapd
+ec228c5b76d06c25dc2a8dc2ff4ccc1e8748d0915058a7cb56de75d948051001  /usr/local/bin/tox-bootstrapd

--- a/other/event_tooling/generate_event_c.cpp
+++ b/other/event_tooling/generate_event_c.cpp
@@ -311,14 +311,21 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
     f << "bool tox_event_" << event_name_l << "_pack(\n";
     f << "    const Tox_Event_" << event_name << " *event, Bin_Pack *bp)\n{\n";
     f << "    assert(event != nullptr);\n";
-    f << "    return bin_pack_array(bp, 2)\n";
-    f << "           && bin_pack_u32(bp, TOX_EVENT_" << str_toupper(event_name) << ")";
+
+    bool return_started = false;
+
     if (event_types.size() > 1) {
-        f << "\n           && bin_pack_array(bp, " << event_types.size() << ")";
+        f << "    return bin_pack_array(bp, " << event_types.size() << ")";
+        return_started = true;
     }
 
     for (const auto& t : event_types) {
-        f << "\n           && ";
+        if (return_started) {
+            f << "\n           && ";
+        } else {
+            f << "    return ";
+        }
+
         std::visit(
             overloaded{
                 [&](const EventTypeTrivial& t) {

--- a/toxcore/events/conference_connected.c
+++ b/toxcore/events/conference_connected.c
@@ -55,9 +55,7 @@ bool tox_event_conference_connected_pack(
     const Tox_Event_Conference_Connected *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_CONFERENCE_CONNECTED)
-           && bin_pack_u32(bp, event->conference_number);
+    return bin_pack_u32(bp, event->conference_number);
 }
 
 non_null()

--- a/toxcore/events/conference_invite.c
+++ b/toxcore/events/conference_invite.c
@@ -108,9 +108,7 @@ bool tox_event_conference_invite_pack(
     const Tox_Event_Conference_Invite *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_CONFERENCE_INVITE)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->type)
            && bin_pack_bin(bp, event->cookie, event->cookie_length);

--- a/toxcore/events/conference_message.c
+++ b/toxcore/events/conference_message.c
@@ -122,9 +122,7 @@ bool tox_event_conference_message_pack(
     const Tox_Event_Conference_Message *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_CONFERENCE_MESSAGE)
-           && bin_pack_array(bp, 4)
+    return bin_pack_array(bp, 4)
            && bin_pack_u32(bp, event->conference_number)
            && bin_pack_u32(bp, event->peer_number)
            && bin_pack_u32(bp, event->type)

--- a/toxcore/events/conference_peer_list_changed.c
+++ b/toxcore/events/conference_peer_list_changed.c
@@ -55,9 +55,7 @@ bool tox_event_conference_peer_list_changed_pack(
     const Tox_Event_Conference_Peer_List_Changed *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_CONFERENCE_PEER_LIST_CHANGED)
-           && bin_pack_u32(bp, event->conference_number);
+    return bin_pack_u32(bp, event->conference_number);
 }
 
 non_null()

--- a/toxcore/events/conference_peer_name.c
+++ b/toxcore/events/conference_peer_name.c
@@ -107,9 +107,7 @@ bool tox_event_conference_peer_name_pack(
     const Tox_Event_Conference_Peer_Name *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_CONFERENCE_PEER_NAME)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->conference_number)
            && bin_pack_u32(bp, event->peer_number)
            && bin_pack_bin(bp, event->name, event->name_length);

--- a/toxcore/events/conference_title.c
+++ b/toxcore/events/conference_title.c
@@ -107,9 +107,7 @@ bool tox_event_conference_title_pack(
     const Tox_Event_Conference_Title *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_CONFERENCE_TITLE)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->conference_number)
            && bin_pack_u32(bp, event->peer_number)
            && bin_pack_bin(bp, event->title, event->title_length);

--- a/toxcore/events/file_chunk_request.c
+++ b/toxcore/events/file_chunk_request.c
@@ -97,9 +97,7 @@ bool tox_event_file_chunk_request_pack(
     const Tox_Event_File_Chunk_Request *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FILE_CHUNK_REQUEST)
-           && bin_pack_array(bp, 4)
+    return bin_pack_array(bp, 4)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->file_number)
            && bin_pack_u64(bp, event->position)

--- a/toxcore/events/file_recv.c
+++ b/toxcore/events/file_recv.c
@@ -135,9 +135,7 @@ bool tox_event_file_recv_pack(
     const Tox_Event_File_Recv *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FILE_RECV)
-           && bin_pack_array(bp, 5)
+    return bin_pack_array(bp, 5)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->file_number)
            && bin_pack_u32(bp, event->kind)

--- a/toxcore/events/file_recv_chunk.c
+++ b/toxcore/events/file_recv_chunk.c
@@ -121,9 +121,7 @@ bool tox_event_file_recv_chunk_pack(
     const Tox_Event_File_Recv_Chunk *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FILE_RECV_CHUNK)
-           && bin_pack_array(bp, 4)
+    return bin_pack_array(bp, 4)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->file_number)
            && bin_pack_u64(bp, event->position)

--- a/toxcore/events/file_recv_control.c
+++ b/toxcore/events/file_recv_control.c
@@ -84,9 +84,7 @@ bool tox_event_file_recv_control_pack(
     const Tox_Event_File_Recv_Control *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FILE_RECV_CONTROL)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->file_number)
            && bin_pack_u32(bp, event->control);

--- a/toxcore/events/friend_connection_status.c
+++ b/toxcore/events/friend_connection_status.c
@@ -71,8 +71,6 @@ bool tox_event_friend_connection_status_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_CONNECTION_STATUS)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->connection_status);
 }

--- a/toxcore/events/friend_lossless_packet.c
+++ b/toxcore/events/friend_lossless_packet.c
@@ -94,8 +94,6 @@ bool tox_event_friend_lossless_packet_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_LOSSLESS_PACKET)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_bin(bp, event->data, event->data_length);
 }

--- a/toxcore/events/friend_lossy_packet.c
+++ b/toxcore/events/friend_lossy_packet.c
@@ -94,8 +94,6 @@ bool tox_event_friend_lossy_packet_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_LOSSY_PACKET)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_bin(bp, event->data, event->data_length);
 }

--- a/toxcore/events/friend_message.c
+++ b/toxcore/events/friend_message.c
@@ -108,9 +108,7 @@ bool tox_event_friend_message_pack(
     const Tox_Event_Friend_Message *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_MESSAGE)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->type)
            && bin_pack_bin(bp, event->message, event->message_length);

--- a/toxcore/events/friend_name.c
+++ b/toxcore/events/friend_name.c
@@ -94,8 +94,6 @@ bool tox_event_friend_name_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_NAME)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_bin(bp, event->name, event->name_length);
 }

--- a/toxcore/events/friend_read_receipt.c
+++ b/toxcore/events/friend_read_receipt.c
@@ -70,8 +70,6 @@ bool tox_event_friend_read_receipt_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_READ_RECEIPT)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->message_id);
 }

--- a/toxcore/events/friend_request.c
+++ b/toxcore/events/friend_request.c
@@ -95,8 +95,6 @@ bool tox_event_friend_request_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_REQUEST)
-           && bin_pack_array(bp, 2)
            && bin_pack_bin(bp, event->public_key, TOX_PUBLIC_KEY_SIZE)
            && bin_pack_bin(bp, event->message, event->message_length);
 }

--- a/toxcore/events/friend_status.c
+++ b/toxcore/events/friend_status.c
@@ -71,8 +71,6 @@ bool tox_event_friend_status_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_STATUS)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_u32(bp, event->status);
 }

--- a/toxcore/events/friend_status_message.c
+++ b/toxcore/events/friend_status_message.c
@@ -94,8 +94,6 @@ bool tox_event_friend_status_message_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_STATUS_MESSAGE)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_bin(bp, event->message, event->message_length);
 }

--- a/toxcore/events/friend_typing.c
+++ b/toxcore/events/friend_typing.c
@@ -70,8 +70,6 @@ bool tox_event_friend_typing_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_FRIEND_TYPING)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_bool(bp, event->typing);
 }

--- a/toxcore/events/group_custom_packet.c
+++ b/toxcore/events/group_custom_packet.c
@@ -107,9 +107,7 @@ bool tox_event_group_custom_packet_pack(
     const Tox_Event_Group_Custom_Packet *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_CUSTOM_PACKET)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_id)
            && bin_pack_bin(bp, event->data, event->data_length);

--- a/toxcore/events/group_custom_private_packet.c
+++ b/toxcore/events/group_custom_private_packet.c
@@ -107,9 +107,7 @@ bool tox_event_group_custom_private_packet_pack(
     const Tox_Event_Group_Custom_Private_Packet *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_CUSTOM_PRIVATE_PACKET)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_id)
            && bin_pack_bin(bp, event->data, event->data_length);

--- a/toxcore/events/group_invite.c
+++ b/toxcore/events/group_invite.c
@@ -130,9 +130,7 @@ bool tox_event_group_invite_pack(
     const Tox_Event_Group_Invite *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_INVITE)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->friend_number)
            && bin_pack_bin(bp, event->invite_data, event->invite_data_length)
            && bin_pack_bin(bp, event->group_name, event->group_name_length);

--- a/toxcore/events/group_join_fail.c
+++ b/toxcore/events/group_join_fail.c
@@ -71,8 +71,6 @@ bool tox_event_group_join_fail_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_JOIN_FAIL)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->fail_type);
 }

--- a/toxcore/events/group_message.c
+++ b/toxcore/events/group_message.c
@@ -136,9 +136,7 @@ bool tox_event_group_message_pack(
     const Tox_Event_Group_Message *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_MESSAGE)
-           && bin_pack_array(bp, 5)
+    return bin_pack_array(bp, 5)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_id)
            && bin_pack_u32(bp, event->type)

--- a/toxcore/events/group_moderation.c
+++ b/toxcore/events/group_moderation.c
@@ -98,9 +98,7 @@ bool tox_event_group_moderation_pack(
     const Tox_Event_Group_Moderation *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_MODERATION)
-           && bin_pack_array(bp, 4)
+    return bin_pack_array(bp, 4)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->source_peer_id)
            && bin_pack_u32(bp, event->target_peer_id)

--- a/toxcore/events/group_password.c
+++ b/toxcore/events/group_password.c
@@ -94,8 +94,6 @@ bool tox_event_group_password_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_PASSWORD)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_bin(bp, event->password, event->password_length);
 }

--- a/toxcore/events/group_peer_exit.c
+++ b/toxcore/events/group_peer_exit.c
@@ -159,9 +159,7 @@ bool tox_event_group_peer_exit_pack(
     const Tox_Event_Group_Peer_Exit *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_PEER_EXIT)
-           && bin_pack_array(bp, 5)
+    return bin_pack_array(bp, 5)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_id)
            && bin_pack_u32(bp, event->exit_type)

--- a/toxcore/events/group_peer_join.c
+++ b/toxcore/events/group_peer_join.c
@@ -70,8 +70,6 @@ bool tox_event_group_peer_join_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_PEER_JOIN)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_id);
 }

--- a/toxcore/events/group_peer_limit.c
+++ b/toxcore/events/group_peer_limit.c
@@ -70,8 +70,6 @@ bool tox_event_group_peer_limit_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_PEER_LIMIT)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_limit);
 }

--- a/toxcore/events/group_peer_name.c
+++ b/toxcore/events/group_peer_name.c
@@ -107,9 +107,7 @@ bool tox_event_group_peer_name_pack(
     const Tox_Event_Group_Peer_Name *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_PEER_NAME)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_id)
            && bin_pack_bin(bp, event->name, event->name_length);

--- a/toxcore/events/group_peer_status.c
+++ b/toxcore/events/group_peer_status.c
@@ -84,9 +84,7 @@ bool tox_event_group_peer_status_pack(
     const Tox_Event_Group_Peer_Status *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_PEER_STATUS)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_id)
            && bin_pack_u32(bp, event->status);

--- a/toxcore/events/group_privacy_state.c
+++ b/toxcore/events/group_privacy_state.c
@@ -71,8 +71,6 @@ bool tox_event_group_privacy_state_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_PRIVACY_STATE)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->privacy_state);
 }

--- a/toxcore/events/group_private_message.c
+++ b/toxcore/events/group_private_message.c
@@ -122,9 +122,7 @@ bool tox_event_group_private_message_pack(
     const Tox_Event_Group_Private_Message *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_PRIVATE_MESSAGE)
-           && bin_pack_array(bp, 4)
+    return bin_pack_array(bp, 4)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_id)
            && bin_pack_u32(bp, event->type)

--- a/toxcore/events/group_self_join.c
+++ b/toxcore/events/group_self_join.c
@@ -55,9 +55,7 @@ bool tox_event_group_self_join_pack(
     const Tox_Event_Group_Self_Join *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_SELF_JOIN)
-           && bin_pack_u32(bp, event->group_number);
+    return bin_pack_u32(bp, event->group_number);
 }
 
 non_null()

--- a/toxcore/events/group_topic.c
+++ b/toxcore/events/group_topic.c
@@ -107,9 +107,7 @@ bool tox_event_group_topic_pack(
     const Tox_Event_Group_Topic *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_TOPIC)
-           && bin_pack_array(bp, 3)
+    return bin_pack_array(bp, 3)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->peer_id)
            && bin_pack_bin(bp, event->topic, event->topic_length);

--- a/toxcore/events/group_topic_lock.c
+++ b/toxcore/events/group_topic_lock.c
@@ -71,8 +71,6 @@ bool tox_event_group_topic_lock_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_TOPIC_LOCK)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->topic_lock);
 }

--- a/toxcore/events/group_voice_state.c
+++ b/toxcore/events/group_voice_state.c
@@ -71,8 +71,6 @@ bool tox_event_group_voice_state_pack(
 {
     assert(event != nullptr);
     return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_GROUP_VOICE_STATE)
-           && bin_pack_array(bp, 2)
            && bin_pack_u32(bp, event->group_number)
            && bin_pack_u32(bp, event->voice_state);
 }

--- a/toxcore/events/self_connection_status.c
+++ b/toxcore/events/self_connection_status.c
@@ -56,9 +56,7 @@ bool tox_event_self_connection_status_pack(
     const Tox_Event_Self_Connection_Status *event, Bin_Pack *bp)
 {
     assert(event != nullptr);
-    return bin_pack_array(bp, 2)
-           && bin_pack_u32(bp, TOX_EVENT_SELF_CONNECTION_STATUS)
-           && bin_pack_u32(bp, event->connection_status);
+    return bin_pack_u32(bp, event->connection_status);
 }
 
 non_null()

--- a/toxcore/tox_event.c
+++ b/toxcore/tox_event.c
@@ -568,6 +568,10 @@ bool tox_event_pack(const Tox_Event *event, Bin_Pack *bp)
 {
     assert(event->type != TOX_EVENT_INVALID);
 
+    if (!(bin_pack_array(bp, 2) && bin_pack_u32(bp, event->type))) {
+        return false;
+    }
+
     switch (event->type) {
         case TOX_EVENT_CONFERENCE_CONNECTED:
             return tox_event_conference_connected_pack(event->data.conference_connected, bp);


### PR DESCRIPTION
It's common across all events. No need to repeat it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2564)
<!-- Reviewable:end -->
