### PR TITLE
refactor: Rename `system_{memory,...}` to `os_{memory,...}`.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -45,11 +45,11 @@ static uint16_t ports[NUM_PORTS] = {13215, 33445, 25643};
 
 static void test_basic(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
 
     Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
@@ -304,11 +304,11 @@ static int read_packet_sec_tcp(const Logger *logger, struct sec_TCP_con *con, ui
 
 static void test_some(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
 
     Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
@@ -499,11 +499,11 @@ static int oob_data_callback(void *object, const uint8_t *public_key, const uint
 
 static void test_client(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
 
     Logger *logger = logger_new();
@@ -633,11 +633,11 @@ static void test_client(void)
 // Test how the client handles servers that don't respond.
 static void test_client_invalid(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
 
     Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
@@ -712,11 +712,11 @@ static int tcp_data_callback(void *object, int id, const uint8_t *data, uint16_t
 
 static void test_tcp_connection(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
 
     Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
@@ -825,11 +825,11 @@ static int tcp_oobdata_callback(void *object, const uint8_t *public_key, unsigne
 
 static void test_tcp_connection2(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
 
     Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);

--- a/auto_tests/announce_test.c
+++ b/auto_tests/announce_test.c
@@ -13,7 +13,7 @@
 
 static void test_bucketnum(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     uint8_t key1[CRYPTO_PUBLIC_KEY_SIZE], key2[CRYPTO_PUBLIC_KEY_SIZE];
     random_bytes(rng, key1, sizeof(key1));
@@ -50,11 +50,11 @@ static void test_announce_data(void *object, const uint8_t *data, uint16_t lengt
 
 static void test_store_data(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
 
     Logger *log = logger_new();

--- a/auto_tests/conference_av_test.c
+++ b/auto_tests/conference_av_test.c
@@ -303,7 +303,7 @@ static void do_audio(AutoTox *autotoxes, uint32_t iterations)
 
 static void run_conference_tests(AutoTox *autotoxes)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     bool disabled[NUM_AV_GROUP_TOX] = {0};
 

--- a/auto_tests/conference_test.c
+++ b/auto_tests/conference_test.c
@@ -192,7 +192,7 @@ static uint32_t random_false_index(const Random *rng, bool *list, const uint32_t
 
 static void run_conference_tests(AutoTox *autotoxes)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     /* disabling name change propagation check for now, as it occasionally
      * fails due to disconnections too short to trigger freezing */

--- a/auto_tests/crypto_test.c
+++ b/auto_tests/crypto_test.c
@@ -125,7 +125,7 @@ static void test_fast_known(void)
 
 static void test_endtoend(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
 
     // Test 100 random messages and keypairs
@@ -192,7 +192,7 @@ static void test_endtoend(void)
 
 static void test_large_data(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     uint8_t k[CRYPTO_SHARED_KEY_SIZE];
     uint8_t n[CRYPTO_NONCE_SIZE];
@@ -236,7 +236,7 @@ static void test_large_data(void)
 
 static void test_large_data_symmetric(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     uint8_t k[CRYPTO_SYMMETRIC_KEY_SIZE];
 
@@ -271,7 +271,7 @@ static void test_large_data_symmetric(void)
 
 static void test_very_large_data(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
 
     uint8_t nonce[CRYPTO_NONCE_SIZE] = {0};
@@ -316,7 +316,7 @@ static void increment_nonce_number_cmp(uint8_t *nonce, uint32_t num)
 
 static void test_increment_nonce(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
 
     uint8_t n[CRYPTO_NONCE_SIZE];

--- a/auto_tests/encryptsave_test.c
+++ b/auto_tests/encryptsave_test.c
@@ -168,7 +168,7 @@ static void test_keys(void)
     ck_assert(encrypted2a != nullptr);
     uint8_t *in_plaintext2a = (uint8_t *)malloc(plaintext_length2a);
     ck_assert(in_plaintext2a != nullptr);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     random_bytes(rng, in_plaintext2a, plaintext_length2a);
     ret = tox_pass_encrypt(in_plaintext2a, plaintext_length2a, key_char, 12, encrypted2a, &encerr);

--- a/auto_tests/forwarding_test.c
+++ b/auto_tests/forwarding_test.c
@@ -104,9 +104,9 @@ typedef struct Forwarding_Subtox {
 
 static Forwarding_Subtox *new_forwarding_subtox(const Memory *mem, bool no_udp, uint32_t *index, uint16_t port)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
 
     Forwarding_Subtox *subtox = (Forwarding_Subtox *)calloc(1, sizeof(Forwarding_Subtox));
@@ -152,11 +152,11 @@ static void kill_forwarding_subtox(const Memory *mem, Forwarding_Subtox *subtox)
 
 static void test_forwarding(void)
 {
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
 
     uint32_t index[NUM_FORWARDER];

--- a/auto_tests/group_message_test.c
+++ b/auto_tests/group_message_test.c
@@ -381,7 +381,7 @@ static void group_message_test(AutoTox *autotoxes)
 {
     ck_assert_msg(NUM_GROUP_TOXES >= 2, "NUM_GROUP_TOXES is too small: %d", NUM_GROUP_TOXES);
 
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
 
     Tox *tox0 = autotoxes[0].tox;

--- a/auto_tests/group_sync_test.c
+++ b/auto_tests/group_sync_test.c
@@ -335,7 +335,7 @@ static void topic_spam(const Random *rng, AutoTox *autotoxes, uint32_t num_peers
 static void group_sync_test(AutoTox *autotoxes)
 {
     ck_assert(NUM_GROUP_TOXES >= 5);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
 
     for (size_t i = 0; i < NUM_GROUP_TOXES; ++i) {

--- a/auto_tests/group_topic_test.c
+++ b/auto_tests/group_topic_test.c
@@ -215,7 +215,7 @@ static void group_topic_test(AutoTox *autotoxes)
 {
     ck_assert_msg(NUM_GROUP_TOXES >= 3, "NUM_GROUP_TOXES is too small: %d", NUM_GROUP_TOXES);
 
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
 
     Tox *tox0 = autotoxes[0].tox;

--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -20,7 +20,7 @@ static void test_addr_resolv_localhost(void)
     errno = 0;
 #endif
 
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
 
     const char localhost[] = "localhost";

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -223,11 +223,11 @@ static Networking_Core *new_networking(const Logger *log, const Memory *mem, con
 static void test_basic(void)
 {
     uint32_t index[] = { 1, 2, 3 };
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     ck_assert(ns != nullptr);
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
 
     Logger *log1 = logger_new();
@@ -407,7 +407,7 @@ static Onions *new_onions(const Memory *mem, const Random *rng, uint16_t port, u
 {
     IP ip = get_loopback();
     ip.ip.v6.uint8[15] = 1;
-    const Network *ns = system_network();
+    const Network *ns = os_network();
     Onions *on = (Onions *)malloc(sizeof(Onions));
 
     if (!on) {
@@ -576,9 +576,9 @@ static void test_announce(void)
 {
     uint32_t index[NUM_ONIONS];
     Onions *onions[NUM_ONIONS];
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     ck_assert(mem != nullptr);
 
     for (uint32_t i = 0; i < NUM_ONIONS; ++i) {

--- a/auto_tests/reconnect_test.c
+++ b/auto_tests/reconnect_test.c
@@ -51,7 +51,7 @@ static bool all_disconnected_from(uint32_t tox_count, AutoTox *autotoxes, uint32
 
 static void test_reconnect(AutoTox *autotoxes)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     const time_t test_start_time = time(nullptr);
 

--- a/auto_tests/save_friend_test.c
+++ b/auto_tests/save_friend_test.c
@@ -98,7 +98,7 @@ int main(void)
     ck_assert(reference_name != nullptr);
     ck_assert(reference_status != nullptr);
 
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     set_random(tox1, rng, tox_self_set_name, tox_max_name_length());
     set_random(tox2, rng, tox_self_set_name, tox_max_name_length());

--- a/auto_tests/tox_many_tcp_test.c
+++ b/auto_tests/tox_many_tcp_test.c
@@ -50,7 +50,7 @@ static uint16_t tcp_relay_port = 33448;
 
 static void test_many_clients_tcp(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     long long unsigned int cur_time = time(nullptr);
     Tox *toxes[NUM_TOXES_TCP];
@@ -162,7 +162,7 @@ loop_top:
 
 static void test_many_clients_tcp_b(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     long long unsigned int cur_time = time(nullptr);
     Tox *toxes[NUM_TOXES_TCP];

--- a/auto_tests/tox_many_test.c
+++ b/auto_tests/tox_many_test.c
@@ -30,7 +30,7 @@ static void accept_friend_request(Tox *m, const Tox_Event_Friend_Request *event,
 
 static void test_many_clients(void)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ck_assert(rng != nullptr);
     time_t cur_time = time(nullptr);
     Tox *toxes[TCP_TEST_NUM_TOXES];

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -151,9 +151,9 @@ int main(int argc, char *argv[])
         logger_callback_log(logger, print_log, nullptr, nullptr);
     }
 
-    const Random *rng = system_random();
-    const Network *ns = system_network();
-    const Memory *mem = system_memory();
+    const Random *rng = os_random();
+    const Network *ns = os_network();
+    const Memory *mem = os_memory();
 
     Mono_Time *mono_time = mono_time_new(mem, nullptr, nullptr);
     const uint16_t start_port = PORT;

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-8a2cc2e20ac0688b42c6e6211cb1bc5797c276ed52a2322d8b786f8ad562d535  /usr/local/bin/tox-bootstrapd
+48ed699a0da0282b7e12142648a322198a2f2af791df3fb49bbe3f7e41afadc4  /usr/local/bin/tox-bootstrapd

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -292,9 +292,9 @@ int main(int argc, char *argv[])
     }
 
     const uint16_t end_port = start_port + (TOX_PORTRANGE_TO - TOX_PORTRANGE_FROM);
-    const Memory *mem = system_memory();
-    const Random *rng = system_random();
-    const Network *ns = system_network();
+    const Memory *mem = os_memory();
+    const Random *rng = os_random();
+    const Network *ns = os_network();
     Networking_Core *net = new_networking_ex(logger, mem, ns, &ip, start_port, end_port, nullptr);
 
     if (net == nullptr) {

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
         exit(0);
     }
 
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
     Mono_Time *const mono_time = mono_time_new(mem, nullptr, nullptr);
 
     if (mono_time == nullptr) {
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
     Messenger_Options options = {0};
     options.ipv6enabled = ipv6enabled;
     Messenger_Error err;
-    m = new_messenger(mono_time, mem, system_random(), system_network(), &options, &err);
+    m = new_messenger(mono_time, mem, os_random(), os_network(), &options, &err);
 
     if (!m) {
         fprintf(stderr, "Failed to allocate messenger datastructure: %d\n", err);

--- a/toxav/rtp_test.cc
+++ b/toxav/rtp_test.cc
@@ -29,7 +29,7 @@ RTPHeader random_header(const Random *rng)
 
 TEST(Rtp, Deserialisation)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ASSERT_NE(rng, nullptr);
     RTPHeader const header = random_header(rng);
 

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -507,14 +507,14 @@ static uint32_t sys_random_uniform(void *obj, uint32_t upper_bound)
     return randombytes_uniform(upper_bound);
 }
 
-static const Random_Funcs system_random_funcs = {
+static const Random_Funcs os_random_funcs = {
     sys_random_bytes,
     sys_random_uniform,
 };
 
-static const Random system_random_obj = {&system_random_funcs};
+static const Random os_random_obj = {&os_random_funcs};
 
-const Random *system_random(void)
+const Random *os_random(void)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if ((true)) {
@@ -526,7 +526,7 @@ const Random *system_random(void)
     if (sodium_init() == -1) {
         return nullptr;
     }
-    return &system_random_obj;
+    return &os_random_obj;
 }
 
 void random_bytes(const Random *rng, uint8_t *bytes, size_t length)

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -88,7 +88,7 @@ typedef struct Random {
     void *obj;
 } Random;
 
-const Random *system_random(void);
+const Random *os_random(void);
 
 /**
  * @brief The number of bytes in an encryption public key used by DHT group chats.

--- a/toxcore/mem.c
+++ b/toxcore/mem.c
@@ -33,17 +33,17 @@ static void sys_free(void *obj, void *ptr)
     free(ptr);
 }
 
-static const Memory_Funcs system_memory_funcs = {
+static const Memory_Funcs os_memory_funcs = {
     sys_malloc,
     sys_calloc,
     sys_realloc,
     sys_free,
 };
-static const Memory system_memory_obj = {&system_memory_funcs};
+static const Memory os_memory_obj = {&os_memory_funcs};
 
-const Memory *system_memory(void)
+const Memory *os_memory(void)
 {
-    return &system_memory_obj;
+    return &os_memory_obj;
 }
 
 void *mem_balloc(const Memory *mem, uint32_t size)

--- a/toxcore/mem.h
+++ b/toxcore/mem.h
@@ -35,7 +35,7 @@ typedef struct Memory {
     void *obj;
 } Memory;
 
-const Memory *system_memory(void);
+const Memory *os_memory(void);
 
 /**
  * @brief Allocate an array of a given size for built-in types.

--- a/toxcore/mem_test.cc
+++ b/toxcore/mem_test.cc
@@ -9,7 +9,7 @@ TEST(Mem, AllocLarge)
     // Mebi prefix: https://en.wikipedia.org/wiki/Binary_prefix.
     constexpr uint32_t MI = 1024 * 1024;
 
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
 
     void *ptr = mem_valloc(mem, 4, MI);
     EXPECT_NE(ptr, nullptr);
@@ -22,7 +22,7 @@ TEST(Mem, AllocOverflow)
     // Gibi prefix.
     constexpr uint32_t GI = 1024 * 1024 * 1024;
 
-    const Memory *mem = system_memory();
+    const Memory *mem = os_memory();
 
     // 1 gibi-elements of 100 bytes each.
     void *ptr = mem_valloc(mem, GI, 100);

--- a/toxcore/mem_test_util.hh
+++ b/toxcore/mem_test_util.hh
@@ -24,11 +24,11 @@ struct Memory_Class {
 };
 
 /**
- * Base test Memory class that just forwards to system_memory. Can be
+ * Base test Memory class that just forwards to os_memory. Can be
  * subclassed to override individual (or all) functions.
  */
 class Test_Memory : public Memory_Class {
-    const Memory *mem = REQUIRE_NOT_NULL(system_memory());
+    const Memory *mem = REQUIRE_NOT_NULL(os_memory());
 
     void *malloc(void *obj, uint32_t size) override;
     void *calloc(void *obj, uint32_t nmemb, uint32_t size) override;

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -574,7 +574,7 @@ static int sys_setsockopt(void *obj, int sock, int level, int optname, const voi
     return setsockopt(sock, level, optname, (const char *)optval, optlen);
 }
 
-static const Network_Funcs system_network_funcs = {
+static const Network_Funcs os_network_funcs = {
     sys_close,
     sys_accept,
     sys_bind,
@@ -589,9 +589,9 @@ static const Network_Funcs system_network_funcs = {
     sys_getsockopt,
     sys_setsockopt,
 };
-static const Network system_network_obj = {&system_network_funcs};
+static const Network os_network_obj = {&os_network_funcs};
 
-const Network *system_network(void)
+const Network *os_network(void)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if ((true)) {
@@ -605,12 +605,12 @@ const Network *system_network(void)
         return nullptr;
     }
 #endif /* OS_WIN32 */
-    return &system_network_obj;
+    return &os_network_obj;
 }
 
 #if 0
-/* TODO(iphydf): Call this from functions that use `system_network()`. */
-void system_network_deinit(const Network *ns)
+/* TODO(iphydf): Call this from functions that use `os_network()`. */
+void os_network_deinit(const Network *ns)
 {
 #ifdef OS_WIN32
     WSACleanup();

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -69,7 +69,7 @@ typedef struct Network {
     void *obj;
 } Network;
 
-const Network *system_network(void);
+const Network *os_network(void);
 
 typedef struct Family {
     uint8_t value;

--- a/toxcore/network_test_util.hh
+++ b/toxcore/network_test_util.hh
@@ -38,11 +38,11 @@ struct Network_Class {
 };
 
 /**
- * Base test Network class that just forwards to system_network. Can be
+ * Base test Network class that just forwards to os_network. Can be
  * subclassed to override individual (or all) functions.
  */
 class Test_Network : public Network_Class {
-    const Network *net = REQUIRE_NOT_NULL(system_network());
+    const Network *net = REQUIRE_NOT_NULL(os_network());
 
     int close(void *obj, int sock) override;
     int accept(void *obj, int sock) override;

--- a/toxcore/ping_array_test.cc
+++ b/toxcore/ping_array_test.cc
@@ -65,7 +65,7 @@ TEST(PingArray, StoredDataCanBeRetrieved)
     Ping_Array_Ptr const arr(ping_array_new(mem, 2, 1));
     Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ASSERT_NE(rng, nullptr);
 
     uint64_t const ping_id = ping_array_add(
@@ -84,7 +84,7 @@ TEST(PingArray, RetrievingDataWithTooSmallOutputBufferHasNoEffect)
     Ping_Array_Ptr const arr(ping_array_new(mem, 2, 1));
     Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ASSERT_NE(rng, nullptr);
 
     uint64_t const ping_id = ping_array_add(
@@ -107,7 +107,7 @@ TEST(PingArray, ZeroLengthDataCanBeAdded)
     Ping_Array_Ptr const arr(ping_array_new(mem, 2, 1));
     Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ASSERT_NE(rng, nullptr);
 
     uint8_t c = 0;
@@ -137,7 +137,7 @@ TEST(PingArray, DataCanOnlyBeRetrievedOnce)
     Ping_Array_Ptr const arr(ping_array_new(mem, 2, 1));
     Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ASSERT_NE(rng, nullptr);
 
     uint8_t c = 0;
@@ -155,7 +155,7 @@ TEST(PingArray, PingIdMustMatchOnCheck)
     Ping_Array_Ptr const arr(ping_array_new(mem, 1, 1));
     Mono_Time_Ptr const mono_time(mono_time_new(mem, nullptr, nullptr), mem);
     ASSERT_NE(mono_time, nullptr);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ASSERT_NE(rng, nullptr);
 
     uint8_t c = 0;

--- a/toxcore/tox_private.c
+++ b/toxcore/tox_private.c
@@ -33,9 +33,9 @@ Tox_System tox_default_system(void)
     const Tox_System sys = {
         nullptr,  // mono_time_callback
         nullptr,  // mono_time_user_data
-        system_random(),
-        system_network(),
-        system_memory(),
+        os_random(),
+        os_network(),
+        os_memory(),
     };
     return sys;
 }

--- a/toxcore/tox_test.cc
+++ b/toxcore/tox_test.cc
@@ -101,7 +101,7 @@ TEST(Tox, OneTest)
 
     Tox *tox1 = tox_new(options, nullptr);
     ASSERT_NE(tox1, nullptr);
-    const Random *rng = system_random();
+    const Random *rng = os_random();
     ASSERT_NE(rng, nullptr);
     set_random_name_and_status_message(tox1, rng, name.data(), status_message.data());
     Tox *tox2 = tox_new(options, nullptr);

--- a/toxencryptsave/toxencryptsave.c
+++ b/toxencryptsave/toxencryptsave.c
@@ -118,7 +118,7 @@ Tox_Pass_Key *tox_pass_key_derive(
         const uint8_t passphrase[], size_t passphrase_len,
         Tox_Err_Key_Derivation *error)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
 
     if (rng == nullptr) {
         SET_ERROR_PARAMETER(error, TOX_ERR_KEY_DERIVATION_FAILED);
@@ -196,7 +196,7 @@ Tox_Pass_Key *tox_pass_key_derive_with_salt(
 bool tox_pass_key_encrypt(const Tox_Pass_Key *key, const uint8_t plaintext[], size_t plaintext_len,
                           uint8_t ciphertext[], Tox_Err_Encryption *error)
 {
-    const Random *rng = system_random();
+    const Random *rng = os_random();
 
     if (rng == nullptr) {
         SET_ERROR_PARAMETER(error, TOX_ERR_ENCRYPTION_FAILED);


### PR DESCRIPTION
This rename happens in the system PR, so I'm pulling it out to reduce the size of that PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2598)
<!-- Reviewable:end -->
