### PR TITLE
refactor: Allow NULL pointers for byte arrays in events.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-030f7ea99c34523091b268df0ea8fb02e81ee340d608af85d502bace4817d6b0  /usr/local/bin/tox-bootstrapd
+4384074ef96cf8f1ed3c420a58b7f67a49a4e22ad5b8fe1d66a4bddf61235fce  /usr/local/bin/tox-bootstrapd

--- a/toxcore/events/conference_invite.c
+++ b/toxcore/events/conference_invite.c
@@ -58,7 +58,7 @@ Tox_Conference_Type tox_event_conference_invite_get_type(const Tox_Event_Confere
     return conference_invite->type;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_conference_invite_set_cookie(Tox_Event_Conference_Invite *conference_invite,
         const uint8_t *cookie, uint32_t cookie_length)
 {
@@ -68,6 +68,11 @@ static bool tox_event_conference_invite_set_cookie(Tox_Event_Conference_Invite *
         free(conference_invite->cookie);
         conference_invite->cookie = nullptr;
         conference_invite->cookie_length = 0;
+    }
+
+    if (cookie == nullptr) {
+        assert(cookie_length == 0);
+        return true;
     }
 
     uint8_t *cookie_copy = (uint8_t *)malloc(cookie_length);

--- a/toxcore/events/conference_message.c
+++ b/toxcore/events/conference_message.c
@@ -72,7 +72,7 @@ Tox_Message_Type tox_event_conference_message_get_type(const Tox_Event_Conferenc
     return conference_message->type;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_conference_message_set_message(Tox_Event_Conference_Message *conference_message,
         const uint8_t *message, uint32_t message_length)
 {
@@ -82,6 +82,11 @@ static bool tox_event_conference_message_set_message(Tox_Event_Conference_Messag
         free(conference_message->message);
         conference_message->message = nullptr;
         conference_message->message_length = 0;
+    }
+
+    if (message == nullptr) {
+        assert(message_length == 0);
+        return true;
     }
 
     uint8_t *message_copy = (uint8_t *)malloc(message_length);

--- a/toxcore/events/conference_peer_name.c
+++ b/toxcore/events/conference_peer_name.c
@@ -56,7 +56,7 @@ uint32_t tox_event_conference_peer_name_get_peer_number(const Tox_Event_Conferen
     return conference_peer_name->peer_number;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_conference_peer_name_set_name(Tox_Event_Conference_Peer_Name *conference_peer_name,
         const uint8_t *name, uint32_t name_length)
 {
@@ -66,6 +66,11 @@ static bool tox_event_conference_peer_name_set_name(Tox_Event_Conference_Peer_Na
         free(conference_peer_name->name);
         conference_peer_name->name = nullptr;
         conference_peer_name->name_length = 0;
+    }
+
+    if (name == nullptr) {
+        assert(name_length == 0);
+        return true;
     }
 
     uint8_t *name_copy = (uint8_t *)malloc(name_length);

--- a/toxcore/events/conference_title.c
+++ b/toxcore/events/conference_title.c
@@ -56,7 +56,7 @@ uint32_t tox_event_conference_title_get_peer_number(const Tox_Event_Conference_T
     return conference_title->peer_number;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_conference_title_set_title(Tox_Event_Conference_Title *conference_title,
         const uint8_t *title, uint32_t title_length)
 {
@@ -66,6 +66,11 @@ static bool tox_event_conference_title_set_title(Tox_Event_Conference_Title *con
         free(conference_title->title);
         conference_title->title = nullptr;
         conference_title->title_length = 0;
+    }
+
+    if (title == nullptr) {
+        assert(title_length == 0);
+        return true;
     }
 
     uint8_t *title_copy = (uint8_t *)malloc(title_length);

--- a/toxcore/events/file_recv.c
+++ b/toxcore/events/file_recv.c
@@ -84,7 +84,7 @@ uint64_t tox_event_file_recv_get_file_size(const Tox_Event_File_Recv *file_recv)
     return file_recv->file_size;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_file_recv_set_filename(Tox_Event_File_Recv *file_recv,
         const uint8_t *filename, uint32_t filename_length)
 {
@@ -94,6 +94,11 @@ static bool tox_event_file_recv_set_filename(Tox_Event_File_Recv *file_recv,
         free(file_recv->filename);
         file_recv->filename = nullptr;
         file_recv->filename_length = 0;
+    }
+
+    if (filename == nullptr) {
+        assert(filename_length == 0);
+        return true;
     }
 
     uint8_t *filename_copy = (uint8_t *)malloc(filename_length);

--- a/toxcore/events/file_recv_chunk.c
+++ b/toxcore/events/file_recv_chunk.c
@@ -70,7 +70,7 @@ uint64_t tox_event_file_recv_chunk_get_position(const Tox_Event_File_Recv_Chunk 
     return file_recv_chunk->position;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_file_recv_chunk_set_data(Tox_Event_File_Recv_Chunk *file_recv_chunk,
         const uint8_t *data, uint32_t data_length)
 {
@@ -80,6 +80,11 @@ static bool tox_event_file_recv_chunk_set_data(Tox_Event_File_Recv_Chunk *file_r
         free(file_recv_chunk->data);
         file_recv_chunk->data = nullptr;
         file_recv_chunk->data_length = 0;
+    }
+
+    if (data == nullptr) {
+        assert(data_length == 0);
+        return true;
     }
 
     uint8_t *data_copy = (uint8_t *)malloc(data_length);

--- a/toxcore/events/friend_lossless_packet.c
+++ b/toxcore/events/friend_lossless_packet.c
@@ -42,7 +42,7 @@ uint32_t tox_event_friend_lossless_packet_get_friend_number(const Tox_Event_Frie
     return friend_lossless_packet->friend_number;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_friend_lossless_packet_set_data(Tox_Event_Friend_Lossless_Packet *friend_lossless_packet,
         const uint8_t *data, uint32_t data_length)
 {
@@ -52,6 +52,11 @@ static bool tox_event_friend_lossless_packet_set_data(Tox_Event_Friend_Lossless_
         free(friend_lossless_packet->data);
         friend_lossless_packet->data = nullptr;
         friend_lossless_packet->data_length = 0;
+    }
+
+    if (data == nullptr) {
+        assert(data_length == 0);
+        return true;
     }
 
     uint8_t *data_copy = (uint8_t *)malloc(data_length);

--- a/toxcore/events/friend_lossy_packet.c
+++ b/toxcore/events/friend_lossy_packet.c
@@ -42,7 +42,7 @@ uint32_t tox_event_friend_lossy_packet_get_friend_number(const Tox_Event_Friend_
     return friend_lossy_packet->friend_number;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_friend_lossy_packet_set_data(Tox_Event_Friend_Lossy_Packet *friend_lossy_packet,
         const uint8_t *data, uint32_t data_length)
 {
@@ -52,6 +52,11 @@ static bool tox_event_friend_lossy_packet_set_data(Tox_Event_Friend_Lossy_Packet
         free(friend_lossy_packet->data);
         friend_lossy_packet->data = nullptr;
         friend_lossy_packet->data_length = 0;
+    }
+
+    if (data == nullptr) {
+        assert(data_length == 0);
+        return true;
     }
 
     uint8_t *data_copy = (uint8_t *)malloc(data_length);

--- a/toxcore/events/friend_message.c
+++ b/toxcore/events/friend_message.c
@@ -58,7 +58,7 @@ Tox_Message_Type tox_event_friend_message_get_type(const Tox_Event_Friend_Messag
     return friend_message->type;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_friend_message_set_message(Tox_Event_Friend_Message *friend_message,
         const uint8_t *message, uint32_t message_length)
 {
@@ -68,6 +68,11 @@ static bool tox_event_friend_message_set_message(Tox_Event_Friend_Message *frien
         free(friend_message->message);
         friend_message->message = nullptr;
         friend_message->message_length = 0;
+    }
+
+    if (message == nullptr) {
+        assert(message_length == 0);
+        return true;
     }
 
     uint8_t *message_copy = (uint8_t *)malloc(message_length);

--- a/toxcore/events/friend_name.c
+++ b/toxcore/events/friend_name.c
@@ -42,7 +42,7 @@ uint32_t tox_event_friend_name_get_friend_number(const Tox_Event_Friend_Name *fr
     return friend_name->friend_number;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_friend_name_set_name(Tox_Event_Friend_Name *friend_name,
         const uint8_t *name, uint32_t name_length)
 {
@@ -52,6 +52,11 @@ static bool tox_event_friend_name_set_name(Tox_Event_Friend_Name *friend_name,
         free(friend_name->name);
         friend_name->name = nullptr;
         friend_name->name_length = 0;
+    }
+
+    if (name == nullptr) {
+        assert(name_length == 0);
+        return true;
     }
 
     uint8_t *name_copy = (uint8_t *)malloc(name_length);

--- a/toxcore/events/friend_status_message.c
+++ b/toxcore/events/friend_status_message.c
@@ -42,7 +42,7 @@ uint32_t tox_event_friend_status_message_get_friend_number(const Tox_Event_Frien
     return friend_status_message->friend_number;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_friend_status_message_set_message(Tox_Event_Friend_Status_Message *friend_status_message,
         const uint8_t *message, uint32_t message_length)
 {
@@ -52,6 +52,11 @@ static bool tox_event_friend_status_message_set_message(Tox_Event_Friend_Status_
         free(friend_status_message->message);
         friend_status_message->message = nullptr;
         friend_status_message->message_length = 0;
+    }
+
+    if (message == nullptr) {
+        assert(message_length == 0);
+        return true;
     }
 
     uint8_t *message_copy = (uint8_t *)malloc(message_length);

--- a/toxcore/events/group_custom_packet.c
+++ b/toxcore/events/group_custom_packet.c
@@ -56,7 +56,7 @@ uint32_t tox_event_group_custom_packet_get_peer_id(const Tox_Event_Group_Custom_
     return group_custom_packet->peer_id;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_custom_packet_set_data(Tox_Event_Group_Custom_Packet *group_custom_packet,
         const uint8_t *data, uint32_t data_length)
 {
@@ -66,6 +66,11 @@ static bool tox_event_group_custom_packet_set_data(Tox_Event_Group_Custom_Packet
         free(group_custom_packet->data);
         group_custom_packet->data = nullptr;
         group_custom_packet->data_length = 0;
+    }
+
+    if (data == nullptr) {
+        assert(data_length == 0);
+        return true;
     }
 
     uint8_t *data_copy = (uint8_t *)malloc(data_length);

--- a/toxcore/events/group_custom_private_packet.c
+++ b/toxcore/events/group_custom_private_packet.c
@@ -56,7 +56,7 @@ uint32_t tox_event_group_custom_private_packet_get_peer_id(const Tox_Event_Group
     return group_custom_private_packet->peer_id;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_custom_private_packet_set_data(Tox_Event_Group_Custom_Private_Packet *group_custom_private_packet,
         const uint8_t *data, uint32_t data_length)
 {
@@ -66,6 +66,11 @@ static bool tox_event_group_custom_private_packet_set_data(Tox_Event_Group_Custo
         free(group_custom_private_packet->data);
         group_custom_private_packet->data = nullptr;
         group_custom_private_packet->data_length = 0;
+    }
+
+    if (data == nullptr) {
+        assert(data_length == 0);
+        return true;
     }
 
     uint8_t *data_copy = (uint8_t *)malloc(data_length);

--- a/toxcore/events/group_invite.c
+++ b/toxcore/events/group_invite.c
@@ -44,7 +44,7 @@ uint32_t tox_event_group_invite_get_friend_number(const Tox_Event_Group_Invite *
     return group_invite->friend_number;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_invite_set_invite_data(Tox_Event_Group_Invite *group_invite,
         const uint8_t *invite_data, uint32_t invite_data_length)
 {
@@ -54,6 +54,11 @@ static bool tox_event_group_invite_set_invite_data(Tox_Event_Group_Invite *group
         free(group_invite->invite_data);
         group_invite->invite_data = nullptr;
         group_invite->invite_data_length = 0;
+    }
+
+    if (invite_data == nullptr) {
+        assert(invite_data_length == 0);
+        return true;
     }
 
     uint8_t *invite_data_copy = (uint8_t *)malloc(invite_data_length);
@@ -78,7 +83,7 @@ const uint8_t *tox_event_group_invite_get_invite_data(const Tox_Event_Group_Invi
     return group_invite->invite_data;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_invite_set_group_name(Tox_Event_Group_Invite *group_invite,
         const uint8_t *group_name, uint32_t group_name_length)
 {
@@ -88,6 +93,11 @@ static bool tox_event_group_invite_set_group_name(Tox_Event_Group_Invite *group_
         free(group_invite->group_name);
         group_invite->group_name = nullptr;
         group_invite->group_name_length = 0;
+    }
+
+    if (group_name == nullptr) {
+        assert(group_name_length == 0);
+        return true;
     }
 
     uint8_t *group_name_copy = (uint8_t *)malloc(group_name_length);

--- a/toxcore/events/group_message.c
+++ b/toxcore/events/group_message.c
@@ -73,7 +73,7 @@ Tox_Message_Type tox_event_group_message_get_type(const Tox_Event_Group_Message 
     return group_message->type;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_message_set_message(Tox_Event_Group_Message *group_message,
         const uint8_t *message, uint32_t message_length)
 {
@@ -83,6 +83,11 @@ static bool tox_event_group_message_set_message(Tox_Event_Group_Message *group_m
         free(group_message->message);
         group_message->message = nullptr;
         group_message->message_length = 0;
+    }
+
+    if (message == nullptr) {
+        assert(message_length == 0);
+        return true;
     }
 
     uint8_t *message_copy = (uint8_t *)malloc(message_length);

--- a/toxcore/events/group_password.c
+++ b/toxcore/events/group_password.c
@@ -42,7 +42,7 @@ uint32_t tox_event_group_password_get_group_number(const Tox_Event_Group_Passwor
     return group_password->group_number;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_password_set_password(Tox_Event_Group_Password *group_password,
         const uint8_t *password, uint32_t password_length)
 {
@@ -52,6 +52,11 @@ static bool tox_event_group_password_set_password(Tox_Event_Group_Password *grou
         free(group_password->password);
         group_password->password = nullptr;
         group_password->password_length = 0;
+    }
+
+    if (password == nullptr) {
+        assert(password_length == 0);
+        return true;
     }
 
     uint8_t *password_copy = (uint8_t *)malloc(password_length);

--- a/toxcore/events/group_peer_exit.c
+++ b/toxcore/events/group_peer_exit.c
@@ -74,7 +74,7 @@ Tox_Group_Exit_Type tox_event_group_peer_exit_get_exit_type(const Tox_Event_Grou
     return group_peer_exit->exit_type;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_peer_exit_set_name(Tox_Event_Group_Peer_Exit *group_peer_exit,
         const uint8_t *name, uint32_t name_length)
 {
@@ -84,6 +84,11 @@ static bool tox_event_group_peer_exit_set_name(Tox_Event_Group_Peer_Exit *group_
         free(group_peer_exit->name);
         group_peer_exit->name = nullptr;
         group_peer_exit->name_length = 0;
+    }
+
+    if (name == nullptr) {
+        assert(name_length == 0);
+        return true;
     }
 
     uint8_t *name_copy = (uint8_t *)malloc(name_length);
@@ -108,7 +113,7 @@ const uint8_t *tox_event_group_peer_exit_get_name(const Tox_Event_Group_Peer_Exi
     return group_peer_exit->name;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_peer_exit_set_part_message(Tox_Event_Group_Peer_Exit *group_peer_exit,
         const uint8_t *part_message, uint32_t part_message_length)
 {
@@ -118,6 +123,11 @@ static bool tox_event_group_peer_exit_set_part_message(Tox_Event_Group_Peer_Exit
         free(group_peer_exit->part_message);
         group_peer_exit->part_message = nullptr;
         group_peer_exit->part_message_length = 0;
+    }
+
+    if (part_message == nullptr) {
+        assert(part_message_length == 0);
+        return true;
     }
 
     uint8_t *part_message_copy = (uint8_t *)malloc(part_message_length);

--- a/toxcore/events/group_peer_name.c
+++ b/toxcore/events/group_peer_name.c
@@ -56,7 +56,7 @@ uint32_t tox_event_group_peer_name_get_peer_id(const Tox_Event_Group_Peer_Name *
     return group_peer_name->peer_id;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_peer_name_set_name(Tox_Event_Group_Peer_Name *group_peer_name,
         const uint8_t *name, uint32_t name_length)
 {
@@ -66,6 +66,11 @@ static bool tox_event_group_peer_name_set_name(Tox_Event_Group_Peer_Name *group_
         free(group_peer_name->name);
         group_peer_name->name = nullptr;
         group_peer_name->name_length = 0;
+    }
+
+    if (name == nullptr) {
+        assert(name_length == 0);
+        return true;
     }
 
     uint8_t *name_copy = (uint8_t *)malloc(name_length);

--- a/toxcore/events/group_private_message.c
+++ b/toxcore/events/group_private_message.c
@@ -72,7 +72,7 @@ Tox_Message_Type tox_event_group_private_message_get_type(const Tox_Event_Group_
     return group_private_message->type;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_private_message_set_message(Tox_Event_Group_Private_Message *group_private_message,
         const uint8_t *message, uint32_t message_length)
 {
@@ -82,6 +82,11 @@ static bool tox_event_group_private_message_set_message(Tox_Event_Group_Private_
         free(group_private_message->message);
         group_private_message->message = nullptr;
         group_private_message->message_length = 0;
+    }
+
+    if (message == nullptr) {
+        assert(message_length == 0);
+        return true;
     }
 
     uint8_t *message_copy = (uint8_t *)malloc(message_length);

--- a/toxcore/events/group_topic.c
+++ b/toxcore/events/group_topic.c
@@ -56,7 +56,7 @@ uint32_t tox_event_group_topic_get_peer_id(const Tox_Event_Group_Topic *group_to
     return group_topic->peer_id;
 }
 
-non_null()
+non_null(1) nullable(2)
 static bool tox_event_group_topic_set_topic(Tox_Event_Group_Topic *group_topic,
         const uint8_t *topic, uint32_t topic_length)
 {
@@ -66,6 +66,11 @@ static bool tox_event_group_topic_set_topic(Tox_Event_Group_Topic *group_topic,
         free(group_topic->topic);
         group_topic->topic = nullptr;
         group_topic->topic_length = 0;
+    }
+
+    if (topic == nullptr) {
+        assert(topic_length == 0);
+        return true;
     }
 
     uint8_t *topic_copy = (uint8_t *)malloc(topic_length);


### PR DESCRIPTION
Some events, notably the file chunk recv one, can give NULL pointers to the client. Not sure they should, but that's what happens, so we support it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2578)
<!-- Reviewable:end -->
