### PR TITLE
cleanup: make some improvements to group moderation test

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-189633f3accb67886c402bf242616d9b3e8258f8050dbd00a10b7c6147ed28aa  /usr/local/bin/tox-bootstrapd
+030f7ea99c34523091b268df0ea8fb02e81ee340d608af85d502bace4817d6b0  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -3862,6 +3862,7 @@ static bool update_gc_topic(GC_Chat *chat, const uint8_t *public_sig_key)
         return true;
     }
 
+    LOGGER_TRACE(chat->log, "founder is re-signing topic");
     return gc_set_topic(chat, chat->topic_info.topic, chat->topic_info.length) == 0;
 }
 


### PR DESCRIPTION
- We no longer assert peer roles in the mod event callback because this causes an issue with the new events implementation, which triggers the events after all the packets from the current tox_iterate() are processed, rather than as the packets are received. These checks were superfluous and shouldn't reduce code coverage.
- A moderator now sets the topic before the founder kicks him in order to increase internal code coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2576)
<!-- Reviewable:end -->
