### PR TITLE
test: Add pkgsrc build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [autotools, clang-tidy, compcert, cppcheck, doxygen, goblint, infer, freebsd, misra, modules, rpm, slimcc, sparse, tcc, tokstyle]
+        tool: [autotools, clang-tidy, compcert, cppcheck, doxygen, goblint, infer, freebsd, misra, modules, pkgsrc, rpm, slimcc, sparse, tcc, tokstyle]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx

--- a/other/docker/pkgsrc/pkgsrc.Dockerfile
+++ b/other/docker/pkgsrc/pkgsrc.Dockerfile
@@ -1,0 +1,10 @@
+FROM toxchat/pkgsrc:latest
+
+WORKDIR /work
+COPY . /work/c-toxcore-0.2.18
+RUN ["tar", "zcf", "c-toxcore.tar.gz", "c-toxcore-0.2.18"]
+
+WORKDIR /work/pkgsrc/chat/toxcore
+RUN ["bmake", "clean"]
+RUN ["bmake", "DISTFILES=c-toxcore.tar.gz", "DISTDIR=/work", "NO_CHECKSUM=yes"]
+RUN ["bmake", "install"]

--- a/other/docker/pkgsrc/pkgsrc.Dockerfile.dockerignore
+++ b/other/docker/pkgsrc/pkgsrc.Dockerfile.dockerignore
@@ -1,0 +1,23 @@
+# ===== common =====
+# Ignore everything ...
+**/*
+# ... except sources
+!**/*.[ch]
+!**/*.cc
+!**/*.hh
+!CHANGELOG.md
+!LICENSE
+!README.md
+!auto_tests/data/*
+!other/bootstrap_daemon/bash-completion/**
+!other/bootstrap_daemon/tox-bootstrapd.*
+!other/proxy/*.mod
+!other/proxy/*.sum
+!other/proxy/*.go
+# ... and CMake build files (used by most builds).
+!**/CMakeLists.txt
+!.github/scripts/flags*.sh
+!cmake/*.cmake
+!other/pkgconfig/*
+!other/rpm/*
+!so.version

--- a/other/docker/pkgsrc/run
+++ b/other/docker/pkgsrc/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")/../sources" && pwd)/run.sh"


### PR DESCRIPTION
Used by NetBSD, but we build on Alpine Linux for speed. Separately, we will build on NetBSD without pkgsrc, to see whether it compiles and runs there. That VM build is more expensive and harder to debug, so we keep the pkgsrc Linux build for development.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2699)
<!-- Reviewable:end -->
