### PR TITLE
refactor: Make tox-bootstrapd use bool instead of int

### DIFF
--- a/other/bootstrap_daemon/src/config.h
+++ b/other/bootstrap_daemon/src/config.h
@@ -17,14 +17,14 @@
  *
  * Important: You are responsible for freeing `pid_file_path` and `keys_file_path`
  *            also, iff `tcp_relay_ports_count` > 0, then you are responsible for freeing `tcp_relay_ports`
- *            and also `motd` iff `enable_motd` is set.
+ *            and also `motd` iff `enable_motd` is true.
  *
  * @return true on success,
  *         false on failure, doesn't modify any data pointed by arguments.
  */
 bool get_general_config(const char *cfg_file_path, char **pid_file_path, char **keys_file_path, int *port,
-                        int *enable_ipv6, int *enable_ipv4_fallback, int *enable_lan_discovery, int *enable_tcp_relay,
-                        uint16_t **tcp_relay_ports, int *tcp_relay_port_count, int *enable_motd, char **motd);
+                        bool *enable_ipv6, bool *enable_ipv4_fallback, bool *enable_lan_discovery, bool *enable_tcp_relay,
+                        uint16_t **tcp_relay_ports, int *tcp_relay_port_count, bool *enable_motd, char **motd);
 
 /**
  * Bootstraps off nodes listed in the config file.

--- a/other/bootstrap_daemon/src/config_defaults.h
+++ b/other/bootstrap_daemon/src/config_defaults.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later
- * Copyright © 2016-2023 The TokTok team.
+ * Copyright © 2016-2024 The TokTok team.
  * Copyright © 2014-2016 Tox project.
  */
 
@@ -10,17 +10,19 @@
 #ifndef C_TOXCORE_OTHER_BOOTSTRAP_DAEMON_SRC_CONFIG_DEFAULTS_H
 #define C_TOXCORE_OTHER_BOOTSTRAP_DAEMON_SRC_CONFIG_DEFAULTS_H
 
+#include <stdbool.h>
+
 #include "global.h"
 
 #define DEFAULT_PID_FILE_PATH         "tox-bootstrapd.pid"
 #define DEFAULT_KEYS_FILE_PATH        "tox-bootstrapd.keys"
 #define DEFAULT_PORT                  33445
-#define DEFAULT_ENABLE_IPV6           1 // 1 - true, 0 - false
-#define DEFAULT_ENABLE_IPV4_FALLBACK  1 // 1 - true, 0 - false
-#define DEFAULT_ENABLE_LAN_DISCOVERY  1 // 1 - true, 0 - false
-#define DEFAULT_ENABLE_TCP_RELAY      1 // 1 - true, 0 - false
+#define DEFAULT_ENABLE_IPV6           true
+#define DEFAULT_ENABLE_IPV4_FALLBACK  true
+#define DEFAULT_ENABLE_LAN_DISCOVERY  true
+#define DEFAULT_ENABLE_TCP_RELAY      true
 #define DEFAULT_TCP_RELAY_PORTS       443, 3389, 33445 // comma-separated list of ports
-#define DEFAULT_ENABLE_MOTD           1 // 1 - true, 0 - false
+#define DEFAULT_ENABLE_MOTD           true
 #define DEFAULT_MOTD                  DAEMON_NAME
 
 #endif // C_TOXCORE_OTHER_BOOTSTRAP_DAEMON_SRC_CONFIG_DEFAULTS_H

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later
- * Copyright © 2016-2018 The TokTok team.
+ * Copyright © 2016-2024 The TokTok team.
  * Copyright © 2014-2016 Tox project.
  */
 
@@ -240,13 +240,13 @@ int main(int argc, char *argv[])
     char *pid_file_path = nullptr;
     char *keys_file_path = nullptr;
     int start_port = 0;
-    int enable_ipv6 = 0;
-    int enable_ipv4_fallback = 0;
-    int enable_lan_discovery = 0;
-    int enable_tcp_relay = 0;
+    bool enable_ipv6 = false;
+    bool enable_ipv4_fallback = false;
+    bool enable_lan_discovery = false;
+    bool enable_tcp_relay = false;
     uint16_t *tcp_relay_ports = nullptr;
     int tcp_relay_port_count = 0;
