### PR TITLE
refactor: Rename founder_set_password to set_password.

### DIFF
--- a/auto_tests/group_invite_test.c
+++ b/auto_tests/group_invite_test.c
@@ -152,9 +152,9 @@ static void group_invite_test(AutoTox *autotoxes)
     printf("Peer 1 joined group\n");
 
     // founder sets a password
-    Tox_Err_Group_Founder_Set_Password pass_set_err;
-    tox_group_founder_set_password(tox0, groupnumber, (const uint8_t *)PASSWORD, PASS_LEN, &pass_set_err);
-    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK, "%d", pass_set_err);
+    Tox_Err_Group_Set_Password pass_set_err;
+    tox_group_set_password(tox0, groupnumber, (const uint8_t *)PASSWORD, PASS_LEN, &pass_set_err);
+    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_SET_PASSWORD_OK, "%d", pass_set_err);
 
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, 5000);
 
@@ -196,8 +196,8 @@ static void group_invite_test(AutoTox *autotoxes)
     printf("Peer 4 successfully blocked from joining full group\n");
 
     // founder removes password and increases peer limit to 100
-    tox_group_founder_set_password(tox0, groupnumber, nullptr, 0, &pass_set_err);
-    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK, "%d", pass_set_err);
+    tox_group_set_password(tox0, groupnumber, nullptr, 0, &pass_set_err);
+    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_SET_PASSWORD_OK, "%d", pass_set_err);
 
     tox_group_founder_set_peer_limit(tox0, groupnumber, 100, &limit_set_err);
     ck_assert_msg(limit_set_err == TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK, "%d", limit_set_err);

--- a/auto_tests/group_save_test.c
+++ b/auto_tests/group_save_test.c
@@ -208,9 +208,9 @@ static void group_save_test(AutoTox *autotoxes)
     tox_group_founder_set_privacy_state(tox0, group_number, NEW_PRIV_STATE, &priv_err);
     ck_assert(priv_err == TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK);
 
-    Tox_Err_Group_Founder_Set_Password pass_set_err;
-    tox_group_founder_set_password(tox0, group_number, (const uint8_t *)PASSWORD, PASS_LEN, &pass_set_err);
-    ck_assert(pass_set_err == TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK);
+    Tox_Err_Group_Set_Password pass_set_err;
+    tox_group_set_password(tox0, group_number, (const uint8_t *)PASSWORD, PASS_LEN, &pass_set_err);
+    ck_assert(pass_set_err == TOX_ERR_GROUP_SET_PASSWORD_OK);
 
     Tox_Err_Group_Founder_Set_Peer_Limit limit_set_err;
     tox_group_founder_set_peer_limit(tox0, group_number, PEER_LIMIT, &limit_set_err);

--- a/auto_tests/group_state_test.c
+++ b/auto_tests/group_state_test.c
@@ -252,9 +252,9 @@ static void set_group_state(Tox *tox, uint32_t groupnumber, uint32_t peer_limit,
     tox_group_founder_set_privacy_state(tox, groupnumber, priv_state, &priv_err);
     ck_assert_msg(priv_err == TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK, "failed to set privacy state: %d", priv_err);
 
-    Tox_Err_Group_Founder_Set_Password pass_set_err;
-    tox_group_founder_set_password(tox, groupnumber, password, pass_len, &pass_set_err);
-    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK, "failed to set password: %d", pass_set_err);
+    Tox_Err_Group_Set_Password pass_set_err;
+    tox_group_set_password(tox, groupnumber, password, pass_len, &pass_set_err);
+    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_SET_PASSWORD_OK, "failed to set password: %d", pass_set_err);
 
     Tox_Err_Group_Founder_Set_Topic_Lock lock_set_err;
     tox_group_founder_set_topic_lock(tox, groupnumber, topic_lock, &lock_set_err);

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -4109,7 +4109,7 @@ uint16_t gc_get_password_size(const GC_Chat *chat)
     return chat->shared_state.password_length;
 }
 
