### PR TITLE
chore: Check that both gtest and gmock exist for tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,7 +527,7 @@ endfunction()
 
 # The actual unit tests follow.
 #
-if(GTEST_FOUND)
+if(TARGET GTest::gtest AND TARGET GTest::gmock)
   unit_test(toxav ring_buffer)
   unit_test(toxav rtp)
   unit_test(toxcore DHT)


### PR DESCRIPTION
We used to assume gtest installation includes gmock, but some users may have only gtest and not gmock.

Fixes #2636.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2637)
<!-- Reviewable:end -->
