### PR TITLE
refactor: Use strong typedef for NGC peer id.

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -177,6 +177,35 @@ non_null() static bool saved_peer_is_valid(const GC_SavedPeerInfo *saved_peer);
 
 static const GC_Chat empty_gc_chat = {nullptr};
 
+#define GC_INVALID_PEER_ID_VALUE ((force GC_Peer_Id_Value)-1)
+
+static GC_Peer_Id gc_invalid_peer_id(void)
+{
+    const GC_Peer_Id invalid = {GC_INVALID_PEER_ID_VALUE};
+    return invalid;
+}
+
+static bool gc_peer_id_is_valid(GC_Peer_Id peer_id)
+{
+    return peer_id.value != GC_INVALID_PEER_ID_VALUE;
+}
+
+GC_Peer_Id gc_peer_id_from_int(uint32_t value)
+{
+    const GC_Peer_Id peer_id = {(force GC_Peer_Id_Value)value};
+    return peer_id;
+}
+
+uint32_t gc_peer_id_to_int(GC_Peer_Id peer_id)
+{
+    return (force uint32_t)peer_id.value;
+}
+
+static GC_Peer_Id gc_unknown_peer_id(void)
+{
+    return gc_peer_id_from_int(0);
+}
+
 non_null()
 static void kill_group_friend_connection(const GC_Session *c, const GC_Chat *chat)
 {
@@ -329,7 +358,7 @@ static void self_gc_set_status(const GC_Chat *chat, Group_Peer_Status status)
     LOGGER_WARNING(chat->log, "Attempting to set user status with invalid status: %u", (uint8_t)status);
 }
 
