### PR TITLE
chore: Only install tox_private.h on request.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,8 @@ if(MIN_LOGGER_LEVEL)
   endif()
 endif()
 
+option(EXPERIMENTAL_API "Install experimental header file with unstable API" OFF)
+
 option(USE_IPV6 "Use IPv6 in tests" ON)
 if(NOT USE_IPV6)
   add_definitions(-DUSE_IPV6=0)
@@ -359,8 +361,11 @@ set(toxcore_PKGCONFIG_REQUIRES ${toxcore_PKGCONFIG_REQUIRES} libsodium)
 set(toxcore_API_HEADERS
   ${toxcore_SOURCE_DIR}/toxcore/tox.h^tox
   ${toxcore_SOURCE_DIR}/toxcore/tox_events.h^tox
-  ${toxcore_SOURCE_DIR}/toxcore/tox_dispatch.h^tox
-  ${toxcore_SOURCE_DIR}/toxcore/tox_private.h^tox)
+  ${toxcore_SOURCE_DIR}/toxcore/tox_dispatch.h^tox)
+if(EXPERIMENTAL_API)
+  set(toxcore_API_HEADERS ${toxcore_API_HEADERS}
+    ${toxcore_SOURCE_DIR}/toxcore/tox_private.h^tox)
+endif()
 
 ################################################################################
 #

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -1,8 +1,7 @@
 lib_LTLIBRARIES += libtoxcore.la
 
 libtoxcore_la_include_HEADERS = \
-                        ../toxcore/tox.h \
-                        ../toxcore/tox_private.h
+                        ../toxcore/tox.h
 
 libtoxcore_la_includedir = $(includedir)/tox
 


### PR DESCRIPTION
Unfortunately, events and dispatch are already installed in .18, so we can't stop, but for .19, let's not add this private header if there's the possibility of moving it to a different location (https://github.com/TokTok/c-toxcore/pull/2599). Installing it makes it a chore for package maintainers (debian, pkgsrc).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2698)
<!-- Reviewable:end -->
