### PR TITLE
fix: a few off by one errors in group autotests

### DIFF
--- a/auto_tests/group_moderation_test.c
+++ b/auto_tests/group_moderation_test.c
@@ -19,13 +19,13 @@
 #define GROUP_NAME_LEN (sizeof(GROUP_NAME) - 1)
 
 typedef struct Peer {
-    char name[TOX_MAX_NAME_LENGTH];
+    char name[TOX_MAX_NAME_LENGTH + 1];
     size_t name_length;
     uint32_t peer_id;
 } Peer;
 
 typedef struct State {
-    char self_name[TOX_MAX_NAME_LENGTH];
+    char self_name[TOX_MAX_NAME_LENGTH + 1];
     size_t self_name_length;
 
     uint32_t group_number;

--- a/auto_tests/group_state_test.c
+++ b/auto_tests/group_state_test.c
@@ -179,7 +179,7 @@ static int check_group_state(const Tox *tox, uint32_t groupnumber, uint32_t peer
     if (password != nullptr && my_pass_len > 0) {
         ck_assert(my_pass_len <= TOX_GROUP_MAX_PASSWORD_SIZE);
 
-        uint8_t my_pass[TOX_GROUP_MAX_PASSWORD_SIZE];
+        uint8_t my_pass[TOX_GROUP_MAX_PASSWORD_SIZE + 1];
         tox_group_get_password(tox, groupnumber, my_pass, &query_err);
         my_pass[my_pass_len] = 0;
         ck_assert_msg(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK, "Failed to get password: %d", query_err);
@@ -199,7 +199,7 @@ static int check_group_state(const Tox *tox, uint32_t groupnumber, uint32_t peer
 
     ck_assert(my_gname_len <= TOX_GROUP_MAX_GROUP_NAME_LENGTH);
 
-    uint8_t my_gname[TOX_GROUP_MAX_GROUP_NAME_LENGTH];
+    uint8_t my_gname[TOX_GROUP_MAX_GROUP_NAME_LENGTH + 1];
     tox_group_get_name(tox, groupnumber, my_gname, &query_err);
     my_gname[my_gname_len] = 0;
 


### PR DESCRIPTION
Since we're nul terminating these buffers they need one extra byte

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2601)
<!-- Reviewable:end -->