-uint32_t gc_get_self_peer_id(const GC_Chat *chat)
+GC_Peer_Id gc_get_self_peer_id(const GC_Chat *chat)
 {
     const GC_Peer *peer = get_gc_peer(chat, 0);
     assert(peer != nullptr);
@@ -689,10 +718,10 @@ static GC_Connection *random_gc_connection(const GC_Chat *chat)
  * Returns -1 if peer_id is invalid.
  */
 non_null()
-static int get_peer_number_of_peer_id(const GC_Chat *chat, uint32_t peer_id)
+static int get_peer_number_of_peer_id(const GC_Chat *chat, GC_Peer_Id peer_id)
 {
     for (uint32_t i = 0; i < chat->numpeers; ++i) {
-        if (chat->group[i].peer_id == peer_id) {
+        if (chat->group[i].peer_id.value == peer_id.value) {
             return i;
         }
     }
@@ -707,15 +736,16 @@ static int get_peer_number_of_peer_id(const GC_Chat *chat, uint32_t peer_id)
  * considered arbitrary values.
  */
 non_null()
-static uint32_t get_new_peer_id(const GC_Chat *chat)
+static GC_Peer_Id get_new_peer_id(const GC_Chat *chat)
 {
     for (uint32_t i = 0; i < UINT32_MAX - 1; ++i) {
-        if (get_peer_number_of_peer_id(chat, i) == -1) {
-            return i;
+        const GC_Peer_Id peer_id = gc_peer_id_from_int(i);
+        if (get_peer_number_of_peer_id(chat, peer_id) == -1) {
+            return peer_id;
         }
     }
 
-    return UINT32_MAX;
+    return gc_invalid_peer_id();
 }
 
 /** @brief Sets the password for the group (locally only).
@@ -2553,7 +2583,7 @@ static int handle_gc_status(const GC_Session *c, const GC_Chat *chat, GC_Peer *p
     return 0;
 }
 
-uint8_t gc_get_status(const GC_Chat *chat, uint32_t peer_id)
+uint8_t gc_get_status(const GC_Chat *chat, GC_Peer_Id peer_id)
 {
     const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
 
@@ -2566,7 +2596,7 @@ uint8_t gc_get_status(const GC_Chat *chat, uint32_t peer_id)
     return peer->status;
 }
 
-uint8_t gc_get_role(const GC_Chat *chat, uint32_t peer_id)
+uint8_t gc_get_role(const GC_Chat *chat, GC_Peer_Id peer_id)
 {
     const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
 
@@ -3069,7 +3099,7 @@ static int handle_gc_mod_list(const GC_Session *c, GC_Chat *chat, const uint8_t 
         update_gc_peer_roles(chat);
 
         if (chat->connection_state == CS_CONNECTED && c->moderation != nullptr) {
-            c->moderation(c->messenger, chat->group_number, (uint32_t) -1, (uint32_t) -1, MV_MOD, userdata);
+            c->moderation(c->messenger, chat->group_number, gc_invalid_peer_id(), gc_invalid_peer_id(), MV_MOD, userdata);
         }
 
         return 0;
@@ -3190,7 +3220,7 @@ static int handle_gc_sanctions_list(const GC_Session *c, GC_Chat *chat, const ui
 
     if (chat->connection_state == CS_CONNECTED) {
         if (c->moderation != nullptr) {
-            c->moderation(c->messenger, chat->group_number, (uint32_t) -1, (uint32_t) -1, MV_OBSERVER, userdata);
+            c->moderation(c->messenger, chat->group_number, gc_invalid_peer_id(), gc_invalid_peer_id(), MV_OBSERVER, userdata);
         }
     }
 
@@ -3451,7 +3481,7 @@ int gc_set_self_nick(const Messenger *m, int group_number, const uint8_t *nick, 
     return 0;
 }
 
-bool gc_get_peer_nick(const GC_Chat *chat, uint32_t peer_id, uint8_t *name)
+bool gc_get_peer_nick(const GC_Chat *chat, GC_Peer_Id peer_id, uint8_t *name)
 {
     const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
 
@@ -3468,7 +3498,7 @@ bool gc_get_peer_nick(const GC_Chat *chat, uint32_t peer_id, uint8_t *name)
     return true;
 }
 
-int gc_get_peer_nick_size(const GC_Chat *chat, uint32_t peer_id)
+int gc_get_peer_nick_size(const GC_Chat *chat, GC_Peer_Id peer_id)
 {
     const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
 
@@ -3532,7 +3562,7 @@ static int get_gc_peer_public_key(const GC_Chat *chat, uint32_t peer_number, uin
     return 0;
 }
 
-int gc_get_peer_public_key_by_peer_id(const GC_Chat *chat, uint32_t peer_id, uint8_t *public_key)
+int gc_get_peer_public_key_by_peer_id(const GC_Chat *chat, GC_Peer_Id peer_id, uint8_t *public_key)
 {
     const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
 
@@ -3567,7 +3597,7 @@ static void get_gc_ip_ntoa(const IP_Port *ip_port, Ip_Ntoa *ip_str)
     }
 }
 
-int gc_get_peer_ip_address_size(const GC_Chat *chat, uint32_t peer_id)
+int gc_get_peer_ip_address_size(const GC_Chat *chat, GC_Peer_Id peer_id)
 {
     const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
     const GC_Connection *gconn = get_gc_connection(chat, peer_number);
@@ -3584,7 +3614,7 @@ int gc_get_peer_ip_address_size(const GC_Chat *chat, uint32_t peer_id)
     return ip_str.length;
 }
 
-int gc_get_peer_ip_address(const GC_Chat *chat, uint32_t peer_id, uint8_t *ip_addr)
+int gc_get_peer_ip_address(const GC_Chat *chat, GC_Peer_Id peer_id, uint8_t *ip_addr)
 {
     const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
     const GC_Connection *gconn = get_gc_connection(chat, peer_number);
@@ -3608,7 +3638,7 @@ int gc_get_peer_ip_address(const GC_Chat *chat, uint32_t peer_id, uint8_t *ip_ad
     return 0;
 }
 
-unsigned int gc_get_peer_connection_status(const GC_Chat *chat, uint32_t peer_id)
+unsigned int gc_get_peer_connection_status(const GC_Chat *chat, GC_Peer_Id peer_id)
 {
     const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
 
@@ -3970,7 +4000,7 @@ static int handle_gc_topic(const GC_Session *c, GC_Chat *chat, const GC_Peer *pe
 
     if (!skip_callback && chat->connection_state == CS_CONNECTED && c->topic_change != nullptr) {
         const int setter_peer_number = get_peer_number_of_sig_pk(chat, topic_info.public_sig_key);
-        const uint32_t peer_id = setter_peer_number >= 0 ? chat->group[setter_peer_number].peer_id : 0;
+        const GC_Peer_Id peer_id = setter_peer_number >= 0 ? chat->group[setter_peer_number].peer_id : gc_unknown_peer_id();
 
         c->topic_change(c->messenger, chat->group_number, peer_id, topic_info.topic, topic_info.length, userdata);
     }
@@ -4590,7 +4620,7 @@ static bool apply_new_gc_role(GC_Chat *chat, uint32_t peer_number, Group_Role cu
     return true;
 }
 
-int gc_set_peer_role(const Messenger *m, int group_number, uint32_t peer_id, Group_Role new_role)
+int gc_set_peer_role(const Messenger *m, int group_number, GC_Peer_Id peer_id, Group_Role new_role)
 {
     const GC_Session *c = m->group_handler;
     GC_Chat *chat = gc_get_group(c, group_number);
@@ -4919,7 +4949,7 @@ static int handle_gc_message(const GC_Session *c, const GC_Chat *chat, const GC_
     return 0;
 }
 
-int gc_send_private_message(const GC_Chat *chat, uint32_t peer_id, uint8_t type, const uint8_t *message,
+int gc_send_private_message(const GC_Chat *chat, GC_Peer_Id peer_id, uint8_t type, const uint8_t *message,
                             uint16_t length)
 {
     if (length > MAX_GC_MESSAGE_SIZE) {
@@ -5013,7 +5043,7 @@ static bool custom_gc_packet_length_is_valid(uint16_t length, bool lossless)
     return length <= (lossless ? MAX_GC_CUSTOM_LOSSLESS_PACKET_SIZE : MAX_GC_CUSTOM_LOSSY_PACKET_SIZE);
 }
 
-int gc_send_custom_private_packet(const GC_Chat *chat, bool lossless, uint32_t peer_id, const uint8_t *message,
+int gc_send_custom_private_packet(const GC_Chat *chat, bool lossless, GC_Peer_Id peer_id, const uint8_t *message,
                                   uint16_t length)
 {
     if (!custom_gc_packet_length_is_valid(length, lossless)) {
@@ -5202,7 +5232,7 @@ static bool send_gc_kick_peer(const GC_Chat *chat, const GC_Connection *gconn)
     return send_gc_broadcast_message(chat, packet, ENC_PUBLIC_KEY_SIZE, GM_KICK_PEER);
 }
 
-int gc_kick_peer(const Messenger *m, int group_number, uint32_t peer_id)
+int gc_kick_peer(const Messenger *m, int group_number, GC_Peer_Id peer_id)
 {
     const GC_Session *c = m->group_handler;
     GC_Chat *chat = gc_get_group(c, group_number);
@@ -5354,7 +5384,7 @@ static int handle_gc_hs_response_ack(const GC_Chat *chat, GC_Connection *gconn)
     return 0;
 }
 
-int gc_set_ignore(const GC_Chat *chat, uint32_t peer_id, bool ignore)
+int gc_set_ignore(const GC_Chat *chat, GC_Peer_Id peer_id, bool ignore)
 {
     const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
 
@@ -6678,7 +6708,7 @@ static bool peer_delete(const GC_Session *c, GC_Chat *chat, uint32_t peer_number
 
     // We need to save some peer info for the callback before deleting it
     const bool peer_confirmed = peer->gconn.confirmed;
-    const uint32_t peer_id = peer->peer_id;
+    const GC_Peer_Id peer_id = peer->peer_id;
     uint8_t nick[MAX_GC_NICK_SIZE];
     const uint16_t nick_length = peer->nick_length;
     const GC_Exit_Info exit_info = peer->gconn.exit_info;
@@ -6756,9 +6786,9 @@ int peer_add(GC_Chat *chat, const IP_Port *ipp, const uint8_t *public_key)
         return -2;
     }
 
-    const uint32_t peer_id = get_new_peer_id(chat);
+    const GC_Peer_Id peer_id = get_new_peer_id(chat);
 
-    if (peer_id == UINT32_MAX) {
+    if (!gc_peer_id_is_valid(peer_id)) {
         LOGGER_WARNING(chat->log, "Failed to add peer: all peer ID's are taken?");
         return -1;
     }

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -182,7 +182,7 @@ int gc_send_message(const GC_Chat *chat, const uint8_t *message, uint16_t length
  * Returns -6 if the packet fails to send.
  */
 non_null()
-int gc_send_private_message(const GC_Chat *chat, uint32_t peer_id, uint8_t type, const uint8_t *message,
+int gc_send_private_message(const GC_Chat *chat, GC_Peer_Id peer_id, uint8_t type, const uint8_t *message,
                             uint16_t length);
 
 /** @brief Sends a custom packet to the group. If lossless is true, the packet will be lossless.
@@ -210,7 +210,7 @@ int gc_send_custom_packet(const GC_Chat *chat, bool lossless, const uint8_t *dat
  * @retval -5 if the packet fails to send.
  */
 non_null()
-int gc_send_custom_private_packet(const GC_Chat *chat, bool lossless, uint32_t peer_id, const uint8_t *message,
+int gc_send_custom_private_packet(const GC_Chat *chat, bool lossless, GC_Peer_Id peer_id, const uint8_t *message,
                                   uint16_t length);
 
 /** @brief Sets ignore for peer_id.
@@ -220,7 +220,7 @@ int gc_send_custom_private_packet(const GC_Chat *chat, bool lossless, uint32_t p
  * Returns -2 if the caller attempted to ignore himself.
  */
 non_null()
-int gc_set_ignore(const GC_Chat *chat, uint32_t peer_id, bool ignore);
+int gc_set_ignore(const GC_Chat *chat, GC_Peer_Id peer_id, bool ignore);
 
 /** @brief Sets the group topic and broadcasts it to the group.
  *
@@ -345,7 +345,7 @@ uint8_t gc_get_self_status(const GC_Chat *chat);
 
 /** @brief Returns your own peer id. */
 non_null()
-uint32_t gc_get_self_peer_id(const GC_Chat *chat);
+GC_Peer_Id gc_get_self_peer_id(const GC_Chat *chat);
 
 /** @brief Copies self public key to `public_key`.
  *
@@ -368,7 +368,7 @@ void gc_get_self_public_key(const GC_Chat *chat, uint8_t *public_key);
  * Returns false if peer_id is invalid.
  */
 non_null(1) nullable(3)
-bool gc_get_peer_nick(const GC_Chat *chat, uint32_t peer_id, uint8_t *name);
+bool gc_get_peer_nick(const GC_Chat *chat, GC_Peer_Id peer_id, uint8_t *name);
 
 /** @brief Returns the length of the nick for the peer designated by `peer_id`.
  * Returns -1 if peer_id is invalid.
@@ -377,7 +377,7 @@ bool gc_get_peer_nick(const GC_Chat *chat, uint32_t peer_id, uint8_t *name);
  * nick_change callback.
  */
 non_null()
-int gc_get_peer_nick_size(const GC_Chat *chat, uint32_t peer_id);
+int gc_get_peer_nick_size(const GC_Chat *chat, GC_Peer_Id peer_id);
 
 /** @brief Copies peer_id's public key to `public_key`.
  *
@@ -392,13 +392,13 @@ int gc_get_peer_nick_size(const GC_Chat *chat, uint32_t peer_id);
  * Returns -2 if `public_key` is null.
  */
 non_null(1) nullable(3)
-int gc_get_peer_public_key_by_peer_id(const GC_Chat *chat, uint32_t peer_id, uint8_t *public_key);
+int gc_get_peer_public_key_by_peer_id(const GC_Chat *chat, GC_Peer_Id peer_id, uint8_t *public_key);
 
 /** @brief Returns the length of the IP address for the peer designated by `peer_id`.
  * Returns -1 if peer_id is invalid.
  */
 non_null()
-int gc_get_peer_ip_address_size(const GC_Chat *chat, uint32_t peer_id);
+int gc_get_peer_ip_address_size(const GC_Chat *chat, GC_Peer_Id peer_id);
 
 /** @brief Copies peer_id's IP address to `ip_addr`.
  *
@@ -415,7 +415,7 @@ int gc_get_peer_ip_address_size(const GC_Chat *chat, uint32_t peer_id);
  * Returns -2 if `ip_addr` is null.
  */
 non_null(1) nullable(3)
-int gc_get_peer_ip_address(const GC_Chat *chat, uint32_t peer_id, uint8_t *ip_addr);
+int gc_get_peer_ip_address(const GC_Chat *chat, GC_Peer_Id peer_id, uint8_t *ip_addr);
 
 /** @brief Gets the connection status for peer associated with `peer_id`.
  *
@@ -429,7 +429,7 @@ int gc_get_peer_ip_address(const GC_Chat *chat, uint32_t peer_id, uint8_t *ip_ad
  * Note: Return values must correspond to Tox_Connection enum in API.
  */
 non_null()
-unsigned int gc_get_peer_connection_status(const GC_Chat *chat, uint32_t peer_id);
+unsigned int gc_get_peer_connection_status(const GC_Chat *chat, GC_Peer_Id peer_id);
 
 /** @brief Sets the caller's status to `status`.
  *
@@ -447,7 +447,7 @@ int gc_set_self_status(const Messenger *m, int group_number, Group_Peer_Status s
  * callback.
  */
 non_null()
-uint8_t gc_get_status(const GC_Chat *chat, uint32_t peer_id);
+uint8_t gc_get_status(const GC_Chat *chat, GC_Peer_Id peer_id);
 
 /** @brief Returns the group role of peer designated by `peer_id`.
  * Returns UINT8_MAX on failure.
@@ -455,7 +455,7 @@ uint8_t gc_get_status(const GC_Chat *chat, uint32_t peer_id);
  * The role returned is equal to the last role received through the moderation callback.
  */
 non_null()
-uint8_t gc_get_role(const GC_Chat *chat, uint32_t peer_id);
+uint8_t gc_get_role(const GC_Chat *chat, GC_Peer_Id peer_id);
 
 /** @brief Sets the role of peer_id. role must be one of: GR_MODERATOR, GR_USER, GR_OBSERVER
  *
@@ -468,7 +468,7 @@ uint8_t gc_get_role(const GC_Chat *chat, uint32_t peer_id);
  * Returns -6 if the caller attempted to kick himself.
  */
 non_null()
-int gc_set_peer_role(const Messenger *m, int group_number, uint32_t peer_id, Group_Role new_role);
+int gc_set_peer_role(const Messenger *m, int group_number, GC_Peer_Id peer_id, Group_Role new_role);
 
 /** @brief Sets the group password and distributes the new shared state to the group.
  *
@@ -563,7 +563,7 @@ int gc_founder_set_max_peers(GC_Chat *chat, uint16_t max_peers);
  * Returns -6 if the caller attempted to kick himself.
  */
 non_null()
-int gc_kick_peer(const Messenger *m, int group_number, uint32_t peer_id);
+int gc_kick_peer(const Messenger *m, int group_number, GC_Peer_Id peer_id);
 
 /** @brief Copies the chat_id to dest. If dest is null this function has no effect.
  *

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -217,6 +217,15 @@ typedef struct GC_TimedOutPeer {
     uint64_t    last_reconn_try;  // the last time we tried to establish a new connection
 } GC_TimedOutPeer;
 
+typedef bitwise uint32_t GC_Peer_Id_Value;
+
+typedef struct GC_Peer_Id {
+    GC_Peer_Id_Value value;
+} GC_Peer_Id;
+
+GC_Peer_Id gc_peer_id_from_int(uint32_t value);
+uint32_t gc_peer_id_to_int(GC_Peer_Id peer_id);
+
 typedef struct GC_Peer {
     /* Below state is sent to other peers in peer info exchange */
     uint8_t       nick[MAX_GC_NICK_SIZE];
@@ -225,7 +234,7 @@ typedef struct GC_Peer {
 
     /* Below state is local only */
     Group_Role    role;
-    uint32_t      peer_id;    // permanent ID (used for the public API)
+    GC_Peer_Id    peer_id;    // permanent ID (used for the public API)
     bool          ignore;
 
     GC_Connection gconn;
@@ -336,21 +345,21 @@ typedef struct GC_Chat {
 typedef struct Messenger Messenger;
 #endif /* MESSENGER_DEFINED */
 
-typedef void gc_message_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, unsigned int type,
+typedef void gc_message_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, unsigned int type,
                            const uint8_t *message, size_t length, uint32_t message_id, void *user_data);
-typedef void gc_private_message_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, unsigned int type,
+typedef void gc_private_message_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, unsigned int type,
                                    const uint8_t *message, size_t length, void *user_data);
-typedef void gc_custom_packet_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, const uint8_t *data,
+typedef void gc_custom_packet_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, const uint8_t *data,
                                  size_t length, void *user_data);
-typedef void gc_custom_private_packet_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id,
+typedef void gc_custom_private_packet_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id,
         const uint8_t *data, size_t length, void *user_data);
-typedef void gc_moderation_cb(const Messenger *m, uint32_t group_number, uint32_t source_peer_number,
-                              uint32_t target_peer_number, unsigned int mod_type, void *user_data);
-typedef void gc_nick_change_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, const uint8_t *name,
+typedef void gc_moderation_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id source_peer_number,
+                              GC_Peer_Id target_peer_number, unsigned int mod_type, void *user_data);
+typedef void gc_nick_change_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, const uint8_t *name,
                                size_t length, void *user_data);
-typedef void gc_status_change_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, unsigned int status,
+typedef void gc_status_change_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, unsigned int status,
                                  void *user_data);
-typedef void gc_topic_change_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, const uint8_t *topic,
+typedef void gc_topic_change_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, const uint8_t *topic,
                                 size_t length, void *user_data);
 typedef void gc_topic_lock_cb(const Messenger *m, uint32_t group_number, unsigned int topic_lock, void *user_data);
 typedef void gc_voice_state_cb(const Messenger *m, uint32_t group_number, unsigned int voice_state, void *user_data);
