### PR TITLE
refactor: Remove "mod" and "founder" from group API naming scheme

### DIFF
--- a/auto_tests/group_general_test.c
+++ b/auto_tests/group_general_test.c
@@ -298,9 +298,9 @@ static void group_announce_test(AutoTox *autotoxes)
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, ITERATION_INTERVAL);
 
     // changes the state (for sync check purposes)
-    Tox_Err_Group_Founder_Set_Peer_Limit limit_set_err;
-    tox_group_founder_set_peer_limit(tox0, groupnumber, PEER_LIMIT, &limit_set_err);
-    ck_assert_msg(limit_set_err == TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK, "failed to set peer limit: %d", limit_set_err);
+    Tox_Err_Group_Set_Peer_Limit limit_set_err;
+    tox_group_set_peer_limit(tox0, groupnumber, PEER_LIMIT, &limit_set_err);
+    ck_assert_msg(limit_set_err == TOX_ERR_GROUP_SET_PEER_LIMIT_OK, "failed to set peer limit: %d", limit_set_err);
 
     Tox_Err_Group_Topic_Set tp_err;
     tox_group_set_topic(tox0, groupnumber, (const uint8_t *)TOPIC, TOPIC_LEN, &tp_err);

--- a/auto_tests/group_invite_test.c
+++ b/auto_tests/group_invite_test.c
@@ -152,9 +152,9 @@ static void group_invite_test(AutoTox *autotoxes)
     printf("Peer 1 joined group\n");
 
     // founder sets a password
-    Tox_Err_Group_Founder_Set_Password pass_set_err;
-    tox_group_founder_set_password(tox0, groupnumber, (const uint8_t *)PASSWORD, PASS_LEN, &pass_set_err);
-    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK, "%d", pass_set_err);
+    Tox_Err_Group_Set_Password pass_set_err;
+    tox_group_set_password(tox0, groupnumber, (const uint8_t *)PASSWORD, PASS_LEN, &pass_set_err);
+    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_SET_PASSWORD_OK, "%d", pass_set_err);
 
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, 5000);
 
@@ -179,9 +179,9 @@ static void group_invite_test(AutoTox *autotoxes)
     printf("Peer 3 successfully blocked with invalid password\n");
 
     // founder sets peer limit to 1
-    Tox_Err_Group_Founder_Set_Peer_Limit limit_set_err;
-    tox_group_founder_set_peer_limit(tox0, groupnumber, 1, &limit_set_err);
-    ck_assert_msg(limit_set_err == TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK, "%d", limit_set_err);
+    Tox_Err_Group_Set_Peer_Limit limit_set_err;
+    tox_group_set_peer_limit(tox0, groupnumber, 1, &limit_set_err);
+    ck_assert_msg(limit_set_err == TOX_ERR_GROUP_SET_PEER_LIMIT_OK, "%d", limit_set_err);
 
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, 5000);
 
@@ -196,11 +196,11 @@ static void group_invite_test(AutoTox *autotoxes)
     printf("Peer 4 successfully blocked from joining full group\n");
 
     // founder removes password and increases peer limit to 100
-    tox_group_founder_set_password(tox0, groupnumber, nullptr, 0, &pass_set_err);
-    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK, "%d", pass_set_err);
+    tox_group_set_password(tox0, groupnumber, nullptr, 0, &pass_set_err);
+    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_SET_PASSWORD_OK, "%d", pass_set_err);
 
-    tox_group_founder_set_peer_limit(tox0, groupnumber, 100, &limit_set_err);
-    ck_assert_msg(limit_set_err == TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK, "%d", limit_set_err);
+    tox_group_set_peer_limit(tox0, groupnumber, 100, &limit_set_err);
+    ck_assert_msg(limit_set_err == TOX_ERR_GROUP_SET_PEER_LIMIT_OK, "%d", limit_set_err);
 
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, 5000);
 
@@ -215,9 +215,9 @@ static void group_invite_test(AutoTox *autotoxes)
     printf("Peer 5 successfully joined the group\n");
 
     // founder makes group private
-    Tox_Err_Group_Founder_Set_Privacy_State priv_err;
-    tox_group_founder_set_privacy_state(tox0, groupnumber, TOX_GROUP_PRIVACY_STATE_PRIVATE, &priv_err);
-    ck_assert_msg(priv_err == TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK, "%d", priv_err);
+    Tox_Err_Group_Set_Privacy_State priv_err;
+    tox_group_set_privacy_state(tox0, groupnumber, TOX_GROUP_PRIVACY_STATE_PRIVATE, &priv_err);
+    ck_assert_msg(priv_err == TOX_ERR_GROUP_SET_PRIVACY_STATE_OK, "%d", priv_err);
 
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, 5000);
 
@@ -233,8 +233,8 @@ static void group_invite_test(AutoTox *autotoxes)
     printf("Peer 6 failed to join private group via chat ID\n");
 
     // founder makes group public again
-    tox_group_founder_set_privacy_state(tox0, groupnumber, TOX_GROUP_PRIVACY_STATE_PUBLIC, &priv_err);
-    ck_assert_msg(priv_err == TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK, "%d", priv_err);
+    tox_group_set_privacy_state(tox0, groupnumber, TOX_GROUP_PRIVACY_STATE_PUBLIC, &priv_err);
+    ck_assert_msg(priv_err == TOX_ERR_GROUP_SET_PRIVACY_STATE_OK, "%d", priv_err);
 
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, ITERATION_INTERVAL);
 

