### PR TITLE
cleanup: Use `memzero(x, s)` instead of `memset(x, 0, s)`.

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-9190d56ef3b346bc1632e6d7ee5fe5362be661bff58f2d6d88b5c1d1827394cd  /usr/local/bin/tox-bootstrapd
+c028527fe5eecde7daa6ac9dacc47bd4bb765463e8e4b5af3881789797bf81a8  /usr/local/bin/tox-bootstrapd

--- a/other/docker/compcert/.gitignore
+++ b/other/docker/compcert/.gitignore
@@ -1,0 +1,1 @@
+!/Makefile

--- a/other/docker/compcert/Dockerfile
+++ b/other/docker/compcert/Dockerfile
@@ -1,5 +1,12 @@
 FROM toxchat/compcert:latest
 
+RUN apt-get update && \
+ DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
+ gdb \
+ make \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /work
 COPY auto_tests/ /work/auto_tests/
 COPY testing/ /work/testing/
@@ -10,21 +17,6 @@ COPY third_party/ /work/third_party/
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN ccomp \
- -o send_message_test \
- -Wall -Werror \
- -Wno-c11-extensions \
- -Wno-unknown-pragmas \
- -Wno-unused-variable \
- -fstruct-passing -fno-unprototyped -g \
- auto_tests/auto_test_support.c \
- auto_tests/send_message_test.c \
- testing/misc_tools.c \
- toxav/*.c \
- toxcore/*.c \
- toxcore/*/*.c \
- toxencryptsave/*.c \
- third_party/cmp/*.c \
- -D__COMPCERT__ -DDISABLE_VLA -Dinline= \
- -lpthread $(pkg-config --cflags --libs libsodium opus vpx) \
- && ./send_message_test | grep 'tox clients connected'
+COPY other/docker/compcert/Makefile /work/
+RUN make "-j$(nproc)"
+RUN ./send_message_test #| grep 'tox clients connected'

--- a/other/docker/compcert/Makefile
+++ b/other/docker/compcert/Makefile
@@ -1,0 +1,26 @@
+SOURCES := $(wildcard auto_tests/auto_test_support.c \
+		   auto_tests/send_message_test.c \
+		   testing/misc_tools.c \
+		   toxav/*.c \
+		   toxcore/*.c \
+		   toxcore/*/*.c \
+		   toxencryptsave/*.c \
+		   third_party/cmp/*.c)
+
+OBJECTS := $(SOURCES:.c=.o)
+
+CC := ccomp
+CFLAGS := -Wall -Werror \
+		  -Wno-c11-extensions \
+		  -Wno-unknown-pragmas \
+		  -Wno-unused-variable \
+		  -fstruct-passing -fno-unprototyped -g \
+		  -D__COMPCERT__ \
+		  -DDISABLE_VLA \
+		  -DMIN_LOGGER_LEVEL=LOGGER_LEVEL_TRACE \
+		  -Dinline= \
+		  $(shell pkg-config --cflags libsodium opus vpx)
+LDFLAGS := -lpthread $(shell pkg-config --libs libsodium opus vpx)
+
+send_message_test: $(OBJECTS)
+	$(CC) -o $@ $+ $(LDFLAGS)

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -167,6 +167,7 @@ cc_library(
     deps = [
         ":attributes",
         ":ccompat",
+        ":util",
         "@libsodium",
     ],
 )

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -853,12 +853,14 @@ static void get_close_nodes_inner(
  */
 non_null()
 static int get_somewhat_close_nodes(
-        uint64_t cur_time, const uint8_t *public_key, Node_format *nodes_list,
+        uint64_t cur_time, const uint8_t *public_key, Node_format nodes_list[MAX_SENT_NODES],
         Family sa_family, const Client_data *close_clientlist,
         const DHT_Friend *friends_list, uint16_t friends_list_size,
         bool is_lan, bool want_announce)
 {
-    memset(nodes_list, 0, MAX_SENT_NODES * sizeof(Node_format));
+    for (uint16_t i = 0; i < MAX_SENT_NODES; ++i) {
+        nodes_list[i] = empty_node_format;
+    }
 
     uint32_t num_nodes = 0;
     get_close_nodes_inner(
@@ -882,7 +884,7 @@ static int get_somewhat_close_nodes(
 
 int get_close_nodes(
         const DHT *dht, const uint8_t *public_key,
-        Node_format *nodes_list, Family sa_family,
+        Node_format nodes_list[MAX_SENT_NODES], Family sa_family,
         bool is_lan, bool want_announce)
 {
     return get_somewhat_close_nodes(
@@ -1101,7 +1103,8 @@ static void update_client_with_reset(const Mono_Time *mono_time, Client_data *cl
     ipptp_write->ret_ip_self = false;
 
     /* zero out other address */
-    memset(ipptp_clear, 0, sizeof(*ipptp_clear));
+    const IPPTsPng empty_ipptp = {{{{0}}}};
+    *ipptp_clear = empty_ipptp;
 }
 
 /**

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -396,7 +396,7 @@ void set_announce_node(DHT *dht, const uint8_t *public_key);
 non_null()
 int get_close_nodes(
         const DHT *dht, const uint8_t *public_key,
-        Node_format *nodes_list, Family sa_family,
+        Node_format nodes_list[MAX_SENT_NODES], Family sa_family,
         bool is_lan, bool want_announce);
 
 

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -9,7 +9,6 @@
 #include "LAN_discovery.h"
 
 #include <stdlib.h>
-#include <string.h>
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 // The mingw32/64 Windows library warns about including winsock2.h after
@@ -143,8 +142,7 @@ static Broadcast_Info *fetch_broadcast_info(const Network *ns)
     }
 
     /* Configure ifconf for the ioctl call. */
-    struct ifreq i_faces[MAX_INTERFACES];
-    memset(i_faces, 0, sizeof(struct ifreq) * MAX_INTERFACES);
+    struct ifreq i_faces[MAX_INTERFACES] = {{0}};
 
     struct ifconf ifc;
     ifc.ifc_buf = (char *)i_faces;

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -857,7 +857,7 @@ int m_copy_statusmessage(const Messenger *m, int32_t friendnumber, uint8_t *buf,
     const uint32_t msglen = min_u32(maxlen, m->friendlist[friendnumber].statusmessage_length);
 
     memcpy(buf, m->friendlist[friendnumber].statusmessage, msglen);
-    memset(buf + msglen, 0, maxlen - msglen);
+    memzero(buf + msglen, maxlen - msglen);
     return msglen;
 }
 
@@ -2620,7 +2620,7 @@ static bool self_announce_group(const Messenger *m, GC_Chat *chat, Onion_Friend 
     if (tcp_num > 0) {
         pk_copy(chat->announced_tcp_relay_pk, announce.base_announce.tcp_relays[0].public_key);
     } else {
-        memset(chat->announced_tcp_relay_pk, 0, sizeof(chat->announced_tcp_relay_pk));
+        memzero(chat->announced_tcp_relay_pk, sizeof(chat->announced_tcp_relay_pk));
     }
 
     LOGGER_DEBUG(chat->log, "Published group announce. TCP relays: %d, UDP status: %d", tcp_num,
@@ -3416,10 +3416,9 @@ static uint32_t path_node_size(const Messenger *m)
 non_null()
 static uint8_t *save_path_nodes(const Messenger *m, uint8_t *data)
 {
-    Node_format nodes[NUM_SAVED_PATH_NODES];
+    Node_format nodes[NUM_SAVED_PATH_NODES] = {{{0}}};
     uint8_t *temp_data = data;
     data = state_write_section_header(data, STATE_COOKIE_TYPE, 0, STATE_TYPE_PATH_NODE);
-    memset(nodes, 0, sizeof(nodes));
     const unsigned int num = onion_backup_nodes(m->onion_c, nodes, NUM_SAVED_PATH_NODES);
     const int l = pack_nodes(m->log, data, NUM_SAVED_PATH_NODES * packed_node_size(net_family_tcp_ipv6()), nodes, num);
 

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -60,6 +60,8 @@ typedef struct TCP_Secure_Connection {
     uint64_t ping_id;
 } TCP_Secure_Connection;
 
+static const TCP_Secure_Connection empty_tcp_secure_connection = {{nullptr}};
+
 
 struct TCP_Server {
     const Logger *logger;
@@ -135,8 +137,9 @@ static int alloc_new_connections(TCP_Server *tcp_server, uint32_t num)
     }
 
     const uint32_t old_size = tcp_server->size_accepted_connections;
-    const uint32_t size_new_entries = num * sizeof(TCP_Secure_Connection);
-    memset(new_connections + old_size, 0, size_new_entries);
+    for (uint32_t i = 0; i < num; ++i) {
+        new_connections[old_size + i] = empty_tcp_secure_connection;
+    }
 
     tcp_server->accepted_connection_array = new_connections;
     tcp_server->size_accepted_connections = new_size;

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -21,6 +21,7 @@
 #include "net_crypto.h"
 #include "network.h"
 #include "onion_client.h"
+#include "util.h"
 
 #define PORTS_PER_DISCOVERY 10
 
@@ -982,7 +983,7 @@ void do_friend_connections(Friend_Connections *fr_c, void *userdata)
                     if (friend_con->dht_lock_token > 0) {
                         dht_delfriend(fr_c->dht, friend_con->dht_temp_pk, friend_con->dht_lock_token);
                         friend_con->dht_lock_token = 0;
-                        memset(friend_con->dht_temp_pk, 0, CRYPTO_PUBLIC_KEY_SIZE);
+                        memzero(friend_con->dht_temp_pk, CRYPTO_PUBLIC_KEY_SIZE);
                     }
                 }
 

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -730,7 +730,7 @@ static bool set_gc_password_local(GC_Chat *chat, const uint8_t *passwd, uint16_t
 
     if (passwd == nullptr || length == 0) {
         chat->shared_state.password_length = 0;
-        memset(chat->shared_state.password, 0, MAX_GC_PASSWORD_SIZE);
+        memzero(chat->shared_state.password, MAX_GC_PASSWORD_SIZE);
     } else {
         chat->shared_state.password_length = length;
         crypto_memlock(chat->shared_state.password, sizeof(chat->shared_state.password));
@@ -1526,7 +1526,7 @@ int group_packet_wrap(
 
     assert(padding_len < packet_size);
 
-    memset(plain, 0, padding_len);
+    memzero(plain, padding_len);
 
     uint16_t enc_header_len = sizeof(uint8_t);
     plain[padding_len] = gp_packet_type;
@@ -2492,8 +2492,7 @@ static int handle_gc_ping(GC_Chat *chat, GC_Connection *gconn, const uint8_t *da
     do_gc_peer_state_sync(chat, gconn, data, length);
 
     if (length > GC_PING_PACKET_MIN_DATA_SIZE) {
-        IP_Port ip_port;
-        memset(&ip_port, 0, sizeof(IP_Port));
+        IP_Port ip_port = {{{0}}};
 
         if (unpack_ip_port(&ip_port, data + GC_PING_PACKET_MIN_DATA_SIZE,
                            length - GC_PING_PACKET_MIN_DATA_SIZE, false) > 0) {
@@ -3792,7 +3791,7 @@ int gc_set_topic(GC_Chat *chat, const uint8_t *topic, uint16_t length)
         assert(topic != nullptr);
         memcpy(chat->topic_info.topic, topic, length);
     } else {
-        memset(chat->topic_info.topic, 0, sizeof(chat->topic_info.topic));
+        memzero(chat->topic_info.topic, sizeof(chat->topic_info.topic));
     }
 
     memcpy(chat->topic_info.public_sig_key, get_sig_pk(chat->self_public_key), SIG_PUBLIC_KEY_SIZE);
@@ -5622,8 +5621,7 @@ static bool send_gc_handshake_packet(const GC_Chat *chat, GC_Connection *gconn, 
         return false;
     }
 
-    Node_format node;
-    memset(&node, 0, sizeof(node));
+    Node_format node = {{0}};
 
     if (!gcc_copy_tcp_relay(chat->rng, &node, gconn)) {
         LOGGER_TRACE(chat->log, "Failed to copy TCP relay during handshake (%u TCP relays)", gconn->tcp_relays_count);
@@ -5678,8 +5676,7 @@ static bool send_gc_oob_handshake_request(const GC_Chat *chat, const GC_Connecti
         return false;
     }
 
-    Node_format node;
-    memset(&node, 0, sizeof(node));
+    Node_format node = {{0}};
 
     if (!gcc_copy_tcp_relay(chat->rng, &node, gconn)) {
         LOGGER_WARNING(chat->log, "Failed to copy TCP relay");

--- a/toxcore/group_moderation.c
+++ b/toxcore/group_moderation.c
@@ -93,7 +93,7 @@ void mod_list_get_data_hash(uint8_t *hash, const uint8_t *packed_mod_list, uint1
 bool mod_list_make_hash(const Moderation *moderation, uint8_t *hash)
 {
     if (moderation->num_mods == 0) {
-        memset(hash, 0, MOD_MODERATION_HASH_SIZE);
+        memzero(hash, MOD_MODERATION_HASH_SIZE);
         return true;
     }
 
@@ -410,7 +410,7 @@ static bool sanctions_list_make_hash(const Mod_Sanction *sanctions, uint32_t new
                                      uint8_t *hash)
 {
     if (num_sanctions == 0 || sanctions == nullptr) {
-        memset(hash, 0, MOD_SANCTION_HASH_SIZE);
+        memzero(hash, MOD_SANCTION_HASH_SIZE);
         return true;
     }
 

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -227,7 +227,7 @@ static int create_cookie_request(const Net_Crypto *c, uint8_t *packet, const uin
     uint8_t plain[COOKIE_REQUEST_PLAIN_LENGTH];
 
     memcpy(plain, c->self_public_key, CRYPTO_PUBLIC_KEY_SIZE);
-    memset(plain + CRYPTO_PUBLIC_KEY_SIZE, 0, CRYPTO_PUBLIC_KEY_SIZE);
+    memzero(plain + CRYPTO_PUBLIC_KEY_SIZE, CRYPTO_PUBLIC_KEY_SIZE);
     memcpy(plain + (CRYPTO_PUBLIC_KEY_SIZE * 2), &number, sizeof(uint64_t));
     const uint8_t *tmp_shared_key = dht_get_shared_key_sent(c->dht, dht_public_key);
     memcpy(shared_key, tmp_shared_key, CRYPTO_SHARED_KEY_SIZE);
@@ -1139,7 +1139,7 @@ static int send_data_packet_helper(Net_Crypto *c, int crypt_connection_id, uint3
     VLA(uint8_t, packet, sizeof(uint32_t) + sizeof(uint32_t) + padding_length + length);
     memcpy(packet, &buffer_start, sizeof(uint32_t));
     memcpy(packet + sizeof(uint32_t), &num, sizeof(uint32_t));
-    memset(packet + (sizeof(uint32_t) * 2), 0, padding_length);
+    memzero(packet + (sizeof(uint32_t) * 2), padding_length);
     memcpy(packet + (sizeof(uint32_t) * 2) + padding_length, data, length);
 
     return send_data_packet(c, crypt_connection_id, packet, SIZEOF_VLA(packet));

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1221,9 +1221,7 @@ Networking_Core *new_networking_ex(
 
     /* Bind our socket to port PORT and the given IP address (usually 0.0.0.0 or ::) */
     uint16_t *portptr = nullptr;
-    Network_Addr addr;
-
-    memset(&addr.addr, 0, sizeof(struct sockaddr_storage));
+    Network_Addr addr = {{0}};
 
     if (net_family_is_ipv4(temp->family)) {
         struct sockaddr_in *addr4 = (struct sockaddr_in *)&addr.addr;
@@ -1262,8 +1260,7 @@ Networking_Core *new_networking_ex(
 
 #ifndef ESP_PLATFORM
         /* multicast local nodes */
-        struct ipv6_mreq mreq;
-        memset(&mreq, 0, sizeof(mreq));
+        struct ipv6_mreq mreq = {{0}};
         mreq.ipv6mr_multiaddr.s6_addr[ 0] = 0xFF;
         mreq.ipv6mr_multiaddr.s6_addr[ 1] = 0x02;
         mreq.ipv6mr_multiaddr.s6_addr[15] = 0x01;
@@ -1625,8 +1622,7 @@ static int addr_resolve(const Network *ns, const char *address, IP *to, IP *extr
     const Family tox_family = to->family;
     const int family = make_family(tox_family);
 
-    struct addrinfo hints;
-    memset(&hints, 0, sizeof(hints));
+    struct addrinfo hints = {0};
     hints.ai_family   = family;
     hints.ai_socktype = SOCK_DGRAM; // type of socket Tox uses.
 

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -19,6 +19,7 @@
 #include "mono_time.h"
 #include "network.h"
 #include "shared_key_cache.h"
+#include "util.h"
 
 #define RETURN_1 ONION_RETURN_1
 #define RETURN_2 ONION_RETURN_2
@@ -53,7 +54,7 @@ static void ip_pack_to_bytes(uint8_t *data, const IP *source)
     data[0] = source->family.value;
 
     if (net_family_is_ipv4(source->family) || net_family_is_tox_tcp_ipv4(source->family)) {
-        memset(data + 1, 0, SIZE_IP6);
+        memzero(data + 1, SIZE_IP6);
         memcpy(data + 1, source->ip.v4.uint8, SIZE_IP4);
     } else {
         memcpy(data + 1, source->ip.v6.uint8, SIZE_IP6);

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -33,6 +33,7 @@
 #include "state.h"
 #include "tox_private.h"
 #include "tox_struct.h"
+#include "util.h"
 
 #include "../toxencryptsave/defines.h"
 
@@ -992,14 +993,14 @@ void tox_get_savedata(const Tox *tox, uint8_t *savedata)
         return;
     }
 
-    memset(savedata, 0, tox_get_savedata_size(tox));
+    memzero(savedata, tox_get_savedata_size(tox));
 
     tox_lock(tox);
 
     const uint32_t size32 = sizeof(uint32_t);
 
     // write cookie
-    memset(savedata, 0, size32);
+    memzero(savedata, size32);
     savedata += size32;
     host_to_lendian_bytes32(savedata, STATE_COOKIE_GLOBAL);
     savedata += size32;

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -96,6 +96,15 @@ uint8_t *memdup(const uint8_t *data, size_t data_size)
     return copy;
 }
 
+void memzero(uint8_t *data, size_t data_size)
+{
+    if (data == nullptr || data_size == 0) {
+        return;
+    }
+
+    memset(data, 0, data_size);
+}
+
 int16_t max_s16(int16_t a, int16_t b)
 {
     return a > b ? a : b;

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -48,6 +48,16 @@ non_null() bool memeq(const uint8_t *a, size_t a_size, const uint8_t *b, size_t 
  */
 nullable(1) uint8_t *memdup(const uint8_t *data, size_t data_size);
 
+/**
+ * @brief Set all bytes in `data` to 0.
+ *
+ * NOTE: This does not securely zero out data. DO NOT USE for sensitive data. Use
+ * `crypto_memzero` from `crypto_core.h`, instead. This function is ok to use for
+ * message buffers, public keys, encrypted data, etc. It is not ok for buffers
+ * containing key material (secret keys, shared keys).
+ */
+nullable(1) void memzero(uint8_t *data, size_t data_size);
+
 // Safe min/max functions with specific types. This forces the conversion to the
 // desired type before the comparison expression, giving the choice of
 // conversion to the caller. Use these instead of inline comparisons or MIN/MAX


### PR DESCRIPTION
It's clearer and doesn't risk having a non-zero filler value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2594)
<!-- Reviewable:end -->