@@ -358,8 +367,8 @@ typedef void gc_peer_limit_cb(const Messenger *m, uint32_t group_number, uint32_
 typedef void gc_privacy_state_cb(const Messenger *m, uint32_t group_number, unsigned int privacy_state, void *user_data);
 typedef void gc_password_cb(const Messenger *m, uint32_t group_number, const uint8_t *password, size_t length,
                             void *user_data);
-typedef void gc_peer_join_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, void *user_data);
-typedef void gc_peer_exit_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, unsigned int exit_type,
+typedef void gc_peer_join_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, void *user_data);
+typedef void gc_peer_exit_cb(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, unsigned int exit_type,
                              const uint8_t *name, size_t name_length, const uint8_t *part_message, size_t length,
                              void *user_data);
 typedef void gc_self_join_cb(const Messenger *m, uint32_t group_number, void *user_data);

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -415,41 +415,41 @@ static void tox_friend_lossless_packet_handler(Messenger *m, uint32_t friend_num
 }
 
 non_null(1, 4) nullable(6)
-static void tox_group_peer_name_handler(const Messenger *m, uint32_t group_number, uint32_t peer_id,
+static void tox_group_peer_name_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id,
                                         const uint8_t *name, size_t length, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->group_peer_name_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_peer_name_callback(tox_data->tox, group_number, peer_id, name, length, tox_data->user_data);
+        tox_data->tox->group_peer_name_callback(tox_data->tox, group_number, gc_peer_id_to_int(peer_id), name, length, tox_data->user_data);
         tox_lock(tox_data->tox);
     }
 }
 
 non_null(1) nullable(5)
