### PR TITLE
fix: partially fix a bug that prevented group part messages from sending

### DIFF
--- a/auto_tests/group_general_test.c
+++ b/auto_tests/group_general_test.c
@@ -441,10 +441,13 @@ static void group_announce_test(AutoTox *autotoxes)
     tox_group_leave(tox1, groupnumber, nullptr, 0, &err_exit);
     ck_assert(err_exit == TOX_ERR_GROUP_LEAVE_OK);
 
-    num_groups1 = tox_group_get_number_groups(tox0);
-    num_groups2 = tox_group_get_number_groups(tox1);
+    while (num_groups1 != 0 || num_groups2 != 0) {
+        num_groups1 = tox_group_get_number_groups(tox0);
+        num_groups2 = tox_group_get_number_groups(tox1);
 
-    ck_assert(num_groups1 == num_groups2 && num_groups2 == 0);
+        iterate_all_wait(autotoxes, NUM_GROUP_TOXES, ITERATION_INTERVAL);
+    }
+
 
     printf("All tests passed!\n");
 }

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-7dfcf534fb80fbd8337337f5aa9eaa120febc72386046c7ab0d5c7545e900657  /usr/local/bin/tox-bootstrapd
+e5ccf844b7ece48d1153c226bdf8462d0e85d517dfcd720c8d6c4abad7da6929  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -321,6 +321,8 @@ typedef struct GC_Chat {
 
     uint8_t     m_group_public_key[CRYPTO_PUBLIC_KEY_SIZE];  // public key for group's messenger friend connection
     int         friend_connection_id;  // identifier for group's messenger friend connection
+
+    bool        flag_exit;  // true if the group will be deleted after the next do_gc() iteration
 } GC_Chat;
 
 #ifndef MESSENGER_DEFINED


### PR DESCRIPTION
When a peer leaves a group, they send a packet to the group indicating that they're leaving. However if this packet is sent via TCP, it gets put in a packet queue, which is then destroyed on the rest of the group cleanup process before ever being able to send.

This pr allows do_gc() to finish an iteration before cleaning the group up, which allows the TCP packet queue to be emptied. However this bug still exists on a tox_kill() event because we don't have a chance to do another do_gc() iteration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2609)
<!-- Reviewable:end -->
