### PR TITLE
refactor: Don't rely on tox_dispatch passing tox in tests.

### DIFF
--- a/auto_tests/conference_av_test.c
+++ b/auto_tests/conference_av_test.c
@@ -85,7 +85,7 @@ static void handle_conference_invite(
 
     ck_assert_msg(type == TOX_CONFERENCE_TYPE_AV, "tox #%u: wrong conference type: %d", autotox->index, type);
 
-    ck_assert_msg(toxav_join_av_groupchat(tox, friend_number, cookie, length, audio_callback, user_data) == 0,
+    ck_assert_msg(toxav_join_av_groupchat(autotox->tox, friend_number, cookie, length, audio_callback, user_data) == 0,
                   "tox #%u: failed to join group", autotox->index);
 }
 
@@ -95,12 +95,12 @@ static void handle_conference_connected(
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;
 
-    if (state->invited_next || tox_self_get_friend_list_size(tox) <= 1) {
+    if (state->invited_next || tox_self_get_friend_list_size(autotox->tox) <= 1) {
         return;
     }
 
     Tox_Err_Conference_Invite err;
-    tox_conference_invite(tox, 1, 0, &err);
+    tox_conference_invite(autotox->tox, 1, 0, &err);
     ck_assert_msg(err == TOX_ERR_CONFERENCE_INVITE_OK, "tox #%u failed to invite next friend: err = %d", autotox->index,
                   err);
     printf("tox #%u: invited next friend\n", autotox->index);

--- a/auto_tests/conference_double_invite_test.c
+++ b/auto_tests/conference_double_invite_test.c
@@ -30,7 +30,7 @@ static void handle_conference_invite(
 
     if (friend_number != -1) {
         Tox_Err_Conference_Join err;
-        state->conference = tox_conference_join(tox, friend_number, cookie, length, &err);
+        state->conference = tox_conference_join(autotox->tox, friend_number, cookie, length, &err);
         ck_assert_msg(err == TOX_ERR_CONFERENCE_JOIN_OK,
                       "attempting to join the conference returned with an error: %d", err);
         fprintf(stderr, "tox%u joined conference %u\n", autotox->index, state->conference);

--- a/auto_tests/conference_invite_merge_test.c
+++ b/auto_tests/conference_invite_merge_test.c
@@ -23,7 +23,7 @@ static void handle_conference_invite(
 
     if (friend_number != -1) {
         Tox_Err_Conference_Join err;
-        state->conference = tox_conference_join(tox, friend_number, cookie, length, &err);
+        state->conference = tox_conference_join(autotox->tox, friend_number, cookie, length, &err);
         ck_assert_msg(err == TOX_ERR_CONFERENCE_JOIN_OK,
                       "attempting to join the conference returned with an error: %d", err);
         fprintf(stderr, "#%u accepted invite to conference %u\n", autotox->index, state->conference);

--- a/auto_tests/conference_peer_nick_test.c
+++ b/auto_tests/conference_peer_nick_test.c
@@ -28,7 +28,7 @@ static void handle_conference_invite(
     fprintf(stderr, "tox%u joining conference\n", autotox->index);
 
     Tox_Err_Conference_Join err;
-    state->conference = tox_conference_join(tox, friend_number, cookie, length, &err);
+    state->conference = tox_conference_join(autotox->tox, friend_number, cookie, length, &err);
     ck_assert_msg(err == TOX_ERR_CONFERENCE_JOIN_OK,
                   "attempting to join the conference returned with an error: %d", err);
     fprintf(stderr, "tox%u joined conference %u\n", autotox->index, state->conference);
@@ -45,7 +45,7 @@ static void handle_peer_list_changed(Tox *tox, const Tox_Event_Conference_Peer_L
             autotox->index, conference_number);
 
     Tox_Err_Conference_Peer_Query err;
-    uint32_t const count = tox_conference_peer_count(tox, conference_number, &err);
+    uint32_t const count = tox_conference_peer_count(autotox->tox, conference_number, &err);
     ck_assert_msg(err == TOX_ERR_CONFERENCE_PEER_QUERY_OK,
                   "failed to get conference peer count: err = %d", err);
     printf("tox%u has %u peers\n", autotox->index, count);

--- a/auto_tests/conference_test.c
+++ b/auto_tests/conference_test.c
@@ -56,13 +56,13 @@ static void handle_conference_invite(
     ck_assert_msg(type == TOX_CONFERENCE_TYPE_TEXT, "tox #%u: wrong conference type: %d", autotox->index, type);
 
     Tox_Err_Conference_Join err;
-    uint32_t g_num = tox_conference_join(tox, friendnumber, data, length, &err);
+    uint32_t g_num = tox_conference_join(autotox->tox, friendnumber, data, length, &err);
 
     ck_assert_msg(err == TOX_ERR_CONFERENCE_JOIN_OK, "tox #%u: error joining group: %d", autotox->index, err);
     ck_assert_msg(g_num == 0, "tox #%u: group number was not 0", autotox->index);
 
     // Try joining again. We should only be allowed to join once.
-    tox_conference_join(tox, friendnumber, data, length, &err);
+    tox_conference_join(autotox->tox, friendnumber, data, length, &err);
     ck_assert_msg(err != TOX_ERR_CONFERENCE_JOIN_OK,
                   "tox #%u: joining groupchat twice should be impossible.", autotox->index);
 }
@@ -73,12 +73,12 @@ static void handle_conference_connected(
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;
 
-    if (state->invited_next || tox_self_get_friend_list_size(tox) <= 1) {
+    if (state->invited_next || tox_self_get_friend_list_size(autotox->tox) <= 1) {
         return;
     }
 
     Tox_Err_Conference_Invite err;
-    tox_conference_invite(tox, 1, 0, &err);
+    tox_conference_invite(autotox->tox, 1, 0, &err);
     ck_assert_msg(err == TOX_ERR_CONFERENCE_INVITE_OK, "tox #%u failed to invite next friend: err = %d", autotox->index,
                   err);
     printf("tox #%u: invited next friend\n", autotox->index);

--- a/auto_tests/dht_getnodes_api_test.c
+++ b/auto_tests/dht_getnodes_api_test.c
@@ -76,8 +76,8 @@ static void getnodes_response_cb(Tox *tox, const Tox_Event_Dht_Get_Nodes_Respons
 {
     ck_assert(user_data != nullptr);
 
-    AutoTox *autotoxes = (AutoTox *)user_data;
-    State *state = (State *)autotoxes->state;
+    AutoTox *autotox = (AutoTox *)user_data;
+    State *state = (State *)autotox->state;
 
     const uint8_t *public_key = tox_event_dht_get_nodes_response_get_public_key(event);
     const char *ip = (const char *)tox_event_dht_get_nodes_response_get_ip(event);
@@ -101,7 +101,7 @@ static void getnodes_response_cb(Tox *tox, const Tox_Event_Dht_Get_Nodes_Respons
 
     // ask new node to give us their close nodes to every public key
     for (size_t i = 0; i < NUM_TOXES; ++i) {
-        tox_dht_get_nodes(tox, public_key, ip, port, state->public_key_list[i], nullptr);
+        tox_dht_get_nodes(autotox->tox, public_key, ip, port, state->public_key_list[i], nullptr);
     }
 }
 

--- a/auto_tests/friend_request_spam_test.c
+++ b/auto_tests/friend_request_spam_test.c
@@ -25,13 +25,15 @@ typedef struct State {
 static void accept_friend_request(Tox *tox, const Tox_Event_Friend_Request *event,
                                   void *userdata)
 {
+    AutoTox *autotox = (AutoTox *)userdata;
+
     const uint8_t *public_key = tox_event_friend_request_get_public_key(event);
     const uint8_t *data = tox_event_friend_request_get_message(event);
     const size_t length = tox_event_friend_request_get_message_length(event);
 
     ck_assert_msg(length == sizeof(FR_MESSAGE) && memcmp(FR_MESSAGE, data, sizeof(FR_MESSAGE)) == 0,
                   "unexpected friend request message");
-    tox_friend_add_norequest(tox, public_key, nullptr);
+    tox_friend_add_norequest(autotox->tox, public_key, nullptr);
 }
 
 static void test_friend_request(AutoTox *autotoxes)

--- a/auto_tests/friend_request_test.c
+++ b/auto_tests/friend_request_test.c
@@ -18,12 +18,15 @@
 static void accept_friend_request(Tox *tox, const Tox_Event_Friend_Request *event,
                                   void *userdata)
 {
+    Tox *state_tox = (Tox *)userdata;
+
     const uint8_t *public_key = tox_event_friend_request_get_public_key(event);
     const uint8_t *data = tox_event_friend_request_get_message(event);
     const size_t length = tox_event_friend_request_get_message_length(event);
+
     ck_assert_msg(length == sizeof(FR_MESSAGE) && memcmp(FR_MESSAGE, data, sizeof(FR_MESSAGE)) == 0,
                   "unexpected friend request message");
-    tox_friend_add_norequest(tox, public_key, nullptr);
+    tox_friend_add_norequest(state_tox, public_key, nullptr);
 }
 
 static void iterate2_wait(const Tox_Dispatch *dispatch, Tox *tox1, Tox *tox2)
@@ -33,12 +36,12 @@ static void iterate2_wait(const Tox_Dispatch *dispatch, Tox *tox1, Tox *tox2)
 
     events = tox_events_iterate(tox1, true, &err);
     ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-    tox_dispatch_invoke(dispatch, events, tox1, nullptr);
+    tox_dispatch_invoke(dispatch, events, tox1, tox1);
     tox_events_free(events);
 
     events = tox_events_iterate(tox2, true, &err);
     ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-    tox_dispatch_invoke(dispatch, events, tox2, nullptr);
+    tox_dispatch_invoke(dispatch, events, tox2, tox2);
     tox_events_free(events);
 
     c_sleep(ITERATION_INTERVAL);

--- a/auto_tests/group_general_test.c
+++ b/auto_tests/group_general_test.c
@@ -93,23 +93,23 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
 
     // we do a connection test here for fun
     Tox_Err_Group_Peer_Query pq_err;
-    Tox_Connection connection_status = tox_group_peer_get_connection_status(tox, groupnumber, peer_id, &pq_err);
+    Tox_Connection connection_status = tox_group_peer_get_connection_status(autotox->tox, groupnumber, peer_id, &pq_err);
     ck_assert(pq_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(connection_status != TOX_CONNECTION_NONE);
 
-    Tox_Group_Role role = tox_group_peer_get_role(tox, groupnumber, peer_id, &pq_err);
+    Tox_Group_Role role = tox_group_peer_get_role(autotox->tox, groupnumber, peer_id, &pq_err);
     ck_assert_msg(pq_err == TOX_ERR_GROUP_PEER_QUERY_OK, "%d", pq_err);
 
-    Tox_User_Status status = tox_group_peer_get_status(tox, groupnumber, peer_id, &pq_err);
+    Tox_User_Status status = tox_group_peer_get_status(autotox->tox, groupnumber, peer_id, &pq_err);
     ck_assert_msg(pq_err == TOX_ERR_GROUP_PEER_QUERY_OK, "%d", pq_err);
 
-    size_t peer_name_len = tox_group_peer_get_name_size(tox, groupnumber, peer_id, &pq_err);
+    size_t peer_name_len = tox_group_peer_get_name_size(autotox->tox, groupnumber, peer_id, &pq_err);
     char peer_name[TOX_MAX_NAME_LENGTH + 1];
 
     ck_assert(pq_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(peer_name_len <= TOX_MAX_NAME_LENGTH);
 
-    tox_group_peer_get_name(tox, groupnumber, peer_id, (uint8_t *) peer_name, &pq_err);
+    tox_group_peer_get_name(autotox->tox, groupnumber, peer_id, (uint8_t *)peer_name, &pq_err);
     ck_assert(pq_err == TOX_ERR_GROUP_PEER_QUERY_OK);
 
     peer_name[peer_name_len] = 0;
@@ -140,7 +140,7 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
     }
 
     fprintf(stderr, "%s joined with IP: ", peer_name);
-    print_ip(tox, groupnumber, peer_id);
+    print_ip(autotox->tox, groupnumber, peer_id);
 
     state->peer_id = peer_id;
     ++state->peer_joined_count;
@@ -158,19 +158,19 @@ static void group_peer_self_join_handler(Tox *tox, const Tox_Event_Group_Self_Jo
     // make sure we see our own correct peer state on join callback
 
     Tox_Err_Group_Self_Query sq_err;
-    size_t self_length = tox_group_self_get_name_size(tox, groupnumber, &sq_err);
+    size_t self_length = tox_group_self_get_name_size(autotox->tox, groupnumber, &sq_err);
 
     ck_assert(sq_err == TOX_ERR_GROUP_SELF_QUERY_OK);
 
     uint8_t self_name[TOX_MAX_NAME_LENGTH];
-    tox_group_self_get_name(tox, groupnumber, self_name, &sq_err);
+    tox_group_self_get_name(autotox->tox, groupnumber, self_name, &sq_err);
 
     ck_assert(sq_err == TOX_ERR_GROUP_SELF_QUERY_OK);
 
-    Tox_User_Status self_status = tox_group_self_get_status(tox, groupnumber, &sq_err);
+    Tox_User_Status self_status = tox_group_self_get_status(autotox->tox, groupnumber, &sq_err);
     ck_assert(sq_err == TOX_ERR_GROUP_SELF_QUERY_OK);
 
-    Tox_Group_Role self_role = tox_group_self_get_role(tox, groupnumber, &sq_err);
+    Tox_Group_Role self_role = tox_group_self_get_role(autotox->tox, groupnumber, &sq_err);
     ck_assert(sq_err == TOX_ERR_GROUP_SELF_QUERY_OK);
 
     if (state->is_founder) {
@@ -190,23 +190,23 @@ static void group_peer_self_join_handler(Tox *tox, const Tox_Event_Group_Self_Jo
     uint8_t group_name[GROUP_NAME_LEN];
     uint8_t topic[TOX_GROUP_MAX_TOPIC_LENGTH];
 
-    ck_assert(tox_group_get_peer_limit(tox, groupnumber, nullptr) == PEER_LIMIT);
-    ck_assert(tox_group_get_name_size(tox, groupnumber, nullptr) == GROUP_NAME_LEN);
-    ck_assert(tox_group_get_topic_size(tox, groupnumber, nullptr) == TOPIC_LEN);
+    ck_assert(tox_group_get_peer_limit(autotox->tox, groupnumber, nullptr) == PEER_LIMIT);
+    ck_assert(tox_group_get_name_size(autotox->tox, groupnumber, nullptr) == GROUP_NAME_LEN);
+    ck_assert(tox_group_get_topic_size(autotox->tox, groupnumber, nullptr) == TOPIC_LEN);
 
     Tox_Err_Group_State_Queries query_err;
-    tox_group_get_name(tox, groupnumber, group_name, &query_err);
+    tox_group_get_name(autotox->tox, groupnumber, group_name, &query_err);
     ck_assert_msg(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK, "%d", query_err);
     ck_assert(memcmp(group_name, GROUP_NAME, GROUP_NAME_LEN) == 0);
 
-    tox_group_get_topic(tox, groupnumber, topic, &query_err);
+    tox_group_get_topic(autotox->tox, groupnumber, topic, &query_err);
     ck_assert_msg(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK, "%d", query_err);
     ck_assert(memcmp(topic, TOPIC, TOPIC_LEN) == 0);
 
-    uint32_t peer_id = tox_group_self_get_peer_id(tox, groupnumber, nullptr);
+    uint32_t peer_id = tox_group_self_get_peer_id(autotox->tox, groupnumber, nullptr);
 
     fprintf(stderr, "self joined with IP: ");
-    print_ip(tox, groupnumber, peer_id);
+    print_ip(autotox->tox, groupnumber, peer_id);
 
     ++state->self_joined_count;
 }
@@ -261,7 +261,7 @@ static void group_peer_status_handler(Tox *tox, const Tox_Event_Group_Peer_Statu
     const Tox_User_Status status = tox_event_group_peer_status_get_status(event);
 
     Tox_Err_Group_Peer_Query err;
-    Tox_User_Status cur_status = tox_group_peer_get_status(tox, groupnumber, peer_id, &err);
+    Tox_User_Status cur_status = tox_group_peer_get_status(autotox->tox, groupnumber, peer_id, &err);
 
     ck_assert_msg(cur_status == status, "%d, %d", cur_status, status);
     ck_assert(status == TOX_USER_STATUS_BUSY);

--- a/auto_tests/group_message_test.c
+++ b/auto_tests/group_message_test.c
@@ -73,13 +73,16 @@ static uint16_t get_message_checksum(const uint8_t *message, uint16_t length)
 
 static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t friend_number = tox_event_group_invite_get_friend_number(event);
     const uint8_t *invite_data = tox_event_group_invite_get_invite_data(event);
     const size_t length = tox_event_group_invite_get_invite_data_length(event);
 
     printf("invite arrived; accepting\n");
     Tox_Err_Group_Invite_Accept err_accept;
-    tox_group_invite_accept(tox, friend_number, invite_data, length, (const uint8_t *)PEER0_NICK, PEER0_NICK_LEN,
+    tox_group_invite_accept(autotox->tox, friend_number, invite_data, length, (const uint8_t *)PEER0_NICK, PEER0_NICK_LEN,
                             nullptr, 0, &err_accept);
     ck_assert(err_accept == TOX_ERR_GROUP_INVITE_ACCEPT_OK);
 }
@@ -108,6 +111,9 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
 
 static void group_custom_private_packet_handler(Tox *tox, const Tox_Event_Group_Custom_Private_Packet *event, void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t groupnumber = tox_event_group_custom_private_packet_get_group_number(event);
     const uint32_t peer_id = tox_event_group_custom_private_packet_get_peer_id(event);
     const uint8_t *data = tox_event_group_custom_private_packet_get_data(event);
@@ -121,25 +127,25 @@ static void group_custom_private_packet_handler(Tox *tox, const Tox_Event_Group_
     message_buf[length] = 0;
 
     Tox_Err_Group_Peer_Query q_err;
-    size_t peer_name_len = tox_group_peer_get_name_size(tox, groupnumber, peer_id, &q_err);
+    size_t peer_name_len = tox_group_peer_get_name_size(autotox->tox, groupnumber, peer_id, &q_err);
 
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(peer_name_len <= TOX_MAX_NAME_LENGTH);
 
     char peer_name[TOX_MAX_NAME_LENGTH + 1];
-    tox_group_peer_get_name(tox, groupnumber, peer_id, (uint8_t *) peer_name, &q_err);
+    tox_group_peer_get_name(autotox->tox, groupnumber, peer_id, (uint8_t *) peer_name, &q_err);
     peer_name[peer_name_len] = 0;
 
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(memcmp(peer_name, PEER0_NICK, peer_name_len) == 0);
 
     Tox_Err_Group_Self_Query s_err;
-    size_t self_name_len = tox_group_self_get_name_size(tox, groupnumber, &s_err);
+    size_t self_name_len = tox_group_self_get_name_size(autotox->tox, groupnumber, &s_err);
     ck_assert(s_err == TOX_ERR_GROUP_SELF_QUERY_OK);
     ck_assert(self_name_len <= TOX_MAX_NAME_LENGTH);
 
     char self_name[TOX_MAX_NAME_LENGTH + 1];
-    tox_group_self_get_name(tox, groupnumber, (uint8_t *) self_name, &s_err);
+    tox_group_self_get_name(autotox->tox, groupnumber, (uint8_t *)self_name, &s_err);
     self_name[self_name_len] = 0;
 
     ck_assert(s_err == TOX_ERR_GROUP_SELF_QUERY_OK);
@@ -148,9 +154,6 @@ static void group_custom_private_packet_handler(Tox *tox, const Tox_Event_Group_
     printf("%s sent custom private packet to %s: %s\n", peer_name, self_name, message_buf);
     ck_assert(memcmp(message_buf, TEST_CUSTOM_PRIVATE_PACKET, length) == 0);
 
-    AutoTox *autotox = (AutoTox *)user_data;
-    ck_assert(autotox != nullptr);
-
     State *state = (State *)autotox->state;
 
     ++state->custom_private_packets_received;
@@ -158,6 +161,9 @@ static void group_custom_private_packet_handler(Tox *tox, const Tox_Event_Group_
 
 static void group_custom_packet_handler(Tox *tox, const Tox_Event_Group_Custom_Packet *event, void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t groupnumber = tox_event_group_custom_packet_get_group_number(event);
     const uint32_t peer_id = tox_event_group_custom_packet_get_peer_id(event);
     const uint8_t *data = tox_event_group_custom_packet_get_data(event);
@@ -170,25 +176,25 @@ static void group_custom_packet_handler(Tox *tox, const Tox_Event_Group_Custom_P
     message_buf[length] = 0;
 
     Tox_Err_Group_Peer_Query q_err;
-    size_t peer_name_len = tox_group_peer_get_name_size(tox, groupnumber, peer_id, &q_err);
+    size_t peer_name_len = tox_group_peer_get_name_size(autotox->tox, groupnumber, peer_id, &q_err);
 
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(peer_name_len <= TOX_MAX_NAME_LENGTH);
 
     char peer_name[TOX_MAX_NAME_LENGTH + 1];
-    tox_group_peer_get_name(tox, groupnumber, peer_id, (uint8_t *) peer_name, &q_err);
+    tox_group_peer_get_name(autotox->tox, groupnumber, peer_id, (uint8_t *)peer_name, &q_err);
     peer_name[peer_name_len] = 0;
 
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(memcmp(peer_name, PEER0_NICK, peer_name_len) == 0);
 
     Tox_Err_Group_Self_Query s_err;
-    size_t self_name_len = tox_group_self_get_name_size(tox, groupnumber, &s_err);
+    size_t self_name_len = tox_group_self_get_name_size(autotox->tox, groupnumber, &s_err);
     ck_assert(s_err == TOX_ERR_GROUP_SELF_QUERY_OK);
     ck_assert(self_name_len <= TOX_MAX_NAME_LENGTH);
 
     char self_name[TOX_MAX_NAME_LENGTH + 1];
-    tox_group_self_get_name(tox, groupnumber, (uint8_t *) self_name, &s_err);
+    tox_group_self_get_name(autotox->tox, groupnumber, (uint8_t *)self_name, &s_err);
     self_name[self_name_len] = 0;
 
     ck_assert(s_err == TOX_ERR_GROUP_SELF_QUERY_OK);
@@ -197,9 +203,6 @@ static void group_custom_packet_handler(Tox *tox, const Tox_Event_Group_Custom_P
     printf("%s sent custom packet to %s: %s\n", peer_name, self_name, message_buf);
     ck_assert(memcmp(message_buf, TEST_CUSTOM_PACKET, length) == 0);
 
-    AutoTox *autotox = (AutoTox *)user_data;
-    ck_assert(autotox != nullptr);
-
     State *state = (State *)autotox->state;
 
     ++state->custom_packets_received;
@@ -207,15 +210,15 @@ static void group_custom_packet_handler(Tox *tox, const Tox_Event_Group_Custom_P
 
 static void group_custom_packet_large_handler(Tox *tox, const Tox_Event_Group_Custom_Packet *event, void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint8_t *data = tox_event_group_custom_packet_get_data(event);
     const size_t length = tox_event_group_custom_packet_get_data_length(event);
 
     ck_assert_msg(length == TEST_CUSTOM_PACKET_LARGE_LEN, "Failed to receive large custom packet. Invalid length: %zu\n", length);
 
     ck_assert(memcmp(data, TEST_CUSTOM_PACKET_LARGE, length) == 0);
-
-    AutoTox *autotox = (AutoTox *)user_data;
-    ck_assert(autotox != nullptr);
 
     State *state = (State *)autotox->state;
 
@@ -224,6 +227,9 @@ static void group_custom_packet_large_handler(Tox *tox, const Tox_Event_Group_Cu
 
 static void group_message_handler(Tox *tox, const Tox_Event_Group_Message *event, void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t groupnumber = tox_event_group_message_get_group_number(event);
     const uint32_t peer_id = tox_event_group_message_get_peer_id(event);
     const uint8_t *message = tox_event_group_message_get_message(event);
@@ -238,25 +244,25 @@ static void group_message_handler(Tox *tox, const Tox_Event_Group_Message *event
     message_buf[length] = 0;
 
     Tox_Err_Group_Peer_Query q_err;
-    size_t peer_name_len = tox_group_peer_get_name_size(tox, groupnumber, peer_id, &q_err);
+    size_t peer_name_len = tox_group_peer_get_name_size(autotox->tox, groupnumber, peer_id, &q_err);
 
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(peer_name_len <= TOX_MAX_NAME_LENGTH);
 
     char peer_name[TOX_MAX_NAME_LENGTH + 1];
-    tox_group_peer_get_name(tox, groupnumber, peer_id, (uint8_t *) peer_name, &q_err);
+    tox_group_peer_get_name(autotox->tox, groupnumber, peer_id, (uint8_t *)peer_name, &q_err);
     peer_name[peer_name_len] = 0;
 
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(memcmp(peer_name, PEER0_NICK, peer_name_len) == 0);
 
     Tox_Err_Group_Self_Query s_err;
-    size_t self_name_len = tox_group_self_get_name_size(tox, groupnumber, &s_err);
+    size_t self_name_len = tox_group_self_get_name_size(autotox->tox, groupnumber, &s_err);
     ck_assert(s_err == TOX_ERR_GROUP_SELF_QUERY_OK);
     ck_assert(self_name_len <= TOX_MAX_NAME_LENGTH);
 
     char self_name[TOX_MAX_NAME_LENGTH + 1];
-    tox_group_self_get_name(tox, groupnumber, (uint8_t *) self_name, &s_err);
+    tox_group_self_get_name(autotox->tox, groupnumber, (uint8_t *)self_name, &s_err);
     self_name[self_name_len] = 0;
 
     ck_assert(s_err == TOX_ERR_GROUP_SELF_QUERY_OK);
@@ -264,9 +270,6 @@ static void group_message_handler(Tox *tox, const Tox_Event_Group_Message *event
 
     printf("%s sent message to %s:(id:%u) %s\n", peer_name, self_name, pseudo_msg_id, message_buf);
     ck_assert(memcmp(message_buf, TEST_MESSAGE, length) == 0);
-
-    AutoTox *autotox = (AutoTox *)user_data;
-    ck_assert(autotox != nullptr);
 
     State *state = (State *)autotox->state;
 
@@ -277,6 +280,9 @@ static void group_message_handler(Tox *tox, const Tox_Event_Group_Message *event
 
 static void group_private_message_handler(Tox *tox, const Tox_Event_Group_Private_Message *event, void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t groupnumber = tox_event_group_private_message_get_group_number(event);
     const uint32_t peer_id = tox_event_group_private_message_get_peer_id(event);
     const Tox_Message_Type type = tox_event_group_private_message_get_type(event);
@@ -290,25 +296,25 @@ static void group_private_message_handler(Tox *tox, const Tox_Event_Group_Privat
     message_buf[length] = 0;
 
     Tox_Err_Group_Peer_Query q_err;
-    size_t peer_name_len = tox_group_peer_get_name_size(tox, groupnumber, peer_id, &q_err);
+    size_t peer_name_len = tox_group_peer_get_name_size(autotox->tox, groupnumber, peer_id, &q_err);
 
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(peer_name_len <= TOX_MAX_NAME_LENGTH);
 
     char peer_name[TOX_MAX_NAME_LENGTH + 1];
-    tox_group_peer_get_name(tox, groupnumber, peer_id, (uint8_t *) peer_name, &q_err);
+    tox_group_peer_get_name(autotox->tox, groupnumber, peer_id, (uint8_t *)peer_name, &q_err);
     peer_name[peer_name_len] = 0;
 
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(memcmp(peer_name, PEER0_NICK, peer_name_len) == 0);
 
     Tox_Err_Group_Self_Query s_err;
-    size_t self_name_len = tox_group_self_get_name_size(tox, groupnumber, &s_err);
+    size_t self_name_len = tox_group_self_get_name_size(autotox->tox, groupnumber, &s_err);
     ck_assert(s_err == TOX_ERR_GROUP_SELF_QUERY_OK);
     ck_assert(self_name_len <= TOX_MAX_NAME_LENGTH);
 
     char self_name[TOX_MAX_NAME_LENGTH + 1];
-    tox_group_self_get_name(tox, groupnumber, (uint8_t *) self_name, &s_err);
+    tox_group_self_get_name(autotox->tox, groupnumber, (uint8_t *)self_name, &s_err);
     self_name[self_name_len] = 0;
 
     ck_assert(s_err == TOX_ERR_GROUP_SELF_QUERY_OK);
@@ -318,9 +324,6 @@ static void group_private_message_handler(Tox *tox, const Tox_Event_Group_Privat
     ck_assert(memcmp(message_buf, TEST_PRIVATE_MESSAGE, length) == 0);
 
     ck_assert(type == TOX_MESSAGE_TYPE_ACTION);
-
-    AutoTox *autotox = (AutoTox *)user_data;
-    ck_assert(autotox != nullptr);
 
     State *state = (State *)autotox->state;
 

--- a/auto_tests/group_moderation_test.c
+++ b/auto_tests/group_moderation_test.c
@@ -176,12 +176,12 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
     char peer_name[TOX_MAX_NAME_LENGTH + 1];
 
     Tox_Err_Group_Peer_Query q_err;
-    size_t peer_name_len = tox_group_peer_get_name_size(tox, group_number, peer_id, &q_err);
+    size_t peer_name_len = tox_group_peer_get_name_size(autotox->tox, group_number, peer_id, &q_err);
 
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(peer_name_len <= TOX_MAX_NAME_LENGTH);
 
-    tox_group_peer_get_name(tox, group_number, peer_id, (uint8_t *) peer_name, &q_err);
+    tox_group_peer_get_name(autotox->tox, group_number, peer_id, (uint8_t *) peer_name, &q_err);
     peer_name[peer_name_len] = 0;
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
 
@@ -262,7 +262,7 @@ static void group_mod_event_handler(Tox *tox, const Tox_Event_Group_Moderation *
     char peer_name[TOX_MAX_NAME_LENGTH + 1];
 
     Tox_Err_Group_Peer_Query q_err;
-    size_t peer_name_len = tox_group_peer_get_name_size(tox, group_number, target_peer_id, &q_err);
+    size_t peer_name_len = tox_group_peer_get_name_size(autotox->tox, group_number, target_peer_id, &q_err);
 
     if (q_err == TOX_ERR_GROUP_PEER_QUERY_PEER_NOT_FOUND) {  // may occurr on sync attempts
         return;
@@ -271,11 +271,11 @@ static void group_mod_event_handler(Tox *tox, const Tox_Event_Group_Moderation *
     ck_assert_msg(q_err == TOX_ERR_GROUP_PEER_QUERY_OK, "error %d", q_err);
     ck_assert(peer_name_len <= TOX_MAX_NAME_LENGTH);
 
-    tox_group_peer_get_name(tox, group_number, target_peer_id, (uint8_t *) peer_name, &q_err);
+    tox_group_peer_get_name(autotox->tox, group_number, target_peer_id, (uint8_t *) peer_name, &q_err);
     peer_name[peer_name_len] = 0;
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
 
-    Tox_Group_Role role = tox_group_peer_get_role(tox, group_number, target_peer_id, &q_err);
+    Tox_Group_Role role = tox_group_peer_get_role(autotox->tox, group_number, target_peer_id, &q_err);
     ck_assert(q_err == TOX_ERR_GROUP_PEER_QUERY_OK);
     ck_assert(role <= TOX_GROUP_ROLE_OBSERVER);
 

--- a/auto_tests/group_save_test.c
+++ b/auto_tests/group_save_test.c
@@ -28,12 +28,15 @@ typedef struct State {
 
 static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t friend_number = tox_event_group_invite_get_friend_number(event);
     const uint8_t *invite_data = tox_event_group_invite_get_invite_data(event);
     const size_t length = tox_event_group_invite_get_invite_data_length(event);
 
     Tox_Err_Group_Invite_Accept err_accept;
-    tox_group_invite_accept(tox, friend_number, invite_data, length, (const uint8_t *)"test2", 5,
+    tox_group_invite_accept(autotox->tox, friend_number, invite_data, length, (const uint8_t *)"test2", 5,
                             nullptr, 0, &err_accept);
     ck_assert(err_accept == TOX_ERR_GROUP_INVITE_ACCEPT_OK);
 

--- a/auto_tests/group_state_test.c
+++ b/auto_tests/group_state_test.c
@@ -63,11 +63,14 @@ static bool all_group_peers_connected(const AutoTox *autotoxes, uint32_t tox_cou
 static void group_topic_lock_handler(Tox *tox, const Tox_Event_Group_Topic_Lock *event,
                                      void *user_data)
 {
+    const AutoTox *autotox = (const AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t groupnumber = tox_event_group_topic_lock_get_group_number(event);
     const Tox_Group_Topic_Lock topic_lock = tox_event_group_topic_lock_get_topic_lock(event);
 
     Tox_Err_Group_State_Queries err;
-    Tox_Group_Topic_Lock current_topic_lock = tox_group_get_topic_lock(tox, groupnumber, &err);
+    Tox_Group_Topic_Lock current_topic_lock = tox_group_get_topic_lock(autotox->tox, groupnumber, &err);
 
     ck_assert(err == TOX_ERR_GROUP_STATE_QUERIES_OK);
     ck_assert_msg(current_topic_lock == topic_lock, "topic locks don't match in callback: %d %d",
@@ -77,11 +80,14 @@ static void group_topic_lock_handler(Tox *tox, const Tox_Event_Group_Topic_Lock 
 static void group_voice_state_handler(Tox *tox, const Tox_Event_Group_Voice_State *event,
                                       void *user_data)
 {
+    const AutoTox *autotox = (const AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t groupnumber = tox_event_group_voice_state_get_group_number(event);
     const Tox_Group_Voice_State voice_state = tox_event_group_voice_state_get_voice_state(event);
 
     Tox_Err_Group_State_Queries err;
-    Tox_Group_Voice_State current_voice_state = tox_group_get_voice_state(tox, groupnumber, &err);
+    Tox_Group_Voice_State current_voice_state = tox_group_get_voice_state(autotox->tox, groupnumber, &err);
 
     ck_assert(err == TOX_ERR_GROUP_STATE_QUERIES_OK);
     ck_assert_msg(current_voice_state == voice_state, "voice states don't match in callback: %d %d",
@@ -91,11 +97,14 @@ static void group_voice_state_handler(Tox *tox, const Tox_Event_Group_Voice_Stat
 static void group_privacy_state_handler(Tox *tox, const Tox_Event_Group_Privacy_State *event,
                                         void *user_data)
 {
+    const AutoTox *autotox = (const AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t groupnumber = tox_event_group_privacy_state_get_group_number(event);
     const Tox_Group_Privacy_State privacy_state = tox_event_group_privacy_state_get_privacy_state(event);
 
     Tox_Err_Group_State_Queries err;
-    Tox_Group_Privacy_State current_pstate = tox_group_get_privacy_state(tox, groupnumber, &err);
+    Tox_Group_Privacy_State current_pstate = tox_group_get_privacy_state(autotox->tox, groupnumber, &err);
 
     ck_assert(err == TOX_ERR_GROUP_STATE_QUERIES_OK);
     ck_assert_msg(current_pstate == privacy_state, "privacy states don't match in callback");
@@ -103,11 +112,14 @@ static void group_privacy_state_handler(Tox *tox, const Tox_Event_Group_Privacy_
 
 static void group_peer_limit_handler(Tox *tox, const Tox_Event_Group_Peer_Limit *event, void *user_data)
 {
+    const AutoTox *autotox = (const AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t groupnumber = tox_event_group_peer_limit_get_group_number(event);
     const uint32_t peer_limit = tox_event_group_peer_limit_get_peer_limit(event);
 
     Tox_Err_Group_State_Queries err;
-    uint32_t current_plimit = tox_group_get_peer_limit(tox, groupnumber, &err);
+    uint32_t current_plimit = tox_group_get_peer_limit(autotox->tox, groupnumber, &err);
 
     ck_assert(err == TOX_ERR_GROUP_STATE_QUERIES_OK);
     ck_assert_msg(peer_limit == current_plimit,
@@ -117,18 +129,21 @@ static void group_peer_limit_handler(Tox *tox, const Tox_Event_Group_Peer_Limit 
 static void group_password_handler(Tox *tox, const Tox_Event_Group_Password *event,
                                    void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t groupnumber = tox_event_group_password_get_group_number(event);
     const uint8_t *password = tox_event_group_password_get_password(event);
     const size_t length = tox_event_group_password_get_password_length(event);
 
     Tox_Err_Group_State_Queries err;
-    size_t curr_pwlength = tox_group_get_password_size(tox, groupnumber, &err);
+    size_t curr_pwlength = tox_group_get_password_size(autotox->tox, groupnumber, &err);
 
     ck_assert(err == TOX_ERR_GROUP_STATE_QUERIES_OK);
     ck_assert(length == curr_pwlength);
 
     uint8_t current_password[TOX_GROUP_MAX_PASSWORD_SIZE];
-    tox_group_get_password(tox, groupnumber, current_password, &err);
+    tox_group_get_password(autotox->tox, groupnumber, current_password, &err);
 
     ck_assert(err == TOX_ERR_GROUP_STATE_QUERIES_OK);
     ck_assert_msg(memcmp(current_password, password, length) == 0,

--- a/auto_tests/group_tcp_test.c
+++ b/auto_tests/group_tcp_test.c
@@ -21,6 +21,9 @@ typedef struct State {
 
 static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t friend_number = tox_event_group_invite_get_friend_number(event);
     const uint8_t *invite_data = tox_event_group_invite_get_invite_data(event);
     const size_t length = tox_event_group_invite_get_invite_data_length(event);
@@ -28,7 +31,7 @@ static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, 
     printf("Accepting friend invite\n");
 
     Tox_Err_Group_Invite_Accept err_accept;
-    tox_group_invite_accept(tox, friend_number, invite_data, length, (const uint8_t *)"test", 4,
+    tox_group_invite_accept(autotox->tox, friend_number, invite_data, length, (const uint8_t *)"test", 4,
                             nullptr, 0, &err_accept);
     ck_assert(err_accept == TOX_ERR_GROUP_INVITE_ACCEPT_OK);
 }

--- a/auto_tests/group_topic_test.c
+++ b/auto_tests/group_topic_test.c
@@ -70,6 +70,9 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
 
 static void group_topic_handler(Tox *tox, const Tox_Event_Group_Topic *event, void *user_data)
 {
+    AutoTox *autotox = (AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t group_number = tox_event_group_topic_get_group_number(event);
     //const uint32_t peer_id = tox_event_group_topic_get_peer_id(event);
     const uint8_t *topic = tox_event_group_topic_get_topic(event);
@@ -79,10 +82,10 @@ static void group_topic_handler(Tox *tox, const Tox_Event_Group_Topic *event, vo
 
     Tox_Err_Group_State_Queries query_err;
     uint8_t topic2[TOX_GROUP_MAX_TOPIC_LENGTH];
-    tox_group_get_topic(tox, group_number, topic2, &query_err);
+    tox_group_get_topic(autotox->tox, group_number, topic2, &query_err);
     ck_assert(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK);
 
-    size_t topic_length_getter = tox_group_get_topic_size(tox, group_number, &query_err);
+    size_t topic_length_getter = tox_group_get_topic_size(autotox->tox, group_number, &query_err);
     ck_assert(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK);
     ck_assert_msg(topic_length_getter == topic_length && memcmp(topic, topic2, topic_length) == 0,
                   "topic differs in callback: %s, %s", topic, topic2);
@@ -90,11 +93,14 @@ static void group_topic_handler(Tox *tox, const Tox_Event_Group_Topic *event, vo
 
 static void group_topic_lock_handler(Tox *tox, const Tox_Event_Group_Topic_Lock *event, void *user_data)
 {
+    const AutoTox *autotox = (const AutoTox *)user_data;
+    ck_assert(autotox != nullptr);
+
     const uint32_t group_number = tox_event_group_topic_lock_get_group_number(event);
     const Tox_Group_Topic_Lock topic_lock = tox_event_group_topic_lock_get_topic_lock(event);
 
     Tox_Err_Group_State_Queries err;
-    Tox_Group_Topic_Lock current_lock = tox_group_get_topic_lock(tox, group_number, &err);
+    Tox_Group_Topic_Lock current_lock = tox_group_get_topic_lock(autotox->tox, group_number, &err);
 
     ck_assert(err == TOX_ERR_GROUP_STATE_QUERIES_OK);
     ck_assert_msg(topic_lock == current_lock, "topic locks differ in callback");

--- a/auto_tests/save_load_test.c
+++ b/auto_tests/save_load_test.c
@@ -34,12 +34,14 @@
 
 static void accept_friend_request(Tox *m, const Tox_Event_Friend_Request *event, void *userdata)
 {
+    Tox *tox = (Tox *)userdata;
+
     const uint8_t *public_key = tox_event_friend_request_get_public_key(event);
     const uint8_t *message = tox_event_friend_request_get_message(event);
     uint32_t message_length = tox_event_friend_request_get_message_length(event);
 
     if (message_length == 7 && memcmp("Gentoo", message, 7) == 0) {
-        tox_friend_add_norequest(m, public_key, nullptr);
+        tox_friend_add_norequest(tox, public_key, nullptr);
     }
 }
 
@@ -208,14 +210,14 @@ static void test_few_clients(void)
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(tox1, true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch1, events, tox1, nullptr);
+            tox_dispatch_invoke(dispatch1, events, tox1, tox1);
             tox_events_free(events);
         }
         {
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(tox2, true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch2, events, tox2, nullptr);
+            tox_dispatch_invoke(dispatch2, events, tox2, tox2);
             tox_events_free(events);
         }
         tox_iterate(tox3, nullptr);
@@ -259,14 +261,14 @@ static void test_few_clients(void)
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(tox1, true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch1, events, tox1, nullptr);
+            tox_dispatch_invoke(dispatch1, events, tox1, tox1);
             tox_events_free(events);
         }
         {
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(tox2, true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch2, events, tox2, nullptr);
+            tox_dispatch_invoke(dispatch2, events, tox2, tox2);
             tox_events_free(events);
         }
         tox_iterate(tox3, nullptr);

--- a/auto_tests/tox_many_tcp_test.c
+++ b/auto_tests/tox_many_tcp_test.c
@@ -26,20 +26,27 @@
 #define TOX_LOCALHOST "127.0.0.1"
 #endif
 
+typedef struct State {
+    uint32_t to_comp;
+    Tox *tox;
+} State;
+
 static bool enable_broken_tests = false;
 
 static void accept_friend_request(Tox *m, const Tox_Event_Friend_Request *event, void *userdata)
 {
+    State *state = (State *)userdata;
+
     const uint8_t *public_key = tox_event_friend_request_get_public_key(event);
     const uint8_t *message = tox_event_friend_request_get_message(event);
     const uint32_t message_length = tox_event_friend_request_get_message_length(event);
 
-    if (*((uint32_t *)userdata) != 974536) {
+    if (state->to_comp != 974536) {
         return;
     }
 
     if (message_length == 7 && memcmp("Gentoo", message, 7) == 0) {
-        tox_friend_add_norequest(m, public_key, nullptr);
+        tox_friend_add_norequest(state->tox, public_key, nullptr);
     }
 }
 
@@ -143,7 +150,8 @@ loop_top:
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(toxes[i], true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch, events, toxes[i], &to_comp);
+            State state = {to_comp, toxes[i]};
+            tox_dispatch_invoke(dispatch, events, toxes[i], &state);
             tox_events_free(events);
         }
 
@@ -254,7 +262,8 @@ loop_top:
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(toxes[i], true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch, events, toxes[i], &to_comp);
+            State state = {to_comp, toxes[i]};
+            tox_dispatch_invoke(dispatch, events, toxes[i], &state);
             tox_events_free(events);
         }
 

--- a/auto_tests/tox_many_test.c
+++ b/auto_tests/tox_many_test.c
@@ -15,12 +15,14 @@
 
 static void accept_friend_request(Tox *m, const Tox_Event_Friend_Request *event, void *userdata)
 {
+    Tox *tox = (Tox *)userdata;
+
     const uint8_t *public_key = tox_event_friend_request_get_public_key(event);
     const uint8_t *message = tox_event_friend_request_get_message(event);
     const uint32_t message_length = tox_event_friend_request_get_message_length(event);
 
     if (message_length == 7 && memcmp("Gentoo", message, 7) == 0) {
-        tox_friend_add_norequest(m, public_key, nullptr);
+        tox_friend_add_norequest(tox, public_key, nullptr);
     }
 }
 
@@ -123,7 +125,7 @@ loop_top:
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(toxes[i], true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch, events, toxes[i], nullptr);
+            tox_dispatch_invoke(dispatch, events, toxes[i], toxes[i]);
             tox_events_free(events);
         }
 


### PR DESCRIPTION
This frees up the dispatcher from having to know that `Tox *` exists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2644)
<!-- Reviewable:end -->