-static void tox_group_peer_status_handler(const Messenger *m, uint32_t group_number, uint32_t peer_id,
+static void tox_group_peer_status_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id,
         unsigned int status, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->group_peer_status_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_peer_status_callback(tox_data->tox, group_number, peer_id, (Tox_User_Status)status,
+        tox_data->tox->group_peer_status_callback(tox_data->tox, group_number, gc_peer_id_to_int(peer_id), (Tox_User_Status)status,
                 tox_data->user_data);
         tox_lock(tox_data->tox);
     }
 }
 
 non_null(1, 4) nullable(6)
-static void tox_group_topic_handler(const Messenger *m, uint32_t group_number, uint32_t peer_id, const uint8_t *topic,
+static void tox_group_topic_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, const uint8_t *topic,
                                     size_t length, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->group_topic_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_topic_callback(tox_data->tox, group_number, peer_id, topic, length, tox_data->user_data);
+        tox_data->tox->group_topic_callback(tox_data->tox, group_number, gc_peer_id_to_int(peer_id), topic, length, tox_data->user_data);
         tox_lock(tox_data->tox);
     }
 }
@@ -523,56 +523,55 @@ static void tox_group_password_handler(const Messenger *m, uint32_t group_number
 }
 
 non_null(1, 5) nullable(8)