--- a/auto_tests/group_moderation_test.c
+++ b/auto_tests/group_moderation_test.c
@@ -402,10 +402,10 @@ static void check_voice_state(AutoTox *autotoxes, uint32_t num_toxes)
 {
     // founder sets voice state to Moderator
     const State *state = (State *)autotoxes[0].state;
-    Tox_Err_Group_Founder_Set_Voice_State voice_set_err;
-    tox_group_founder_set_voice_state(autotoxes[0].tox, state->group_number, TOX_GROUP_VOICE_STATE_MODERATOR,
-                                      &voice_set_err);
-    ck_assert(voice_set_err == TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_OK);
+    Tox_Err_Group_Set_Voice_State voice_set_err;
+    tox_group_set_voice_state(autotoxes[0].tox, state->group_number, TOX_GROUP_VOICE_STATE_MODERATOR,
+                              &voice_set_err);
+    ck_assert(voice_set_err == TOX_ERR_GROUP_SET_VOICE_STATE_OK);
 
     for (uint32_t i = 0; i < num_toxes; ++i) {
         do {
@@ -415,8 +415,8 @@ static void check_voice_state(AutoTox *autotoxes, uint32_t num_toxes)
         voice_state_message_test(&autotoxes[i], TOX_GROUP_VOICE_STATE_MODERATOR);
     }
 
-    tox_group_founder_set_voice_state(autotoxes[0].tox, state->group_number, TOX_GROUP_VOICE_STATE_FOUNDER, &voice_set_err);
-    ck_assert(voice_set_err == TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_OK);
+    tox_group_set_voice_state(autotoxes[0].tox, state->group_number, TOX_GROUP_VOICE_STATE_FOUNDER, &voice_set_err);
+    ck_assert(voice_set_err == TOX_ERR_GROUP_SET_VOICE_STATE_OK);
 
     for (uint32_t i = 0; i < num_toxes; ++i) {
         do {
@@ -426,8 +426,8 @@ static void check_voice_state(AutoTox *autotoxes, uint32_t num_toxes)
         voice_state_message_test(&autotoxes[i], TOX_GROUP_VOICE_STATE_FOUNDER);
     }
 
-    tox_group_founder_set_voice_state(autotoxes[0].tox, state->group_number, TOX_GROUP_VOICE_STATE_ALL, &voice_set_err);
-    ck_assert(voice_set_err == TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_OK);
+    tox_group_set_voice_state(autotoxes[0].tox, state->group_number, TOX_GROUP_VOICE_STATE_ALL, &voice_set_err);
+    ck_assert(voice_set_err == TOX_ERR_GROUP_SET_VOICE_STATE_OK);
 
     for (uint32_t i = 0; i < num_toxes; ++i) {
         do {
@@ -525,9 +525,9 @@ static void group_moderation_test(AutoTox *autotoxes)
     /* founder sets first peer to moderator */
     fprintf(stderr, "Founder setting %s to moderator\n", state0->peers[0].name);
 
-    Tox_Err_Group_Mod_Set_Role role_err;
-    tox_group_mod_set_role(tox0, state0->group_number, state0->peers[0].peer_id, TOX_GROUP_ROLE_MODERATOR, &role_err);
-    ck_assert_msg(role_err == TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Failed to set moderator. error: %d", role_err);
+    Tox_Err_Group_Set_Role role_err;
+    tox_group_set_role(tox0, state0->group_number, state0->peers[0].peer_id, TOX_GROUP_ROLE_MODERATOR, &role_err);
+    ck_assert_msg(role_err == TOX_ERR_GROUP_SET_ROLE_OK, "Failed to set moderator. error: %d", role_err);
 
     // manually flag the role setter because they don't get a callback
     state0->mod_check = true;
@@ -541,8 +541,8 @@ static void group_moderation_test(AutoTox *autotoxes)
     /* founder sets second and third peer to observer */
     fprintf(stderr, "Founder setting %s to observer\n", state0->peers[1].name);
 
-    tox_group_mod_set_role(tox0, state0->group_number, state0->peers[1].peer_id, TOX_GROUP_ROLE_OBSERVER, &role_err);
-    ck_assert_msg(role_err == TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Failed to set observer. error: %d", role_err);
+    tox_group_set_role(tox0, state0->group_number, state0->peers[1].peer_id, TOX_GROUP_ROLE_OBSERVER, &role_err);
+    ck_assert_msg(role_err == TOX_ERR_GROUP_SET_ROLE_OK, "Failed to set observer. error: %d", role_err);
 
     state0->observer_check = true;
     ++state0->observer_event_count;
@@ -552,8 +552,8 @@ static void group_moderation_test(AutoTox *autotoxes)
 
     fprintf(stderr, "Founder setting %s to observer\n", state0->peers[2].name);
 
-    tox_group_mod_set_role(tox0, state0->group_number, state0->peers[2].peer_id, TOX_GROUP_ROLE_OBSERVER, &role_err);
-    ck_assert_msg(role_err == TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Failed to set observer. error: %d", role_err);
+    tox_group_set_role(tox0, state0->group_number, state0->peers[2].peer_id, TOX_GROUP_ROLE_OBSERVER, &role_err);
+    ck_assert_msg(role_err == TOX_ERR_GROUP_SET_ROLE_OK, "Failed to set observer. error: %d", role_err);
 
     state0->observer_check = true;
     ++state0->observer_event_count;
@@ -578,8 +578,8 @@ static void group_moderation_test(AutoTox *autotoxes)
 
     fprintf(stderr, "%s is promoting %s back to user\n", state1->self_name, state0->peers[1].name);
 
-    tox_group_mod_set_role(tox1, state1->group_number, obs_peer_id, TOX_GROUP_ROLE_USER, &role_err);
-    ck_assert_msg(role_err == TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Failed to promote observer back to user. error: %d",
+    tox_group_set_role(tox1, state1->group_number, obs_peer_id, TOX_GROUP_ROLE_USER, &role_err);
+    ck_assert_msg(role_err == TOX_ERR_GROUP_SET_ROLE_OK, "Failed to promote observer back to user. error: %d",
                   role_err);
 
     state1->user_check = true;
@@ -591,8 +591,8 @@ static void group_moderation_test(AutoTox *autotoxes)
     /* founder assigns third peer to moderator (this triggers two events: user and moderator) */
     fprintf(stderr, "Founder setting %s to moderator\n", state0->peers[2].name);
 
-    tox_group_mod_set_role(tox0, state0->group_number, state0->peers[2].peer_id, TOX_GROUP_ROLE_MODERATOR, &role_err);
-    ck_assert_msg(role_err == TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Failed to set moderator. error: %d", role_err);
+    tox_group_set_role(tox0, state0->group_number, state0->peers[2].peer_id, TOX_GROUP_ROLE_MODERATOR, &role_err);
+    ck_assert_msg(role_err == TOX_ERR_GROUP_SET_ROLE_OK, "Failed to set moderator. error: %d", role_err);
 
     state0->mod_check = true;
     ++state0->mod_event_count;
@@ -604,12 +604,12 @@ static void group_moderation_test(AutoTox *autotoxes)
 
     /* moderator attempts to demote and kick founder */
     uint32_t founder_peer_id = get_peer_id_by_nick(state1->peers, NUM_GROUP_TOXES - 1, state0->self_name);
-    tox_group_mod_set_role(tox1, state1->group_number, founder_peer_id, TOX_GROUP_ROLE_OBSERVER, &role_err);
-    ck_assert_msg(role_err != TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Mod set founder to observer");
+    tox_group_set_role(tox1, state1->group_number, founder_peer_id, TOX_GROUP_ROLE_OBSERVER, &role_err);
+    ck_assert_msg(role_err != TOX_ERR_GROUP_SET_ROLE_OK, "Mod set founder to observer");
 
-    Tox_Err_Group_Mod_Kick_Peer k_err;
-    tox_group_mod_kick_peer(tox1, state1->group_number, founder_peer_id, &k_err);
-    ck_assert_msg(k_err != TOX_ERR_GROUP_MOD_KICK_PEER_OK, "Mod kicked founder");
+    Tox_Err_Group_Kick_Peer k_err;
+    tox_group_kick_peer(tox1, state1->group_number, founder_peer_id, &k_err);
+    ck_assert_msg(k_err != TOX_ERR_GROUP_KICK_PEER_OK, "Mod kicked founder");
 
     /* the moderator about to be kicked changes the topic to trigger the founder to
      * re-sign and redistribute it after the kick.
@@ -623,8 +623,8 @@ static void group_moderation_test(AutoTox *autotoxes)
     /* founder kicks moderator (this triggers two events: user and kick) */
     fprintf(stderr, "Founder is kicking %s\n", state0->peers[0].name);
 
-    tox_group_mod_kick_peer(tox0, state0->group_number, state0->peers[0].peer_id, &k_err);
-    ck_assert_msg(k_err == TOX_ERR_GROUP_MOD_KICK_PEER_OK, "Failed to kick peer. error: %d", k_err);
+    tox_group_kick_peer(tox0, state0->group_number, state0->peers[0].peer_id, &k_err);
+    ck_assert_msg(k_err == TOX_ERR_GROUP_KICK_PEER_OK, "Failed to kick peer. error: %d", k_err);
 
     state0->kick_check = true;
     check_mod_event(autotoxes, NUM_GROUP_TOXES, TOX_GROUP_MOD_EVENT_KICK);
@@ -632,8 +632,8 @@ static void group_moderation_test(AutoTox *autotoxes)
     fprintf(stderr, "All peers successfully received kick event\n");
 
     fprintf(stderr, "Founder is demoting moderator to user\n");
-    tox_group_mod_set_role(tox0, state0->group_number, state0->peers[2].peer_id, TOX_GROUP_ROLE_USER, &role_err);
-    ck_assert_msg(role_err == TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Failed to demote peer 3 to User. error: %d", role_err);
+    tox_group_set_role(tox0, state0->group_number, state0->peers[2].peer_id, TOX_GROUP_ROLE_USER, &role_err);
+    ck_assert_msg(role_err == TOX_ERR_GROUP_SET_ROLE_OK, "Failed to demote peer 3 to User. error: %d", role_err);
 
     state0->user_check = true;
     ++state0->user_event_count;

--- a/auto_tests/group_save_test.c
+++ b/auto_tests/group_save_test.c
@@ -200,21 +200,21 @@ static void group_save_test(AutoTox *autotoxes)
     tox_group_set_topic(tox0, group_number, (const uint8_t *)TOPIC, TOPIC_LEN, &top_err);
     ck_assert(top_err == TOX_ERR_GROUP_TOPIC_SET_OK);
 
-    Tox_Err_Group_Founder_Set_Topic_Lock lock_set_err;
-    tox_group_founder_set_topic_lock(tox0, group_number, TOX_GROUP_TOPIC_LOCK_DISABLED, &lock_set_err);
-    ck_assert(lock_set_err == TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK);
+    Tox_Err_Group_Set_Topic_Lock lock_set_err;
+    tox_group_set_topic_lock(tox0, group_number, TOX_GROUP_TOPIC_LOCK_DISABLED, &lock_set_err);
+    ck_assert(lock_set_err == TOX_ERR_GROUP_SET_TOPIC_LOCK_OK);
 
-    Tox_Err_Group_Founder_Set_Privacy_State priv_err;
-    tox_group_founder_set_privacy_state(tox0, group_number, NEW_PRIV_STATE, &priv_err);
-    ck_assert(priv_err == TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK);
+    Tox_Err_Group_Set_Privacy_State priv_err;
+    tox_group_set_privacy_state(tox0, group_number, NEW_PRIV_STATE, &priv_err);
+    ck_assert(priv_err == TOX_ERR_GROUP_SET_PRIVACY_STATE_OK);
 
-    Tox_Err_Group_Founder_Set_Password pass_set_err;
-    tox_group_founder_set_password(tox0, group_number, (const uint8_t *)PASSWORD, PASS_LEN, &pass_set_err);
-    ck_assert(pass_set_err == TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK);
+    Tox_Err_Group_Set_Password pass_set_err;
+    tox_group_set_password(tox0, group_number, (const uint8_t *)PASSWORD, PASS_LEN, &pass_set_err);
+    ck_assert(pass_set_err == TOX_ERR_GROUP_SET_PASSWORD_OK);
 
-    Tox_Err_Group_Founder_Set_Peer_Limit limit_set_err;
-    tox_group_founder_set_peer_limit(tox0, group_number, PEER_LIMIT, &limit_set_err);
-    ck_assert(limit_set_err == TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK);
+    Tox_Err_Group_Set_Peer_Limit limit_set_err;
+    tox_group_set_peer_limit(tox0, group_number, PEER_LIMIT, &limit_set_err);
+    ck_assert(limit_set_err == TOX_ERR_GROUP_SET_PEER_LIMIT_OK);
 
     // change self state
     Tox_Err_Group_Self_Name_Set n_err;

--- a/auto_tests/group_state_test.c
+++ b/auto_tests/group_state_test.c
@@ -244,26 +244,26 @@ static void set_group_state(Tox *tox, uint32_t groupnumber, uint32_t peer_limit,
                             Tox_Group_Topic_Lock topic_lock)
 {
 
-    Tox_Err_Group_Founder_Set_Peer_Limit limit_set_err;
-    tox_group_founder_set_peer_limit(tox, groupnumber, peer_limit, &limit_set_err);
-    ck_assert_msg(limit_set_err == TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK, "failed to set peer limit: %d", limit_set_err);
+    Tox_Err_Group_Set_Peer_Limit limit_set_err;
+    tox_group_set_peer_limit(tox, groupnumber, peer_limit, &limit_set_err);
+    ck_assert_msg(limit_set_err == TOX_ERR_GROUP_SET_PEER_LIMIT_OK, "failed to set peer limit: %d", limit_set_err);
 
-    Tox_Err_Group_Founder_Set_Privacy_State priv_err;
-    tox_group_founder_set_privacy_state(tox, groupnumber, priv_state, &priv_err);
-    ck_assert_msg(priv_err == TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK, "failed to set privacy state: %d", priv_err);
+    Tox_Err_Group_Set_Privacy_State priv_err;
+    tox_group_set_privacy_state(tox, groupnumber, priv_state, &priv_err);
+    ck_assert_msg(priv_err == TOX_ERR_GROUP_SET_PRIVACY_STATE_OK, "failed to set privacy state: %d", priv_err);
 
-    Tox_Err_Group_Founder_Set_Password pass_set_err;
-    tox_group_founder_set_password(tox, groupnumber, password, pass_len, &pass_set_err);
-    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK, "failed to set password: %d", pass_set_err);
+    Tox_Err_Group_Set_Password pass_set_err;
+    tox_group_set_password(tox, groupnumber, password, pass_len, &pass_set_err);
+    ck_assert_msg(pass_set_err == TOX_ERR_GROUP_SET_PASSWORD_OK, "failed to set password: %d", pass_set_err);
 
-    Tox_Err_Group_Founder_Set_Topic_Lock lock_set_err;
-    tox_group_founder_set_topic_lock(tox, groupnumber, topic_lock, &lock_set_err);
-    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK, "failed to set topic lock: %d",
+    Tox_Err_Group_Set_Topic_Lock lock_set_err;
+    tox_group_set_topic_lock(tox, groupnumber, topic_lock, &lock_set_err);
+    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_SET_TOPIC_LOCK_OK, "failed to set topic lock: %d",
                   lock_set_err);
 
-    Tox_Err_Group_Founder_Set_Voice_State voice_set_err;
-    tox_group_founder_set_voice_state(tox, groupnumber, voice_state, &voice_set_err);
-    ck_assert_msg(voice_set_err == TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_OK, "failed to set voice state: %d",
+    Tox_Err_Group_Set_Voice_State voice_set_err;
+    tox_group_set_voice_state(tox, groupnumber, voice_state, &voice_set_err);
+    ck_assert_msg(voice_set_err == TOX_ERR_GROUP_SET_VOICE_STATE_OK, "failed to set voice state: %d",
                   voice_set_err);
 }
 

--- a/auto_tests/group_sync_test.c
+++ b/auto_tests/group_sync_test.c
@@ -205,7 +205,7 @@ static void role_spam(const Random *rng, AutoTox *autotoxes, uint32_t num_peers,
         int64_t peer_id = state0->peers->peer_ids[idx];
 
         if (peer_id >= 0) {
-            tox_group_mod_set_role(tox0, groupnumber, (uint32_t)peer_id, f_role, nullptr);
+            tox_group_set_role(tox0, groupnumber, (uint32_t)peer_id, f_role, nullptr);
         }
 
         // mods randomly promote or demote one of the non-mods
@@ -222,7 +222,7 @@ static void role_spam(const Random *rng, AutoTox *autotoxes, uint32_t num_peers,
                 peer_id = state_j->peers->peer_ids[i];
 
                 if (peer_id >= 0) {
-                    tox_group_mod_set_role(autotoxes[j].tox, groupnumber, (uint32_t)peer_id, role, nullptr);
+                    tox_group_set_role(autotoxes[j].tox, groupnumber, (uint32_t)peer_id, role, nullptr);
                 }
             }
         }
@@ -379,9 +379,9 @@ static void group_sync_test(AutoTox *autotoxes)
 
     fprintf(stderr, "%d peers joined the group\n", NUM_GROUP_TOXES);
 
-    Tox_Err_Group_Founder_Set_Topic_Lock lock_set_err;
-    tox_group_founder_set_topic_lock(tox0, groupnumber, TOX_GROUP_TOPIC_LOCK_DISABLED, &lock_set_err);
-    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK, "failed to disable topic lock: %d",
+    Tox_Err_Group_Set_Topic_Lock lock_set_err;
+    tox_group_set_topic_lock(tox0, groupnumber, TOX_GROUP_TOPIC_LOCK_DISABLED, &lock_set_err);
+    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_SET_TOPIC_LOCK_OK, "failed to disable topic lock: %d",
                   lock_set_err);
 
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, ITERATION_INTERVAL);
@@ -392,8 +392,8 @@ static void group_sync_test(AutoTox *autotoxes)
 
     iterate_all_wait(autotoxes, NUM_GROUP_TOXES, ITERATION_INTERVAL);
 
-    tox_group_founder_set_topic_lock(tox0, groupnumber, TOX_GROUP_TOPIC_LOCK_ENABLED, &lock_set_err);
-    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK, "failed to enable topic lock: %d",
+    tox_group_set_topic_lock(tox0, groupnumber, TOX_GROUP_TOPIC_LOCK_ENABLED, &lock_set_err);
+    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_SET_TOPIC_LOCK_OK, "failed to enable topic lock: %d",
                   lock_set_err);
 
     do {
@@ -402,12 +402,12 @@ static void group_sync_test(AutoTox *autotoxes)
              && !all_peers_see_same_roles(autotoxes, NUM_GROUP_TOXES, groupnumber)
              && state0->peers->num_peers != NUM_GROUP_TOXES - 1);
 
-    Tox_Err_Group_Mod_Set_Role role_err;
+    Tox_Err_Group_Set_Role role_err;
 
     for (size_t i = 0; i < state0->peers->num_peers; ++i) {
-        tox_group_mod_set_role(tox0, groupnumber, (uint32_t)state0->peers->peer_ids[i], TOX_GROUP_ROLE_MODERATOR,
-                               &role_err);
-        ck_assert_msg(role_err == TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Failed to set moderator. error: %d", role_err);
+        tox_group_set_role(tox0, groupnumber, (uint32_t)state0->peers->peer_ids[i], TOX_GROUP_ROLE_MODERATOR,
+                           &role_err);
+        ck_assert_msg(role_err == TOX_ERR_GROUP_SET_ROLE_OK, "Failed to set moderator. error: %d", role_err);
     }
 
     fprintf(stderr, "founder enabled topic lock and set all peers to moderator role\n");
@@ -423,9 +423,9 @@ static void group_sync_test(AutoTox *autotoxes)
     fprintf(stderr, "founder demoting %u moderators to user\n", num_demoted);
 
     for (size_t i = 0; i < num_demoted; ++i) {
-        tox_group_mod_set_role(tox0, groupnumber, (uint32_t)state0->peers->peer_ids[i], TOX_GROUP_ROLE_USER,
-                               &role_err);
-        ck_assert_msg(role_err == TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Failed to set user. error: %d", role_err);
+        tox_group_set_role(tox0, groupnumber, (uint32_t)state0->peers->peer_ids[i], TOX_GROUP_ROLE_USER,
+                           &role_err);
+        ck_assert_msg(role_err == TOX_ERR_GROUP_SET_ROLE_OK, "Failed to set user. error: %d", role_err);
     }
 
     do {

--- a/auto_tests/group_topic_test.c
+++ b/auto_tests/group_topic_test.c
@@ -274,9 +274,9 @@ static void group_topic_test(AutoTox *autotoxes)
     wait_state_topic(autotoxes, groupnumber, TOPIC, TOPIC_LEN);
 
     /* Founder disables topic lock */
-    Tox_Err_Group_Founder_Set_Topic_Lock lock_set_err;
-    tox_group_founder_set_topic_lock(tox0, groupnumber, TOX_GROUP_TOPIC_LOCK_DISABLED, &lock_set_err);
-    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK, "failed to disable topic lock: %d",
+    Tox_Err_Group_Set_Topic_Lock lock_set_err;
+    tox_group_set_topic_lock(tox0, groupnumber, TOX_GROUP_TOPIC_LOCK_DISABLED, &lock_set_err);
+    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_SET_TOPIC_LOCK_OK, "failed to disable topic lock: %d",
                   lock_set_err);
 
     fprintf(stderr, "Topic lock disabled\n");
@@ -290,9 +290,9 @@ static void group_topic_test(AutoTox *autotoxes)
     ck_assert_msg(change_count == NUM_GROUP_TOXES, "%u peers changed the topic with topic lock disabled", change_count);
 
     /* founder silences the last peer he saw join */
-    Tox_Err_Group_Mod_Set_Role merr;
-    tox_group_mod_set_role(tox0, groupnumber, state0->peer_id, TOX_GROUP_ROLE_OBSERVER, &merr);
-    ck_assert_msg(merr == TOX_ERR_GROUP_MOD_SET_ROLE_OK, "Failed to set %u to observer role: %d", state0->peer_id, merr);
+    Tox_Err_Group_Set_Role merr;
+    tox_group_set_role(tox0, groupnumber, state0->peer_id, TOX_GROUP_ROLE_OBSERVER, &merr);
+    ck_assert_msg(merr == TOX_ERR_GROUP_SET_ROLE_OK, "Failed to set %u to observer role: %d", state0->peer_id, merr);
 
     fprintf(stderr, "Random peer is set to observer\n");
 
@@ -304,8 +304,8 @@ static void group_topic_test(AutoTox *autotoxes)
     ck_assert_msg(change_count == NUM_GROUP_TOXES - 1, "%u peers changed the topic with a silenced peer", change_count);
 
     /* Founder enables topic lock and sets topic back to original */
-    tox_group_founder_set_topic_lock(tox0, groupnumber, TOX_GROUP_TOPIC_LOCK_ENABLED, &lock_set_err);
-    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK, "failed to enable topic lock: %d",
+    tox_group_set_topic_lock(tox0, groupnumber, TOX_GROUP_TOPIC_LOCK_ENABLED, &lock_set_err);
+    ck_assert_msg(lock_set_err == TOX_ERR_GROUP_SET_TOPIC_LOCK_OK, "failed to enable topic lock: %d",
                   lock_set_err);
 
     fprintf(stderr, "Topic lock enabled\n");

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -4294,8 +4294,8 @@ uint32_t tox_group_invite_accept(Tox *tox, uint32_t friend_number, const uint8_t
     return UINT32_MAX;
 }
 
-bool tox_group_founder_set_password(Tox *tox, uint32_t group_number, const uint8_t *password, size_t length,
-                                    Tox_Err_Group_Founder_Set_Password *error)
+bool tox_group_set_password(Tox *tox, uint32_t group_number, const uint8_t *password, size_t length,
+                            Tox_Err_Group_Set_Password *error)
 {
     assert(tox != nullptr);
 
@@ -4303,13 +4303,13 @@ bool tox_group_founder_set_password(Tox *tox, uint32_t group_number, const uint8
     GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
 
     if (chat == nullptr) {
-        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_GROUP_NOT_FOUND);
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_GROUP_NOT_FOUND);
         tox_unlock(tox);
         return false;
     }
 
     if (chat->connection_state == CS_DISCONNECTED) {
-        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_DISCONNECTED);
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_DISCONNECTED);
         tox_unlock(tox);
         return false;
     }
@@ -4319,27 +4319,27 @@ bool tox_group_founder_set_password(Tox *tox, uint32_t group_number, const uint8
 
     switch (ret) {
         case 0: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_OK);
             return true;
         }
 
         case -1: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_PERMISSIONS);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_PERMISSIONS);
             return false;
         }
 
         case -2: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_TOO_LONG);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_TOO_LONG);
             return false;
         }
 
         case -3: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_FAIL_SEND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_FAIL_SEND);
             return false;
         }
 
         case -4: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_MALLOC);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PASSWORD_MALLOC);
             return false;
         }
     }
