### PR TITLE
refactor: Add common msgpack array packer with callback.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-3b4f5c3224e919d4474c4af4b5058916b181a2689f59a3b04e72305b454b2ae3  /usr/local/bin/tox-bootstrapd
+3acc3a1f08e67dac66d91657a36d98be397fa3f14bc4798d3349605e37a90fc3  /usr/local/bin/tox-bootstrapd

--- a/other/event_tooling/generate_event_c.cpp
+++ b/other/event_tooling/generate_event_c.cpp
@@ -452,6 +452,7 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
     f << "bool tox_event_" << event_name_l << "_unpack(\n";
     f << "    Tox_Event_" << event_name << " **event, Bin_Unpack *bu, const Memory *mem)\n{\n";
     f << "    assert(event != nullptr);\n";
+    f << "    assert(*event == nullptr);\n";
     f << "    *event = tox_event_" << event_name_l << "_new(mem);\n\n";
     f << "    if (*event == nullptr) {\n        return false;\n    }\n\n";
     f << "    return tox_event_" << event_name_l << "_unpack_into(*event, bu);\n}\n\n";

--- a/toxcore/bin_pack.c
+++ b/toxcore/bin_pack.c
@@ -109,6 +109,26 @@ bool bin_pack_obj_array_b(bin_pack_array_cb *callback, const void *arr, uint32_t
     return true;
 }
 
