### PR TITLE
cleanup: Remove plan9 support.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-09cd2be2005d21ad9f146a59d4f7d7b2221a07d7b6e72a63387dc468ea477a1d  /usr/local/bin/tox-bootstrapd
+9190d56ef3b346bc1632e6d7ee5fe5362be661bff58f2d6d88b5c1d1827394cd  /usr/local/bin/tox-bootstrapd

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -37,12 +37,6 @@
 
 #include "network.h"
 
-#ifdef PLAN9
-#include <u.h> // Plan 9 requires this is imported first
-// Comment line here to avoid reordering by source code formatters.
-#include <libc.h>
-#endif /* PLAN9 */
-
 #ifdef OS_WIN32 // Put win32 includes here
 // The mingw32/64 Windows library warns about including winsock2.h after
 // windows.h even though with the above it's a valid thing to do. So, to make


### PR DESCRIPTION
We really don't support it. I tried for half an hour to get some kind of plan9 cross compilation to work, but it's not working. If anyone wants to bring it back, they are welcome to send a PR including a CI check for it. Until then, these 5 lines of unused code are gone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2588)
<!-- Reviewable:end -->