-static void tox_group_message_handler(const Messenger *m, uint32_t group_number, uint32_t peer_id, unsigned int type,
+static void tox_group_message_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, unsigned int type,
                                       const uint8_t *message, size_t length, uint32_t message_id, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->group_message_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_message_callback(tox_data->tox, group_number, peer_id, (Tox_Message_Type)type, message, length,
+        tox_data->tox->group_message_callback(tox_data->tox, group_number, gc_peer_id_to_int(peer_id), (Tox_Message_Type)type, message, length,
                                               message_id, tox_data->user_data);
         tox_lock(tox_data->tox);
     }
 }
 
 non_null(1, 5) nullable(7)
-static void tox_group_private_message_handler(const Messenger *m, uint32_t group_number, uint32_t peer_id,
+static void tox_group_private_message_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id,
         unsigned int type, const uint8_t *message, size_t length, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->group_private_message_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_private_message_callback(tox_data->tox, group_number, peer_id, (Tox_Message_Type)type, message,
-                length,
-                tox_data->user_data);
+        tox_data->tox->group_private_message_callback(tox_data->tox, group_number, gc_peer_id_to_int(peer_id), (Tox_Message_Type)type, message,
+                length, tox_data->user_data);
         tox_lock(tox_data->tox);
     }
 }
 
 non_null(1, 4) nullable(6)
