### PR TITLE
fix: do proper groupchat cleanup on exit

### DIFF
--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-7dfcf534fb80fbd8337337f5aa9eaa120febc72386046c7ab0d5c7545e900657  /usr/local/bin/tox-bootstrapd
+b6d4d3db464ec5bbc8b43b4f1186f6ffd1caf477c3bab0b2d61d3fe0788d1ebc  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -8270,7 +8270,7 @@ static void group_delete(GC_Session *c, GC_Chat *chat)
         c->chats_index = i;
 
         if (!realloc_groupchats(c, c->chats_index)) {
-            LOGGER_ERROR(chat->log, "Failed to reallocate groupchats array");
+            LOGGER_ERROR(c->messenger->log, "Failed to reallocate groupchats array");
         }
     }
 }
@@ -8295,11 +8295,9 @@ void kill_dht_groupchats(GC_Session *c)
             continue;
         }
 
-        if (group_can_handle_packets(chat)) {
-            send_gc_self_exit(chat, nullptr, 0);
+        if (gc_group_exit(c, chat, nullptr, 0) != 0) {
+            LOGGER_WARNING(c->messenger->log, "Failed to send group exit packet");
         }
-
-        group_cleanup(c, chat);
     }
 
     networking_registerhandler(c->messenger->net, NET_PACKET_GC_LOSSY, nullptr, nullptr);


### PR DESCRIPTION
The wrong function was being called here. We need to call group_delete() on every group.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2608)
<!-- Reviewable:end -->