+bool bin_pack_obj_array(Bin_Pack *bp, bin_pack_array_cb *callback, const void *arr, uint32_t arr_size, const Logger *logger)
+{
+    if (arr == nullptr) {
+        assert(arr_size == 0);
+        return bin_pack_array(bp, 0);
+    }
+
+    if (!bin_pack_array(bp, arr_size)) {
+        return false;
+    }
+
+    for (uint32_t i = 0; i < arr_size; ++i) {
+        if (!callback(arr, i, logger, bp)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool bin_pack_array(Bin_Pack *bp, uint32_t size)
 {
     return cmp_write_array(&bp->ctx, size);

--- a/toxcore/events/conference_connected.c
+++ b/toxcore/events/conference_connected.c
@@ -119,6 +119,7 @@ bool tox_event_conference_connected_unpack(
     Tox_Event_Conference_Connected **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_conference_connected_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/conference_invite.c
+++ b/toxcore/events/conference_invite.c
@@ -187,6 +187,7 @@ bool tox_event_conference_invite_unpack(
     Tox_Event_Conference_Invite **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_conference_invite_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/conference_message.c
+++ b/toxcore/events/conference_message.c
@@ -203,6 +203,7 @@ bool tox_event_conference_message_unpack(
     Tox_Event_Conference_Message **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_conference_message_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/conference_peer_list_changed.c
+++ b/toxcore/events/conference_peer_list_changed.c
@@ -119,6 +119,7 @@ bool tox_event_conference_peer_list_changed_unpack(
     Tox_Event_Conference_Peer_List_Changed **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_conference_peer_list_changed_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/conference_peer_name.c
+++ b/toxcore/events/conference_peer_name.c
@@ -185,6 +185,7 @@ bool tox_event_conference_peer_name_unpack(
     Tox_Event_Conference_Peer_Name **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_conference_peer_name_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/conference_title.c
+++ b/toxcore/events/conference_title.c
@@ -185,6 +185,7 @@ bool tox_event_conference_title_unpack(
     Tox_Event_Conference_Title **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_conference_title_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/file_chunk_request.c
+++ b/toxcore/events/file_chunk_request.c
@@ -172,6 +172,7 @@ bool tox_event_file_chunk_request_unpack(
     Tox_Event_File_Chunk_Request **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_file_chunk_request_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/file_recv.c
+++ b/toxcore/events/file_recv.c
@@ -217,6 +217,7 @@ bool tox_event_file_recv_unpack(
     Tox_Event_File_Recv **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_file_recv_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/file_recv_chunk.c
+++ b/toxcore/events/file_recv_chunk.c
@@ -201,6 +201,7 @@ bool tox_event_file_recv_chunk_unpack(
     Tox_Event_File_Recv_Chunk **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_file_recv_chunk_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/file_recv_control.c
+++ b/toxcore/events/file_recv_control.c
@@ -158,6 +158,7 @@ bool tox_event_file_recv_control_unpack(
     Tox_Event_File_Recv_Control **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_file_recv_control_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_connection_status.c
+++ b/toxcore/events/friend_connection_status.c
@@ -142,6 +142,7 @@ bool tox_event_friend_connection_status_unpack(
     Tox_Event_Friend_Connection_Status **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_connection_status_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_lossless_packet.c
+++ b/toxcore/events/friend_lossless_packet.c
@@ -169,6 +169,7 @@ bool tox_event_friend_lossless_packet_unpack(
     Tox_Event_Friend_Lossless_Packet **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_lossless_packet_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_lossy_packet.c
+++ b/toxcore/events/friend_lossy_packet.c
@@ -169,6 +169,7 @@ bool tox_event_friend_lossy_packet_unpack(
     Tox_Event_Friend_Lossy_Packet **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_lossy_packet_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_message.c
+++ b/toxcore/events/friend_message.c
@@ -187,6 +187,7 @@ bool tox_event_friend_message_unpack(
     Tox_Event_Friend_Message **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_message_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_name.c
+++ b/toxcore/events/friend_name.c
@@ -169,6 +169,7 @@ bool tox_event_friend_name_unpack(
     Tox_Event_Friend_Name **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_name_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_read_receipt.c
+++ b/toxcore/events/friend_read_receipt.c
@@ -140,6 +140,7 @@ bool tox_event_friend_read_receipt_unpack(
     Tox_Event_Friend_Read_Receipt **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_read_receipt_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_request.c
+++ b/toxcore/events/friend_request.c
@@ -159,6 +159,7 @@ bool tox_event_friend_request_unpack(
     Tox_Event_Friend_Request **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_request_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_status.c
+++ b/toxcore/events/friend_status.c
@@ -142,6 +142,7 @@ bool tox_event_friend_status_unpack(
     Tox_Event_Friend_Status **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_status_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_status_message.c
+++ b/toxcore/events/friend_status_message.c
@@ -169,6 +169,7 @@ bool tox_event_friend_status_message_unpack(
     Tox_Event_Friend_Status_Message **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_status_message_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/friend_typing.c
+++ b/toxcore/events/friend_typing.c
@@ -140,6 +140,7 @@ bool tox_event_friend_typing_unpack(
     Tox_Event_Friend_Typing **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_friend_typing_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_custom_packet.c
+++ b/toxcore/events/group_custom_packet.c
@@ -185,6 +185,7 @@ bool tox_event_group_custom_packet_unpack(
     Tox_Event_Group_Custom_Packet **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_custom_packet_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_custom_private_packet.c
+++ b/toxcore/events/group_custom_private_packet.c
@@ -185,6 +185,7 @@ bool tox_event_group_custom_private_packet_unpack(
     Tox_Event_Group_Custom_Private_Packet **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_custom_private_packet_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_invite.c
+++ b/toxcore/events/group_invite.c
@@ -213,6 +213,7 @@ bool tox_event_group_invite_unpack(
     Tox_Event_Group_Invite **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_invite_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_join_fail.c
+++ b/toxcore/events/group_join_fail.c
@@ -142,6 +142,7 @@ bool tox_event_group_join_fail_unpack(
     Tox_Event_Group_Join_Fail **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_join_fail_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_message.c
+++ b/toxcore/events/group_message.c
@@ -219,6 +219,7 @@ bool tox_event_group_message_unpack(
     Tox_Event_Group_Message **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_message_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_moderation.c
+++ b/toxcore/events/group_moderation.c
@@ -174,6 +174,7 @@ bool tox_event_group_moderation_unpack(
     Tox_Event_Group_Moderation **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_moderation_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_password.c
+++ b/toxcore/events/group_password.c
@@ -169,6 +169,7 @@ bool tox_event_group_password_unpack(
     Tox_Event_Group_Password **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_password_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_peer_exit.c
+++ b/toxcore/events/group_peer_exit.c
@@ -247,6 +247,7 @@ bool tox_event_group_peer_exit_unpack(
     Tox_Event_Group_Peer_Exit **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_peer_exit_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_peer_join.c
+++ b/toxcore/events/group_peer_join.c
@@ -140,6 +140,7 @@ bool tox_event_group_peer_join_unpack(
     Tox_Event_Group_Peer_Join **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_peer_join_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_peer_limit.c
+++ b/toxcore/events/group_peer_limit.c
@@ -140,6 +140,7 @@ bool tox_event_group_peer_limit_unpack(
     Tox_Event_Group_Peer_Limit **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_peer_limit_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_peer_name.c
+++ b/toxcore/events/group_peer_name.c
@@ -185,6 +185,7 @@ bool tox_event_group_peer_name_unpack(
     Tox_Event_Group_Peer_Name **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_peer_name_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_peer_status.c
+++ b/toxcore/events/group_peer_status.c
@@ -158,6 +158,7 @@ bool tox_event_group_peer_status_unpack(
     Tox_Event_Group_Peer_Status **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_peer_status_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_privacy_state.c
+++ b/toxcore/events/group_privacy_state.c
@@ -142,6 +142,7 @@ bool tox_event_group_privacy_state_unpack(
     Tox_Event_Group_Privacy_State **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_privacy_state_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_private_message.c
+++ b/toxcore/events/group_private_message.c
@@ -203,6 +203,7 @@ bool tox_event_group_private_message_unpack(
     Tox_Event_Group_Private_Message **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_private_message_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_self_join.c
+++ b/toxcore/events/group_self_join.c
@@ -119,6 +119,7 @@ bool tox_event_group_self_join_unpack(
     Tox_Event_Group_Self_Join **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_self_join_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_topic.c
+++ b/toxcore/events/group_topic.c
@@ -185,6 +185,7 @@ bool tox_event_group_topic_unpack(
     Tox_Event_Group_Topic **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_topic_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_topic_lock.c
+++ b/toxcore/events/group_topic_lock.c
@@ -142,6 +142,7 @@ bool tox_event_group_topic_lock_unpack(
     Tox_Event_Group_Topic_Lock **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_topic_lock_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/group_voice_state.c
+++ b/toxcore/events/group_voice_state.c
@@ -142,6 +142,7 @@ bool tox_event_group_voice_state_unpack(
     Tox_Event_Group_Voice_State **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_group_voice_state_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/events/self_connection_status.c
+++ b/toxcore/events/self_connection_status.c
@@ -121,6 +121,7 @@ bool tox_event_self_connection_status_unpack(
     Tox_Event_Self_Connection_Status **event, Bin_Unpack *bu, const Memory *mem)
 {
     assert(event != nullptr);
+    assert(*event == nullptr);
     *event = tox_event_self_connection_status_new(mem);
 
     if (*event == nullptr) {

--- a/toxcore/tox_event.c
+++ b/toxcore/tox_event.c
@@ -947,6 +947,137 @@ static bool tox_event_type_unpack(Bin_Unpack *bu, Tox_Event_Type *val)
            && tox_event_type_from_int(u32, val);
 }
 
+non_null()
+static bool tox_event_data_unpack(Tox_Event_Type type, Tox_Event_Data *data, Bin_Unpack *bu, const Memory *mem)
+{
+    switch (type) {
+        case TOX_EVENT_CONFERENCE_CONNECTED:
+            return tox_event_conference_connected_unpack(&data->conference_connected, bu, mem);
+
+        case TOX_EVENT_CONFERENCE_INVITE:
+            return tox_event_conference_invite_unpack(&data->conference_invite, bu, mem);
+
+        case TOX_EVENT_CONFERENCE_MESSAGE:
+            return tox_event_conference_message_unpack(&data->conference_message, bu, mem);
+
+        case TOX_EVENT_CONFERENCE_PEER_LIST_CHANGED:
+            return tox_event_conference_peer_list_changed_unpack(&data->conference_peer_list_changed, bu, mem);
+
+        case TOX_EVENT_CONFERENCE_PEER_NAME:
+            return tox_event_conference_peer_name_unpack(&data->conference_peer_name, bu, mem);
+
+        case TOX_EVENT_CONFERENCE_TITLE:
+            return tox_event_conference_title_unpack(&data->conference_title, bu, mem);
+
+        case TOX_EVENT_FILE_CHUNK_REQUEST:
+            return tox_event_file_chunk_request_unpack(&data->file_chunk_request, bu, mem);
+
+        case TOX_EVENT_FILE_RECV_CHUNK:
+            return tox_event_file_recv_chunk_unpack(&data->file_recv_chunk, bu, mem);
+
+        case TOX_EVENT_FILE_RECV_CONTROL:
+            return tox_event_file_recv_control_unpack(&data->file_recv_control, bu, mem);
+
+        case TOX_EVENT_FILE_RECV:
+            return tox_event_file_recv_unpack(&data->file_recv, bu, mem);
+
+        case TOX_EVENT_FRIEND_CONNECTION_STATUS:
+            return tox_event_friend_connection_status_unpack(&data->friend_connection_status, bu, mem);
+
+        case TOX_EVENT_FRIEND_LOSSLESS_PACKET:
+            return tox_event_friend_lossless_packet_unpack(&data->friend_lossless_packet, bu, mem);
+
+        case TOX_EVENT_FRIEND_LOSSY_PACKET:
+            return tox_event_friend_lossy_packet_unpack(&data->friend_lossy_packet, bu, mem);
+
+        case TOX_EVENT_FRIEND_MESSAGE:
+            return tox_event_friend_message_unpack(&data->friend_message, bu, mem);
+
+        case TOX_EVENT_FRIEND_NAME:
+            return tox_event_friend_name_unpack(&data->friend_name, bu, mem);
+
+        case TOX_EVENT_FRIEND_READ_RECEIPT:
+            return tox_event_friend_read_receipt_unpack(&data->friend_read_receipt, bu, mem);
+
+        case TOX_EVENT_FRIEND_REQUEST:
+            return tox_event_friend_request_unpack(&data->friend_request, bu, mem);
+
+        case TOX_EVENT_FRIEND_STATUS_MESSAGE:
+            return tox_event_friend_status_message_unpack(&data->friend_status_message, bu, mem);
+
+        case TOX_EVENT_FRIEND_STATUS:
+            return tox_event_friend_status_unpack(&data->friend_status, bu, mem);
+
+        case TOX_EVENT_FRIEND_TYPING:
+            return tox_event_friend_typing_unpack(&data->friend_typing, bu, mem);
+
+        case TOX_EVENT_SELF_CONNECTION_STATUS:
+            return tox_event_self_connection_status_unpack(&data->self_connection_status, bu, mem);
+
+        case TOX_EVENT_GROUP_PEER_NAME:
+            return tox_event_group_peer_name_unpack(&data->group_peer_name, bu, mem);
+
+        case TOX_EVENT_GROUP_PEER_STATUS:
+            return tox_event_group_peer_status_unpack(&data->group_peer_status, bu, mem);
+
+        case TOX_EVENT_GROUP_TOPIC:
+            return tox_event_group_topic_unpack(&data->group_topic, bu, mem);
+
+        case TOX_EVENT_GROUP_PRIVACY_STATE:
+            return tox_event_group_privacy_state_unpack(&data->group_privacy_state, bu, mem);
+
+        case TOX_EVENT_GROUP_VOICE_STATE:
+            return tox_event_group_voice_state_unpack(&data->group_voice_state, bu, mem);
+
+        case TOX_EVENT_GROUP_TOPIC_LOCK:
+            return tox_event_group_topic_lock_unpack(&data->group_topic_lock, bu, mem);
+
+        case TOX_EVENT_GROUP_PEER_LIMIT:
+            return tox_event_group_peer_limit_unpack(&data->group_peer_limit, bu, mem);
+
+        case TOX_EVENT_GROUP_PASSWORD:
+            return tox_event_group_password_unpack(&data->group_password, bu, mem);
+
+        case TOX_EVENT_GROUP_MESSAGE:
+            return tox_event_group_message_unpack(&data->group_message, bu, mem);
+
+        case TOX_EVENT_GROUP_PRIVATE_MESSAGE:
+            return tox_event_group_private_message_unpack(&data->group_private_message, bu, mem);
+
+        case TOX_EVENT_GROUP_CUSTOM_PACKET:
+            return tox_event_group_custom_packet_unpack(&data->group_custom_packet, bu, mem);
+
+        case TOX_EVENT_GROUP_CUSTOM_PRIVATE_PACKET:
+            return tox_event_group_custom_private_packet_unpack(&data->group_custom_private_packet, bu, mem);
+
+        case TOX_EVENT_GROUP_INVITE:
+            return tox_event_group_invite_unpack(&data->group_invite, bu, mem);
+
+        case TOX_EVENT_GROUP_PEER_JOIN:
+            return tox_event_group_peer_join_unpack(&data->group_peer_join, bu, mem);
+
+        case TOX_EVENT_GROUP_PEER_EXIT:
+            return tox_event_group_peer_exit_unpack(&data->group_peer_exit, bu, mem);
+
+        case TOX_EVENT_GROUP_SELF_JOIN:
+            return tox_event_group_self_join_unpack(&data->group_self_join, bu, mem);
+
+        case TOX_EVENT_GROUP_JOIN_FAIL:
+            return tox_event_group_join_fail_unpack(&data->group_join_fail, bu, mem);
+
+        case TOX_EVENT_GROUP_MODERATION:
+            return tox_event_group_moderation_unpack(&data->group_moderation, bu, mem);
+
+        case TOX_EVENT_DHT_GET_NODES_RESPONSE:
+            return tox_event_dht_get_nodes_response_unpack(&data->dht_get_nodes_response, bu, mem);
+
+        case TOX_EVENT_INVALID:
+            return false;
+    }
+
+    return false;
+}
+
 bool tox_event_unpack_into(Tox_Event *event, Bin_Unpack *bu, const Memory *mem)
 {
     uint32_t size;
@@ -965,130 +1096,5 @@ bool tox_event_unpack_into(Tox_Event *event, Bin_Unpack *bu, const Memory *mem)
 
     event->type = type;
 
-    switch (type) {
-        case TOX_EVENT_CONFERENCE_CONNECTED:
-            return tox_event_conference_connected_unpack(&event->data.conference_connected, bu, mem);
-
-        case TOX_EVENT_CONFERENCE_INVITE:
-            return tox_event_conference_invite_unpack(&event->data.conference_invite, bu, mem);
-
-        case TOX_EVENT_CONFERENCE_MESSAGE:
-            return tox_event_conference_message_unpack(&event->data.conference_message, bu, mem);
-
-        case TOX_EVENT_CONFERENCE_PEER_LIST_CHANGED:
-            return tox_event_conference_peer_list_changed_unpack(&event->data.conference_peer_list_changed, bu, mem);
-
-        case TOX_EVENT_CONFERENCE_PEER_NAME:
-            return tox_event_conference_peer_name_unpack(&event->data.conference_peer_name, bu, mem);
-
-        case TOX_EVENT_CONFERENCE_TITLE:
-            return tox_event_conference_title_unpack(&event->data.conference_title, bu, mem);
-
-        case TOX_EVENT_FILE_CHUNK_REQUEST:
-            return tox_event_file_chunk_request_unpack(&event->data.file_chunk_request, bu, mem);
-
-        case TOX_EVENT_FILE_RECV_CHUNK:
-            return tox_event_file_recv_chunk_unpack(&event->data.file_recv_chunk, bu, mem);
-
-        case TOX_EVENT_FILE_RECV_CONTROL:
-            return tox_event_file_recv_control_unpack(&event->data.file_recv_control, bu, mem);
-
-        case TOX_EVENT_FILE_RECV:
-            return tox_event_file_recv_unpack(&event->data.file_recv, bu, mem);
-
-        case TOX_EVENT_FRIEND_CONNECTION_STATUS:
-            return tox_event_friend_connection_status_unpack(&event->data.friend_connection_status, bu, mem);
-
-        case TOX_EVENT_FRIEND_LOSSLESS_PACKET:
-            return tox_event_friend_lossless_packet_unpack(&event->data.friend_lossless_packet, bu, mem);
-
-        case TOX_EVENT_FRIEND_LOSSY_PACKET:
-            return tox_event_friend_lossy_packet_unpack(&event->data.friend_lossy_packet, bu, mem);
-
-        case TOX_EVENT_FRIEND_MESSAGE:
-            return tox_event_friend_message_unpack(&event->data.friend_message, bu, mem);
-
-        case TOX_EVENT_FRIEND_NAME:
-            return tox_event_friend_name_unpack(&event->data.friend_name, bu, mem);
-
-        case TOX_EVENT_FRIEND_READ_RECEIPT:
-            return tox_event_friend_read_receipt_unpack(&event->data.friend_read_receipt, bu, mem);
-
-        case TOX_EVENT_FRIEND_REQUEST:
-            return tox_event_friend_request_unpack(&event->data.friend_request, bu, mem);
-
-        case TOX_EVENT_FRIEND_STATUS_MESSAGE:
-            return tox_event_friend_status_message_unpack(&event->data.friend_status_message, bu, mem);
-
-        case TOX_EVENT_FRIEND_STATUS:
-            return tox_event_friend_status_unpack(&event->data.friend_status, bu, mem);
-
-        case TOX_EVENT_FRIEND_TYPING:
-            return tox_event_friend_typing_unpack(&event->data.friend_typing, bu, mem);
-
-        case TOX_EVENT_SELF_CONNECTION_STATUS:
-            return tox_event_self_connection_status_unpack(&event->data.self_connection_status, bu, mem);
-
-        case TOX_EVENT_GROUP_PEER_NAME:
-            return tox_event_group_peer_name_unpack(&event->data.group_peer_name, bu, mem);
-
-        case TOX_EVENT_GROUP_PEER_STATUS:
-            return tox_event_group_peer_status_unpack(&event->data.group_peer_status, bu, mem);
-
-        case TOX_EVENT_GROUP_TOPIC:
-            return tox_event_group_topic_unpack(&event->data.group_topic, bu, mem);
-
-        case TOX_EVENT_GROUP_PRIVACY_STATE:
-            return tox_event_group_privacy_state_unpack(&event->data.group_privacy_state, bu, mem);
-
-        case TOX_EVENT_GROUP_VOICE_STATE:
-            return tox_event_group_voice_state_unpack(&event->data.group_voice_state, bu, mem);
-
-        case TOX_EVENT_GROUP_TOPIC_LOCK:
-            return tox_event_group_topic_lock_unpack(&event->data.group_topic_lock, bu, mem);
-
-        case TOX_EVENT_GROUP_PEER_LIMIT:
-            return tox_event_group_peer_limit_unpack(&event->data.group_peer_limit, bu, mem);
-
-        case TOX_EVENT_GROUP_PASSWORD:
-            return tox_event_group_password_unpack(&event->data.group_password, bu, mem);
-
-        case TOX_EVENT_GROUP_MESSAGE:
-            return tox_event_group_message_unpack(&event->data.group_message, bu, mem);
-
-        case TOX_EVENT_GROUP_PRIVATE_MESSAGE:
-            return tox_event_group_private_message_unpack(&event->data.group_private_message, bu, mem);
-
-        case TOX_EVENT_GROUP_CUSTOM_PACKET:
-            return tox_event_group_custom_packet_unpack(&event->data.group_custom_packet, bu, mem);
-
-        case TOX_EVENT_GROUP_CUSTOM_PRIVATE_PACKET:
-            return tox_event_group_custom_private_packet_unpack(&event->data.group_custom_private_packet, bu, mem);
-
-        case TOX_EVENT_GROUP_INVITE:
-            return tox_event_group_invite_unpack(&event->data.group_invite, bu, mem);
-
-        case TOX_EVENT_GROUP_PEER_JOIN:
-            return tox_event_group_peer_join_unpack(&event->data.group_peer_join, bu, mem);
-
-        case TOX_EVENT_GROUP_PEER_EXIT:
-            return tox_event_group_peer_exit_unpack(&event->data.group_peer_exit, bu, mem);
-
-        case TOX_EVENT_GROUP_SELF_JOIN:
-            return tox_event_group_self_join_unpack(&event->data.group_self_join, bu, mem);
-
-        case TOX_EVENT_GROUP_JOIN_FAIL:
-            return tox_event_group_join_fail_unpack(&event->data.group_join_fail, bu, mem);
-
-        case TOX_EVENT_GROUP_MODERATION:
-            return tox_event_group_moderation_unpack(&event->data.group_moderation, bu, mem);
-
-        case TOX_EVENT_DHT_GET_NODES_RESPONSE:
-            return tox_event_dht_get_nodes_response_unpack(&event->data.dht_get_nodes_response, bu, mem);
-
-        case TOX_EVENT_INVALID:
-            return false;
-    }
-
-    return false;
+    return tox_event_data_unpack(event->type, &event->data, bu, mem);
 }


### PR DESCRIPTION
There will be more object arrays that need to be packed. This function
takes care of NULL (creating an empty array), and putting the correct
array size and calling the per-element callback the right amount of
times.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2577)
<!-- Reviewable:end -->
