### PR TITLE
refactor: Remove `Tox *` from `tox_dispatch`.

### DIFF
--- a/auto_tests/auto_test_support.c
+++ b/auto_tests/auto_test_support.c
@@ -138,7 +138,7 @@ void iterate_all_wait(AutoTox *autotoxes, uint32_t tox_count, uint32_t wait)
                 Tox_Err_Events_Iterate err;
                 Tox_Events *events = tox_events_iterate(autotoxes[i].tox, true, &err);
                 ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-                tox_dispatch_invoke(autotoxes[i].dispatch, events, autotoxes[i].tox, &autotoxes[i]);
+                tox_dispatch_invoke(autotoxes[i].dispatch, events, &autotoxes[i]);
                 tox_events_free(events);
             } else {
                 tox_iterate(autotoxes[i].tox, &autotoxes[i]);

--- a/auto_tests/conference_av_test.c
+++ b/auto_tests/conference_av_test.c
@@ -23,7 +23,7 @@ typedef struct State {
 } State;
 
 static void handle_self_connection_status(
-    Tox *tox, const Tox_Event_Self_Connection_Status *event, void *user_data)
+    const Tox_Event_Self_Connection_Status *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
 
@@ -36,7 +36,7 @@ static void handle_self_connection_status(
 }
 
 static void handle_friend_connection_status(
-    Tox *tox, const Tox_Event_Friend_Connection_Status *event, void *user_data)
+    const Tox_Event_Friend_Connection_Status *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
 
@@ -74,7 +74,7 @@ static void audio_callback(void *tox, uint32_t groupnumber, uint32_t peernumber,
 }
 
 static void handle_conference_invite(
-    Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data)
+    const Tox_Event_Conference_Invite *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
 
@@ -90,7 +90,7 @@ static void handle_conference_invite(
 }
 
 static void handle_conference_connected(
-    Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data)
+    const Tox_Event_Conference_Connected *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;
@@ -149,7 +149,7 @@ static void disconnect_toxes(uint32_t tox_count, AutoTox *autotoxes,
                 if (!disconnect_now[i]) {
                     Tox_Err_Events_Iterate err;
                     Tox_Events *events = tox_events_iterate(autotoxes[i].tox, true, &err);
-                    tox_dispatch_invoke(autotoxes[i].dispatch, events, autotoxes[i].tox, &autotoxes[i]);
+                    tox_dispatch_invoke(autotoxes[i].dispatch, events, &autotoxes[i]);
                     tox_events_free(events);
                     autotoxes[i].clock += 1000;
                 }

--- a/auto_tests/conference_double_invite_test.c
+++ b/auto_tests/conference_double_invite_test.c
@@ -12,7 +12,7 @@ typedef struct State {
 #include "auto_test_support.h"
 
 static void handle_conference_invite(
-    Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data)
+    const Tox_Event_Conference_Invite *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;

--- a/auto_tests/conference_invite_merge_test.c
+++ b/auto_tests/conference_invite_merge_test.c
@@ -12,7 +12,7 @@ typedef struct State {
 #include "auto_test_support.h"
 
 static void handle_conference_invite(
-    Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data)
+    const Tox_Event_Conference_Invite *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;
@@ -31,7 +31,7 @@ static void handle_conference_invite(
 }
 
 static void handle_conference_connected(
-    Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data)
+    const Tox_Event_Conference_Connected *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;

--- a/auto_tests/conference_peer_nick_test.c
+++ b/auto_tests/conference_peer_nick_test.c
@@ -13,7 +13,7 @@ typedef struct State {
 #include "auto_test_support.h"
 
 static void handle_conference_invite(
-    Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data)
+    const Tox_Event_Conference_Invite *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;
@@ -35,7 +35,7 @@ static void handle_conference_invite(
     state->joined = true;
 }
 
-static void handle_peer_list_changed(Tox *tox, const Tox_Event_Conference_Peer_List_Changed *event, void *user_data)
+static void handle_peer_list_changed(const Tox_Event_Conference_Peer_List_Changed *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;

--- a/auto_tests/conference_simple_test.c
+++ b/auto_tests/conference_simple_test.c
@@ -23,7 +23,7 @@ typedef struct State {
     uint32_t peers;
 } State;
 
-static void handle_self_connection_status(Tox *tox, const Tox_Event_Self_Connection_Status *event, void *user_data)
+static void handle_self_connection_status(const Tox_Event_Self_Connection_Status *event, void *user_data)
 {
     State *state = (State *)user_data;
 
@@ -32,7 +32,7 @@ static void handle_self_connection_status(Tox *tox, const Tox_Event_Self_Connect
     state->self_online = connection_status != TOX_CONNECTION_NONE;
 }
 
-static void handle_friend_connection_status(Tox *tox, const Tox_Event_Friend_Connection_Status *event,
+static void handle_friend_connection_status(const Tox_Event_Friend_Connection_Status *event,
         void *user_data)
 {
     State *state = (State *)user_data;
@@ -43,7 +43,7 @@ static void handle_friend_connection_status(Tox *tox, const Tox_Event_Friend_Con
     state->friend_online = connection_status != TOX_CONNECTION_NONE;
 }
 
-static void handle_conference_invite(Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data)
+static void handle_conference_invite(const Tox_Event_Conference_Invite *event, void *user_data)
 {
     State *state = (State *)user_data;
 
@@ -64,7 +64,7 @@ static void handle_conference_invite(Tox *tox, const Tox_Event_Conference_Invite
     }
 }
 
-static void handle_conference_message(Tox *tox, const Tox_Event_Conference_Message *event, void *user_data)
+static void handle_conference_message(const Tox_Event_Conference_Message *event, void *user_data)
 {
     State *state = (State *)user_data;
 
@@ -81,7 +81,7 @@ static void handle_conference_message(Tox *tox, const Tox_Event_Conference_Messa
     state->received = true;
 }
 
-static void handle_conference_peer_list_changed(Tox *tox, const Tox_Event_Conference_Peer_List_Changed *event, void *user_data)
+static void handle_conference_peer_list_changed(const Tox_Event_Conference_Peer_List_Changed *event, void *user_data)
 {
     State *state = (State *)user_data;
 
@@ -101,7 +101,7 @@ static void handle_conference_peer_list_changed(Tox *tox, const Tox_Event_Confer
     state->peers = count;
 }
 
-static void handle_conference_connected(Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data)
+static void handle_conference_connected(const Tox_Event_Conference_Connected *event, void *user_data)
 {
     State *state = (State *)user_data;
 
@@ -122,7 +122,7 @@ static void iterate_one(
     Tox_Err_Events_Iterate err;
     Tox_Events *events = tox_events_iterate(tox, true, &err);
     ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-    tox_dispatch_invoke(dispatch, events, tox, state);
+    tox_dispatch_invoke(dispatch, events, state);
     tox_events_free(events);
 }
 

--- a/auto_tests/dht_getnodes_api_test.c
+++ b/auto_tests/dht_getnodes_api_test.c
@@ -72,7 +72,7 @@ static bool all_nodes_crawled(const AutoTox *autotoxes, uint32_t num_toxes, uint
     return true;
 }
 
-static void getnodes_response_cb(Tox *tox, const Tox_Event_Dht_Get_Nodes_Response *event, void *user_data)
+static void getnodes_response_cb(const Tox_Event_Dht_Get_Nodes_Response *event, void *user_data)
 {
     ck_assert(user_data != nullptr);
 

--- a/auto_tests/file_transfer_test.c
+++ b/auto_tests/file_transfer_test.c
@@ -26,7 +26,7 @@
 #define TOX_LOCALHOST "127.0.0.1"
 #endif
 
-static void accept_friend_request(Tox *m, const Tox_Event_Friend_Request *event, void *userdata)
+static void accept_friend_request(const Tox_Event_Friend_Request *event, void *userdata)
 {
     Tox *tox = (Tox *)userdata;
 
@@ -45,7 +45,7 @@ static uint64_t sending_pos;
 static uint8_t file_cmp_id[TOX_FILE_ID_LENGTH];
 static uint32_t file_accepted;
 static uint64_t file_size;
-static void tox_file_receive(Tox *tox, const Tox_Event_File_Recv *event, void *userdata)
+static void tox_file_receive(const Tox_Event_File_Recv *event, void *userdata)
 {
     Tox *state_tox = (Tox *)userdata;
 
@@ -100,7 +100,7 @@ static void tox_file_receive(Tox *tox, const Tox_Event_File_Recv *event, void *u
 }
 
 static uint32_t sendf_ok;
-static void file_print_control(Tox *tox, const Tox_Event_File_Recv_Control *event,
+static void file_print_control(const Tox_Event_File_Recv_Control *event,
                                void *userdata)
 {
     const uint32_t file_number = tox_event_file_recv_control_get_file_number(event);
@@ -116,7 +116,7 @@ static uint64_t max_sending;
 static bool m_send_reached;
 static uint8_t sending_num;
 static bool file_sending_done;
-static void tox_file_chunk_request(Tox *tox, const Tox_Event_File_Chunk_Request *event, void *user_data)
+static void tox_file_chunk_request(const Tox_Event_File_Chunk_Request *event, void *user_data)
 {
     Tox *state_tox = (Tox *)user_data;
 
@@ -158,7 +158,7 @@ static void tox_file_chunk_request(Tox *tox, const Tox_Event_File_Chunk_Request 
 
 static uint8_t num;
 static bool file_recv;
-static void write_file(Tox *tox, const Tox_Event_File_Recv_Chunk *event, void *user_data)
+static void write_file(const Tox_Event_File_Recv_Chunk *event, void *user_data)
 {
     const uint64_t position = tox_event_file_recv_chunk_get_position(event);
     const uint8_t *data = tox_event_file_recv_chunk_get_data(event);
@@ -187,7 +187,7 @@ static void iterate_and_dispatch(const Tox_Dispatch *dispatch, Tox *tox)
 
     events = tox_events_iterate(tox, true, &err);
     ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-    tox_dispatch_invoke(dispatch, events, tox, tox);
+    tox_dispatch_invoke(dispatch, events, tox);
     tox_events_free(events);
 }
 

--- a/auto_tests/friend_request_spam_test.c
+++ b/auto_tests/friend_request_spam_test.c
@@ -22,7 +22,7 @@ typedef struct State {
     bool unused;
 } State;
 
-static void accept_friend_request(Tox *tox, const Tox_Event_Friend_Request *event,
+static void accept_friend_request(const Tox_Event_Friend_Request *event,
                                   void *userdata)
 {
     AutoTox *autotox = (AutoTox *)userdata;

--- a/auto_tests/friend_request_test.c
+++ b/auto_tests/friend_request_test.c
@@ -15,7 +15,7 @@
 
 #define FR_MESSAGE "Gentoo"
 
-static void accept_friend_request(Tox *tox, const Tox_Event_Friend_Request *event,
+static void accept_friend_request(const Tox_Event_Friend_Request *event,
                                   void *userdata)
 {
     Tox *state_tox = (Tox *)userdata;
@@ -36,12 +36,12 @@ static void iterate2_wait(const Tox_Dispatch *dispatch, Tox *tox1, Tox *tox2)
 
     events = tox_events_iterate(tox1, true, &err);
     ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-    tox_dispatch_invoke(dispatch, events, tox1, tox1);
+    tox_dispatch_invoke(dispatch, events, tox1);
     tox_events_free(events);
 
     events = tox_events_iterate(tox2, true, &err);
     ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-    tox_dispatch_invoke(dispatch, events, tox2, tox2);
+    tox_dispatch_invoke(dispatch, events, tox2);
     tox_events_free(events);
 
     c_sleep(ITERATION_INTERVAL);

--- a/auto_tests/group_general_test.c
+++ b/auto_tests/group_general_test.c
@@ -81,7 +81,7 @@ static bool all_group_peers_connected(AutoTox *autotoxes, uint32_t tox_count, ui
     return true;
 }
 
-static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data)
+static void group_peer_join_handler(const Tox_Event_Group_Peer_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -146,7 +146,7 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
     ++state->peer_joined_count;
 }
 
-static void group_peer_self_join_handler(Tox *tox, const Tox_Event_Group_Self_Join *event, void *user_data)
+static void group_peer_self_join_handler(const Tox_Event_Group_Self_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -211,7 +211,7 @@ static void group_peer_self_join_handler(Tox *tox, const Tox_Event_Group_Self_Jo
     ++state->self_joined_count;
 }
 
-static void group_peer_exit_handler(Tox *tox, const Tox_Event_Group_Peer_Exit *event, void *user_data)
+static void group_peer_exit_handler(const Tox_Event_Group_Peer_Exit *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -230,7 +230,7 @@ static void group_peer_exit_handler(Tox *tox, const Tox_Event_Group_Peer_Exit *e
     }
 }
 
-static void group_peer_name_handler(Tox *tox, const Tox_Event_Group_Peer_Name *event, void *user_data)
+static void group_peer_name_handler(const Tox_Event_Group_Peer_Name *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -248,7 +248,7 @@ static void group_peer_name_handler(Tox *tox, const Tox_Event_Group_Peer_Name *e
     state->peer_nick = true;
 }
 
-static void group_peer_status_handler(Tox *tox, const Tox_Event_Group_Peer_Status *event,
+static void group_peer_status_handler(const Tox_Event_Group_Peer_Status *event,
                                       void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;

--- a/auto_tests/group_invite_test.c
+++ b/auto_tests/group_invite_test.c
@@ -51,7 +51,7 @@ static bool group_has_full_graph(const AutoTox *autotoxes, uint32_t group_number
     return true;
 }
 
-static void group_join_fail_handler(Tox *tox, const Tox_Event_Group_Join_Fail *event, void *user_data)
+static void group_join_fail_handler(const Tox_Event_Group_Join_Fail *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -81,7 +81,7 @@ static void group_join_fail_handler(Tox *tox, const Tox_Event_Group_Join_Fail *e
     }
 }
 
-static void group_self_join_handler(Tox *tox, const Tox_Event_Group_Self_Join *event, void *user_data)
+static void group_self_join_handler(const Tox_Event_Group_Self_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -91,7 +91,7 @@ static void group_self_join_handler(Tox *tox, const Tox_Event_Group_Self_Join *e
     state->connected = true;
 }
 
-static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data)
+static void group_peer_join_handler(const Tox_Event_Group_Peer_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);

--- a/auto_tests/group_message_test.c
+++ b/auto_tests/group_message_test.c
@@ -71,7 +71,7 @@ static uint16_t get_message_checksum(const uint8_t *message, uint16_t length)
     return sum;
 }
 
-static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, void *user_data)
+static void group_invite_handler(const Tox_Event_Group_Invite *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -87,13 +87,13 @@ static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, 
     ck_assert(err_accept == TOX_ERR_GROUP_INVITE_ACCEPT_OK);
 }
 
-static void group_join_fail_handler(Tox *tox, const Tox_Event_Group_Join_Fail *event, void *user_data)
+static void group_join_fail_handler(const Tox_Event_Group_Join_Fail *event, void *user_data)
 {
     const Tox_Group_Join_Fail fail_type = tox_event_group_join_fail_get_fail_type(event);
     printf("join failed: %d\n", fail_type);
 }
 
-static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data)
+static void group_peer_join_handler(const Tox_Event_Group_Peer_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -109,7 +109,7 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
     state->peer_id = peer_id;
 }
 
-static void group_custom_private_packet_handler(Tox *tox, const Tox_Event_Group_Custom_Private_Packet *event, void *user_data)
+static void group_custom_private_packet_handler(const Tox_Event_Group_Custom_Private_Packet *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -159,7 +159,7 @@ static void group_custom_private_packet_handler(Tox *tox, const Tox_Event_Group_
     ++state->custom_private_packets_received;
 }
 
-static void group_custom_packet_handler(Tox *tox, const Tox_Event_Group_Custom_Packet *event, void *user_data)
+static void group_custom_packet_handler(const Tox_Event_Group_Custom_Packet *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -208,7 +208,7 @@ static void group_custom_packet_handler(Tox *tox, const Tox_Event_Group_Custom_P
     ++state->custom_packets_received;
 }
 
-static void group_custom_packet_large_handler(Tox *tox, const Tox_Event_Group_Custom_Packet *event, void *user_data)
+static void group_custom_packet_large_handler(const Tox_Event_Group_Custom_Packet *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -225,7 +225,7 @@ static void group_custom_packet_large_handler(Tox *tox, const Tox_Event_Group_Cu
     ++state->custom_packets_received;
 }
 
-static void group_message_handler(Tox *tox, const Tox_Event_Group_Message *event, void *user_data)
+static void group_message_handler(const Tox_Event_Group_Message *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -278,7 +278,7 @@ static void group_message_handler(Tox *tox, const Tox_Event_Group_Message *event
     state->pseudo_msg_id = pseudo_msg_id;
 }
 
-static void group_private_message_handler(Tox *tox, const Tox_Event_Group_Private_Message *event, void *user_data)
+static void group_private_message_handler(const Tox_Event_Group_Private_Message *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -330,7 +330,7 @@ static void group_private_message_handler(Tox *tox, const Tox_Event_Group_Privat
     state->private_message_received = true;
 }
 
-static void group_message_handler_lossless_test(Tox *tox, const Tox_Event_Group_Message *event, void *user_data)
+static void group_message_handler_lossless_test(const Tox_Event_Group_Message *event, void *user_data)
 {
     const uint8_t *message = tox_event_group_message_get_message(event);
     const size_t length = tox_event_group_message_get_message_length(event);
@@ -356,7 +356,7 @@ static void group_message_handler_lossless_test(Tox *tox, const Tox_Event_Group_
         state->lossless_check = true;
     }
 }
-static void group_message_handler_wraparound_test(Tox *tox, const Tox_Event_Group_Message *event, void *user_data)
+static void group_message_handler_wraparound_test(const Tox_Event_Group_Message *event, void *user_data)
 {
     const uint8_t *message = tox_event_group_message_get_message(event);
     const size_t length = tox_event_group_message_get_message_length(event);

--- a/auto_tests/group_moderation_test.c
+++ b/auto_tests/group_moderation_test.c
@@ -155,13 +155,13 @@ static size_t get_state_index_by_nick(const AutoTox *autotoxes, size_t num_peers
     ck_assert_msg(0, "Failed to find index");
 }
 
-static void group_join_fail_handler(Tox *tox, const Tox_Event_Group_Join_Fail *event, void *user_data)
+static void group_join_fail_handler(const Tox_Event_Group_Join_Fail *event, void *user_data)
 {
     const Tox_Group_Join_Fail fail_type = tox_event_group_join_fail_get_fail_type(event);
     fprintf(stderr, "Failed to join group: %d", fail_type);
 }
 
-static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data)
+static void group_peer_join_handler(const Tox_Event_Group_Peer_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -246,7 +246,7 @@ static void handle_user(State *state, const char *peer_name, size_t peer_name_le
     state->user_check = true;
 }
 
-static void group_mod_event_handler(Tox *tox, const Tox_Event_Group_Moderation *event, void *user_data)
+static void group_mod_event_handler(const Tox_Event_Group_Moderation *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);

--- a/auto_tests/group_save_test.c
+++ b/auto_tests/group_save_test.c
@@ -26,7 +26,7 @@ typedef struct State {
 #define PEER0_NICK_LEN (sizeof(PEER0_NICK) -1)
 #define NEW_USER_STATUS TOX_USER_STATUS_BUSY
 
-static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, void *user_data)
+static void group_invite_handler(const Tox_Event_Group_Invite *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -42,7 +42,7 @@ static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, 
 
 }
 
-static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data)
+static void group_peer_join_handler(const Tox_Event_Group_Peer_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);

--- a/auto_tests/group_state_test.c
+++ b/auto_tests/group_state_test.c
@@ -60,7 +60,7 @@ static bool all_group_peers_connected(const AutoTox *autotoxes, uint32_t tox_cou
     return true;
 }
 
-static void group_topic_lock_handler(Tox *tox, const Tox_Event_Group_Topic_Lock *event,
+static void group_topic_lock_handler(const Tox_Event_Group_Topic_Lock *event,
                                      void *user_data)
 {
     const AutoTox *autotox = (const AutoTox *)user_data;
@@ -77,7 +77,7 @@ static void group_topic_lock_handler(Tox *tox, const Tox_Event_Group_Topic_Lock 
                   topic_lock, current_topic_lock);
 }
 
-static void group_voice_state_handler(Tox *tox, const Tox_Event_Group_Voice_State *event,
+static void group_voice_state_handler(const Tox_Event_Group_Voice_State *event,
                                       void *user_data)
 {
     const AutoTox *autotox = (const AutoTox *)user_data;
@@ -94,7 +94,7 @@ static void group_voice_state_handler(Tox *tox, const Tox_Event_Group_Voice_Stat
                   voice_state, current_voice_state);
 }
 
-static void group_privacy_state_handler(Tox *tox, const Tox_Event_Group_Privacy_State *event,
+static void group_privacy_state_handler(const Tox_Event_Group_Privacy_State *event,
                                         void *user_data)
 {
     const AutoTox *autotox = (const AutoTox *)user_data;
@@ -110,7 +110,7 @@ static void group_privacy_state_handler(Tox *tox, const Tox_Event_Group_Privacy_
     ck_assert_msg(current_pstate == privacy_state, "privacy states don't match in callback");
 }
 
-static void group_peer_limit_handler(Tox *tox, const Tox_Event_Group_Peer_Limit *event, void *user_data)
+static void group_peer_limit_handler(const Tox_Event_Group_Peer_Limit *event, void *user_data)
 {
     const AutoTox *autotox = (const AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -126,7 +126,7 @@ static void group_peer_limit_handler(Tox *tox, const Tox_Event_Group_Peer_Limit 
                   "Peer limits don't match in callback: %u, %u\n", peer_limit, current_plimit);
 }
 
-static void group_password_handler(Tox *tox, const Tox_Event_Group_Password *event,
+static void group_password_handler(const Tox_Event_Group_Password *event,
                                    void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
@@ -150,7 +150,7 @@ static void group_password_handler(Tox *tox, const Tox_Event_Group_Password *eve
                   "Passwords don't match: %s, %s", password, current_password);
 }
 
-static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data)
+static void group_peer_join_handler(const Tox_Event_Group_Peer_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);

--- a/auto_tests/group_sync_test.c
+++ b/auto_tests/group_sync_test.c
@@ -96,7 +96,7 @@ static void peers_cleanup(Peers *peers)
     free(peers);
 }
 
-static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data)
+static void group_peer_join_handler(const Tox_Event_Group_Peer_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -109,7 +109,7 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
 
 }
 
-static void group_peer_exit_handler(Tox *tox, const Tox_Event_Group_Peer_Exit *event, void *user_data)
+static void group_peer_exit_handler(const Tox_Event_Group_Peer_Exit *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -122,7 +122,7 @@ static void group_peer_exit_handler(Tox *tox, const Tox_Event_Group_Peer_Exit *e
 
 }
 
-static void group_topic_handler(Tox *tox, const Tox_Event_Group_Topic *event, void *user_data)
+static void group_topic_handler(const Tox_Event_Group_Topic *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);

--- a/auto_tests/group_tcp_test.c
+++ b/auto_tests/group_tcp_test.c
@@ -19,7 +19,7 @@ typedef struct State {
     uint32_t peer_id[NUM_GROUP_TOXES - 1];
 } State;
 
-static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, void *user_data)
+static void group_invite_handler(const Tox_Event_Group_Invite *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -36,7 +36,7 @@ static void group_invite_handler(Tox *tox, const Tox_Event_Group_Invite *event, 
     ck_assert(err_accept == TOX_ERR_GROUP_INVITE_ACCEPT_OK);
 }
 
-static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data)
+static void group_peer_join_handler(const Tox_Event_Group_Peer_Join *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -51,7 +51,7 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
     state->peer_id[state->num_peers++] = peer_id;
 }
 
-static void group_private_message_handler(Tox *tox, const Tox_Event_Group_Private_Message *event, void *user_data)
+static void group_private_message_handler(const Tox_Event_Group_Private_Message *event, void *user_data)
 {
     const uint8_t *message = tox_event_group_private_message_get_message(event);
     const size_t length = tox_event_group_private_message_get_message_length(event);
@@ -69,7 +69,7 @@ static void group_private_message_handler(Tox *tox, const Tox_Event_Group_Privat
     state->got_code = true;
 }
 
-static void group_message_handler(Tox *tox, const Tox_Event_Group_Message *event, void *user_data)
+static void group_message_handler(const Tox_Event_Group_Message *event, void *user_data)
 {
     const uint8_t *message = tox_event_group_message_get_message(event);
     const size_t length = tox_event_group_message_get_message_length(event);

--- a/auto_tests/group_topic_test.c
+++ b/auto_tests/group_topic_test.c
@@ -55,7 +55,7 @@ static bool all_group_peers_connected(const AutoTox *autotoxes, uint32_t tox_cou
     return true;
 }
 
-static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data)
+static void group_peer_join_handler(const Tox_Event_Group_Peer_Join *event, void *user_data)
 {
     //const uint32_t group_number = tox_event_group_peer_join_get_group_number(event);
     const uint32_t peer_id = tox_event_group_peer_join_get_peer_id(event);
@@ -68,7 +68,7 @@ static void group_peer_join_handler(Tox *tox, const Tox_Event_Group_Peer_Join *e
     state->peer_id = peer_id;
 }
 
-static void group_topic_handler(Tox *tox, const Tox_Event_Group_Topic *event, void *user_data)
+static void group_topic_handler(const Tox_Event_Group_Topic *event, void *user_data)
 {
     AutoTox *autotox = (AutoTox *)user_data;
     ck_assert(autotox != nullptr);
@@ -91,7 +91,7 @@ static void group_topic_handler(Tox *tox, const Tox_Event_Group_Topic *event, vo
                   "topic differs in callback: %s, %s", topic, topic2);
 }
 
-static void group_topic_lock_handler(Tox *tox, const Tox_Event_Group_Topic_Lock *event, void *user_data)
+static void group_topic_lock_handler(const Tox_Event_Group_Topic_Lock *event, void *user_data)
 {
     const AutoTox *autotox = (const AutoTox *)user_data;
     ck_assert(autotox != nullptr);

--- a/auto_tests/lossless_packet_test.c
+++ b/auto_tests/lossless_packet_test.c
@@ -18,7 +18,7 @@ typedef struct State {
 
 #define LOSSLESS_PACKET_FILLER 160
 
-static void handle_lossless_packet(Tox *tox, const Tox_Event_Friend_Lossless_Packet *event, void *user_data)
+static void handle_lossless_packet(const Tox_Event_Friend_Lossless_Packet *event, void *user_data)
 {
     //const uint32_t friend_number = tox_event_friend_lossless_packet_get_friend_number(event);
     const uint8_t *data = tox_event_friend_lossless_packet_get_data(event);

--- a/auto_tests/lossy_packet_test.c
+++ b/auto_tests/lossy_packet_test.c
@@ -18,7 +18,7 @@ typedef struct State {
 
 #define LOSSY_PACKET_FILLER 200
 
-static void handle_lossy_packet(Tox *tox, const Tox_Event_Friend_Lossy_Packet *event, void *user_data)
+static void handle_lossy_packet(const Tox_Event_Friend_Lossy_Packet *event, void *user_data)
 {
     //const uint32_t friend_number = tox_event_friend_lossy_packet_get_friend_number(event);
     const uint8_t *data = tox_event_friend_lossy_packet_get_data(event);

--- a/auto_tests/overflow_recvq_test.c
+++ b/auto_tests/overflow_recvq_test.c
@@ -11,7 +11,7 @@ typedef struct State {
 
 #define NUM_MSGS 40000
 
-static void handle_friend_message(Tox *tox, const Tox_Event_Friend_Message *event, void *user_data)
+static void handle_friend_message(const Tox_Event_Friend_Message *event, void *user_data)
 {
     //const uint32_t friend_number = tox_event_friend_message_get_friend_number(event);
     //const Tox_Message_Type type = tox_event_friend_message_get_type(event);

--- a/auto_tests/reconnect_test.c
+++ b/auto_tests/reconnect_test.c
@@ -70,7 +70,7 @@ static void test_reconnect(AutoTox *autotoxes)
                 Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
                 Tox_Events *events = tox_events_iterate(autotoxes[i].tox, true, &err);
                 ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-                tox_dispatch_invoke(autotoxes[i].dispatch, events, autotoxes[i].tox, &autotoxes[i]);
+                tox_dispatch_invoke(autotoxes[i].dispatch, events, &autotoxes[i]);
                 tox_events_free(events);
 
                 autotoxes[i].clock += 1000;

--- a/auto_tests/save_friend_test.c
+++ b/auto_tests/save_friend_test.c
@@ -43,7 +43,7 @@ static void set_string(uint8_t **to, const uint8_t *from, size_t length)
     memcpy(*to, from, length);
 }
 
-static void namechange_callback(Tox *tox, const Tox_Event_Friend_Name *event, void *user_data)
+static void namechange_callback(const Tox_Event_Friend_Name *event, void *user_data)
 {
     //const uint32_t friend_number = tox_event_friend_name_get_friend_number(event);
     const uint8_t *name = tox_event_friend_name_get_name(event);
@@ -54,7 +54,7 @@ static void namechange_callback(Tox *tox, const Tox_Event_Friend_Name *event, vo
     to_compare->received_name = true;
 }
 
-static void statuschange_callback(Tox *tox, const Tox_Event_Friend_Status_Message *event, void *user_data)
+static void statuschange_callback(const Tox_Event_Friend_Status_Message *event, void *user_data)
 {
     //const uint32_t friend_number = tox_event_friend_status_message_get_friend_number(event);
     const uint8_t *message = tox_event_friend_status_message_get_message(event);
@@ -122,7 +122,7 @@ int main(void)
         Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
         Tox_Events *events = tox_events_iterate(tox1, true, &err);
         ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-        tox_dispatch_invoke(dispatch1, events, tox1, &to_compare);
+        tox_dispatch_invoke(dispatch1, events, &to_compare);
         tox_events_free(events);
 
         tox_iterate(tox2, nullptr);
@@ -139,7 +139,7 @@ int main(void)
         Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
         Tox_Events *events = tox_events_iterate(tox1, true, &err);
         ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-        tox_dispatch_invoke(dispatch1, events, tox1, &to_compare);
+        tox_dispatch_invoke(dispatch1, events, &to_compare);
         tox_events_free(events);
 
         tox_iterate(tox2, nullptr);

--- a/auto_tests/save_load_test.c
+++ b/auto_tests/save_load_test.c
@@ -32,7 +32,7 @@
 #endif
 #define TCP_RELAY_PORT 33431
 
-static void accept_friend_request(Tox *m, const Tox_Event_Friend_Request *event, void *userdata)
+static void accept_friend_request(const Tox_Event_Friend_Request *event, void *userdata)
 {
     Tox *tox = (Tox *)userdata;
 
@@ -46,7 +46,7 @@ static void accept_friend_request(Tox *m, const Tox_Event_Friend_Request *event,
 }
 
 static unsigned int connected_t1;
-static void tox_connection_status(Tox *tox, const Tox_Event_Self_Connection_Status *event, void *user_data)
+static void tox_connection_status(const Tox_Event_Self_Connection_Status *event, void *user_data)
 {
     const Tox_Connection connection_status = tox_event_self_connection_status_get_connection_status(event);
 
@@ -210,14 +210,14 @@ static void test_few_clients(void)
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(tox1, true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch1, events, tox1, tox1);
+            tox_dispatch_invoke(dispatch1, events, tox1);
             tox_events_free(events);
         }
         {
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(tox2, true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch2, events, tox2, tox2);
+            tox_dispatch_invoke(dispatch2, events, tox2);
             tox_events_free(events);
         }
         tox_iterate(tox3, nullptr);
@@ -261,14 +261,14 @@ static void test_few_clients(void)
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(tox1, true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch1, events, tox1, tox1);
+            tox_dispatch_invoke(dispatch1, events, tox1);
             tox_events_free(events);
         }
         {
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(tox2, true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch2, events, tox2, tox2);
+            tox_dispatch_invoke(dispatch2, events, tox2);
             tox_events_free(events);
         }
         tox_iterate(tox3, nullptr);

--- a/auto_tests/send_message_test.c
+++ b/auto_tests/send_message_test.c
@@ -14,7 +14,7 @@ typedef struct State {
 #define MESSAGE_FILLER 'G'
 
 static void message_callback(
-    Tox *m, const Tox_Event_Friend_Message *event, void *user_data)
+    const Tox_Event_Friend_Message *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;

--- a/auto_tests/set_name_test.c
+++ b/auto_tests/set_name_test.c
@@ -15,7 +15,7 @@
 
 #define NICKNAME "Gentoo"
 
-static void nickchange_callback(Tox *tox, const Tox_Event_Friend_Name *event, void *user_data)
+static void nickchange_callback(const Tox_Event_Friend_Name *event, void *user_data)
 {
     //const uint32_t friend_number = tox_event_friend_name_get_friend_number(event);
     const uint8_t *name = tox_event_friend_name_get_name(event);
@@ -64,7 +64,7 @@ static void test_set_name(void)
         Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
         Tox_Events *events = tox_events_iterate(tox2, true, &err);
         ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-        //tox_dispatch_invoke(dispatch2, events, tox2, nullptr);
+        //tox_dispatch_invoke(dispatch2, events, nullptr);
         tox_events_free(events);
 
         c_sleep(ITERATION_INTERVAL);
@@ -80,7 +80,7 @@ static void test_set_name(void)
         Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
         Tox_Events *events = tox_events_iterate(tox2, true, &err);
         ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-        //tox_dispatch_invoke(dispatch2, events, tox2, nullptr);
+        //tox_dispatch_invoke(dispatch2, events, nullptr);
         tox_events_free(events);
 
         c_sleep(ITERATION_INTERVAL);
@@ -102,7 +102,7 @@ static void test_set_name(void)
         Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
         Tox_Events *events = tox_events_iterate(tox2, true, &err);
         ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-        tox_dispatch_invoke(dispatch2, events, tox2, &nickname_updated);
+        tox_dispatch_invoke(dispatch2, events, &nickname_updated);
         tox_events_free(events);
 
         c_sleep(ITERATION_INTERVAL);

--- a/auto_tests/set_status_message_test.c
+++ b/auto_tests/set_status_message_test.c
@@ -15,7 +15,7 @@
 
 #define STATUS_MESSAGE "Installing Gentoo"
 
-static void status_callback(Tox *tox, const Tox_Event_Friend_Status_Message *event, void *user_data)
+static void status_callback(const Tox_Event_Friend_Status_Message *event, void *user_data)
 {
     //uint32_t friend_number = tox_event_friend_status_message_get_friend_number(event);
     const uint8_t *message = tox_event_friend_status_message_get_message(event);
@@ -64,7 +64,7 @@ static void test_set_status_message(void)
         Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
         Tox_Events *events = tox_events_iterate(tox2, true, &err);
         ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-        //tox_dispatch_invoke(dispatch2, events, tox2, nullptr);
+        //tox_dispatch_invoke(dispatch2, events, nullptr);
         tox_events_free(events);
 
         c_sleep(ITERATION_INTERVAL);
@@ -80,7 +80,7 @@ static void test_set_status_message(void)
         Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
         Tox_Events *events = tox_events_iterate(tox2, true, &err);
         ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-        //tox_dispatch_invoke(dispatch2, events, tox2, nullptr);
+        //tox_dispatch_invoke(dispatch2, events, nullptr);
         tox_events_free(events);
 
         c_sleep(ITERATION_INTERVAL);
@@ -103,7 +103,7 @@ static void test_set_status_message(void)
         Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
         Tox_Events *events = tox_events_iterate(tox2, true, &err);
         ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-        tox_dispatch_invoke(dispatch2, events, tox2, &status_updated);
+        tox_dispatch_invoke(dispatch2, events, &status_updated);
         tox_events_free(events);
 
         c_sleep(ITERATION_INTERVAL);

--- a/auto_tests/tox_dispatch_test.c
+++ b/auto_tests/tox_dispatch_test.c
@@ -18,7 +18,7 @@
 // Set to true to produce an msgpack file at /tmp/test.mp.
 static const bool want_dump_events = false;
 
-static void handle_events_friend_message(Tox *tox, const Tox_Event_Friend_Message *event, void *user_data)
+static void handle_events_friend_message(const Tox_Event_Friend_Message *event, void *user_data)
 {
     bool *success = (bool *)user_data;
 
@@ -84,7 +84,7 @@ static bool await_message(Tox **toxes, const Tox_Dispatch *dispatch)
         }
 
         bool success = false;
-        tox_dispatch_invoke(dispatch, events, toxes[1], &success);
+        tox_dispatch_invoke(dispatch, events, &success);
         print_events(sys, events);
 
         if (success) {

--- a/auto_tests/tox_many_tcp_test.c
+++ b/auto_tests/tox_many_tcp_test.c
@@ -33,7 +33,7 @@ typedef struct State {
 
 static bool enable_broken_tests = false;
 
-static void accept_friend_request(Tox *m, const Tox_Event_Friend_Request *event, void *userdata)
+static void accept_friend_request(const Tox_Event_Friend_Request *event, void *userdata)
 {
     State *state = (State *)userdata;
 
@@ -151,7 +151,7 @@ loop_top:
             Tox_Events *events = tox_events_iterate(toxes[i], true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
             State state = {to_comp, toxes[i]};
-            tox_dispatch_invoke(dispatch, events, toxes[i], &state);
+            tox_dispatch_invoke(dispatch, events, &state);
             tox_events_free(events);
         }
 
@@ -263,7 +263,7 @@ loop_top:
             Tox_Events *events = tox_events_iterate(toxes[i], true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
             State state = {to_comp, toxes[i]};
-            tox_dispatch_invoke(dispatch, events, toxes[i], &state);
+            tox_dispatch_invoke(dispatch, events, &state);
             tox_events_free(events);
         }
 

--- a/auto_tests/tox_many_test.c
+++ b/auto_tests/tox_many_test.c
@@ -13,7 +13,7 @@
 #include "auto_test_support.h"
 #include "check_compat.h"
 
-static void accept_friend_request(Tox *m, const Tox_Event_Friend_Request *event, void *userdata)
+static void accept_friend_request(const Tox_Event_Friend_Request *event, void *userdata)
 {
     Tox *tox = (Tox *)userdata;
 
@@ -125,7 +125,7 @@ loop_top:
             Tox_Err_Events_Iterate err = TOX_ERR_EVENTS_ITERATE_OK;
             Tox_Events *events = tox_events_iterate(toxes[i], true, &err);
             ck_assert(err == TOX_ERR_EVENTS_ITERATE_OK);
-            tox_dispatch_invoke(dispatch, events, toxes[i], toxes[i]);
+            tox_dispatch_invoke(dispatch, events, toxes[i]);
             tox_events_free(events);
         }
 

--- a/auto_tests/typing_test.c
+++ b/auto_tests/typing_test.c
@@ -17,7 +17,7 @@ typedef struct State {
 
 #include "auto_test_support.h"
 
-static void typing_callback(Tox *m, const Tox_Event_Friend_Typing *event, void *user_data)
+static void typing_callback(const Tox_Event_Friend_Typing *event, void *user_data)
 {
     const AutoTox *autotox = (AutoTox *)user_data;
     State *state = (State *)autotox->state;

--- a/testing/fuzzing/bootstrap_fuzz_test.cc
+++ b/testing/fuzzing/bootstrap_fuzz_test.cc
@@ -12,75 +12,66 @@ namespace {
 void setup_callbacks(Tox_Dispatch *dispatch)
 {
     tox_events_callback_conference_connected(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Connected *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_connected(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Connected *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_invite(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Invite *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_message(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Message *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_conference_peer_list_changed(dispatch,
-        [](Tox *tox, const Tox_Event_Conference_Peer_List_Changed *event, void *user_data) {
+    tox_events_callback_conference_peer_list_changed(
+        dispatch, [](const Tox_Event_Conference_Peer_List_Changed *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_peer_name(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Peer_Name *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Peer_Name *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_conference_title(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Title *event, void *user_data) {
-            assert(event == nullptr);
-        });
+    tox_events_callback_conference_title(dispatch,
+        [](const Tox_Event_Conference_Title *event, void *user_data) { assert(event == nullptr); });
     tox_events_callback_file_chunk_request(
-        dispatch, [](Tox *tox, const Tox_Event_File_Chunk_Request *event, void *user_data) {
+        dispatch, [](const Tox_Event_File_Chunk_Request *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_file_recv(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv *event, void *user_data) {
-            assert(event == nullptr);
-        });
-    tox_events_callback_file_recv_chunk(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv_Chunk *event, void *user_data) {
-            assert(event == nullptr);
-        });
+    tox_events_callback_file_recv(dispatch,
+        [](const Tox_Event_File_Recv *event, void *user_data) { assert(event == nullptr); });
+    tox_events_callback_file_recv_chunk(dispatch,
+        [](const Tox_Event_File_Recv_Chunk *event, void *user_data) { assert(event == nullptr); });
     tox_events_callback_file_recv_control(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv_Control *event, void *user_data) {
+        dispatch, [](const Tox_Event_File_Recv_Control *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_connection_status(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Connection_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Connection_Status *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_lossless_packet(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Lossless_Packet *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Lossless_Packet *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_lossy_packet(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Lossy_Packet *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Lossy_Packet *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_friend_message(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Message *event, void *user_data) {
-            assert(event == nullptr);
-        });
-    tox_events_callback_friend_name(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Name *event, void *user_data) {
-            assert(event == nullptr);
-        });
+    tox_events_callback_friend_message(dispatch,
+        [](const Tox_Event_Friend_Message *event, void *user_data) { assert(event == nullptr); });
+    tox_events_callback_friend_name(dispatch,
+        [](const Tox_Event_Friend_Name *event, void *user_data) { assert(event == nullptr); });
     tox_events_callback_friend_read_receipt(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Read_Receipt *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Read_Receipt *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_request(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Request *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Request *event, void *user_data) {
+            Tox *tox = static_cast<Tox *>(user_data);
             Tox_Err_Friend_Add err;
             tox_friend_add_norequest(tox, tox_event_friend_request_get_public_key(event), &err);
             if (!(err == TOX_ERR_FRIEND_ADD_OK || err == TOX_ERR_FRIEND_ADD_OWN_KEY
@@ -90,20 +81,16 @@ void setup_callbacks(Tox_Dispatch *dispatch)
                 printf("unexpected error: %s\n", tox_err_friend_add_to_string(err));
             }
         });
-    tox_events_callback_friend_status(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Status *event, void *user_data) {
-            assert(event == nullptr);
-        });
+    tox_events_callback_friend_status(dispatch,
+        [](const Tox_Event_Friend_Status *event, void *user_data) { assert(event == nullptr); });
     tox_events_callback_friend_status_message(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Status_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Status_Message *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_friend_typing(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Typing *event, void *user_data) {
-            assert(event == nullptr);
-        });
+    tox_events_callback_friend_typing(dispatch,
+        [](const Tox_Event_Friend_Typing *event, void *user_data) { assert(event == nullptr); });
     tox_events_callback_self_connection_status(
-        dispatch, [](Tox *tox, const Tox_Event_Self_Connection_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Self_Connection_Status *event, void *user_data) {
             assert(event == nullptr);
         });
 }
@@ -174,7 +161,7 @@ void TestBootstrap(Fuzz_Data &input)
         Tox_Err_Events_Iterate error_iterate;
         Tox_Events *events = tox_events_iterate(tox, true, &error_iterate);
         assert(tox_events_equal(null_sys.sys.get(), events, events));
-        tox_dispatch_invoke(dispatch, events, tox, nullptr);
+        tox_dispatch_invoke(dispatch, events, tox);
         tox_events_free(events);
         // Move the clock forward a decent amount so all the time-based checks
         // trigger more quickly.

--- a/testing/fuzzing/e2e_fuzz_test.cc
+++ b/testing/fuzzing/e2e_fuzz_test.cc
@@ -20,63 +20,61 @@ namespace {
 void setup_callbacks(Tox_Dispatch *dispatch)
 {
     tox_events_callback_conference_connected(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Connected *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_connected(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Connected *event, void *user_data) {
             assert(event != nullptr);
         });
     tox_events_callback_conference_invite(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Invite *event, void *user_data) {
+            Tox *tox = static_cast<Tox *>(user_data);
             const uint32_t friend_number = tox_event_conference_invite_get_friend_number(event);
             const uint8_t *cookie = tox_event_conference_invite_get_cookie(event);
             const uint32_t cookie_length = tox_event_conference_invite_get_cookie_length(event);
             tox_conference_join(tox, friend_number, cookie, cookie_length, nullptr);
         });
     tox_events_callback_conference_message(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Message *event, void *user_data) {
             assert(event != nullptr);
         });
-    tox_events_callback_conference_peer_list_changed(dispatch,
-        [](Tox *tox, const Tox_Event_Conference_Peer_List_Changed *event, void *user_data) {
+    tox_events_callback_conference_peer_list_changed(
+        dispatch, [](const Tox_Event_Conference_Peer_List_Changed *event, void *user_data) {
             assert(event != nullptr);
         });
     tox_events_callback_conference_peer_name(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Peer_Name *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Peer_Name *event, void *user_data) {
             assert(event != nullptr);
         });
-    tox_events_callback_conference_title(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Title *event, void *user_data) {
-            assert(event != nullptr);
-        });
+    tox_events_callback_conference_title(dispatch,
+        [](const Tox_Event_Conference_Title *event, void *user_data) { assert(event != nullptr); });
     tox_events_callback_file_chunk_request(
-        dispatch, [](Tox *tox, const Tox_Event_File_Chunk_Request *event, void *user_data) {
+        dispatch, [](const Tox_Event_File_Chunk_Request *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_file_recv(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv *event, void *user_data) {
-            const uint32_t friend_number = tox_event_file_recv_get_friend_number(event);
-            const uint32_t file_number = tox_event_file_recv_get_file_number(event);
-            tox_file_control(tox, friend_number, file_number, TOX_FILE_CONTROL_RESUME, nullptr);
-        });
-    tox_events_callback_file_recv_chunk(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv_Chunk *event, void *user_data) {
-            assert(event != nullptr);
-        });
+    tox_events_callback_file_recv(dispatch, [](const Tox_Event_File_Recv *event, void *user_data) {
+        Tox *tox = static_cast<Tox *>(user_data);
+        const uint32_t friend_number = tox_event_file_recv_get_friend_number(event);
+        const uint32_t file_number = tox_event_file_recv_get_file_number(event);
+        tox_file_control(tox, friend_number, file_number, TOX_FILE_CONTROL_RESUME, nullptr);
+    });
+    tox_events_callback_file_recv_chunk(dispatch,
+        [](const Tox_Event_File_Recv_Chunk *event, void *user_data) { assert(event != nullptr); });
     tox_events_callback_file_recv_control(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv_Control *event, void *user_data) {
+        dispatch, [](const Tox_Event_File_Recv_Control *event, void *user_data) {
             assert(event != nullptr);
         });
     tox_events_callback_friend_connection_status(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Connection_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Connection_Status *event, void *user_data) {
             // OK: friend came online.
             const uint32_t friend_number
                 = tox_event_friend_connection_status_get_friend_number(event);
             assert(friend_number != UINT32_MAX);
         });
     tox_events_callback_friend_lossless_packet(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Lossless_Packet *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Lossless_Packet *event, void *user_data) {
+            Tox *tox = static_cast<Tox *>(user_data);
             const uint32_t friend_number
                 = tox_event_friend_lossless_packet_get_friend_number(event);
             const uint32_t data_length = tox_event_friend_lossless_packet_get_data_length(event);
@@ -84,14 +82,16 @@ void setup_callbacks(Tox_Dispatch *dispatch)
             tox_friend_send_lossless_packet(tox, friend_number, data, data_length, nullptr);
         });
     tox_events_callback_friend_lossy_packet(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Lossy_Packet *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Lossy_Packet *event, void *user_data) {
+            Tox *tox = static_cast<Tox *>(user_data);
             const uint32_t friend_number = tox_event_friend_lossy_packet_get_friend_number(event);
             const uint32_t data_length = tox_event_friend_lossy_packet_get_data_length(event);
             const uint8_t *data = tox_event_friend_lossy_packet_get_data(event);
             tox_friend_send_lossy_packet(tox, friend_number, data, data_length, nullptr);
         });
     tox_events_callback_friend_message(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Message *event, void *user_data) {
+            Tox *tox = static_cast<Tox *>(user_data);
             const uint32_t friend_number = tox_event_friend_message_get_friend_number(event);
             const Tox_Message_Type type = tox_event_friend_message_get_type(event);
             const uint32_t message_length = tox_event_friend_message_get_message_length(event);
@@ -99,32 +99,33 @@ void setup_callbacks(Tox_Dispatch *dispatch)
             tox_friend_send_message(tox, friend_number, type, message, message_length, nullptr);
         });
     tox_events_callback_friend_name(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Name *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Name *event, void *user_data) {
             // OK: friend name received.
         });
     tox_events_callback_friend_read_receipt(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Read_Receipt *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Read_Receipt *event, void *user_data) {
             // OK: message has been received.
         });
     tox_events_callback_friend_request(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Request *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Request *event, void *user_data) {
+            Tox *tox = static_cast<Tox *>(user_data);
             Tox_Err_Friend_Add err;
             tox_friend_add_norequest(tox, tox_event_friend_request_get_public_key(event), &err);
         });
     tox_events_callback_friend_status(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Status *event, void *user_data) {
             // OK: friend status received.
         });
     tox_events_callback_friend_status_message(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Status_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Status_Message *event, void *user_data) {
             // OK: friend status message received.
         });
     tox_events_callback_friend_typing(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Typing *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Typing *event, void *user_data) {
             // OK: friend may be typing.
         });
     tox_events_callback_self_connection_status(
-        dispatch, [](Tox *tox, const Tox_Event_Self_Connection_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Self_Connection_Status *event, void *user_data) {
             // OK: we got connected.
         });
 }
@@ -171,7 +172,7 @@ void TestEndToEnd(Fuzz_Data &input)
         Tox_Err_Events_Iterate error_iterate;
         Tox_Events *events = tox_events_iterate(tox, true, &error_iterate);
         assert(tox_events_equal(null_sys.sys.get(), events, events));
-        tox_dispatch_invoke(dispatch, events, tox, nullptr);
+        tox_dispatch_invoke(dispatch, events, tox);
         tox_events_free(events);
         // Move the clock forward a decent amount so all the time-based checks
         // trigger more quickly.

--- a/testing/fuzzing/protodump.cc
+++ b/testing/fuzzing/protodump.cc
@@ -45,73 +45,75 @@ namespace {
  */
 constexpr uint32_t MESSAGE_COUNT = 5;
 
+struct State {
+    Tox *tox;
+    uint32_t done;
+};
+
 void setup_callbacks(Tox_Dispatch *dispatch)
 {
     tox_events_callback_conference_connected(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Connected *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_connected(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Connected *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_invite(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Invite *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_message(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Message *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_conference_peer_list_changed(dispatch,
-        [](Tox *tox, const Tox_Event_Conference_Peer_List_Changed *event, void *user_data) {
+    tox_events_callback_conference_peer_list_changed(
+        dispatch, [](const Tox_Event_Conference_Peer_List_Changed *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_peer_name(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Peer_Name *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Peer_Name *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_conference_title(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Title *event, void *user_data) {
-            assert(event == nullptr);
-        });
+    tox_events_callback_conference_title(dispatch,
+        [](const Tox_Event_Conference_Title *event, void *user_data) { assert(event == nullptr); });
     tox_events_callback_file_chunk_request(
-        dispatch, [](Tox *tox, const Tox_Event_File_Chunk_Request *event, void *user_data) {
+        dispatch, [](const Tox_Event_File_Chunk_Request *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_file_recv(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv *event, void *user_data) {
-            assert(event == nullptr);
-        });
-    tox_events_callback_file_recv_chunk(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv_Chunk *event, void *user_data) {
-            assert(event == nullptr);
-        });
+    tox_events_callback_file_recv(dispatch,
+        [](const Tox_Event_File_Recv *event, void *user_data) { assert(event == nullptr); });
+    tox_events_callback_file_recv_chunk(dispatch,
+        [](const Tox_Event_File_Recv_Chunk *event, void *user_data) { assert(event == nullptr); });
     tox_events_callback_file_recv_control(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv_Control *event, void *user_data) {
+        dispatch, [](const Tox_Event_File_Recv_Control *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_connection_status(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Connection_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Connection_Status *event, void *user_data) {
+            State *state = static_cast<State *>(user_data);
             // OK: friend came online.
             const uint32_t friend_number
                 = tox_event_friend_connection_status_get_friend_number(event);
             assert(friend_number == 0);
             const uint8_t message = 'A';
             Tox_Err_Friend_Send_Message err;
-            tox_friend_send_message(tox, friend_number, TOX_MESSAGE_TYPE_NORMAL, &message, 1, &err);
+            tox_friend_send_message(
+                state->tox, friend_number, TOX_MESSAGE_TYPE_NORMAL, &message, 1, &err);
             assert(err == TOX_ERR_FRIEND_SEND_MESSAGE_OK);
         });
     tox_events_callback_friend_lossless_packet(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Lossless_Packet *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Lossless_Packet *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_lossy_packet(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Lossy_Packet *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Lossy_Packet *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_message(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Message *event, void *user_data) {
+            State *state = static_cast<State *>(user_data);
             const uint32_t friend_number = tox_event_friend_message_get_friend_number(event);
             assert(friend_number == 0);
             const uint32_t message_length = tox_event_friend_message_get_message_length(event);
@@ -119,48 +121,51 @@ void setup_callbacks(Tox_Dispatch *dispatch)
             const uint8_t *message = tox_event_friend_message_get_message(event);
             const uint8_t reply = message[0] + 1;
             Tox_Err_Friend_Send_Message err;
-            tox_friend_send_message(tox, friend_number, TOX_MESSAGE_TYPE_NORMAL, &reply, 1, &err);
+            tox_friend_send_message(
+                state->tox, friend_number, TOX_MESSAGE_TYPE_NORMAL, &reply, 1, &err);
             assert(err == TOX_ERR_FRIEND_SEND_MESSAGE_OK);
         });
     tox_events_callback_friend_name(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Name *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Name *event, void *user_data) {
             const uint32_t friend_number = tox_event_friend_name_get_friend_number(event);
             assert(friend_number == 0);
         });
     tox_events_callback_friend_read_receipt(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Read_Receipt *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Read_Receipt *event, void *user_data) {
+            State *state = static_cast<State *>(user_data);
             const uint32_t friend_number = tox_event_friend_read_receipt_get_friend_number(event);
             assert(friend_number == 0);
             const uint32_t message_id = tox_event_friend_read_receipt_get_message_id(event);
-            uint32_t *done = static_cast<uint32_t *>(user_data);
-            *done = std::max(*done, message_id);
+            state->done = std::max(state->done, message_id);
         });
     tox_events_callback_friend_request(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Request *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Request *event, void *user_data) {
+            State *state = static_cast<State *>(user_data);
             Tox_Err_Friend_Add err;
-            tox_friend_add_norequest(tox, tox_event_friend_request_get_public_key(event), &err);
+            tox_friend_add_norequest(
+                state->tox, tox_event_friend_request_get_public_key(event), &err);
             assert(err == TOX_ERR_FRIEND_ADD_OK || err == TOX_ERR_FRIEND_ADD_OWN_KEY
                 || err == TOX_ERR_FRIEND_ADD_ALREADY_SENT
                 || err == TOX_ERR_FRIEND_ADD_BAD_CHECKSUM);
         });
     tox_events_callback_friend_status(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Status *event, void *user_data) {
             const uint32_t friend_number = tox_event_friend_status_get_friend_number(event);
             assert(friend_number == 0);
         });
     tox_events_callback_friend_status_message(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Status_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Status_Message *event, void *user_data) {
             const uint32_t friend_number = tox_event_friend_status_message_get_friend_number(event);
             assert(friend_number == 0);
         });
     tox_events_callback_friend_typing(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Typing *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Typing *event, void *user_data) {
             const uint32_t friend_number = tox_event_friend_typing_get_friend_number(event);
             assert(friend_number == 0);
             assert(!tox_event_friend_typing_get_typing(event));
         });
     tox_events_callback_self_connection_status(
-        dispatch, [](Tox *tox, const Tox_Event_Self_Connection_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Self_Connection_Status *event, void *user_data) {
             // OK: we got connected.
         });
 }
@@ -235,8 +240,8 @@ void RecordBootstrap(const char *init, const char *bootstrap)
     assert(dispatch != nullptr);
     setup_callbacks(dispatch);
 
-    uint32_t done1 = 0;
-    uint32_t done2 = 0;
+    State state1 = {tox1, 0};
+    State state2 = {tox2, 0};
 
     const auto iterate = [&](uint8_t clock_increment) {
         Tox_Err_Events_Iterate error_iterate;
@@ -244,12 +249,12 @@ void RecordBootstrap(const char *init, const char *bootstrap)
 
         events = tox_events_iterate(tox1, true, &error_iterate);
         assert(tox_events_equal(sys1.sys.get(), events, events));
-        tox_dispatch_invoke(dispatch, events, tox1, &done1);
+        tox_dispatch_invoke(dispatch, events, &state1);
         tox_events_free(events);
 
         events = tox_events_iterate(tox2, true, &error_iterate);
         assert(tox_events_equal(sys2.sys.get(), events, events));
-        tox_dispatch_invoke(dispatch, events, tox2, &done2);
+        tox_dispatch_invoke(dispatch, events, &state2);
         tox_events_free(events);
 
         // Move the clock forward a decent amount so all the time-based checks
@@ -295,7 +300,7 @@ void RecordBootstrap(const char *init, const char *bootstrap)
 
     dump(sys1.take_recording(), init);
 
-    while (done1 < MESSAGE_COUNT && done2 < MESSAGE_COUNT) {
+    while (state1.done < MESSAGE_COUNT && state2.done < MESSAGE_COUNT) {
         if (Fuzz_Data::DEBUG) {
             std::printf("tox1: %d, tox2: %d, tox1 -> tox2: %d, tox2 -> tox1: %d\n",
                 tox_self_get_connection_status(tox1), tox_self_get_connection_status(tox2),

--- a/testing/fuzzing/protodump_reduce.cc
+++ b/testing/fuzzing/protodump_reduce.cc
@@ -16,51 +16,46 @@ constexpr bool PROTODUMP_DEBUG = Fuzz_Data::DEBUG;
 void setup_callbacks(Tox_Dispatch *dispatch)
 {
     tox_events_callback_conference_connected(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Connected *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_connected(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Connected *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_invite(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Invite *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_message(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Message *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_conference_peer_list_changed(dispatch,
-        [](Tox *tox, const Tox_Event_Conference_Peer_List_Changed *event, void *user_data) {
+    tox_events_callback_conference_peer_list_changed(
+        dispatch, [](const Tox_Event_Conference_Peer_List_Changed *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_conference_peer_name(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Peer_Name *event, void *user_data) {
+        dispatch, [](const Tox_Event_Conference_Peer_Name *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_conference_title(
-        dispatch, [](Tox *tox, const Tox_Event_Conference_Title *event, void *user_data) {
-            assert(event == nullptr);
-        });
+    tox_events_callback_conference_title(dispatch,
+        [](const Tox_Event_Conference_Title *event, void *user_data) { assert(event == nullptr); });
     tox_events_callback_file_chunk_request(
-        dispatch, [](Tox *tox, const Tox_Event_File_Chunk_Request *event, void *user_data) {
+        dispatch, [](const Tox_Event_File_Chunk_Request *event, void *user_data) {
             assert(event == nullptr);
         });
-    tox_events_callback_file_recv(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv *event, void *user_data) {
-            assert(event == nullptr);
-        });
-    tox_events_callback_file_recv_chunk(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv_Chunk *event, void *user_data) {
-            assert(event == nullptr);
-        });
+    tox_events_callback_file_recv(dispatch,
+        [](const Tox_Event_File_Recv *event, void *user_data) { assert(event == nullptr); });
+    tox_events_callback_file_recv_chunk(dispatch,
+        [](const Tox_Event_File_Recv_Chunk *event, void *user_data) { assert(event == nullptr); });
     tox_events_callback_file_recv_control(
-        dispatch, [](Tox *tox, const Tox_Event_File_Recv_Control *event, void *user_data) {
+        dispatch, [](const Tox_Event_File_Recv_Control *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_connection_status(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Connection_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Connection_Status *event, void *user_data) {
+            Tox *tox = static_cast<Tox *>(user_data);
             // OK: friend came online.
             const uint32_t friend_number
                 = tox_event_friend_connection_status_get_friend_number(event);
@@ -71,15 +66,16 @@ void setup_callbacks(Tox_Dispatch *dispatch)
             assert(err == TOX_ERR_FRIEND_SEND_MESSAGE_OK);
         });
     tox_events_callback_friend_lossless_packet(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Lossless_Packet *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Lossless_Packet *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_lossy_packet(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Lossy_Packet *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Lossy_Packet *event, void *user_data) {
             assert(event == nullptr);
         });
     tox_events_callback_friend_message(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Message *event, void *user_data) {
+            Tox *tox = static_cast<Tox *>(user_data);
             const uint32_t friend_number = tox_event_friend_message_get_friend_number(event);
             assert(friend_number == 0);
             const uint32_t message_length = tox_event_friend_message_get_message_length(event);
@@ -91,12 +87,12 @@ void setup_callbacks(Tox_Dispatch *dispatch)
             assert(err == TOX_ERR_FRIEND_SEND_MESSAGE_OK);
         });
     tox_events_callback_friend_name(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Name *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Name *event, void *user_data) {
             const uint32_t friend_number = tox_event_friend_name_get_friend_number(event);
             assert(friend_number == 0);
         });
     tox_events_callback_friend_read_receipt(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Read_Receipt *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Read_Receipt *event, void *user_data) {
             const uint32_t friend_number = tox_event_friend_read_receipt_get_friend_number(event);
             assert(friend_number == 0);
             const uint32_t message_id = tox_event_friend_read_receipt_get_message_id(event);
@@ -104,28 +100,29 @@ void setup_callbacks(Tox_Dispatch *dispatch)
             *done = std::max(*done, message_id);
         });
     tox_events_callback_friend_request(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Request *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Request *event, void *user_data) {
+            Tox *tox = static_cast<Tox *>(user_data);
             Tox_Err_Friend_Add err;
             tox_friend_add_norequest(tox, tox_event_friend_request_get_public_key(event), &err);
         });
     tox_events_callback_friend_status(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Status *event, void *user_data) {
             const uint32_t friend_number = tox_event_friend_status_get_friend_number(event);
             assert(friend_number == 0);
         });
     tox_events_callback_friend_status_message(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Status_Message *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Status_Message *event, void *user_data) {
             const uint32_t friend_number = tox_event_friend_status_message_get_friend_number(event);
             assert(friend_number == 0);
         });
     tox_events_callback_friend_typing(
-        dispatch, [](Tox *tox, const Tox_Event_Friend_Typing *event, void *user_data) {
+        dispatch, [](const Tox_Event_Friend_Typing *event, void *user_data) {
             const uint32_t friend_number = tox_event_friend_typing_get_friend_number(event);
             assert(friend_number == 0);
             assert(!tox_event_friend_typing_get_typing(event));
         });
     tox_events_callback_self_connection_status(
-        dispatch, [](Tox *tox, const Tox_Event_Self_Connection_Status *event, void *user_data) {
+        dispatch, [](const Tox_Event_Self_Connection_Status *event, void *user_data) {
             // OK: we got connected.
         });
 }
@@ -179,7 +176,7 @@ void TestEndToEnd(Fuzz_Data &input)
         Tox_Err_Events_Iterate error_iterate;
         Tox_Events *events = tox_events_iterate(tox, true, &error_iterate);
         tox_events_equal(tox_get_system(tox), events, events);  // TODO(iphydf): assert?
-        tox_dispatch_invoke(dispatch, events, tox, nullptr);
+        tox_dispatch_invoke(dispatch, events, tox);
         tox_events_free(events);
         const uint8_t clock_increment = random_u08(sys.rng.get());
         if (PROTODUMP_DEBUG) {

--- a/toxcore/tox_dispatch.c
+++ b/toxcore/tox_dispatch.c
@@ -285,13 +285,13 @@ void tox_events_callback_dht_get_nodes_response(
     dispatch->dht_get_nodes_response_callback = callback;
 }
 
-non_null(1, 2) nullable(3, 4)
-static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Event *event, Tox *tox, void *user_data)
+non_null(1, 2) nullable(3)
+static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Event *event, void *user_data)
 {
     switch (event->type) {
         case TOX_EVENT_CONFERENCE_CONNECTED: {
             if (dispatch->conference_connected_callback != nullptr) {
-                dispatch->conference_connected_callback(tox, event->data.conference_connected, user_data);
+                dispatch->conference_connected_callback(event->data.conference_connected, user_data);
             }
 
             break;
@@ -299,7 +299,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_CONFERENCE_INVITE: {
             if (dispatch->conference_invite_callback != nullptr) {
-                dispatch->conference_invite_callback(tox, event->data.conference_invite, user_data);
+                dispatch->conference_invite_callback(event->data.conference_invite, user_data);
             }
 
             break;
@@ -307,7 +307,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_CONFERENCE_MESSAGE: {
             if (dispatch->conference_message_callback != nullptr) {
-                dispatch->conference_message_callback(tox, event->data.conference_message, user_data);
+                dispatch->conference_message_callback(event->data.conference_message, user_data);
             }
 
             break;
@@ -315,7 +315,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_CONFERENCE_PEER_LIST_CHANGED: {
             if (dispatch->conference_peer_list_changed_callback != nullptr) {
-                dispatch->conference_peer_list_changed_callback(tox, event->data.conference_peer_list_changed, user_data);
+                dispatch->conference_peer_list_changed_callback(event->data.conference_peer_list_changed, user_data);
             }
 
             break;
@@ -323,7 +323,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_CONFERENCE_PEER_NAME: {
             if (dispatch->conference_peer_name_callback != nullptr) {
-                dispatch->conference_peer_name_callback(tox, event->data.conference_peer_name, user_data);
+                dispatch->conference_peer_name_callback(event->data.conference_peer_name, user_data);
             }
 
             break;
@@ -331,7 +331,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_CONFERENCE_TITLE: {
             if (dispatch->conference_title_callback != nullptr) {
-                dispatch->conference_title_callback(tox, event->data.conference_title, user_data);
+                dispatch->conference_title_callback(event->data.conference_title, user_data);
             }
 
             break;
@@ -339,7 +339,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FILE_CHUNK_REQUEST: {
             if (dispatch->file_chunk_request_callback != nullptr) {
-                dispatch->file_chunk_request_callback(tox, event->data.file_chunk_request, user_data);
+                dispatch->file_chunk_request_callback(event->data.file_chunk_request, user_data);
             }
 
             break;
@@ -347,7 +347,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FILE_RECV_CHUNK: {
             if (dispatch->file_recv_chunk_callback != nullptr) {
-                dispatch->file_recv_chunk_callback(tox, event->data.file_recv_chunk, user_data);
+                dispatch->file_recv_chunk_callback(event->data.file_recv_chunk, user_data);
             }
 
             break;
@@ -355,7 +355,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FILE_RECV_CONTROL: {
             if (dispatch->file_recv_control_callback != nullptr) {
-                dispatch->file_recv_control_callback(tox, event->data.file_recv_control, user_data);
+                dispatch->file_recv_control_callback(event->data.file_recv_control, user_data);
             }
 
             break;
@@ -363,7 +363,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FILE_RECV: {
             if (dispatch->file_recv_callback != nullptr) {
-                dispatch->file_recv_callback(tox, event->data.file_recv, user_data);
+                dispatch->file_recv_callback(event->data.file_recv, user_data);
             }
 
             break;
@@ -371,7 +371,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_CONNECTION_STATUS: {
             if (dispatch->friend_connection_status_callback != nullptr) {
-                dispatch->friend_connection_status_callback(tox, event->data.friend_connection_status, user_data);
+                dispatch->friend_connection_status_callback(event->data.friend_connection_status, user_data);
             }
 
             break;
@@ -379,7 +379,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_LOSSLESS_PACKET: {
             if (dispatch->friend_lossless_packet_callback != nullptr) {
-                dispatch->friend_lossless_packet_callback(tox, event->data.friend_lossless_packet, user_data);
+                dispatch->friend_lossless_packet_callback(event->data.friend_lossless_packet, user_data);
             }
 
             break;
@@ -387,7 +387,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_LOSSY_PACKET: {
             if (dispatch->friend_lossy_packet_callback != nullptr) {
-                dispatch->friend_lossy_packet_callback(tox, event->data.friend_lossy_packet, user_data);
+                dispatch->friend_lossy_packet_callback(event->data.friend_lossy_packet, user_data);
             }
 
             break;
@@ -395,7 +395,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_MESSAGE: {
             if (dispatch->friend_message_callback != nullptr) {
-                dispatch->friend_message_callback(tox, event->data.friend_message, user_data);
+                dispatch->friend_message_callback(event->data.friend_message, user_data);
             }
 
             break;
@@ -403,7 +403,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_NAME: {
             if (dispatch->friend_name_callback != nullptr) {
-                dispatch->friend_name_callback(tox, event->data.friend_name, user_data);
+                dispatch->friend_name_callback(event->data.friend_name, user_data);
             }
 
             break;
@@ -411,7 +411,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_READ_RECEIPT: {
             if (dispatch->friend_read_receipt_callback != nullptr) {
-                dispatch->friend_read_receipt_callback(tox, event->data.friend_read_receipt, user_data);
+                dispatch->friend_read_receipt_callback(event->data.friend_read_receipt, user_data);
             }
 
             break;
@@ -419,7 +419,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_REQUEST: {
             if (dispatch->friend_request_callback != nullptr) {
-                dispatch->friend_request_callback(tox, event->data.friend_request, user_data);
+                dispatch->friend_request_callback(event->data.friend_request, user_data);
             }
 
             break;
@@ -427,7 +427,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_STATUS: {
             if (dispatch->friend_status_callback != nullptr) {
-                dispatch->friend_status_callback(tox, event->data.friend_status, user_data);
+                dispatch->friend_status_callback(event->data.friend_status, user_data);
             }
 
             break;
@@ -435,7 +435,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_STATUS_MESSAGE: {
             if (dispatch->friend_status_message_callback != nullptr) {
-                dispatch->friend_status_message_callback(tox, event->data.friend_status_message, user_data);
+                dispatch->friend_status_message_callback(event->data.friend_status_message, user_data);
             }
 
             break;
@@ -443,7 +443,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_FRIEND_TYPING: {
             if (dispatch->friend_typing_callback != nullptr) {
-                dispatch->friend_typing_callback(tox, event->data.friend_typing, user_data);
+                dispatch->friend_typing_callback(event->data.friend_typing, user_data);
             }
 
             break;
@@ -451,7 +451,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_SELF_CONNECTION_STATUS: {
             if (dispatch->self_connection_status_callback != nullptr) {
-                dispatch->self_connection_status_callback(tox, event->data.self_connection_status, user_data);
+                dispatch->self_connection_status_callback(event->data.self_connection_status, user_data);
             }
 
             break;
@@ -459,7 +459,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_PEER_NAME: {
             if (dispatch->group_peer_name_callback != nullptr) {
-                dispatch->group_peer_name_callback(tox, event->data.group_peer_name, user_data);
+                dispatch->group_peer_name_callback(event->data.group_peer_name, user_data);
             }
 
             break;
@@ -467,7 +467,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_PEER_STATUS: {
             if (dispatch->group_peer_status_callback != nullptr) {
-                dispatch->group_peer_status_callback(tox, event->data.group_peer_status, user_data);
+                dispatch->group_peer_status_callback(event->data.group_peer_status, user_data);
             }
 
             break;
@@ -475,7 +475,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_TOPIC: {
             if (dispatch->group_topic_callback != nullptr) {
-                dispatch->group_topic_callback(tox, event->data.group_topic, user_data);
+                dispatch->group_topic_callback(event->data.group_topic, user_data);
             }
 
             break;
@@ -483,7 +483,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_PRIVACY_STATE: {
             if (dispatch->group_privacy_state_callback != nullptr) {
-                dispatch->group_privacy_state_callback(tox, event->data.group_privacy_state, user_data);
+                dispatch->group_privacy_state_callback(event->data.group_privacy_state, user_data);
             }
 
             break;
@@ -491,7 +491,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_VOICE_STATE: {
             if (dispatch->group_voice_state_callback != nullptr) {
-                dispatch->group_voice_state_callback(tox, event->data.group_voice_state, user_data);
+                dispatch->group_voice_state_callback(event->data.group_voice_state, user_data);
             }
 
             break;
@@ -499,7 +499,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_TOPIC_LOCK: {
             if (dispatch->group_topic_lock_callback != nullptr) {
-                dispatch->group_topic_lock_callback(tox, event->data.group_topic_lock, user_data);
+                dispatch->group_topic_lock_callback(event->data.group_topic_lock, user_data);
             }
 
             break;
@@ -507,7 +507,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_PEER_LIMIT: {
             if (dispatch->group_peer_limit_callback != nullptr) {
-                dispatch->group_peer_limit_callback(tox, event->data.group_peer_limit, user_data);
+                dispatch->group_peer_limit_callback(event->data.group_peer_limit, user_data);
             }
 
             break;
@@ -515,7 +515,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_PASSWORD: {
             if (dispatch->group_password_callback != nullptr) {
-                dispatch->group_password_callback(tox, event->data.group_password, user_data);
+                dispatch->group_password_callback(event->data.group_password, user_data);
             }
 
             break;
@@ -523,7 +523,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_MESSAGE: {
             if (dispatch->group_message_callback != nullptr) {
-                dispatch->group_message_callback(tox, event->data.group_message, user_data);
+                dispatch->group_message_callback(event->data.group_message, user_data);
             }
 
             break;
@@ -531,7 +531,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_PRIVATE_MESSAGE: {
             if (dispatch->group_private_message_callback != nullptr) {
-                dispatch->group_private_message_callback(tox, event->data.group_private_message, user_data);
+                dispatch->group_private_message_callback(event->data.group_private_message, user_data);
             }
 
             break;
@@ -539,7 +539,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_CUSTOM_PACKET: {
             if (dispatch->group_custom_packet_callback != nullptr) {
-                dispatch->group_custom_packet_callback(tox, event->data.group_custom_packet, user_data);
+                dispatch->group_custom_packet_callback(event->data.group_custom_packet, user_data);
             }
 
             break;
@@ -547,7 +547,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_CUSTOM_PRIVATE_PACKET: {
             if (dispatch->group_custom_private_packet_callback != nullptr) {
-                dispatch->group_custom_private_packet_callback(tox, event->data.group_custom_private_packet, user_data);
+                dispatch->group_custom_private_packet_callback(event->data.group_custom_private_packet, user_data);
             }
 
             break;
@@ -555,7 +555,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_INVITE: {
             if (dispatch->group_invite_callback != nullptr) {
-                dispatch->group_invite_callback(tox, event->data.group_invite, user_data);
+                dispatch->group_invite_callback(event->data.group_invite, user_data);
             }
 
             break;
@@ -563,7 +563,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_PEER_JOIN: {
             if (dispatch->group_peer_join_callback != nullptr) {
-                dispatch->group_peer_join_callback(tox, event->data.group_peer_join, user_data);
+                dispatch->group_peer_join_callback(event->data.group_peer_join, user_data);
             }
 
             break;
@@ -571,7 +571,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_PEER_EXIT: {
             if (dispatch->group_peer_exit_callback != nullptr) {
-                dispatch->group_peer_exit_callback(tox, event->data.group_peer_exit, user_data);
+                dispatch->group_peer_exit_callback(event->data.group_peer_exit, user_data);
             }
 
             break;
@@ -579,7 +579,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_SELF_JOIN: {
             if (dispatch->group_self_join_callback != nullptr) {
-                dispatch->group_self_join_callback(tox, event->data.group_self_join, user_data);
+                dispatch->group_self_join_callback(event->data.group_self_join, user_data);
             }
 
             break;
@@ -587,7 +587,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_JOIN_FAIL: {
             if (dispatch->group_join_fail_callback != nullptr) {
-                dispatch->group_join_fail_callback(tox, event->data.group_join_fail, user_data);
+                dispatch->group_join_fail_callback(event->data.group_join_fail, user_data);
             }
 
             break;
@@ -595,7 +595,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_GROUP_MODERATION: {
             if (dispatch->group_moderation_callback != nullptr) {
-                dispatch->group_moderation_callback(tox, event->data.group_moderation, user_data);
+                dispatch->group_moderation_callback(event->data.group_moderation, user_data);
             }
 
             break;
@@ -603,7 +603,7 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
 
         case TOX_EVENT_DHT_GET_NODES_RESPONSE: {
             if (dispatch->dht_get_nodes_response_callback != nullptr) {
-                dispatch->dht_get_nodes_response_callback(tox, event->data.dht_get_nodes_response, user_data);
+                dispatch->dht_get_nodes_response_callback(event->data.dht_get_nodes_response, user_data);
             }
 
             break;
@@ -615,11 +615,11 @@ static void tox_dispatch_invoke_event(const Tox_Dispatch *dispatch, const Tox_Ev
     }
 }
 
-void tox_dispatch_invoke(const Tox_Dispatch *dispatch, const Tox_Events *events, Tox *tox, void *user_data)
+void tox_dispatch_invoke(const Tox_Dispatch *dispatch, const Tox_Events *events, void *user_data)
 {
     const uint32_t size = tox_events_get_size(events);
     for (uint32_t i = 0; i < size; ++i) {
         const Tox_Event *event = &events->events[i];
-        tox_dispatch_invoke_event(dispatch, event, tox, user_data);
+        tox_dispatch_invoke_event(dispatch, event, user_data);
     }
 }

--- a/toxcore/tox_dispatch.h
+++ b/toxcore/tox_dispatch.h
@@ -47,91 +47,90 @@ void tox_dispatch_free(Tox_Dispatch *dispatch);
  *
  * @param dispatch The events dispatch table.
  * @param events The events object received from @ref tox_events_iterate.
- * @param tox The tox object to pass down to the callbacks.
  * @param user_data User data pointer to pass down to the callbacks.
  */
-void tox_dispatch_invoke(const Tox_Dispatch *dispatch, const Tox_Events *events, Tox *tox, void *user_data);
+void tox_dispatch_invoke(const Tox_Dispatch *dispatch, const Tox_Events *events, void *user_data);
 
 typedef void tox_events_conference_connected_cb(
-    Tox *tox, const Tox_Event_Conference_Connected *event, void *user_data);
+    const Tox_Event_Conference_Connected *event, void *user_data);
 typedef void tox_events_conference_invite_cb(
-    Tox *tox, const Tox_Event_Conference_Invite *event, void *user_data);
+    const Tox_Event_Conference_Invite *event, void *user_data);
 typedef void tox_events_conference_message_cb(
-    Tox *tox, const Tox_Event_Conference_Message *event, void *user_data);
+    const Tox_Event_Conference_Message *event, void *user_data);
 typedef void tox_events_conference_peer_list_changed_cb(
-    Tox *tox, const Tox_Event_Conference_Peer_List_Changed *event, void *user_data);
+    const Tox_Event_Conference_Peer_List_Changed *event, void *user_data);
 typedef void tox_events_conference_peer_name_cb(
-    Tox *tox, const Tox_Event_Conference_Peer_Name *event, void *user_data);
+    const Tox_Event_Conference_Peer_Name *event, void *user_data);
 typedef void tox_events_conference_title_cb(
-    Tox *tox, const Tox_Event_Conference_Title *event, void *user_data);
+    const Tox_Event_Conference_Title *event, void *user_data);
 typedef void tox_events_file_chunk_request_cb(
-    Tox *tox, const Tox_Event_File_Chunk_Request *event, void *user_data);
+    const Tox_Event_File_Chunk_Request *event, void *user_data);
 typedef void tox_events_file_recv_cb(
-    Tox *tox, const Tox_Event_File_Recv *event, void *user_data);
+    const Tox_Event_File_Recv *event, void *user_data);
 typedef void tox_events_file_recv_chunk_cb(
-    Tox *tox, const Tox_Event_File_Recv_Chunk *event, void *user_data);
+    const Tox_Event_File_Recv_Chunk *event, void *user_data);
 typedef void tox_events_file_recv_control_cb(
-    Tox *tox, const Tox_Event_File_Recv_Control *event, void *user_data);
+    const Tox_Event_File_Recv_Control *event, void *user_data);
 typedef void tox_events_friend_connection_status_cb(
-    Tox *tox, const Tox_Event_Friend_Connection_Status *event, void *user_data);
+    const Tox_Event_Friend_Connection_Status *event, void *user_data);
 typedef void tox_events_friend_lossless_packet_cb(
-    Tox *tox, const Tox_Event_Friend_Lossless_Packet *event, void *user_data);
+    const Tox_Event_Friend_Lossless_Packet *event, void *user_data);
 typedef void tox_events_friend_lossy_packet_cb(
-    Tox *tox, const Tox_Event_Friend_Lossy_Packet *event, void *user_data);
+    const Tox_Event_Friend_Lossy_Packet *event, void *user_data);
 typedef void tox_events_friend_message_cb(
-    Tox *tox, const Tox_Event_Friend_Message *event, void *user_data);
+    const Tox_Event_Friend_Message *event, void *user_data);
 typedef void tox_events_friend_name_cb(
-    Tox *tox, const Tox_Event_Friend_Name *event, void *user_data);
+    const Tox_Event_Friend_Name *event, void *user_data);
 typedef void tox_events_friend_read_receipt_cb(
-    Tox *tox, const Tox_Event_Friend_Read_Receipt *event, void *user_data);
+    const Tox_Event_Friend_Read_Receipt *event, void *user_data);
 typedef void tox_events_friend_request_cb(
-    Tox *tox, const Tox_Event_Friend_Request *event, void *user_data);
+    const Tox_Event_Friend_Request *event, void *user_data);
 typedef void tox_events_friend_status_cb(
-    Tox *tox, const Tox_Event_Friend_Status *event, void *user_data);
+    const Tox_Event_Friend_Status *event, void *user_data);
 typedef void tox_events_friend_status_message_cb(
-    Tox *tox, const Tox_Event_Friend_Status_Message *event, void *user_data);
+    const Tox_Event_Friend_Status_Message *event, void *user_data);
 typedef void tox_events_friend_typing_cb(
-    Tox *tox, const Tox_Event_Friend_Typing *event, void *user_data);
+    const Tox_Event_Friend_Typing *event, void *user_data);
 typedef void tox_events_self_connection_status_cb(
-    Tox *tox, const Tox_Event_Self_Connection_Status *event, void *user_data);
+    const Tox_Event_Self_Connection_Status *event, void *user_data);
 typedef void tox_events_group_peer_name_cb(
-    Tox *tox, const Tox_Event_Group_Peer_Name *event, void *user_data);
+    const Tox_Event_Group_Peer_Name *event, void *user_data);
 typedef void tox_events_group_peer_status_cb(
-    Tox *tox, const Tox_Event_Group_Peer_Status *event, void *user_data);
+    const Tox_Event_Group_Peer_Status *event, void *user_data);
 typedef void tox_events_group_topic_cb(
-    Tox *tox, const Tox_Event_Group_Topic *event, void *user_data);
+    const Tox_Event_Group_Topic *event, void *user_data);
 typedef void tox_events_group_privacy_state_cb(
-    Tox *tox, const Tox_Event_Group_Privacy_State *event, void *user_data);
+    const Tox_Event_Group_Privacy_State *event, void *user_data);
 typedef void tox_events_group_voice_state_cb(
-    Tox *tox, const Tox_Event_Group_Voice_State *event, void *user_data);
+    const Tox_Event_Group_Voice_State *event, void *user_data);
 typedef void tox_events_group_topic_lock_cb(
-    Tox *tox, const Tox_Event_Group_Topic_Lock *event, void *user_data);
+    const Tox_Event_Group_Topic_Lock *event, void *user_data);
 typedef void tox_events_group_peer_limit_cb(
-    Tox *tox, const Tox_Event_Group_Peer_Limit *event, void *user_data);
+    const Tox_Event_Group_Peer_Limit *event, void *user_data);
 typedef void tox_events_group_password_cb(
-    Tox *tox, const Tox_Event_Group_Password *event, void *user_data);
+    const Tox_Event_Group_Password *event, void *user_data);
 typedef void tox_events_group_message_cb(
-    Tox *tox, const Tox_Event_Group_Message *event, void *user_data);
+    const Tox_Event_Group_Message *event, void *user_data);
 typedef void tox_events_group_private_message_cb(
-    Tox *tox, const Tox_Event_Group_Private_Message *event, void *user_data);
+    const Tox_Event_Group_Private_Message *event, void *user_data);
 typedef void tox_events_group_custom_packet_cb(
-    Tox *tox, const Tox_Event_Group_Custom_Packet *event, void *user_data);
+    const Tox_Event_Group_Custom_Packet *event, void *user_data);
 typedef void tox_events_group_custom_private_packet_cb(
-    Tox *tox, const Tox_Event_Group_Custom_Private_Packet *event, void *user_data);
+    const Tox_Event_Group_Custom_Private_Packet *event, void *user_data);
 typedef void tox_events_group_invite_cb(
-    Tox *tox, const Tox_Event_Group_Invite *event, void *user_data);
+    const Tox_Event_Group_Invite *event, void *user_data);
 typedef void tox_events_group_peer_join_cb(
-    Tox *tox, const Tox_Event_Group_Peer_Join *event, void *user_data);
+    const Tox_Event_Group_Peer_Join *event, void *user_data);
 typedef void tox_events_group_peer_exit_cb(
-    Tox *tox, const Tox_Event_Group_Peer_Exit *event, void *user_data);
+    const Tox_Event_Group_Peer_Exit *event, void *user_data);
 typedef void tox_events_group_self_join_cb(
-    Tox *tox, const Tox_Event_Group_Self_Join *event, void *user_data);
+    const Tox_Event_Group_Self_Join *event, void *user_data);
 typedef void tox_events_group_join_fail_cb(
-    Tox *tox, const Tox_Event_Group_Join_Fail *event, void *user_data);
+    const Tox_Event_Group_Join_Fail *event, void *user_data);
 typedef void tox_events_group_moderation_cb(
-    Tox *tox, const Tox_Event_Group_Moderation *event, void *user_data);
+    const Tox_Event_Group_Moderation *event, void *user_data);
 typedef void tox_events_dht_get_nodes_response_cb(
-    Tox *tox, const Tox_Event_Dht_Get_Nodes_Response *event, void *user_data);
+    const Tox_Event_Dht_Get_Nodes_Response *event, void *user_data);
 
 void tox_events_callback_conference_connected(
     Tox_Dispatch *dispatch, tox_events_conference_connected_cb *callback);

--- a/toxcore/tox_events_fuzz_test.cc
+++ b/toxcore/tox_events_fuzz_test.cc
@@ -32,7 +32,7 @@ void TestUnpack(Fuzz_Data data)
     Tox_Dispatch *dispatch = tox_dispatch_new(nullptr);
     assert(dispatch != nullptr);
 
-    auto ignore = [](Tox *tox, auto *event, void *user_data) {};
+    auto ignore = [](auto *event, void *user_data) {};
     tox_events_callback_conference_connected(dispatch, ignore);
     tox_events_callback_conference_invite(dispatch, ignore);
     tox_events_callback_conference_message(dispatch, ignore);
@@ -78,7 +78,7 @@ void TestUnpack(Fuzz_Data data)
         std::vector<uint8_t> packed(tox_events_bytes_size(events));
         tox_events_get_bytes(events, packed.data());
 
-        tox_dispatch_invoke(dispatch, events, nullptr, nullptr);
+        tox_dispatch_invoke(dispatch, events, nullptr);
     }
     tox_events_free(events);
     tox_dispatch_free(dispatch);


### PR DESCRIPTION
User data can contain a tox instance if it needs to.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2645)
<!-- Reviewable:end -->
