### PR TITLE
refactor: Use tox rng to seed the keypair generation.

### DIFF
--- a/other/docker/goblint/sodium.c
+++ b/other/docker/goblint/sodium.c
@@ -2,7 +2,7 @@
 
 #include <string.h>
 
-int crypto_sign_keypair(unsigned char *pk, unsigned char *sk)
+int crypto_sign_seed_keypair(unsigned char *pk, unsigned char *sk, const unsigned char *seed)
 {
     memset(pk, 0, 32);
     memset(sk, 0, 32);

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -45,10 +45,12 @@ static_assert(CRYPTO_SIGN_PUBLIC_KEY_SIZE == crypto_sign_PUBLICKEYBYTES,
 static_assert(CRYPTO_SIGN_SECRET_KEY_SIZE == crypto_sign_SECRETKEYBYTES,
               "CRYPTO_SIGN_SECRET_KEY_SIZE should be equal to crypto_sign_SECRETKEYBYTES");
 
-bool create_extended_keypair(uint8_t pk[EXT_PUBLIC_KEY_SIZE], uint8_t sk[EXT_SECRET_KEY_SIZE])
+bool create_extended_keypair(uint8_t pk[EXT_PUBLIC_KEY_SIZE], uint8_t sk[EXT_SECRET_KEY_SIZE], const Random *rng)
 {
     /* create signature key pair */
-    crypto_sign_keypair(pk + ENC_PUBLIC_KEY_SIZE, sk + ENC_SECRET_KEY_SIZE);
+    uint8_t seed[crypto_sign_SEEDBYTES];
+    random_bytes(rng, seed, crypto_sign_SEEDBYTES);
+    crypto_sign_seed_keypair(pk + ENC_PUBLIC_KEY_SIZE, sk + ENC_SECRET_KEY_SIZE, seed);
 
     /* convert public signature key to public encryption key */
     const int res1 = crypto_sign_ed25519_pk_to_curve25519(pk, pk + ENC_PUBLIC_KEY_SIZE);

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -333,11 +333,12 @@ bool public_key_valid(const uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE]);
  *
  * @param[out] pk The buffer where the public key will be stored. Must have room for EXT_PUBLIC_KEY_SIZE bytes.
  * @param[out] sk The buffer where the secret key will be stored. Must have room for EXT_SECRET_KEY_SIZE bytes.
+ * @param rng The random number generator to use for the key generator seed.
  *
  * @retval true on success.
  */
 non_null()
-bool create_extended_keypair(uint8_t pk[EXT_PUBLIC_KEY_SIZE], uint8_t sk[EXT_SECRET_KEY_SIZE]);
+bool create_extended_keypair(uint8_t pk[EXT_PUBLIC_KEY_SIZE], uint8_t sk[EXT_SECRET_KEY_SIZE], const Random *rng);
 
 /** Functions for groupchat extended keys */
 non_null() const uint8_t *get_enc_key(const uint8_t *key);

--- a/toxcore/crypto_core_test.cc
+++ b/toxcore/crypto_core_test.cc
@@ -75,7 +75,7 @@ TEST(CryptoCore, Signatures)
     ExtPublicKey pk;
     ExtSecretKey sk;
 
-    EXPECT_TRUE(create_extended_keypair(pk.data(), sk.data()));
+    EXPECT_TRUE(create_extended_keypair(pk.data(), sk.data(), rng));
 
     std::vector<uint8_t> message{0};
     message.clear();

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -7656,8 +7656,8 @@ int gc_group_load(GC_Session *c, Bin_Unpack *bu)
     return group_number;
 }
 
-int gc_group_add(GC_Session *c, Group_Privacy_State privacy_state, const uint8_t *group_name,
-                 uint16_t group_name_length,
+int gc_group_add(GC_Session *c, Group_Privacy_State privacy_state,
+                 const uint8_t *group_name, uint16_t group_name_length,
                  const uint8_t *nick, size_t nick_length)
 {
     if (group_name_length > MAX_GC_GROUP_NAME_SIZE) {
@@ -7690,7 +7690,7 @@ int gc_group_add(GC_Session *c, Group_Privacy_State privacy_state, const uint8_t
 
     crypto_memlock(chat->chat_secret_key, sizeof(chat->chat_secret_key));
 
-    create_extended_keypair(chat->chat_public_key, chat->chat_secret_key);
+    create_extended_keypair(chat->chat_public_key, chat->chat_secret_key, chat->rng);
 
     if (!init_gc_shared_state_founder(chat, privacy_state, group_name, group_name_length)) {
         group_delete(c, chat);
@@ -8439,7 +8439,7 @@ static bool create_new_chat_ext_keypair(GC_Chat *chat)
 {
     crypto_memlock(chat->self_secret_key, sizeof(chat->self_secret_key));
 
-    if (!create_extended_keypair(chat->self_public_key, chat->self_secret_key)) {
+    if (!create_extended_keypair(chat->self_public_key, chat->self_secret_key, chat->rng)) {
         crypto_memunlock(chat->self_secret_key, sizeof(chat->self_secret_key));
         return false;
     }

--- a/toxcore/group_moderation_test.cc
+++ b/toxcore/group_moderation_test.cc
@@ -194,6 +194,7 @@ protected:
     ExtPublicKey pk;
     ExtSecretKey sk;
     Logger *log = logger_new();
+    Test_Random rng;
     Test_Memory mem;
     Moderation mod{mem};
 
@@ -203,7 +204,7 @@ protected:
 
     void SetUp() override
     {
-        ASSERT_TRUE(create_extended_keypair(pk.data(), sk.data()));
+        ASSERT_TRUE(create_extended_keypair(pk.data(), sk.data(), rng));
 
         mod.log = log;
 


### PR DESCRIPTION
Fixes #2649

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2671)
<!-- Reviewable:end -->
