### PR TITLE
cleanup: Use explicit 0 instead of `PACKET_ID_PADDING`.

### DIFF
--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -1139,7 +1139,7 @@ static int send_data_packet_helper(Net_Crypto *c, int crypt_connection_id, uint3
     VLA(uint8_t, packet, sizeof(uint32_t) + sizeof(uint32_t) + padding_length + length);
     memcpy(packet, &buffer_start, sizeof(uint32_t));
     memcpy(packet + sizeof(uint32_t), &num, sizeof(uint32_t));
-    memset(packet + (sizeof(uint32_t) * 2), PACKET_ID_PADDING, padding_length);
+    memset(packet + (sizeof(uint32_t) * 2), 0, padding_length);
     memcpy(packet + (sizeof(uint32_t) * 2) + padding_length, data, length);
 
     return send_data_packet(c, crypt_connection_id, packet, SIZEOF_VLA(packet));
@@ -1589,7 +1589,7 @@ static int handle_data_packet_core(Net_Crypto *c, int crypt_connection_id, const
     const uint8_t *real_data = data + (sizeof(uint32_t) * 2);
     uint16_t real_length = len - (sizeof(uint32_t) * 2);
 
-    while (real_data[0] == PACKET_ID_PADDING) { /* Remove Padding */
+    while (real_data[0] == 0) { /* Remove Padding */
         ++real_data;
         --real_length;
 

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -44,7 +44,6 @@
 /*** Messages. */
 
 typedef enum Packet_Id {
-    PACKET_ID_PADDING            = 0, // Denotes padding
     PACKET_ID_REQUEST            = 1, // Used to request unreceived packets
     PACKET_ID_KILL               = 2, // Used to kill connection
 


### PR DESCRIPTION
Calling it a packet ID is a lie, and we'd rather "memzero" than memset with some named value that happens to be 0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2593)
<!-- Reviewable:end -->
