### PR TITLE
chore: Simplify coverage dockerfile.

### DIFF
--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -28,11 +28,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build toxchat/c-toxcore:sources
-        uses: docker/build-push-action@v4
-        with:
-          file: other/docker/sources/sources.Dockerfile
-          tags: toxchat/c-toxcore:sources
       - name: Build and push
         uses: docker/build-push-action@v4
         with:

--- a/other/docker/coverage/coverage.Dockerfile.dockerignore
+++ b/other/docker/coverage/coverage.Dockerfile.dockerignore
@@ -1,0 +1,25 @@
+# ===== common =====
+# Ignore everything ...
+**/*
+# ... except sources
+!**/*.[ch]
+!**/*.cc
+!**/*.hh
+!CHANGELOG.md
+!LICENSE
+!README.md
+!auto_tests/data/*
+!other/bootstrap_daemon/bash-completion/**
+!other/bootstrap_daemon/tox-bootstrapd.*
+!other/proxy/*.mod
+!other/proxy/*.sum
+!other/proxy/*.go
+# ... and CMake build files (used by most builds).
+!**/CMakeLists.txt
+!.github/scripts/flags*.sh
+!cmake/*.cmake
+!other/pkgconfig/*
+!other/rpm/*
+!so.version
+# ===== custom =====
+!other/docker/coverage/run_mallocfail

--- a/other/docker/coverage/dockerignore
+++ b/other/docker/coverage/dockerignore
@@ -1,0 +1,2 @@
+# ===== custom =====
+!other/docker/coverage/run_mallocfail

--- a/other/docker/coverage/run
+++ b/other/docker/coverage/run
@@ -4,8 +4,5 @@ set -eux
 
 read -a ci_env <<<"$(bash <(curl -s https://codecov.io/env))"
 
-BUILD=coverage
-other/docker/sources/build
-docker build -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/$BUILD.Dockerfile" .
-
-docker run "${ci_env[@]}" -e CI=true --name toxcore-coverage --rm -t toxchat/c-toxcore:coverage /usr/local/bin/codecov
+. "$(realpath -- "$(dirname "${BASH_SOURCE[0]}")/../sources/run.sh")"
+docker run "${ci_env[@]}" -e CI=true --name "toxcore-$BUILD" --rm -t "toxchat/c-toxcore:$BUILD" /usr/local/bin/codecov

--- a/other/docker/coverage/serve
+++ b/other/docker/coverage/serve
@@ -2,9 +2,7 @@
 
 set -eux
 
-BUILD=coverage
-other/docker/sources/build
-docker build -t "toxchat/c-toxcore:$BUILD" -f "other/docker/$BUILD/$BUILD.Dockerfile" .
+. "$(realpath -- "$(dirname "${BASH_SOURCE[0]}")/../sources/run.sh")"
 
-docker build -t toxchat/c-toxcore:coverage-nginx -f other/docker/coverage/nginx.Dockerfile other/docker/coverage
-docker run --name toxcore-coverage --rm -it -p "28192:80" toxchat/c-toxcore:coverage-nginx
+docker build -t "toxchat/c-toxcore:$BUILD-nginx" -f "$DOCKERDIR/nginx.Dockerfile" "$DOCKERDIR"
+docker run --name "toxcore-$BUILD" --rm -it -p "28192:80" "toxchat/c-toxcore:$BUILD-nginx"

--- a/other/docker/doxygen/run
+++ b/other/docker/doxygen/run
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")/../sources" && pwd)/run.sh"
+. "$(realpath -- "$(dirname "${BASH_SOURCE[0]}")/../sources/run.sh")"
 docker run --name toxcore-doxygen --rm -it -p "28192:80" "toxchat/c-toxcore:$BUILD"


### PR DESCRIPTION
Use per-dockerfile dockerignore instead of sources for coverage. It's a bit more duplication (dockerignore is copied out of the sources one), but it's a bit more efficient and works in more situations (e.g. one where you can only build 1 dockerfile such as on render.com).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2679)
<!-- Reviewable:end -->
