### PR TITLE
chore: Disable NGC saving by default, enable through Tox_Options.

### DIFF
--- a/auto_tests/group_save_test.c
+++ b/auto_tests/group_save_test.c
@@ -246,8 +246,8 @@ static void group_save_test(AutoTox *autotoxes)
     ck_assert(options != nullptr);
 
     tox_options_set_savedata_type(options, TOX_SAVEDATA_TYPE_TOX_SAVE);
-
     tox_options_set_savedata_data(options, save, save_length);
+    tox_options_set_experimental_groups_persistence(options, true);
 
     Tox *new_tox = tox_new_log(options, nullptr, nullptr);
 
@@ -283,7 +283,11 @@ int main(void)
     Run_Auto_Options autotest_opts = default_run_auto_options();
     autotest_opts.graph = GRAPH_COMPLETE;
 
-    run_auto_test(nullptr, NUM_GROUP_TOXES, group_save_test, sizeof(State), &autotest_opts);
+    Tox_Options *opts = tox_options_new(nullptr);
+    ck_assert(opts != nullptr);
+    tox_options_set_experimental_groups_persistence(opts, true);
+    run_auto_test(opts, NUM_GROUP_TOXES, group_save_test, sizeof(State), &autotest_opts);
+    tox_options_free(opts);
 
     return 0;
 }

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -3454,7 +3454,9 @@ static void m_register_default_plugins(Messenger *m)
     m_register_state_plugin(m, STATE_TYPE_STATUSMESSAGE, status_message_size, load_status_message,
                             save_status_message);
     m_register_state_plugin(m, STATE_TYPE_STATUS, status_size, load_status, save_status);
-    m_register_state_plugin(m, STATE_TYPE_GROUPS, saved_groups_size, groups_load, groups_save);
+    if (m->options.groups_persistence_enabled) {
+        m_register_state_plugin(m, STATE_TYPE_GROUPS, saved_groups_size, groups_load, groups_save);
+    }
     m_register_state_plugin(m, STATE_TYPE_TCP_RELAY, tcp_relay_size, load_tcp_relays, save_tcp_relays);
     m_register_state_plugin(m, STATE_TYPE_PATH_NODE, path_node_size, load_path_nodes, save_path_nodes);
 }

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -78,6 +78,7 @@ typedef struct Messenger_Options {
     bool hole_punching_enabled;
     bool local_discovery_enabled;
     bool dht_announcements_enabled;
+    bool groups_persistence_enabled;
 
     logger_cb *log_callback;
     void *log_context;

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -795,6 +795,7 @@ Tox *tox_new(const struct Tox_Options *options, Tox_Err_New *error)
     m_options.hole_punching_enabled = tox_options_get_hole_punching_enabled(opts);
     m_options.local_discovery_enabled = tox_options_get_local_discovery_enabled(opts);
     m_options.dht_announcements_enabled = tox_options_get_dht_announcements_enabled(opts);
+    m_options.groups_persistence_enabled = tox_options_get_experimental_groups_persistence(opts);
 
     if (m_options.udp_disabled) {
         m_options.local_discovery_enabled = false;

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -678,6 +678,17 @@ struct Tox_Options {
      */
     const Tox_System *operating_system;
 
+    /**
+     * Enable saving DHT-based group chats to Tox save data (via `tox_get_savedata`).
+     * This format will change in the future, so don't rely on it.
+     *
+     * As an alternative, clients can save the group chat ID in client-owned
+     * savedata. Then, when the client starts, it can use `tox_group_join`
+     * with the saved chat ID to recreate the group chat.
+     *
+     * Default: false.
+     */
+    bool experimental_groups_persistence;
 };
 
 bool tox_options_get_ipv6_enabled(const Tox_Options *options);
@@ -751,6 +762,10 @@ void tox_options_set_experimental_thread_safety(Tox_Options *options, bool exper
 const Tox_System *tox_options_get_operating_system(const Tox_Options *options);
 
 void tox_options_set_operating_system(Tox_Options *options, const Tox_System *operating_system);
+
+bool tox_options_get_experimental_groups_persistence(const Tox_Options *options);
+
+void tox_options_set_experimental_groups_persistence(Tox_Options *options, bool experimental_groups_persistence);
 
 /**
  * @brief Initialises a Tox_Options object with the default options.

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -273,6 +273,15 @@ void tox_options_set_operating_system(Tox_Options *options, const Tox_System *op
 {
     options->operating_system = operating_system;
 }
+bool tox_options_get_experimental_groups_persistence(const Tox_Options *options)
+{
+    return options->experimental_groups_persistence;
+}
+void tox_options_set_experimental_groups_persistence(
+    Tox_Options *options, bool experimental_groups_persistence)
+{
+    options->experimental_groups_persistence = experimental_groups_persistence;
+}
 
 const uint8_t *tox_options_get_savedata_data(const Tox_Options *options)
 {
@@ -297,6 +306,7 @@ void tox_options_default(Tox_Options *options)
         tox_options_set_local_discovery_enabled(options, true);
         tox_options_set_dht_announcements_enabled(options, true);
         tox_options_set_experimental_thread_safety(options, false);
+        tox_options_set_experimental_groups_persistence(options, false);
     }
 }
 


### PR DESCRIPTION
This way, clients can decide whether they want to depend on unstable functionality while we change the NGC save format. We can release with experimental functionality disabled by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2678)
<!-- Reviewable:end -->
