### PR TITLE
fix: Add missing memunlock of local variable when it goes out of scope.

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -4033,6 +4033,7 @@ static int handle_gc_key_exchange(const GC_Chat *chat, GC_Connection *gconn, con
         // we're doing it anyway for symmetry with the memzero+munlock below, where we
         // really do care about it.
         crypto_memzero(new_session_sk, sizeof(new_session_sk));
+        crypto_memunlock(new_session_sk, sizeof(new_session_sk));
         return -3;
     }
 


### PR DESCRIPTION
Issue found by PVS Studio. It also found another one, but that's a false positive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2660)
<!-- Reviewable:end -->