@@ -4350,8 +4350,8 @@ bool tox_group_founder_set_password(Tox *tox, uint32_t group_number, const uint8
     return false;
 }
 
-bool tox_group_founder_set_privacy_state(Tox *tox, uint32_t group_number, Tox_Group_Privacy_State privacy_state,
-        Tox_Err_Group_Founder_Set_Privacy_State *error)
+bool tox_group_set_privacy_state(Tox *tox, uint32_t group_number, Tox_Group_Privacy_State privacy_state,
+                                 Tox_Err_Group_Set_Privacy_State *error)
 {
     assert(tox != nullptr);
 
@@ -4361,32 +4361,32 @@ bool tox_group_founder_set_privacy_state(Tox *tox, uint32_t group_number, Tox_Gr
 
     switch (ret) {
         case 0: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PRIVACY_STATE_OK);
             return true;
         }
 
         case -1: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_GROUP_NOT_FOUND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PRIVACY_STATE_GROUP_NOT_FOUND);
             return false;
         }
 
         case -2: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_PERMISSIONS);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PRIVACY_STATE_PERMISSIONS);
             return false;
         }
 
         case -3: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_DISCONNECTED);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PRIVACY_STATE_DISCONNECTED);
             return false;
         }
 
         case -4: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_FAIL_SET);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PRIVACY_STATE_FAIL_SET);
             return false;
         }
 
         case -5: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_FAIL_SEND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PRIVACY_STATE_FAIL_SEND);
             return false;
         }
     }