-    int enable_motd = 0;
+    bool enable_motd = false;
     char *motd = nullptr;
 
     if (get_general_config(cfg_file_path, &pid_file_path, &keys_file_path, &start_port, &enable_ipv6, &enable_ipv4_fallback,
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
     free(pid_file_path);
 
     IP ip;
-    ip_init(&ip, enable_ipv6 != 0);
+    ip_init(&ip, enable_ipv6);
 
     Logger *logger = logger_new();
 
@@ -296,10 +296,10 @@ int main(int argc, char *argv[])
     Networking_Core *net = new_networking_ex(logger, mem, ns, &ip, start_port, end_port, nullptr);
 
     if (net == nullptr) {
-        if (enable_ipv6 != 0 && enable_ipv4_fallback != 0) {
+        if (enable_ipv6 && enable_ipv4_fallback) {
             log_write(LOG_LEVEL_WARNING, "Couldn't initialize IPv6 networking. Falling back to using IPv4.\n");
-            enable_ipv6 = 0;
-            ip_init(&ip, enable_ipv6 != 0);
+            enable_ipv6 = false;
+            ip_init(&ip, enable_ipv6);
             net = new_networking_ex(logger, mem, ns, &ip, start_port, end_port, nullptr);
 
             if (net == nullptr) {
@@ -334,7 +334,7 @@ int main(int argc, char *argv[])
 
     mono_time_update(mono_time);
 
-    DHT *const dht = new_dht(logger, mem, rng, ns, mono_time, net, true, enable_lan_discovery != 0);
+    DHT *const dht = new_dht(logger, mem, rng, ns, mono_time, net, true, enable_lan_discovery);
 
     if (dht == nullptr) {
         log_write(LOG_LEVEL_ERROR, "Couldn't initialize Tox DHT instance. Exiting.\n");
@@ -429,7 +429,7 @@ int main(int argc, char *argv[])
 
     gca_onion_init(group_announce, onion_a);
 
-    if (enable_motd != 0) {
+    if (enable_motd) {
         if (bootstrap_set_callbacks(dht_get_net(dht), DAEMON_VERSION_NUMBER, (uint8_t *)motd, strlen(motd) + 1) == 0) {
             log_write(LOG_LEVEL_INFO, "Set MOTD successfully.\n");
             free(motd);
@@ -472,7 +472,7 @@ int main(int argc, char *argv[])
 
     TCP_Server *tcp_server = nullptr;
 
-    if (enable_tcp_relay != 0) {
+    if (enable_tcp_relay) {
         if (tcp_relay_port_count == 0) {
             log_write(LOG_LEVEL_ERROR, "No TCP relay ports read. Exiting.\n");
             kill_onion_announce(onion_a);
@@ -488,7 +488,7 @@ int main(int argc, char *argv[])
             return 1;
         }
 
-        tcp_server = new_tcp_server(logger, mem, rng, ns, enable_ipv6 != 0,
+        tcp_server = new_tcp_server(logger, mem, rng, ns, enable_ipv6,
                                     tcp_relay_port_count, tcp_relay_ports,
                                     dht_get_self_secret_key(dht), onion, forwarding);
 
@@ -535,7 +535,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (bootstrap_from_config(cfg_file_path, dht, enable_ipv6 != 0)) {
+    if (bootstrap_from_config(cfg_file_path, dht, enable_ipv6)) {
         log_write(LOG_LEVEL_INFO, "List of bootstrap nodes read successfully.\n");
     } else {
         log_write(LOG_LEVEL_ERROR, "Couldn't read list of bootstrap nodes in %s. Exiting.\n", cfg_file_path);
@@ -561,7 +561,7 @@ int main(int argc, char *argv[])
 
     Broadcast_Info *broadcast = nullptr;
 
-    if (enable_lan_discovery != 0) {
+    if (enable_lan_discovery) {
         broadcast = lan_discovery_init(ns);
         log_write(LOG_LEVEL_INFO, "Initialized LAN discovery successfully.\n");
     }
@@ -589,12 +589,12 @@ int main(int argc, char *argv[])
 
         do_dht(dht);
 
-        if (enable_lan_discovery != 0 && mono_time_is_timeout(mono_time, last_lan_discovery, LAN_DISCOVERY_INTERVAL)) {
+        if (enable_lan_discovery && mono_time_is_timeout(mono_time, last_lan_discovery, LAN_DISCOVERY_INTERVAL)) {
             lan_discovery_send(dht_get_net(dht), broadcast, dht_get_self_public_key(dht), net_htons_port);
             last_lan_discovery = mono_time_get(mono_time);
         }
 
-        if (enable_tcp_relay != 0) {
+        if (enable_tcp_relay) {
             do_tcp_server(tcp_server, mono_time);
         }
 


### PR DESCRIPTION
A continuation of the cleanup done in https://github.com/TokTok/c-toxcore/pull/2621.

tox-bootrstrapd historically had used ints for boolean values, as it was initially written in C89 which has no `stdbool.h`. Since then it has modernized and moved on to using C11, but the usage of the int type to represent boolean values, "boolean ints", remained. Recently, driven by a desire to eliminate implicit int-to-bool conversion, @iphydf did a cleanup in b7404f24f63054c00c26abab4bd0b9dc58f96efb, changing some of the boolean ints to bools and doing manual int-to-bool conversion on the remaining boolean ints. This left the codebase in an inconsistent state of both ints and bools now being used to represent boolean values, not to mention that the explicit int-to-bool conversions are a bit ugly. The only boolean ints that remained are those stemming from libconfig's `config_lookup_bool()` taking an `*int` parameter to return a boolean value, as libconfig still uses C89. This commit adds a wrapper function around libconfig's `config_lookup_bool()` that takes a `*bool` instead,  eliminating the remaining boolean ints and majority of the explicit int-to-bool conversions in tox-bootstrapd.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2692)
<!-- Reviewable:end -->