-static void tox_group_custom_packet_handler(const Messenger *m, uint32_t group_number, uint32_t peer_id,
+static void tox_group_custom_packet_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id,
         const uint8_t *data, size_t length, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->group_custom_packet_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_custom_packet_callback(tox_data->tox, group_number, peer_id, data, length, tox_data->user_data);
+        tox_data->tox->group_custom_packet_callback(tox_data->tox, group_number, gc_peer_id_to_int(peer_id), data, length, tox_data->user_data);
         tox_lock(tox_data->tox);
     }
 }
 
 non_null(1, 4) nullable(6)
-static void tox_group_custom_private_packet_handler(const Messenger *m, uint32_t group_number, uint32_t peer_id,
+static void tox_group_custom_private_packet_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id,
         const uint8_t *data, size_t length, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->group_custom_private_packet_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_custom_private_packet_callback(tox_data->tox, group_number, peer_id, data, length,
+        tox_data->tox->group_custom_private_packet_callback(tox_data->tox, group_number, gc_peer_id_to_int(peer_id), data, length,
                 tox_data->user_data);
         tox_lock(tox_data->tox);
     }
@@ -593,19 +592,19 @@ static void tox_group_invite_handler(const Messenger *m, uint32_t friend_number,
 }
 
 non_null(1) nullable(4)
-static void tox_group_peer_join_handler(const Messenger *m, uint32_t group_number, uint32_t peer_id, void *user_data)
+static void tox_group_peer_join_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->group_peer_join_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_peer_join_callback(tox_data->tox, group_number, peer_id, tox_data->user_data);
+        tox_data->tox->group_peer_join_callback(tox_data->tox, group_number, gc_peer_id_to_int(peer_id), tox_data->user_data);
         tox_lock(tox_data->tox);
     }
 }
 
 non_null(1, 5) nullable(7, 9)
