### PR TITLE
cleanup: Never pass `void*` directly to `memcpy`.

### DIFF
--- a/toxcore/bin_pack.c
+++ b/toxcore/bin_pack.c
@@ -36,6 +36,7 @@ static bool null_skipper(cmp_ctx_t *ctx, size_t count)
 non_null()
 static size_t buf_writer(cmp_ctx_t *ctx, const void *data, size_t count)
 {
+    const uint8_t *bytes = (const uint8_t *)data;
     Bin_Pack *bp = (Bin_Pack *)ctx->buf;
     assert(bp != nullptr);
     const uint32_t new_pos = bp->bytes_pos + count;
@@ -48,7 +49,7 @@ static size_t buf_writer(cmp_ctx_t *ctx, const void *data, size_t count)
             // Buffer too small.
             return 0;
         }
-        memcpy(&bp->bytes[bp->bytes_pos], data, count);
+        memcpy(&bp->bytes[bp->bytes_pos], bytes, count);
     }
     bp->bytes_pos += count;
     return count;

--- a/toxcore/bin_unpack.c
+++ b/toxcore/bin_unpack.c
@@ -21,12 +21,13 @@ struct Bin_Unpack {
 non_null()
 static bool buf_reader(cmp_ctx_t *ctx, void *data, size_t limit)
 {
+    uint8_t *bytes = (uint8_t *)data;
     Bin_Unpack *reader = (Bin_Unpack *)ctx->buf;
     assert(reader != nullptr && reader->bytes != nullptr);
     if (limit > reader->bytes_size) {
         return false;
     }
-    memcpy(data, reader->bytes, limit);
+    memcpy(bytes, reader->bytes, limit);
     reader->bytes += limit;
     reader->bytes_size -= limit;
     return true;


### PR DESCRIPTION
It cannot be type-checked easily, so we avoid void pointers entirely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2682)
<!-- Reviewable:end -->
