### PR TITLE
test: Fix off-by-one error in bounds check for password.

### DIFF
--- a/auto_tests/group_state_test.c
+++ b/auto_tests/group_state_test.c
@@ -177,7 +177,7 @@ static int check_group_state(const Tox *tox, uint32_t groupnumber, uint32_t peer
     }
 
     if (password != nullptr && my_pass_len > 0) {
-        ck_assert(my_pass_len <= TOX_GROUP_MAX_PASSWORD_SIZE);
+        ck_assert(my_pass_len < TOX_GROUP_MAX_PASSWORD_SIZE);
 
         uint8_t my_pass[TOX_GROUP_MAX_PASSWORD_SIZE];
         tox_group_get_password(tox, groupnumber, my_pass, &query_err);


### PR DESCRIPTION
If we want to null-terminate it, we need to require the password length to be 1 less than the max password size.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2600)
<!-- Reviewable:end -->