-static void tox_group_peer_exit_handler(const Messenger *m, uint32_t group_number, uint32_t peer_id,
+static void tox_group_peer_exit_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id,
                                         unsigned int exit_type, const uint8_t *name, size_t name_length,
                                         const uint8_t *part_message, size_t length, void *user_data)
 {
@@ -613,8 +612,9 @@ static void tox_group_peer_exit_handler(const Messenger *m, uint32_t group_numbe
 
     if (tox_data->tox->group_peer_exit_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_peer_exit_callback(tox_data->tox, group_number, peer_id, (Tox_Group_Exit_Type) exit_type, name,
-                                                name_length, part_message, length, tox_data->user_data);
+        tox_data->tox->group_peer_exit_callback(tox_data->tox, group_number, gc_peer_id_to_int(peer_id),
+                                                (Tox_Group_Exit_Type)exit_type, name, name_length,
+                                                part_message, length, tox_data->user_data);
         tox_lock(tox_data->tox);
     }
 }
@@ -646,16 +646,16 @@ static void tox_group_join_fail_handler(const Messenger *m, uint32_t group_numbe
 }
 
 non_null(1) nullable(6)
-static void tox_group_moderation_handler(const Messenger *m, uint32_t group_number, uint32_t source_peer_number,
-        uint32_t target_peer_number, unsigned int mod_type, void *user_data)
+static void tox_group_moderation_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id source_peer_number,
+        GC_Peer_Id target_peer_number, unsigned int mod_type, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
     if (tox_data->tox->group_moderation_callback != nullptr) {
         tox_unlock(tox_data->tox);
-        tox_data->tox->group_moderation_callback(tox_data->tox, group_number, source_peer_number, target_peer_number,
-                (Tox_Group_Mod_Event)mod_type,
-                tox_data->user_data);
+        tox_data->tox->group_moderation_callback(tox_data->tox, group_number,
+                gc_peer_id_to_int(source_peer_number), gc_peer_id_to_int(target_peer_number),
+                (Tox_Group_Mod_Event)mod_type, tox_data->user_data);
         tox_lock(tox_data->tox);
     }
 }
@@ -3447,10 +3447,10 @@ uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_E
 
     SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
 
-    const uint32_t ret = gc_get_self_peer_id(chat);
+    const GC_Peer_Id ret = gc_get_self_peer_id(chat);
     tox_unlock(tox);
 
-    return ret;
+    return gc_peer_id_to_int(ret);
 }
 
 bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
@@ -3489,7 +3489,7 @@ size_t tox_group_peer_get_name_size(const Tox *tox, uint32_t group_number, uint3
         return -1;
     }
 