-int gc_founder_set_password(GC_Chat *chat, const uint8_t *password, uint16_t password_length)
+int gc_set_password(GC_Chat *chat, const uint8_t *password, uint16_t password_length)
 {
     if (!self_gc_is_founder(chat)) {
         return -1;

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -483,7 +483,7 @@ int gc_set_peer_role(const Messenger *m, int group_number, GC_Peer_Id peer_id, G
  * Returns -4 if malloc failed.
  */
 non_null(1) nullable(2)
-int gc_founder_set_password(GC_Chat *chat, const uint8_t *password, uint16_t password_length);
+int gc_set_password(GC_Chat *chat, const uint8_t *password, uint16_t password_length);
 
 /** @brief Sets the topic lock and distributes the new shared state to the group.
  *

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -4294,8 +4294,8 @@ uint32_t tox_group_invite_accept(Tox *tox, uint32_t friend_number, const uint8_t
     return UINT32_MAX;
 }
 
-bool tox_group_founder_set_password(Tox *tox, uint32_t group_number, const uint8_t *password, size_t length,
-                                    Tox_Err_Group_Founder_Set_Password *error)
+bool tox_group_set_password(Tox *tox, uint32_t group_number, const uint8_t *password, size_t length,
+                            Tox_Err_Group_Set_Password *error)
 {
     assert(tox != nullptr);
 
@@ -4303,43 +4303,43 @@ bool tox_group_founder_set_password(Tox *tox, uint32_t group_number, const uint8
     GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
 
     if (chat == nullptr) {
-        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_GROUP_NOT_FOUND);
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_GROUP_NOT_FOUND);
         tox_unlock(tox);
         return false;
     }
 
     if (chat->connection_state == CS_DISCONNECTED) {
-        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_DISCONNECTED);
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_DISCONNECTED);
         tox_unlock(tox);
         return false;
     }
 
-    const int ret = gc_founder_set_password(chat, password, length);
+    const int ret = gc_set_password(chat, password, length);
     tox_unlock(tox);
 
     switch (ret) {
         case 0: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_OK);
             return true;
         }
 
         case -1: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_PERMISSIONS);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_PERMISSIONS);
             return false;
         }
 
         case -2: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_TOO_LONG);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_TOO_LONG);
             return false;
         }
 
         case -3: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_FAIL_SEND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_FAIL_SEND);
             return false;
         }
 
         case -4: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_MALLOC);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_MALLOC);
             return false;
         }
     }

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -5083,46 +5083,46 @@ void tox_callback_group_join_fail(Tox *tox, tox_group_join_fail_cb *callback);
  *
  ******************************************************************************/
 
-typedef enum Tox_Err_Group_Founder_Set_Password {
+typedef enum Tox_Err_Group_Set_Password {
 
     /**
      * The function returned successfully.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK,
+    TOX_ERR_GROUP_SET_PASSWORD_OK,
 
     /**
      * The group number passed did not designate a valid group.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_GROUP_NOT_FOUND,
+    TOX_ERR_GROUP_SET_PASSWORD_GROUP_NOT_FOUND,
 
     /**
      * The caller does not have the required permissions to set the password.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_PERMISSIONS,
+    TOX_ERR_GROUP_SET_PASSWORD_PERMISSIONS,
 
     /**
      * Password length exceeded TOX_GROUP_MAX_PASSWORD_SIZE.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_TOO_LONG,
+    TOX_ERR_GROUP_SET_PASSWORD_TOO_LONG,
 
     /**
      * The packet failed to send.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_FAIL_SEND,
+    TOX_ERR_GROUP_SET_PASSWORD_FAIL_SEND,
 
     /**
      * The function failed to allocate enough memory for the operation.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_MALLOC,
+    TOX_ERR_GROUP_SET_PASSWORD_MALLOC,
 
     /**
      * The group is disconnected.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_DISCONNECTED,
+    TOX_ERR_GROUP_SET_PASSWORD_DISCONNECTED,
 
-} Tox_Err_Group_Founder_Set_Password;
+} Tox_Err_Group_Set_Password;
 
-const char *tox_err_group_founder_set_password_to_string(Tox_Err_Group_Founder_Set_Password value);
+const char *tox_err_group_set_password_to_string(Tox_Err_Group_Set_Password value);
 
 /**
  * Set or unset the group password.
@@ -5136,10 +5136,10 @@ const char *tox_err_group_founder_set_password_to_string(Tox_Err_Group_Founder_S
  *
  * @return true on success.
  */
-bool tox_group_founder_set_password(
+bool tox_group_set_password(
     Tox *tox, Tox_Group_Number group_number,
     const uint8_t password[], size_t length,
-    Tox_Err_Group_Founder_Set_Password *error);
+    Tox_Err_Group_Set_Password *error);
 
 typedef enum Tox_Err_Group_Founder_Set_Topic_Lock {
 

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -1505,32 +1505,32 @@ const char *tox_group_join_fail_to_string(Tox_Group_Join_Fail value)
 
     return "<invalid Tox_Group_Join_Fail>";
 }
-const char *tox_err_group_founder_set_password_to_string(Tox_Err_Group_Founder_Set_Password value)
+const char *tox_err_group_set_password_to_string(Tox_Err_Group_Set_Password value)
 {
     switch (value) {
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK";
+        case TOX_ERR_GROUP_SET_PASSWORD_OK:
+            return "TOX_ERR_GROUP_SET_PASSWORD_OK";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_GROUP_NOT_FOUND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_GROUP_NOT_FOUND";
+        case TOX_ERR_GROUP_SET_PASSWORD_GROUP_NOT_FOUND:
+            return "TOX_ERR_GROUP_SET_PASSWORD_GROUP_NOT_FOUND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_PERMISSIONS:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_PERMISSIONS";
+        case TOX_ERR_GROUP_SET_PASSWORD_PERMISSIONS:
+            return "TOX_ERR_GROUP_SET_PASSWORD_PERMISSIONS";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_TOO_LONG:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_TOO_LONG";
+        case TOX_ERR_GROUP_SET_PASSWORD_TOO_LONG:
+            return "TOX_ERR_GROUP_SET_PASSWORD_TOO_LONG";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_FAIL_SEND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_FAIL_SEND";
+        case TOX_ERR_GROUP_SET_PASSWORD_FAIL_SEND:
+            return "TOX_ERR_GROUP_SET_PASSWORD_FAIL_SEND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_MALLOC:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_MALLOC";
+        case TOX_ERR_GROUP_SET_PASSWORD_MALLOC:
+            return "TOX_ERR_GROUP_SET_PASSWORD_MALLOC";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_DISCONNECTED:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_DISCONNECTED";
+        case TOX_ERR_GROUP_SET_PASSWORD_DISCONNECTED:
+            return "TOX_ERR_GROUP_SET_PASSWORD_DISCONNECTED";
     }
 
-    return "<invalid Tox_Err_Group_Founder_Set_Password>";
+    return "<invalid Tox_Err_Group_Set_Password>";
 }
 const char *tox_err_group_founder_set_topic_lock_to_string(Tox_Err_Group_Founder_Set_Topic_Lock value)
 {


### PR DESCRIPTION
To align with get_password in the same namespace.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2706)
<!-- Reviewable:end -->
