### PR TITLE
fix: Fix some false positive from PVS Studio.

### DIFF
--- a/other/docker/sources/run.sh
+++ b/other/docker/sources/run.sh
@@ -18,4 +18,4 @@ if [ -f "$DOCKERDIR/dockerignore" ]; then
   cat "$DOCKERDIR/dockerignore" >>"$DOCKERDIR/$BUILD.Dockerfile.dockerignore"
 fi
 
-docker build -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/$BUILD.Dockerfile" .
+docker build "${DOCKERFLAGS[@]}" -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/$BUILD.Dockerfile" .

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -5560,12 +5560,12 @@ static int make_gc_handshake_packet(const GC_Chat *chat, const GC_Connection *gc
                                     uint8_t request_type, uint8_t join_type, uint8_t *packet, size_t packet_size,
                                     const Node_format *node)
 {
-    if (packet_size != GC_MIN_ENCRYPTED_HS_PAYLOAD_SIZE + sizeof(Node_format)) {
-        LOGGER_FATAL(chat->log, "invalid packet size: %zu", packet_size);
+    if (chat == nullptr || gconn == nullptr || node == nullptr) {
         return -1;
     }
 
-    if (chat == nullptr || gconn == nullptr || node == nullptr) {
+    if (packet_size != GC_MIN_ENCRYPTED_HS_PAYLOAD_SIZE + sizeof(Node_format)) {
+        LOGGER_FATAL(chat->log, "invalid packet size: %zu", packet_size);
         return -1;
     }
 


### PR DESCRIPTION
It correctly warns about potentially dereferencing NULL chat in a log statement. However, chat can semantically never be NULL in that call, and it's just a defensive check. Still good to fix for clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2657)
<!-- Reviewable:end -->