-    const int ret = gc_get_peer_nick_size(chat, peer_id);
+    const int ret = gc_get_peer_nick_size(chat, gc_peer_id_from_int(peer_id));
     tox_unlock(tox);
 
     if (ret == -1) {
@@ -3515,7 +3515,7 @@ bool tox_group_peer_get_name(const Tox *tox, uint32_t group_number, uint32_t pee
         return false;
     }
 
-    const bool ret = gc_get_peer_nick(chat, peer_id, name);
+    const bool ret = gc_get_peer_nick(chat, gc_peer_id_from_int(peer_id), name);
     tox_unlock(tox);
 
     if (!ret) {
@@ -3541,7 +3541,7 @@ Tox_User_Status tox_group_peer_get_status(const Tox *tox, uint32_t group_number,
         return (Tox_User_Status) - 1;
     }
 
-    const uint8_t ret = gc_get_status(chat, peer_id);
+    const uint8_t ret = gc_get_status(chat, gc_peer_id_from_int(peer_id));
     tox_unlock(tox);
 
     if (ret == UINT8_MAX) {
@@ -3567,7 +3567,7 @@ Tox_Group_Role tox_group_peer_get_role(const Tox *tox, uint32_t group_number, ui
         return (Tox_Group_Role) - 1;
     }
 
-    const uint8_t ret = gc_get_role(chat, peer_id);
+    const uint8_t ret = gc_get_role(chat, gc_peer_id_from_int(peer_id));
     tox_unlock(tox);
 
     if (ret == (uint8_t) -1) {
@@ -3593,7 +3593,7 @@ bool tox_group_peer_get_public_key(const Tox *tox, uint32_t group_number, uint32
         return false;
     }
 
-    const int ret = gc_get_peer_public_key_by_peer_id(chat, peer_id, public_key);
+    const int ret = gc_get_peer_public_key_by_peer_id(chat, gc_peer_id_from_int(peer_id), public_key);
     tox_unlock(tox);
 
     if (ret == -1) {
@@ -3619,7 +3619,7 @@ Tox_Connection tox_group_peer_get_connection_status(const Tox *tox, uint32_t gro
         return TOX_CONNECTION_NONE;
     }
 
-    const unsigned int ret = gc_get_peer_connection_status(chat, peer_id);
+    const unsigned int ret = gc_get_peer_connection_status(chat, gc_peer_id_from_int(peer_id));
     tox_unlock(tox);
 
     if (ret == 0) {
@@ -4013,7 +4013,7 @@ bool tox_group_send_private_message(const Tox *tox, uint32_t group_number, uint3
         return false;
     }
 
-    const int ret = gc_send_private_message(chat, peer_id, type, message, length);
+    const int ret = gc_send_private_message(chat, gc_peer_id_from_int(peer_id), type, message, length);
     tox_unlock(tox);
 
     switch (ret) {
@@ -4136,7 +4136,7 @@ bool tox_group_send_custom_private_packet(const Tox *tox, uint32_t group_number,
         return false;
     }
 
-    const int ret = gc_send_custom_private_packet(chat, lossless, peer_id, data, length);
+    const int ret = gc_send_custom_private_packet(chat, lossless, gc_peer_id_from_int(peer_id), data, length);
     tox_unlock(tox);
 
     switch (ret) {
@@ -4560,7 +4560,7 @@ bool tox_group_set_ignore(Tox *tox, uint32_t group_number, uint32_t peer_id, boo
         return false;
     }
 
-    const int ret = gc_set_ignore(chat, peer_id, ignore);
+    const int ret = gc_set_ignore(chat, gc_peer_id_from_int(peer_id), ignore);
     tox_unlock(tox);
 
     switch (ret) {
@@ -4592,7 +4592,7 @@ bool tox_group_mod_set_role(Tox *tox, uint32_t group_number, uint32_t peer_id, T
     assert(tox != nullptr);
 
     tox_lock(tox);
-    const int ret = gc_set_peer_role(tox->m, group_number, peer_id, (Group_Role) role);
+    const int ret = gc_set_peer_role(tox->m, group_number, gc_peer_id_from_int(peer_id), (Group_Role) role);
     tox_unlock(tox);
 
     switch (ret) {
@@ -4644,7 +4644,7 @@ bool tox_group_mod_kick_peer(const Tox *tox, uint32_t group_number, uint32_t pee
     assert(tox != nullptr);
 
     tox_lock(tox);
-    const int ret = gc_kick_peer(tox->m, group_number, peer_id);
+    const int ret = gc_kick_peer(tox->m, group_number, gc_peer_id_from_int(peer_id));
     tox_unlock(tox);
 
     switch (ret) {

--- a/toxcore/tox_private.c
+++ b/toxcore/tox_private.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 
 #include "DHT.h"
+#include "attributes.h"
 #include "ccompat.h"
 #include "crypto_core.h"
 #include "group_chats.h"
@@ -188,7 +189,7 @@ size_t tox_group_peer_get_ip_address_size(const Tox *tox, uint32_t group_number,
         return -1;
     }
 
-    const int ret = gc_get_peer_ip_address_size(chat, peer_id);
+    const int ret = gc_get_peer_ip_address_size(chat, gc_peer_id_from_int(peer_id));
     tox_unlock(tox);
 
     if (ret == -1) {
@@ -214,7 +215,7 @@ bool tox_group_peer_get_ip_address(const Tox *tox, uint32_t group_number, uint32
         return false;
     }
 
-    const int ret = gc_get_peer_ip_address(chat, peer_id, ip_addr);
+    const int ret = gc_get_peer_ip_address(chat, gc_peer_id_from_int(peer_id), ip_addr);
     tox_unlock(tox);
 
     if (ret == -1) {


### PR DESCRIPTION
This makes me wonder (again) whether we should somehow share types between the public API and the internal ones. All these casts (including the enum casts we already do) are not very nice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2643)
<!-- Reviewable:end -->
