### PR TITLE
refactor: Use `arrcpy` instead of `memcpy` for byte arrays.

### DIFF
--- a/toxcore/TCP_common.c
+++ b/toxcore/TCP_common.c
@@ -112,7 +112,7 @@ static bool add_priority(TCP_Connection *con, const uint8_t *packet, uint16_t si
         return false;
     }
 
-    memcpy(data, packet, size);
+    arrcpy(data, packet, size);
     new_list->data = data;
     new_list->size = size;
 
@@ -189,7 +189,7 @@ int write_packet_tcp_secure_connection(const Logger *logger, TCP_Connection *con
         return 1;
     }
 
-    memcpy(con->last_packet, packet, SIZEOF_VLA(packet));
+    arrcpy(con->last_packet, packet, SIZEOF_VLA(packet));
     con->last_packet_length = SIZEOF_VLA(packet);
     con->last_packet_sent = len;
     return 1;

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -96,6 +96,11 @@ uint8_t *memdup(const uint8_t *data, size_t data_size)
     return copy;
 }
 
+void arrcpy(uint8_t *dst, const uint8_t *src, size_t size)
+{
+    memcpy(dst, src, size);
+}
+
 void memzero(uint8_t *data, size_t data_size)
 {
     if (data == nullptr || data_size == 0) {

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -49,6 +49,13 @@ non_null() bool memeq(const uint8_t *a, size_t a_size, const uint8_t *b, size_t 
 nullable(1) uint8_t *memdup(const uint8_t *data, size_t data_size);
 
 /**
+ * @brief Exactly the same as `memcpy` but specialised to `uint8_t`.
+ *
+ * Prevents accidental use of memcpy for non-byte-arrays.
+ */
+non_null() void arrcpy(uint8_t *dst, const uint8_t *src, size_t size);
+
+/**
  * @brief Set all bytes in `data` to 0.
  *
  * NOTE: This does not securely zero out data. DO NOT USE for sensitive data. Use


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2596)
<!-- Reviewable:end -->