@@ -4397,8 +4397,8 @@ bool tox_group_founder_set_privacy_state(Tox *tox, uint32_t group_number, Tox_Gr
     return false;
 }
 
-bool tox_group_founder_set_topic_lock(Tox *tox, uint32_t group_number, Tox_Group_Topic_Lock topic_lock,
-                                      Tox_Err_Group_Founder_Set_Topic_Lock *error)
+bool tox_group_set_topic_lock(Tox *tox, uint32_t group_number, Tox_Group_Topic_Lock topic_lock,
+                              Tox_Err_Group_Set_Topic_Lock *error)
 {
     assert(tox != nullptr);
 
@@ -4408,37 +4408,37 @@ bool tox_group_founder_set_topic_lock(Tox *tox, uint32_t group_number, Tox_Group
 
     switch (ret) {
         case 0: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_TOPIC_LOCK_OK);
             return true;
         }
 
         case -1: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_GROUP_NOT_FOUND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_TOPIC_LOCK_GROUP_NOT_FOUND);
             return false;
         }
 
         case -2: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_INVALID);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_TOPIC_LOCK_INVALID);
             return false;
         }
 
         case -3: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_PERMISSIONS);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_TOPIC_LOCK_PERMISSIONS);
             return false;
         }
 
         case -4: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_DISCONNECTED);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_TOPIC_LOCK_DISCONNECTED);
             return false;
         }
 
         case -5: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_FAIL_SET);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_TOPIC_LOCK_FAIL_SET);
             return false;
         }
 
         case -6: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_FAIL_SEND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_TOPIC_LOCK_FAIL_SEND);
             return false;
         }
     }
@@ -4449,8 +4449,8 @@ bool tox_group_founder_set_topic_lock(Tox *tox, uint32_t group_number, Tox_Group
     return false;
 }
 
-bool tox_group_founder_set_voice_state(Tox *tox, uint32_t group_number, Tox_Group_Voice_State voice_state,
-                                       Tox_Err_Group_Founder_Set_Voice_State *error)
+bool tox_group_set_voice_state(Tox *tox, uint32_t group_number, Tox_Group_Voice_State voice_state,
+                               Tox_Err_Group_Set_Voice_State *error)
 {
     assert(tox != nullptr);
 
@@ -4460,32 +4460,32 @@ bool tox_group_founder_set_voice_state(Tox *tox, uint32_t group_number, Tox_Grou
 
     switch (ret) {
         case 0: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_OK);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_VOICE_STATE_OK);
             return true;
         }
 
         case -1: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_GROUP_NOT_FOUND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_VOICE_STATE_GROUP_NOT_FOUND);
             return false;
         }
 
         case -2: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_PERMISSIONS);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_VOICE_STATE_PERMISSIONS);
             return false;
         }
 
         case -3: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_DISCONNECTED);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_VOICE_STATE_DISCONNECTED);
             return false;
         }
 
         case -4: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_FAIL_SET);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_VOICE_STATE_FAIL_SET);
             return false;
         }
 
         case -5: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_FAIL_SEND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_VOICE_STATE_FAIL_SEND);
             return false;
         }
     }
@@ -4496,8 +4496,8 @@ bool tox_group_founder_set_voice_state(Tox *tox, uint32_t group_number, Tox_Grou
     return false;
 }
 
-bool tox_group_founder_set_peer_limit(Tox *tox, uint32_t group_number, uint16_t peer_limit,
-                                      Tox_Err_Group_Founder_Set_Peer_Limit *error)
+bool tox_group_set_peer_limit(Tox *tox, uint32_t group_number, uint16_t peer_limit,
+                              Tox_Err_Group_Set_Peer_Limit *error)
 {
     assert(tox != nullptr);
 
@@ -4505,13 +4505,13 @@ bool tox_group_founder_set_peer_limit(Tox *tox, uint32_t group_number, uint16_t 
     GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
 
     if (chat == nullptr) {
-        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_GROUP_NOT_FOUND);
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PEER_LIMIT_GROUP_NOT_FOUND);
         tox_unlock(tox);
         return false;
     }
 
     if (chat->connection_state == CS_DISCONNECTED) {
-        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_DISCONNECTED);
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PEER_LIMIT_DISCONNECTED);
         tox_unlock(tox);
         return false;
     }
@@ -4521,22 +4521,22 @@ bool tox_group_founder_set_peer_limit(Tox *tox, uint32_t group_number, uint16_t 
 
     switch (ret) {
         case 0: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PEER_LIMIT_OK);
             return true;
         }
 
         case -1: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_PERMISSIONS);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PEER_LIMIT_PERMISSIONS);
             return false;
         }
 
         case -2: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_FAIL_SET);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PEER_LIMIT_FAIL_SET);
             return false;
         }
 
         case -3: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_FAIL_SEND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_PEER_LIMIT_FAIL_SEND);
             return false;
         }
     }
@@ -4587,8 +4587,8 @@ bool tox_group_set_ignore(Tox *tox, uint32_t group_number, uint32_t peer_id, boo
     return false;
 }
 
-bool tox_group_mod_set_role(Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Group_Role role,
-                            Tox_Err_Group_Mod_Set_Role *error)
+bool tox_group_set_role(Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Group_Role role,
+                        Tox_Err_Group_Set_Role *error)
 {
     assert(tox != nullptr);
 
@@ -4598,37 +4598,37 @@ bool tox_group_mod_set_role(Tox *tox, uint32_t group_number, uint32_t peer_id, T
 
     switch (ret) {
         case 0: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_SET_ROLE_OK);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_ROLE_OK);
             return true;
         }
 
         case -1: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_SET_ROLE_GROUP_NOT_FOUND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_ROLE_GROUP_NOT_FOUND);
             return false;
         }
 
         case -2: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_SET_ROLE_PEER_NOT_FOUND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_ROLE_PEER_NOT_FOUND);
             return false;
         }
 
         case -3: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_SET_ROLE_PERMISSIONS);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_ROLE_PERMISSIONS);
             return false;
         }
 
         case -4: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_SET_ROLE_ASSIGNMENT);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_ROLE_ASSIGNMENT);
             return false;
         }
 
         case -5: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_SET_ROLE_FAIL_ACTION);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_ROLE_FAIL_ACTION);
             return false;
         }
 
         case -6: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_SET_ROLE_SELF);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SET_ROLE_SELF);
             return false;
         }
     }
@@ -4639,8 +4639,8 @@ bool tox_group_mod_set_role(Tox *tox, uint32_t group_number, uint32_t peer_id, T
     return false;
 }
 
