### PR TITLE
refactor: Install headers into repo-equivalent directories.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,32 +3,32 @@ load("//tools/project:build_defs.bzl", "project")
 
 project(license = "gpl3-https")
 
-genrule(
+filegroup(
+    name = "legacy_headers",
+    srcs = [
+        "tox/tox.h",
+        "tox/toxav.h",
+        "tox/toxencryptsave.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "public_headers",
     srcs = [
         "//c-toxcore/toxav:toxav.h",
         "//c-toxcore/toxcore:tox.h",
-        "//c-toxcore/toxcore:tox_private.h",
         "//c-toxcore/toxencryptsave:toxencryptsave.h",
     ],
-    outs = [
-        "tox/toxav.h",
-        "tox/tox.h",
-        "tox/tox_private.h",
-        "tox/toxencryptsave.h",
-    ],
-    cmd = """
-        cp $(location //c-toxcore/toxav:toxav.h) $(GENDIR)/c-toxcore/tox/toxav.h
-        cp $(location //c-toxcore/toxcore:tox.h) $(GENDIR)/c-toxcore/tox/tox.h
-        cp $(location //c-toxcore/toxcore:tox_private.h) $(GENDIR)/c-toxcore/tox/tox_private.h
-        cp $(location //c-toxcore/toxencryptsave:toxencryptsave.h) $(GENDIR)/c-toxcore/tox/toxencryptsave.h
-    """,
     visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "c-toxcore",
-    hdrs = [":public_headers"],
+    hdrs = [
+        ":legacy_headers",
+        ":public_headers",
+    ],
     includes = ["."],
     visibility = ["//visibility:public"],
     deps = [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,7 @@ else()
 endif()
 set(toxcore_PKGCONFIG_REQUIRES ${toxcore_PKGCONFIG_REQUIRES} libsodium)
 set(toxcore_API_HEADERS
+  ${toxcore_SOURCE_DIR}/tox/tox.h^tox
   ${toxcore_SOURCE_DIR}/toxcore/tox.h^tox
   ${toxcore_SOURCE_DIR}/toxcore/tox_events.h^tox
   ${toxcore_SOURCE_DIR}/toxcore/tox_dispatch.h^tox
@@ -386,6 +387,7 @@ if(BUILD_TOXAV)
     toxav/video.c
     toxav/video.h)
   set(toxcore_API_HEADERS ${toxcore_API_HEADERS}
+    ${toxcore_SOURCE_DIR}/tox/toxav.h^toxav
     ${toxcore_SOURCE_DIR}/toxav/toxav.h^toxav)
 
   if(MSVC)
@@ -409,6 +411,7 @@ set(toxcore_SOURCES ${toxcore_SOURCES}
   toxencryptsave/toxencryptsave.c
   toxencryptsave/toxencryptsave.h)
 set(toxcore_API_HEADERS ${toxcore_API_HEADERS}
+  ${toxcore_SOURCE_DIR}/tox/toxencryptsave.h^tox
   ${toxcore_SOURCE_DIR}/toxencryptsave/toxencryptsave.h^tox)
 
 ################################################################################
@@ -490,8 +493,8 @@ endif()
 make_version_script(toxcore ${toxcore_API_HEADERS})
 
 # Generate pkg-config file, install library to "${CMAKE_INSTALL_LIBDIR}" and install headers to
-# "${CMAKE_INSTALL_INCLUDEDIR}/tox".
-install_module(toxcore DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tox)
+# "${CMAKE_INSTALL_INCLUDEDIR}".
+install_module(toxcore DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 ################################################################################
 #

--- a/cmake/ModulePackage.cmake
+++ b/cmake/ModulePackage.cmake
@@ -20,6 +20,7 @@ if(FULLY_STATIC)
 endif()
 
 function(install_module lib)
+  cmake_parse_arguments(INSTALL_MODULE "" "DESTINATION" "" ${ARGN})
   if(TARGET ${lib}_shared)
     set_target_properties(${lib}_shared PROPERTIES
       VERSION ${SOVERSION}
@@ -59,7 +60,10 @@ function(install_module lib)
   foreach(sublib ${${lib}_API_HEADERS})
     string(REPLACE "^" ";" sublib ${sublib})
     list(GET sublib 0 header)
+    string(REPLACE "${${lib}_SOURCE_DIR}/" "" target_header ${header})
+    get_filename_component(target_path ${target_header} DIRECTORY)
 
-    install(FILES ${header} ${ARGN})
+    install(FILES ${header} DESTINATION
+            "${INSTALL_MODULE_DESTINATION}/${target_path}")
   endforeach()
 endfunction()

--- a/cmake/StrictAbi.cmake
+++ b/cmake/StrictAbi.cmake
@@ -32,12 +32,14 @@ function(_make_version_script target)
       COMMAND ${SHELL} -c "egrep '^\\w' ${header} | grep '${ns}_[a-z0-9_]*(' | grep -v '^typedef' | grep -o '${ns}_[a-z0-9_]*(' | egrep -o '[a-z0-9_]+' | sort -u"
       OUTPUT_VARIABLE sublib_SYMS
       OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(REPLACE "\n" ";" sublib_SYMS ${sublib_SYMS})
+    if(sublib_SYMS)
+      string(REPLACE "\n" ";" sublib_SYMS ${sublib_SYMS})
 
-    foreach(sym ${sublib_SYMS})
-      file(APPEND ${${target}_VERSION_SCRIPT}
-        "${sym};\n")
-    endforeach(sym)
+      foreach(sym ${sublib_SYMS})
+        file(APPEND ${${target}_VERSION_SCRIPT}
+          "${sym};\n")
+      endforeach(sym)
+    endif()
   endforeach(sublib)
 
   file(APPEND ${${target}_VERSION_SCRIPT}

--- a/other/docker/sources/Dockerfile
+++ b/other/docker/sources/Dockerfile
@@ -2,6 +2,7 @@ FROM scratch
 
 # Roughly in order of change frequency.
 COPY third_party/ /src/third_party/
+COPY tox/ /src/tox/
 COPY .github/scripts/flags*.sh /src/.github/scripts/
 COPY other/proxy/ /src/other/proxy/
 COPY cmake/ /src/cmake/

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 CIMPLE_FILES = [
+    "//c-toxcore:legacy_headers",
     "//c-toxcore/toxav:cimple_files",
     "//c-toxcore/toxcore:cimple_files",
     "//c-toxcore/toxencryptsave:cimple_files",

--- a/tox/tox.h
+++ b/tox/tox.h
@@ -1,0 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2024 The TokTok team.
+ */
+#include "../toxcore/tox.h"

--- a/tox/toxav.h
+++ b/tox/toxav.h
@@ -1,0 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2024 The TokTok team.
+ */
+#include "../toxav/toxav.h"

--- a/tox/toxencryptsave.h
+++ b/tox/toxencryptsave.h
@@ -1,0 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2024 The TokTok team.
+ */
+#include "../toxencryptsave/toxencryptsave.h"

--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -47,7 +47,6 @@ cc_library(
     hdrs = ["bwcontroller.h"],
     deps = [
         ":ring_buffer",
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:Messenger",
         "//c-toxcore/toxcore:ccompat",
         "//c-toxcore/toxcore:logger",
@@ -129,7 +128,6 @@ cc_library(
     srcs = ["groupav.c"],
     hdrs = ["groupav.h"],
     deps = [
-        "//c-toxcore/toxcore",
         "//c-toxcore/toxcore:ccompat",
         "//c-toxcore/toxcore:group",
         "//c-toxcore/toxcore:logger",

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -982,10 +982,10 @@ cc_library(
     ],
 )
 
-alias(
+cc_library(
     name = "toxcore",
-    actual = ":tox_dispatch",
-    visibility = ["//c-toxcore:__subpackages__"],
+    visibility = ["//c-toxcore:__pkg__"],
+    deps = [":tox_dispatch"],
 )
 
 sh_library(


### PR DESCRIPTION
This allows code to be built from an un-installed toxcore repo the same way it's built from an installed toxcore. I.e. all `#include` directives will work the same inside the toxcore repo and on a system which has toxcore installed.

Previously, "toxcore/tox.h" was installed as "tox/tox.h", making `make install` a requirement for building any client code. Now, clients can be built directly from the repo source, which is especially nice for simple clients like echobots.

Output:
```
-- Installing: /usr/local/include/tox/tox.h
-- Installing: /usr/local/include/toxcore/tox.h
-- Installing: /usr/local/include/toxcore/tox_events.h
-- Installing: /usr/local/include/toxcore/tox_dispatch.h
-- Installing: /usr/local/include/toxcore/tox_private.h
-- Installing: /usr/local/include/tox/toxav.h
-- Installing: /usr/local/include/toxav/toxav.h
-- Installing: /usr/local/include/tox/toxencryptsave.h
-- Installing: /usr/local/include/toxencryptsave/toxencryptsave.h
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2599)
<!-- Reviewable:end -->
