### PR TITLE
cleanup: skip a do_gc iteration before removing peers marked for deletion

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-0b58b866f87d92267db4577d26eebe10dcf5a96ff53ac5a863dade83f471961c  /usr/local/bin/tox-bootstrapd
+738c98673260593fc150b8d5b0cb770cd521f469b4eb04c873f19d89bb7238cf  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -133,6 +133,7 @@ typedef struct GC_Connection {
     bool        pending_key_rotation_request;
 
     bool        pending_delete;  /* true if this peer has been marked for deletion */
+    bool        delete_this_iteration;  /* true if this peer should be deleted this do_gc() iteration*/
     GC_Exit_Info exit_info;
 } GC_Connection;
 


### PR DESCRIPTION
This fixes an issue with events where we try to make queries on peers that no longer exist internally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2573)
<!-- Reviewable:end -->