-bool tox_group_mod_kick_peer(const Tox *tox, uint32_t group_number, uint32_t peer_id,
-                             Tox_Err_Group_Mod_Kick_Peer *error)
+bool tox_group_kick_peer(const Tox *tox, uint32_t group_number, uint32_t peer_id,
+                         Tox_Err_Group_Kick_Peer *error)
 {
     assert(tox != nullptr);
 
@@ -4650,37 +4650,37 @@ bool tox_group_mod_kick_peer(const Tox *tox, uint32_t group_number, uint32_t pee
 
     switch (ret) {
         case 0: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_KICK_PEER_OK);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_KICK_PEER_OK);
             return true;
         }
 
         case -1: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_KICK_PEER_GROUP_NOT_FOUND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_KICK_PEER_GROUP_NOT_FOUND);
             return false;
         }
 
         case -2: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_KICK_PEER_PEER_NOT_FOUND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_KICK_PEER_PEER_NOT_FOUND);
             return false;
         }
 
         case -3: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_KICK_PEER_PERMISSIONS);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_KICK_PEER_PERMISSIONS);
             return false;
         }
 
         case -4: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_KICK_PEER_FAIL_ACTION);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_KICK_PEER_FAIL_ACTION);
             return false;
         }
 
         case -5: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_KICK_PEER_FAIL_SEND);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_KICK_PEER_FAIL_SEND);
             return false;
         }
 
         case -6: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_MOD_KICK_PEER_SELF);
+            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_KICK_PEER_SELF);
             return false;
         }
     }

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -4402,7 +4402,7 @@ size_t tox_group_get_password_size(const Tox *tox, Tox_Group_Number group_number
  * The data received is equal to the data received by the last
  * `group_password` callback.
  *
- * @see the `Group chat founder controls` section for the respective set function.
+ * @see the `Group chat Founder controls` section for the respective set function.
  *
  * @param password A valid memory region large enough to store the group password.
  *   If this parameter is NULL, this function call has no effect.
@@ -5079,56 +5079,56 @@ void tox_callback_group_join_fail(Tox *tox, tox_group_join_fail_cb *callback);
 
 /*******************************************************************************
  *
- * :: Group chat founder controls (these only work for the group founder)
+ * :: Group chat Founder controls
  *
  ******************************************************************************/
 
-typedef enum Tox_Err_Group_Founder_Set_Password {
+typedef enum Tox_Err_Group_Set_Password {
 
     /**
      * The function returned successfully.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK,
+    TOX_ERR_GROUP_SET_PASSWORD_OK,
 
     /**
      * The group number passed did not designate a valid group.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_GROUP_NOT_FOUND,
+    TOX_ERR_GROUP_SET_PASSWORD_GROUP_NOT_FOUND,
 
     /**
      * The caller does not have the required permissions to set the password.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_PERMISSIONS,
+    TOX_ERR_GROUP_SET_PASSWORD_PERMISSIONS,
 
     /**
      * Password length exceeded TOX_GROUP_MAX_PASSWORD_SIZE.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_TOO_LONG,
+    TOX_ERR_GROUP_SET_PASSWORD_TOO_LONG,
 
     /**
      * The packet failed to send.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_FAIL_SEND,
+    TOX_ERR_GROUP_SET_PASSWORD_FAIL_SEND,
 
     /**
      * The function failed to allocate enough memory for the operation.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_MALLOC,
+    TOX_ERR_GROUP_SET_PASSWORD_MALLOC,
 
     /**
      * The group is disconnected.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_DISCONNECTED,
+    TOX_ERR_GROUP_SET_PASSWORD_DISCONNECTED,
 
-} Tox_Err_Group_Founder_Set_Password;
+} Tox_Err_Group_Set_Password;
 
-const char *tox_err_group_founder_set_password_to_string(Tox_Err_Group_Founder_Set_Password value);
+const char *tox_err_group_set_password_to_string(Tox_Err_Group_Set_Password value);
 
 /**
  * Set or unset the group password.
  *
- * This function sets the groups password, creates a new group shared state including the change,
- * and distributes it to the rest of the group.
+ * This function allows Founders to set or unset a group password. It will create a new
+ * group shared state including the change and distribute it to the rest of the group.
  *
  * @param group_number The group number of the group for which we wish to set the password.
  * @param password The password we want to set. Set password to NULL to unset the password.
@@ -5136,58 +5136,58 @@ const char *tox_err_group_founder_set_password_to_string(Tox_Err_Group_Founder_S
  *
  * @return true on success.
  */
-bool tox_group_founder_set_password(
+bool tox_group_set_password(
     Tox *tox, Tox_Group_Number group_number,
     const uint8_t password[], size_t length,
-    Tox_Err_Group_Founder_Set_Password *error);
+    Tox_Err_Group_Set_Password *error);
 
-typedef enum Tox_Err_Group_Founder_Set_Topic_Lock {
+typedef enum Tox_Err_Group_Set_Topic_Lock {
 
     /**
      * The function returned successfully.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK,
+    TOX_ERR_GROUP_SET_TOPIC_LOCK_OK,
 
     /**
      * The group number passed did not designate a valid group.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_GROUP_NOT_FOUND,
+    TOX_ERR_GROUP_SET_TOPIC_LOCK_GROUP_NOT_FOUND,
 
     /**
      * Tox_Group_Topic_Lock is an invalid type.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_INVALID,
+    TOX_ERR_GROUP_SET_TOPIC_LOCK_INVALID,
 
     /**
      * The caller does not have the required permissions to set the topic lock.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_PERMISSIONS,
+    TOX_ERR_GROUP_SET_TOPIC_LOCK_PERMISSIONS,
 
     /**
      * The topic lock could not be set. This may occur due to an error related to
      * cryptographic signing of the new shared state.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_FAIL_SET,
+    TOX_ERR_GROUP_SET_TOPIC_LOCK_FAIL_SET,
 
     /**
      * The packet failed to send.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_FAIL_SEND,
+    TOX_ERR_GROUP_SET_TOPIC_LOCK_FAIL_SEND,
 
     /**
      * The group is disconnected.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_DISCONNECTED,
+    TOX_ERR_GROUP_SET_TOPIC_LOCK_DISCONNECTED,
 
-} Tox_Err_Group_Founder_Set_Topic_Lock;
+} Tox_Err_Group_Set_Topic_Lock;
 
-const char *tox_err_group_founder_set_topic_lock_to_string(Tox_Err_Group_Founder_Set_Topic_Lock value);
+const char *tox_err_group_set_topic_lock_to_string(Tox_Err_Group_Set_Topic_Lock value);
 
 /**
  * Set the group topic lock state.
  *
- * This function sets the group's topic lock state to enabled or disabled, creates a new shared
- * state including the change, and distributes it to the rest of the group.
+ * This function allows Founders to enable or disable the group's topic lock. It will create a
+ * new shared state including the change and distribute it to the rest of the group.
  *
  * When the topic lock is enabled, only the group founder and moderators may set the topic.
  * When disabled, all peers except those with the observer role may set the topic.
@@ -5197,51 +5197,51 @@ const char *tox_err_group_founder_set_topic_lock_to_string(Tox_Err_Group_Founder
  *
  * @return true on success.
  */
-bool tox_group_founder_set_topic_lock(Tox *tox, Tox_Group_Number group_number, Tox_Group_Topic_Lock topic_lock,
-                                      Tox_Err_Group_Founder_Set_Topic_Lock *error);
+bool tox_group_set_topic_lock(Tox *tox, Tox_Group_Number group_number, Tox_Group_Topic_Lock topic_lock,
+                              Tox_Err_Group_Set_Topic_Lock *error);
 
-typedef enum Tox_Err_Group_Founder_Set_Voice_State {
+typedef enum Tox_Err_Group_Set_Voice_State {
 
     /**
      * The function returned successfully.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_OK,
+    TOX_ERR_GROUP_SET_VOICE_STATE_OK,
 
     /**
      * The group number passed did not designate a valid group.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_GROUP_NOT_FOUND,
+    TOX_ERR_GROUP_SET_VOICE_STATE_GROUP_NOT_FOUND,
 
     /**
      * The caller does not have the required permissions to set the privacy state.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_PERMISSIONS,
+    TOX_ERR_GROUP_SET_VOICE_STATE_PERMISSIONS,
 
     /**
      * The voice state could not be set. This may occur due to an error related to
      * cryptographic signing of the new shared state.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_FAIL_SET,
+    TOX_ERR_GROUP_SET_VOICE_STATE_FAIL_SET,
 
     /**
      * The packet failed to send.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_FAIL_SEND,
+    TOX_ERR_GROUP_SET_VOICE_STATE_FAIL_SEND,
 
     /**
      * The group is disconnected.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_DISCONNECTED,
+    TOX_ERR_GROUP_SET_VOICE_STATE_DISCONNECTED,
 
-} Tox_Err_Group_Founder_Set_Voice_State;
+} Tox_Err_Group_Set_Voice_State;
 
-const char *tox_err_group_founder_set_voice_state_to_string(Tox_Err_Group_Founder_Set_Voice_State value);
+const char *tox_err_group_set_voice_state_to_string(Tox_Err_Group_Set_Voice_State value);
 
 /**
  * Set the group voice state.
  *
- * This function sets the group's voice state, creates a new group shared state
- * including the change, and distributes it to the rest of the group.
+ * This function allows Founders to set the group's voice state. It will create a new group
+ * shared state including the change and distribute it to the rest of the group.
  *
  * If an attempt is made to set the voice state to the same state that the group is already
  * in, the function call will be successful and no action will be taken.
@@ -5251,51 +5251,51 @@ const char *tox_err_group_founder_set_voice_state_to_string(Tox_Err_Group_Founde
  *
  * @return true on success.
  */
-bool tox_group_founder_set_voice_state(Tox *tox, Tox_Group_Number group_number, Tox_Group_Voice_State voice_state,
-                                       Tox_Err_Group_Founder_Set_Voice_State *error);
+bool tox_group_set_voice_state(Tox *tox, Tox_Group_Number group_number, Tox_Group_Voice_State voice_state,
+                               Tox_Err_Group_Set_Voice_State *error);
 
-typedef enum Tox_Err_Group_Founder_Set_Privacy_State {
+typedef enum Tox_Err_Group_Set_Privacy_State {
 
     /**
      * The function returned successfully.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK,
+    TOX_ERR_GROUP_SET_PRIVACY_STATE_OK,
 
     /**
      * The group number passed did not designate a valid group.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_GROUP_NOT_FOUND,
+    TOX_ERR_GROUP_SET_PRIVACY_STATE_GROUP_NOT_FOUND,
 
     /**
      * The caller does not have the required permissions to set the privacy state.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_PERMISSIONS,
+    TOX_ERR_GROUP_SET_PRIVACY_STATE_PERMISSIONS,
 
     /**
      * The privacy state could not be set. This may occur due to an error related to
      * cryptographic signing of the new shared state.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_FAIL_SET,
+    TOX_ERR_GROUP_SET_PRIVACY_STATE_FAIL_SET,
 
     /**
      * The packet failed to send.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_FAIL_SEND,
+    TOX_ERR_GROUP_SET_PRIVACY_STATE_FAIL_SEND,
 
     /**
      * The group is disconnected.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_DISCONNECTED,
+    TOX_ERR_GROUP_SET_PRIVACY_STATE_DISCONNECTED,
 
-} Tox_Err_Group_Founder_Set_Privacy_State;
+} Tox_Err_Group_Set_Privacy_State;
 
-const char *tox_err_group_founder_set_privacy_state_to_string(Tox_Err_Group_Founder_Set_Privacy_State value);
+const char *tox_err_group_set_privacy_state_to_string(Tox_Err_Group_Set_Privacy_State value);
 
 /**
  * Set the group privacy state.
  *
- * This function sets the group's privacy state, creates a new group shared state
- * including the change, and distributes it to the rest of the group.
+ * This function allows Founders to set the group's privacy state. It will create a new group
+ * shared state including the change and distribute it to the rest of the group.
  *
  * If an attempt is made to set the privacy state to the same state that the group is already
  * in, the function call will be successful and no action will be taken.
@@ -5305,63 +5305,64 @@ const char *tox_err_group_founder_set_privacy_state_to_string(Tox_Err_Group_Foun
  *
  * @return true on success.
  */
-bool tox_group_founder_set_privacy_state(Tox *tox, Tox_Group_Number group_number, Tox_Group_Privacy_State privacy_state,
-        Tox_Err_Group_Founder_Set_Privacy_State *error);
+bool tox_group_set_privacy_state(Tox *tox, Tox_Group_Number group_number, Tox_Group_Privacy_State privacy_state,
+                                 Tox_Err_Group_Set_Privacy_State *error);
 
-typedef enum Tox_Err_Group_Founder_Set_Peer_Limit {
+typedef enum Tox_Err_Group_Set_Peer_Limit {
 
     /**
      * The function returned successfully.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK,
+    TOX_ERR_GROUP_SET_PEER_LIMIT_OK,
 
     /**
      * The group number passed did not designate a valid group.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_GROUP_NOT_FOUND,
+    TOX_ERR_GROUP_SET_PEER_LIMIT_GROUP_NOT_FOUND,
 
     /**
      * The caller does not have the required permissions to set the peer limit.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_PERMISSIONS,
+    TOX_ERR_GROUP_SET_PEER_LIMIT_PERMISSIONS,
 
     /**
      * The peer limit could not be set. This may occur due to an error related to
      * cryptographic signing of the new shared state.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_FAIL_SET,
+    TOX_ERR_GROUP_SET_PEER_LIMIT_FAIL_SET,
 
     /**
      * The packet failed to send.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_FAIL_SEND,
+    TOX_ERR_GROUP_SET_PEER_LIMIT_FAIL_SEND,
 
     /**
      * The group is disconnected.
      */
-    TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_DISCONNECTED,
+    TOX_ERR_GROUP_SET_PEER_LIMIT_DISCONNECTED,
 
-} Tox_Err_Group_Founder_Set_Peer_Limit;
+} Tox_Err_Group_Set_Peer_Limit;
 
-const char *tox_err_group_founder_set_peer_limit_to_string(Tox_Err_Group_Founder_Set_Peer_Limit value);
+const char *tox_err_group_set_peer_limit_to_string(Tox_Err_Group_Set_Peer_Limit value);
 
 /**
  * Set the group peer limit.
  *
- * This function sets a limit for the number of peers who may be in the group, creates a new
- * group shared state including the change, and distributes it to the rest of the group.
+ * This function allows Founders to set a limit for the number of peers who may be in the
+ * group. It will create a new group shared state including the change and distribute it to the
+ * rest of the group.
  *
  * @param group_number The group number of the group for which we wish to set the peer limit.
  * @param peer_limit The maximum number of peers to allow in the group.
  *
  * @return true on success.
  */
-bool tox_group_founder_set_peer_limit(Tox *tox, Tox_Group_Number group_number, uint16_t peer_limit,
-                                      Tox_Err_Group_Founder_Set_Peer_Limit *error);
+bool tox_group_set_peer_limit(Tox *tox, Tox_Group_Number group_number, uint16_t peer_limit,
+                              Tox_Err_Group_Set_Peer_Limit *error);
 
 /*******************************************************************************
  *
- * :: Group chat moderation
+ * :: Group chat moderation controls
  *
  ******************************************************************************/
 
@@ -5403,55 +5404,59 @@ const char *tox_err_group_set_ignore_to_string(Tox_Err_Group_Set_Ignore value);
 bool tox_group_set_ignore(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, bool ignore,
                           Tox_Err_Group_Set_Ignore *error);
 
-typedef enum Tox_Err_Group_Mod_Set_Role {
+typedef enum Tox_Err_Group_Set_Role {
 
     /**
      * The function returned successfully.
      */
-    TOX_ERR_GROUP_MOD_SET_ROLE_OK,
+    TOX_ERR_GROUP_SET_ROLE_OK,
 
     /**
      * The group number passed did not designate a valid group.
      */
-    TOX_ERR_GROUP_MOD_SET_ROLE_GROUP_NOT_FOUND,
+    TOX_ERR_GROUP_SET_ROLE_GROUP_NOT_FOUND,
 
     /**
      * The ID passed did not designate a valid peer. Note: you cannot set your own role.
      */
-    TOX_ERR_GROUP_MOD_SET_ROLE_PEER_NOT_FOUND,
+    TOX_ERR_GROUP_SET_ROLE_PEER_NOT_FOUND,
 
     /**
      * The caller does not have the required permissions for this action.
      */
-    TOX_ERR_GROUP_MOD_SET_ROLE_PERMISSIONS,
+    TOX_ERR_GROUP_SET_ROLE_PERMISSIONS,
 
     /**
      * The role assignment is invalid. This will occur if you try to set a peer's role to
      * the role they already have.
      */
-    TOX_ERR_GROUP_MOD_SET_ROLE_ASSIGNMENT,
+    TOX_ERR_GROUP_SET_ROLE_ASSIGNMENT,
 
     /**
      * The role was not successfully set. This may occur if the packet failed to send, or
      * if the role limit has been reached.
      */
-    TOX_ERR_GROUP_MOD_SET_ROLE_FAIL_ACTION,
+    TOX_ERR_GROUP_SET_ROLE_FAIL_ACTION,
 
     /**
      * The caller attempted to set their own role.
      */
-    TOX_ERR_GROUP_MOD_SET_ROLE_SELF,
+    TOX_ERR_GROUP_SET_ROLE_SELF,
 
-} Tox_Err_Group_Mod_Set_Role;
+} Tox_Err_Group_Set_Role;
 
-const char *tox_err_group_mod_set_role_to_string(Tox_Err_Group_Mod_Set_Role value);
+const char *tox_err_group_set_role_to_string(Tox_Err_Group_Set_Role value);
 
 /**
  * Set a peer's role.
  *
  * This function will first remove the peer's previous role and then assign them a new role.
  * It will also send a packet to the rest of the group, requesting that they perform
- * the role reassignment. Note: peers cannot be set to the founder role.
+ * the role reassignment.
+ *
+ * Only Founders may promote peers to the Moderator role, and only Founders and Moderators may
+ * set peers to the Observer or User role. Moderators may not set the role of other Moderators
+ * or the Founder. Peers may not be promoted to the Founder role.
  *
  * @param group_number The group number of the group the in which you wish set the peer's role.
  * @param peer_id The ID of the peer whose role you wish to set.
@@ -5459,64 +5464,65 @@ const char *tox_err_group_mod_set_role_to_string(Tox_Err_Group_Mod_Set_Role valu
  *
  * @return true on success.
  */
-bool tox_group_mod_set_role(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Group_Role role,
-                            Tox_Err_Group_Mod_Set_Role *error);
+bool tox_group_set_role(Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Group_Role role,
+                        Tox_Err_Group_Set_Role *error);
 
-typedef enum Tox_Err_Group_Mod_Kick_Peer {
+typedef enum Tox_Err_Group_Kick_Peer {
 
     /**
      * The function returned successfully.
      */
-    TOX_ERR_GROUP_MOD_KICK_PEER_OK,
+    TOX_ERR_GROUP_KICK_PEER_OK,
 
     /**
      * The group number passed did not designate a valid group.
      */
-    TOX_ERR_GROUP_MOD_KICK_PEER_GROUP_NOT_FOUND,
+    TOX_ERR_GROUP_KICK_PEER_GROUP_NOT_FOUND,
 
     /**
      * The ID passed did not designate a valid peer.
      */
-    TOX_ERR_GROUP_MOD_KICK_PEER_PEER_NOT_FOUND,
+    TOX_ERR_GROUP_KICK_PEER_PEER_NOT_FOUND,
 
     /**
      * The caller does not have the required permissions for this action.
      */
-    TOX_ERR_GROUP_MOD_KICK_PEER_PERMISSIONS,
+    TOX_ERR_GROUP_KICK_PEER_PERMISSIONS,
 
     /**
      * The peer could not be kicked from the group.
      */
-    TOX_ERR_GROUP_MOD_KICK_PEER_FAIL_ACTION,
+    TOX_ERR_GROUP_KICK_PEER_FAIL_ACTION,
 
     /**
      * The packet failed to send.
      */
-    TOX_ERR_GROUP_MOD_KICK_PEER_FAIL_SEND,
+    TOX_ERR_GROUP_KICK_PEER_FAIL_SEND,
 
     /**
      * The caller attempted to set their own role.
      */
-    TOX_ERR_GROUP_MOD_KICK_PEER_SELF,
+    TOX_ERR_GROUP_KICK_PEER_SELF,
 
-} Tox_Err_Group_Mod_Kick_Peer;
+} Tox_Err_Group_Kick_Peer;
 
-const char *tox_err_group_mod_kick_peer_to_string(Tox_Err_Group_Mod_Kick_Peer value);
+const char *tox_err_group_kick_peer_to_string(Tox_Err_Group_Kick_Peer value);
 
 /**
  * Kick a peer.
  *
- * This function will remove a peer from the caller's peer list and send a packet to all
- * group members requesting them to do the same. Note: This function will not trigger
- * the `group_peer_exit` event for the caller.
+ * This function allows peers with the Founder or Moderator role to silently instruct
+ * all other peers in the group to remove a particular peer from their peer list.
+ *
+ * Note: This function will not trigger the `group_peer_exit` event for the caller.
  *
  * @param group_number The group number of the group the action is intended for.
  * @param peer_id The ID of the peer who will be kicked.
  *
  * @return true on success.
  */
-bool tox_group_mod_kick_peer(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
-                             Tox_Err_Group_Mod_Kick_Peer *error);
+bool tox_group_kick_peer(const Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id,
+                         Tox_Err_Group_Kick_Peer *error);
 
 /**
  * Represents moderation events. These should be used with the `group_moderation` event.

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -1505,131 +1505,131 @@ const char *tox_group_join_fail_to_string(Tox_Group_Join_Fail value)
 
     return "<invalid Tox_Group_Join_Fail>";
 }
-const char *tox_err_group_founder_set_password_to_string(Tox_Err_Group_Founder_Set_Password value)
+const char *tox_err_group_set_password_to_string(Tox_Err_Group_Set_Password value)
 {
     switch (value) {
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_OK";
+        case TOX_ERR_GROUP_SET_PASSWORD_OK:
+            return "TOX_ERR_GROUP_SET_PASSWORD_OK";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_GROUP_NOT_FOUND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_GROUP_NOT_FOUND";
+        case TOX_ERR_GROUP_SET_PASSWORD_GROUP_NOT_FOUND:
+            return "TOX_ERR_GROUP_SET_PASSWORD_GROUP_NOT_FOUND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_PERMISSIONS:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_PERMISSIONS";
+        case TOX_ERR_GROUP_SET_PASSWORD_PERMISSIONS:
+            return "TOX_ERR_GROUP_SET_PASSWORD_PERMISSIONS";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_TOO_LONG:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_TOO_LONG";
+        case TOX_ERR_GROUP_SET_PASSWORD_TOO_LONG:
+            return "TOX_ERR_GROUP_SET_PASSWORD_TOO_LONG";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_FAIL_SEND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_FAIL_SEND";
+        case TOX_ERR_GROUP_SET_PASSWORD_FAIL_SEND:
+            return "TOX_ERR_GROUP_SET_PASSWORD_FAIL_SEND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_MALLOC:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_MALLOC";
+        case TOX_ERR_GROUP_SET_PASSWORD_MALLOC:
+            return "TOX_ERR_GROUP_SET_PASSWORD_MALLOC";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_DISCONNECTED:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PASSWORD_DISCONNECTED";
+        case TOX_ERR_GROUP_SET_PASSWORD_DISCONNECTED:
+            return "TOX_ERR_GROUP_SET_PASSWORD_DISCONNECTED";
     }
 
-    return "<invalid Tox_Err_Group_Founder_Set_Password>";
+    return "<invalid Tox_Err_Group_Set_Password>";
 }
-const char *tox_err_group_founder_set_topic_lock_to_string(Tox_Err_Group_Founder_Set_Topic_Lock value)
+const char *tox_err_group_set_topic_lock_to_string(Tox_Err_Group_Set_Topic_Lock value)
 {
     switch (value) {
-        case TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK:
-            return "TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_OK";
+        case TOX_ERR_GROUP_SET_TOPIC_LOCK_OK:
+            return "TOX_ERR_GROUP_SET_TOPIC_LOCK_OK";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_GROUP_NOT_FOUND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_GROUP_NOT_FOUND";
+        case TOX_ERR_GROUP_SET_TOPIC_LOCK_GROUP_NOT_FOUND:
+            return "TOX_ERR_GROUP_SET_TOPIC_LOCK_GROUP_NOT_FOUND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_INVALID:
-            return "TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_INVALID";
+        case TOX_ERR_GROUP_SET_TOPIC_LOCK_INVALID:
+            return "TOX_ERR_GROUP_SET_TOPIC_LOCK_INVALID";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_PERMISSIONS:
-            return "TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_PERMISSIONS";
+        case TOX_ERR_GROUP_SET_TOPIC_LOCK_PERMISSIONS:
+            return "TOX_ERR_GROUP_SET_TOPIC_LOCK_PERMISSIONS";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_FAIL_SET:
-            return "TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_FAIL_SET";
+        case TOX_ERR_GROUP_SET_TOPIC_LOCK_FAIL_SET:
+            return "TOX_ERR_GROUP_SET_TOPIC_LOCK_FAIL_SET";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_FAIL_SEND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_FAIL_SEND";
+        case TOX_ERR_GROUP_SET_TOPIC_LOCK_FAIL_SEND:
+            return "TOX_ERR_GROUP_SET_TOPIC_LOCK_FAIL_SEND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_DISCONNECTED:
-            return "TOX_ERR_GROUP_FOUNDER_SET_TOPIC_LOCK_DISCONNECTED";
+        case TOX_ERR_GROUP_SET_TOPIC_LOCK_DISCONNECTED:
+            return "TOX_ERR_GROUP_SET_TOPIC_LOCK_DISCONNECTED";
     }
 
-    return "<invalid Tox_Err_Group_Founder_Set_Topic_Lock>";
+    return "<invalid Tox_Err_Group_Set_Topic_Lock>";
 }
-const char *tox_err_group_founder_set_voice_state_to_string(Tox_Err_Group_Founder_Set_Voice_State value)
+const char *tox_err_group_set_voice_state_to_string(Tox_Err_Group_Set_Voice_State value)
 {
     switch (value) {
-        case TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_OK:
-            return "TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_OK";
+        case TOX_ERR_GROUP_SET_VOICE_STATE_OK:
+            return "TOX_ERR_GROUP_SET_VOICE_STATE_OK";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_GROUP_NOT_FOUND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_GROUP_NOT_FOUND";
+        case TOX_ERR_GROUP_SET_VOICE_STATE_GROUP_NOT_FOUND:
+            return "TOX_ERR_GROUP_SET_VOICE_STATE_GROUP_NOT_FOUND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_PERMISSIONS:
-            return "TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_PERMISSIONS";
+        case TOX_ERR_GROUP_SET_VOICE_STATE_PERMISSIONS:
+            return "TOX_ERR_GROUP_SET_VOICE_STATE_PERMISSIONS";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_FAIL_SET:
-            return "TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_FAIL_SET";
+        case TOX_ERR_GROUP_SET_VOICE_STATE_FAIL_SET:
+            return "TOX_ERR_GROUP_SET_VOICE_STATE_FAIL_SET";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_FAIL_SEND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_FAIL_SEND";
+        case TOX_ERR_GROUP_SET_VOICE_STATE_FAIL_SEND:
+            return "TOX_ERR_GROUP_SET_VOICE_STATE_FAIL_SEND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_DISCONNECTED:
-            return "TOX_ERR_GROUP_FOUNDER_SET_VOICE_STATE_DISCONNECTED";
+        case TOX_ERR_GROUP_SET_VOICE_STATE_DISCONNECTED:
+            return "TOX_ERR_GROUP_SET_VOICE_STATE_DISCONNECTED";
     }
 
-    return "<invalid Tox_Err_Group_Founder_Set_Voice_State>";
+    return "<invalid Tox_Err_Group_Set_Voice_State>";
 }
-const char *tox_err_group_founder_set_privacy_state_to_string(Tox_Err_Group_Founder_Set_Privacy_State value)
+const char *tox_err_group_set_privacy_state_to_string(Tox_Err_Group_Set_Privacy_State value)
 {
     switch (value) {
-        case TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_OK";
+        case TOX_ERR_GROUP_SET_PRIVACY_STATE_OK:
+            return "TOX_ERR_GROUP_SET_PRIVACY_STATE_OK";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_GROUP_NOT_FOUND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_GROUP_NOT_FOUND";
+        case TOX_ERR_GROUP_SET_PRIVACY_STATE_GROUP_NOT_FOUND:
+            return "TOX_ERR_GROUP_SET_PRIVACY_STATE_GROUP_NOT_FOUND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_PERMISSIONS:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_PERMISSIONS";
+        case TOX_ERR_GROUP_SET_PRIVACY_STATE_PERMISSIONS:
+            return "TOX_ERR_GROUP_SET_PRIVACY_STATE_PERMISSIONS";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_FAIL_SET:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_FAIL_SET";
+        case TOX_ERR_GROUP_SET_PRIVACY_STATE_FAIL_SET:
+            return "TOX_ERR_GROUP_SET_PRIVACY_STATE_FAIL_SET";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_FAIL_SEND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_FAIL_SEND";
+        case TOX_ERR_GROUP_SET_PRIVACY_STATE_FAIL_SEND:
+            return "TOX_ERR_GROUP_SET_PRIVACY_STATE_FAIL_SEND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_DISCONNECTED:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PRIVACY_STATE_DISCONNECTED";
+        case TOX_ERR_GROUP_SET_PRIVACY_STATE_DISCONNECTED:
+            return "TOX_ERR_GROUP_SET_PRIVACY_STATE_DISCONNECTED";
     }
 
-    return "<invalid Tox_Err_Group_Founder_Set_Privacy_State>";
+    return "<invalid Tox_Err_Group_Set_Privacy_State>";
 }
-const char *tox_err_group_founder_set_peer_limit_to_string(Tox_Err_Group_Founder_Set_Peer_Limit value)
+const char *tox_err_group_set_peer_limit_to_string(Tox_Err_Group_Set_Peer_Limit value)
 {
     switch (value) {
-        case TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_OK";
+        case TOX_ERR_GROUP_SET_PEER_LIMIT_OK:
+            return "TOX_ERR_GROUP_SET_PEER_LIMIT_OK";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_GROUP_NOT_FOUND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_GROUP_NOT_FOUND";
+        case TOX_ERR_GROUP_SET_PEER_LIMIT_GROUP_NOT_FOUND:
+            return "TOX_ERR_GROUP_SET_PEER_LIMIT_GROUP_NOT_FOUND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_PERMISSIONS:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_PERMISSIONS";
+        case TOX_ERR_GROUP_SET_PEER_LIMIT_PERMISSIONS:
+            return "TOX_ERR_GROUP_SET_PEER_LIMIT_PERMISSIONS";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_FAIL_SET:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_FAIL_SET";
+        case TOX_ERR_GROUP_SET_PEER_LIMIT_FAIL_SET:
+            return "TOX_ERR_GROUP_SET_PEER_LIMIT_FAIL_SET";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_FAIL_SEND:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_FAIL_SEND";
+        case TOX_ERR_GROUP_SET_PEER_LIMIT_FAIL_SEND:
+            return "TOX_ERR_GROUP_SET_PEER_LIMIT_FAIL_SEND";
 
-        case TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_DISCONNECTED:
-            return "TOX_ERR_GROUP_FOUNDER_SET_PEER_LIMIT_DISCONNECTED";
+        case TOX_ERR_GROUP_SET_PEER_LIMIT_DISCONNECTED:
+            return "TOX_ERR_GROUP_SET_PEER_LIMIT_DISCONNECTED";
     }
 
-    return "<invalid Tox_Err_Group_Founder_Set_Peer_Limit>";
+    return "<invalid Tox_Err_Group_Set_Peer_Limit>";
 }
 const char *tox_err_group_set_ignore_to_string(Tox_Err_Group_Set_Ignore value)
 {
@@ -1649,59 +1649,59 @@ const char *tox_err_group_set_ignore_to_string(Tox_Err_Group_Set_Ignore value)
 
     return "<invalid Tox_Err_Group_Set_Ignore>";
 }
-const char *tox_err_group_mod_set_role_to_string(Tox_Err_Group_Mod_Set_Role value)
+const char *tox_err_group_set_role_to_string(Tox_Err_Group_Set_Role value)
 {
     switch (value) {
-        case TOX_ERR_GROUP_MOD_SET_ROLE_OK:
-            return "TOX_ERR_GROUP_MOD_SET_ROLE_OK";
+        case TOX_ERR_GROUP_SET_ROLE_OK:
+            return "TOX_ERR_GROUP_SET_ROLE_OK";
 
-        case TOX_ERR_GROUP_MOD_SET_ROLE_GROUP_NOT_FOUND:
-            return "TOX_ERR_GROUP_MOD_SET_ROLE_GROUP_NOT_FOUND";
+        case TOX_ERR_GROUP_SET_ROLE_GROUP_NOT_FOUND:
+            return "TOX_ERR_GROUP_SET_ROLE_GROUP_NOT_FOUND";
 
-        case TOX_ERR_GROUP_MOD_SET_ROLE_PEER_NOT_FOUND:
-            return "TOX_ERR_GROUP_MOD_SET_ROLE_PEER_NOT_FOUND";
+        case TOX_ERR_GROUP_SET_ROLE_PEER_NOT_FOUND:
+            return "TOX_ERR_GROUP_SET_ROLE_PEER_NOT_FOUND";
 
-        case TOX_ERR_GROUP_MOD_SET_ROLE_PERMISSIONS:
-            return "TOX_ERR_GROUP_MOD_SET_ROLE_PERMISSIONS";
+        case TOX_ERR_GROUP_SET_ROLE_PERMISSIONS:
+            return "TOX_ERR_GROUP_SET_ROLE_PERMISSIONS";
 
-        case TOX_ERR_GROUP_MOD_SET_ROLE_ASSIGNMENT:
-            return "TOX_ERR_GROUP_MOD_SET_ROLE_ASSIGNMENT";
+        case TOX_ERR_GROUP_SET_ROLE_ASSIGNMENT:
+            return "TOX_ERR_GROUP_SET_ROLE_ASSIGNMENT";
 
-        case TOX_ERR_GROUP_MOD_SET_ROLE_FAIL_ACTION:
-            return "TOX_ERR_GROUP_MOD_SET_ROLE_FAIL_ACTION";
+        case TOX_ERR_GROUP_SET_ROLE_FAIL_ACTION:
+            return "TOX_ERR_GROUP_SET_ROLE_FAIL_ACTION";
 
-        case TOX_ERR_GROUP_MOD_SET_ROLE_SELF:
-            return "TOX_ERR_GROUP_MOD_SET_ROLE_SELF";
+        case TOX_ERR_GROUP_SET_ROLE_SELF:
+            return "TOX_ERR_GROUP_SET_ROLE_SELF";
     }
 
-    return "<invalid Tox_Err_Group_Mod_Set_Role>";
+    return "<invalid Tox_Err_Group_Set_Role>";
 }
-const char *tox_err_group_mod_kick_peer_to_string(Tox_Err_Group_Mod_Kick_Peer value)
+const char *tox_err_group_kick_peer_to_string(Tox_Err_Group_Kick_Peer value)
 {
     switch (value) {
-        case TOX_ERR_GROUP_MOD_KICK_PEER_OK:
-            return "TOX_ERR_GROUP_MOD_KICK_PEER_OK";
+        case TOX_ERR_GROUP_KICK_PEER_OK:
+            return "TOX_ERR_GROUP_KICK_PEER_OK";
 
-        case TOX_ERR_GROUP_MOD_KICK_PEER_GROUP_NOT_FOUND:
-            return "TOX_ERR_GROUP_MOD_KICK_PEER_GROUP_NOT_FOUND";
+        case TOX_ERR_GROUP_KICK_PEER_GROUP_NOT_FOUND:
+            return "TOX_ERR_GROUP_KICK_PEER_GROUP_NOT_FOUND";
 
-        case TOX_ERR_GROUP_MOD_KICK_PEER_PEER_NOT_FOUND:
-            return "TOX_ERR_GROUP_MOD_KICK_PEER_PEER_NOT_FOUND";
+        case TOX_ERR_GROUP_KICK_PEER_PEER_NOT_FOUND:
+            return "TOX_ERR_GROUP_KICK_PEER_PEER_NOT_FOUND";
 
-        case TOX_ERR_GROUP_MOD_KICK_PEER_PERMISSIONS:
-            return "TOX_ERR_GROUP_MOD_KICK_PEER_PERMISSIONS";
+        case TOX_ERR_GROUP_KICK_PEER_PERMISSIONS:
+            return "TOX_ERR_GROUP_KICK_PEER_PERMISSIONS";
 
-        case TOX_ERR_GROUP_MOD_KICK_PEER_FAIL_ACTION:
-            return "TOX_ERR_GROUP_MOD_KICK_PEER_FAIL_ACTION";
+        case TOX_ERR_GROUP_KICK_PEER_FAIL_ACTION:
+            return "TOX_ERR_GROUP_KICK_PEER_FAIL_ACTION";
 
-        case TOX_ERR_GROUP_MOD_KICK_PEER_FAIL_SEND:
-            return "TOX_ERR_GROUP_MOD_KICK_PEER_FAIL_SEND";
+        case TOX_ERR_GROUP_KICK_PEER_FAIL_SEND:
+            return "TOX_ERR_GROUP_KICK_PEER_FAIL_SEND";
 
-        case TOX_ERR_GROUP_MOD_KICK_PEER_SELF:
-            return "TOX_ERR_GROUP_MOD_KICK_PEER_SELF";
+        case TOX_ERR_GROUP_KICK_PEER_SELF:
+            return "TOX_ERR_GROUP_KICK_PEER_SELF";
     }
 
-    return "<invalid Tox_Err_Group_Mod_Kick_Peer>";
+    return "<invalid Tox_Err_Group_Kick_Peer>";
 }
 const char *tox_group_mod_event_to_string(Tox_Group_Mod_Event value)
 {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2709)
<!-- Reviewable:end -->
