### PR TITLE
refactor: Rename `out` parameters to `out_$something`.

### DIFF
--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -14,6 +14,7 @@ sh_test(
     args = ["$(locations %s)" % f for f in CIMPLE_FILES] + [
         "-Wno-boolean-return",
         "-Wno-callback-names",
+        "-Wno-enum-from-int",
         "+RTS",
         "-N4",
         "-RTS",

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -775,31 +775,31 @@ int m_set_statusmessage(Messenger *m, const uint8_t *status, uint16_t length)
 }
 
 non_null()
-static bool userstatus_from_int(uint8_t status, Userstatus *out)
+static bool userstatus_from_int(uint8_t status, Userstatus *out_enum)
 {
     switch (status) {
         case USERSTATUS_NONE: {
-            *out = USERSTATUS_NONE;
+            *out_enum = USERSTATUS_NONE;
             return true;
         }
 
         case USERSTATUS_AWAY: {
-            *out = USERSTATUS_AWAY;
+            *out_enum = USERSTATUS_AWAY;
             return true;
         }
 
         case USERSTATUS_BUSY: {
-            *out = USERSTATUS_BUSY;
+            *out_enum = USERSTATUS_BUSY;
             return true;
         }
 
         case USERSTATUS_INVALID: {
-            *out = USERSTATUS_INVALID;
+            *out_enum = USERSTATUS_INVALID;
             return true;
         }
 
         default: {
-            *out = USERSTATUS_INVALID;
+            *out_enum = USERSTATUS_INVALID;
             return false;
         }
     }

--- a/toxcore/group_pack.c
+++ b/toxcore/group_pack.c
@@ -26,46 +26,46 @@
 #include "network.h"
 #include "util.h"
 
-bool group_privacy_state_from_int(uint8_t value, Group_Privacy_State *out)
+bool group_privacy_state_from_int(uint8_t value, Group_Privacy_State *out_enum)
 {
     switch (value) {
         case GI_PUBLIC: {
-            *out = GI_PUBLIC;
+            *out_enum = GI_PUBLIC;
             return true;
         }
 
         case GI_PRIVATE: {
-            *out = GI_PRIVATE;
+            *out_enum = GI_PRIVATE;
             return true;
         }
 
         default: {
-            *out = GI_PUBLIC;
+            *out_enum = GI_PUBLIC;
             return false;
         }
     }
 }
 
-bool group_voice_state_from_int(uint8_t value, Group_Voice_State *out)
+bool group_voice_state_from_int(uint8_t value, Group_Voice_State *out_enum)
 {
     switch (value) {
         case GV_ALL: {
-            *out = GV_ALL;
+            *out_enum = GV_ALL;
             return true;
         }
 
         case GV_MODS: {
-            *out = GV_MODS;
+            *out_enum = GV_MODS;
             return true;
         }
 
         case GV_FOUNDER: {
-            *out = GV_FOUNDER;
+            *out_enum = GV_FOUNDER;
             return true;
         }
 
         default: {
-            *out = GV_ALL;
+            *out_enum = GV_ALL;
             return false;
         }
     }

--- a/toxcore/group_pack.h
+++ b/toxcore/group_pack.h
@@ -34,8 +34,8 @@ non_null()
 bool gc_load_unpack_group(GC_Chat *chat, Bin_Unpack *bu);
 
 non_null()
-bool group_privacy_state_from_int(uint8_t value, Group_Privacy_State *out);
+bool group_privacy_state_from_int(uint8_t value, Group_Privacy_State *out_enum);
 non_null()
-bool group_voice_state_from_int(uint8_t value, Group_Voice_State *out);
+bool group_voice_state_from_int(uint8_t value, Group_Voice_State *out_enum);
 
 #endif /* C_TOXCORE_TOXCORE_GROUP_PACK_H */

--- a/toxcore/tox_event.c
+++ b/toxcore/tox_event.c
@@ -725,216 +725,216 @@ bool tox_event_pack(const Tox_Event *event, Bin_Pack *bp)
 }
 
 non_null()
-static bool tox_event_type_from_int(uint32_t value, Tox_Event_Type *out)
+static bool tox_event_type_from_int(uint32_t value, Tox_Event_Type *out_enum)
 {
     switch (value) {
         case TOX_EVENT_SELF_CONNECTION_STATUS: {
-            *out = TOX_EVENT_SELF_CONNECTION_STATUS;
+            *out_enum = TOX_EVENT_SELF_CONNECTION_STATUS;
             return true;
         }
 
         case TOX_EVENT_FRIEND_REQUEST: {
-            *out = TOX_EVENT_FRIEND_REQUEST;
+            *out_enum = TOX_EVENT_FRIEND_REQUEST;
             return true;
         }
 
         case TOX_EVENT_FRIEND_CONNECTION_STATUS: {
-            *out = TOX_EVENT_FRIEND_CONNECTION_STATUS;
+            *out_enum = TOX_EVENT_FRIEND_CONNECTION_STATUS;
             return true;
         }
 
         case TOX_EVENT_FRIEND_LOSSY_PACKET: {
-            *out = TOX_EVENT_FRIEND_LOSSY_PACKET;
+            *out_enum = TOX_EVENT_FRIEND_LOSSY_PACKET;
             return true;
         }
 
         case TOX_EVENT_FRIEND_LOSSLESS_PACKET: {
-            *out = TOX_EVENT_FRIEND_LOSSLESS_PACKET;
+            *out_enum = TOX_EVENT_FRIEND_LOSSLESS_PACKET;
             return true;
         }
 
         case TOX_EVENT_FRIEND_NAME: {
-            *out = TOX_EVENT_FRIEND_NAME;
+            *out_enum = TOX_EVENT_FRIEND_NAME;
             return true;
         }
 
         case TOX_EVENT_FRIEND_STATUS: {
-            *out = TOX_EVENT_FRIEND_STATUS;
+            *out_enum = TOX_EVENT_FRIEND_STATUS;
             return true;
         }
 
         case TOX_EVENT_FRIEND_STATUS_MESSAGE: {
-            *out = TOX_EVENT_FRIEND_STATUS_MESSAGE;
+            *out_enum = TOX_EVENT_FRIEND_STATUS_MESSAGE;
             return true;
         }
 
         case TOX_EVENT_FRIEND_MESSAGE: {
-            *out = TOX_EVENT_FRIEND_MESSAGE;
+            *out_enum = TOX_EVENT_FRIEND_MESSAGE;
             return true;
         }
 
         case TOX_EVENT_FRIEND_READ_RECEIPT: {
-            *out = TOX_EVENT_FRIEND_READ_RECEIPT;
+            *out_enum = TOX_EVENT_FRIEND_READ_RECEIPT;
             return true;
         }
 
         case TOX_EVENT_FRIEND_TYPING: {
-            *out = TOX_EVENT_FRIEND_TYPING;
+            *out_enum = TOX_EVENT_FRIEND_TYPING;
             return true;
         }
 
         case TOX_EVENT_FILE_CHUNK_REQUEST: {
-            *out = TOX_EVENT_FILE_CHUNK_REQUEST;
+            *out_enum = TOX_EVENT_FILE_CHUNK_REQUEST;
             return true;
         }
 
         case TOX_EVENT_FILE_RECV: {
-            *out = TOX_EVENT_FILE_RECV;
+            *out_enum = TOX_EVENT_FILE_RECV;
             return true;
         }
 
         case TOX_EVENT_FILE_RECV_CHUNK: {
-            *out = TOX_EVENT_FILE_RECV_CHUNK;
+            *out_enum = TOX_EVENT_FILE_RECV_CHUNK;
             return true;
         }
 
         case TOX_EVENT_FILE_RECV_CONTROL: {
-            *out = TOX_EVENT_FILE_RECV_CONTROL;
+            *out_enum = TOX_EVENT_FILE_RECV_CONTROL;
             return true;
         }
 
         case TOX_EVENT_CONFERENCE_INVITE: {
-            *out = TOX_EVENT_CONFERENCE_INVITE;
+            *out_enum = TOX_EVENT_CONFERENCE_INVITE;
             return true;
         }
 
         case TOX_EVENT_CONFERENCE_CONNECTED: {
-            *out = TOX_EVENT_CONFERENCE_CONNECTED;
+            *out_enum = TOX_EVENT_CONFERENCE_CONNECTED;
             return true;
         }
 
         case TOX_EVENT_CONFERENCE_PEER_LIST_CHANGED: {
-            *out = TOX_EVENT_CONFERENCE_PEER_LIST_CHANGED;
+            *out_enum = TOX_EVENT_CONFERENCE_PEER_LIST_CHANGED;
             return true;
         }
 
         case TOX_EVENT_CONFERENCE_PEER_NAME: {
-            *out = TOX_EVENT_CONFERENCE_PEER_NAME;
+            *out_enum = TOX_EVENT_CONFERENCE_PEER_NAME;
             return true;
         }
 
         case TOX_EVENT_CONFERENCE_TITLE: {
-            *out = TOX_EVENT_CONFERENCE_TITLE;
+            *out_enum = TOX_EVENT_CONFERENCE_TITLE;
             return true;
         }
 
         case TOX_EVENT_CONFERENCE_MESSAGE: {
-            *out = TOX_EVENT_CONFERENCE_MESSAGE;
+            *out_enum = TOX_EVENT_CONFERENCE_MESSAGE;
             return true;
         }
 
         case TOX_EVENT_GROUP_PEER_NAME: {
-            *out = TOX_EVENT_GROUP_PEER_NAME;
+            *out_enum = TOX_EVENT_GROUP_PEER_NAME;
             return true;
         }
 
         case TOX_EVENT_GROUP_PEER_STATUS: {
-            *out = TOX_EVENT_GROUP_PEER_STATUS;
+            *out_enum = TOX_EVENT_GROUP_PEER_STATUS;
             return true;
         }
 
         case TOX_EVENT_GROUP_TOPIC: {
-            *out = TOX_EVENT_GROUP_TOPIC;
+            *out_enum = TOX_EVENT_GROUP_TOPIC;
             return true;
         }
 
         case TOX_EVENT_GROUP_PRIVACY_STATE: {
-            *out = TOX_EVENT_GROUP_PRIVACY_STATE;
+            *out_enum = TOX_EVENT_GROUP_PRIVACY_STATE;
             return true;
         }
 
         case TOX_EVENT_GROUP_VOICE_STATE: {
-            *out = TOX_EVENT_GROUP_VOICE_STATE;
+            *out_enum = TOX_EVENT_GROUP_VOICE_STATE;
             return true;
         }
 
         case TOX_EVENT_GROUP_TOPIC_LOCK: {
-            *out = TOX_EVENT_GROUP_TOPIC_LOCK;
+            *out_enum = TOX_EVENT_GROUP_TOPIC_LOCK;
             return true;
         }
 
         case TOX_EVENT_GROUP_PEER_LIMIT: {
-            *out = TOX_EVENT_GROUP_PEER_LIMIT;
+            *out_enum = TOX_EVENT_GROUP_PEER_LIMIT;
             return true;
         }
 
         case TOX_EVENT_GROUP_PASSWORD: {
-            *out = TOX_EVENT_GROUP_PASSWORD;
+            *out_enum = TOX_EVENT_GROUP_PASSWORD;
             return true;
         }
 
         case TOX_EVENT_GROUP_MESSAGE: {
-            *out = TOX_EVENT_GROUP_MESSAGE;
+            *out_enum = TOX_EVENT_GROUP_MESSAGE;
             return true;
         }
 
         case TOX_EVENT_GROUP_PRIVATE_MESSAGE: {
-            *out = TOX_EVENT_GROUP_PRIVATE_MESSAGE;
+            *out_enum = TOX_EVENT_GROUP_PRIVATE_MESSAGE;
             return true;
         }
 
         case TOX_EVENT_GROUP_CUSTOM_PACKET: {
-            *out = TOX_EVENT_GROUP_CUSTOM_PACKET;
+            *out_enum = TOX_EVENT_GROUP_CUSTOM_PACKET;
             return true;
         }
 
         case TOX_EVENT_GROUP_CUSTOM_PRIVATE_PACKET: {
-            *out = TOX_EVENT_GROUP_CUSTOM_PRIVATE_PACKET;
+            *out_enum = TOX_EVENT_GROUP_CUSTOM_PRIVATE_PACKET;
             return true;
         }
 
         case TOX_EVENT_GROUP_INVITE: {
-            *out = TOX_EVENT_GROUP_INVITE;
+            *out_enum = TOX_EVENT_GROUP_INVITE;
             return true;
         }
 
         case TOX_EVENT_GROUP_PEER_JOIN: {
-            *out = TOX_EVENT_GROUP_PEER_JOIN;
+            *out_enum = TOX_EVENT_GROUP_PEER_JOIN;
             return true;
         }
 
         case TOX_EVENT_GROUP_PEER_EXIT: {
-            *out = TOX_EVENT_GROUP_PEER_EXIT;
+            *out_enum = TOX_EVENT_GROUP_PEER_EXIT;
             return true;
         }
 
         case TOX_EVENT_GROUP_SELF_JOIN: {
-            *out = TOX_EVENT_GROUP_SELF_JOIN;
+            *out_enum = TOX_EVENT_GROUP_SELF_JOIN;
             return true;
         }
 
         case TOX_EVENT_GROUP_JOIN_FAIL: {
-            *out = TOX_EVENT_GROUP_JOIN_FAIL;
+            *out_enum = TOX_EVENT_GROUP_JOIN_FAIL;
             return true;
         }
 
         case TOX_EVENT_GROUP_MODERATION: {
-            *out = TOX_EVENT_GROUP_MODERATION;
+            *out_enum = TOX_EVENT_GROUP_MODERATION;
             return true;
         }
 
         case TOX_EVENT_DHT_GET_NODES_RESPONSE: {
-            *out = TOX_EVENT_DHT_GET_NODES_RESPONSE;
+            *out_enum = TOX_EVENT_DHT_GET_NODES_RESPONSE;
             return true;
         }
 
         case TOX_EVENT_INVALID: {
-            *out = TOX_EVENT_INVALID;
+            *out_enum = TOX_EVENT_INVALID;
             return true;
         }
 
         default: {
-            *out = TOX_EVENT_INVALID;
+            *out_enum = TOX_EVENT_INVALID;
             return false;
         }
     }

--- a/toxcore/tox_unpack.c
+++ b/toxcore/tox_unpack.c
@@ -11,21 +11,21 @@
 #include "tox.h"
 
 non_null()
-static bool tox_conference_type_from_int(uint32_t value, Tox_Conference_Type *out)
+static bool tox_conference_type_from_int(uint32_t value, Tox_Conference_Type *out_enum)
 {
     switch (value) {
         case TOX_CONFERENCE_TYPE_TEXT: {
-            *out = TOX_CONFERENCE_TYPE_TEXT;
+            *out_enum = TOX_CONFERENCE_TYPE_TEXT;
             return true;
         }
 
         case TOX_CONFERENCE_TYPE_AV: {
-            *out = TOX_CONFERENCE_TYPE_AV;
+            *out_enum = TOX_CONFERENCE_TYPE_AV;
             return true;
         }
 
         default: {
-            *out = TOX_CONFERENCE_TYPE_TEXT;
+            *out_enum = TOX_CONFERENCE_TYPE_TEXT;
             return false;
         }
     }
@@ -38,26 +38,26 @@ bool tox_conference_type_unpack(Tox_Conference_Type *val, Bin_Unpack *bu)
 }
 
 non_null()
-static bool tox_connection_from_int(uint32_t value, Tox_Connection *out)
+static bool tox_connection_from_int(uint32_t value, Tox_Connection *out_enum)
 {
     switch (value) {
         case TOX_CONNECTION_NONE: {
-            *out = TOX_CONNECTION_NONE;
+            *out_enum = TOX_CONNECTION_NONE;
             return true;
         }
 
         case TOX_CONNECTION_TCP: {
-            *out = TOX_CONNECTION_TCP;
+            *out_enum = TOX_CONNECTION_TCP;
             return true;
         }
 
         case TOX_CONNECTION_UDP: {
-            *out = TOX_CONNECTION_UDP;
+            *out_enum = TOX_CONNECTION_UDP;
             return true;
         }
 
         default: {
-            *out = TOX_CONNECTION_NONE;
+            *out_enum = TOX_CONNECTION_NONE;
             return false;
         }
     }
@@ -71,26 +71,26 @@ bool tox_connection_unpack(Tox_Connection *val, Bin_Unpack *bu)
 }
 
 non_null()
-static bool tox_file_control_from_int(uint32_t value, Tox_File_Control *out)
+static bool tox_file_control_from_int(uint32_t value, Tox_File_Control *out_enum)
 {
     switch (value) {
         case TOX_FILE_CONTROL_RESUME: {
-            *out = TOX_FILE_CONTROL_RESUME;
+            *out_enum = TOX_FILE_CONTROL_RESUME;
             return true;
         }
 
         case TOX_FILE_CONTROL_PAUSE: {
-            *out = TOX_FILE_CONTROL_PAUSE;
+            *out_enum = TOX_FILE_CONTROL_PAUSE;
             return true;
         }
 
         case TOX_FILE_CONTROL_CANCEL: {
-            *out = TOX_FILE_CONTROL_CANCEL;
+            *out_enum = TOX_FILE_CONTROL_CANCEL;
             return true;
         }
 
         default: {
-            *out = TOX_FILE_CONTROL_RESUME;
+            *out_enum = TOX_FILE_CONTROL_RESUME;
             return false;
         }
     }
@@ -104,21 +104,21 @@ bool tox_file_control_unpack(Tox_File_Control *val, Bin_Unpack *bu)
 }
 
 non_null()
-static bool tox_message_type_from_int(uint32_t value, Tox_Message_Type *out)
+static bool tox_message_type_from_int(uint32_t value, Tox_Message_Type *out_enum)
 {
     switch (value) {
         case TOX_MESSAGE_TYPE_NORMAL: {
-            *out = TOX_MESSAGE_TYPE_NORMAL;
+            *out_enum = TOX_MESSAGE_TYPE_NORMAL;
             return true;
         }
 
         case TOX_MESSAGE_TYPE_ACTION: {
-            *out = TOX_MESSAGE_TYPE_ACTION;
+            *out_enum = TOX_MESSAGE_TYPE_ACTION;
             return true;
         }
 
         default: {
-            *out = TOX_MESSAGE_TYPE_NORMAL;
+            *out_enum = TOX_MESSAGE_TYPE_NORMAL;
             return false;
         }
     }
@@ -132,26 +132,26 @@ bool tox_message_type_unpack(Tox_Message_Type *val, Bin_Unpack *bu)
 }
 
 non_null()
-static bool tox_user_status_from_int(uint32_t value, Tox_User_Status *out)
+static bool tox_user_status_from_int(uint32_t value, Tox_User_Status *out_enum)
 {
     switch (value) {
         case TOX_USER_STATUS_NONE: {
-            *out = TOX_USER_STATUS_NONE;
+            *out_enum = TOX_USER_STATUS_NONE;
             return true;
         }
 
         case TOX_USER_STATUS_AWAY: {
-            *out = TOX_USER_STATUS_AWAY;
+            *out_enum = TOX_USER_STATUS_AWAY;
             return true;
         }
 
         case TOX_USER_STATUS_BUSY: {
-            *out = TOX_USER_STATUS_BUSY;
+            *out_enum = TOX_USER_STATUS_BUSY;
             return true;
         }
 
         default: {
-            *out = TOX_USER_STATUS_NONE;
+            *out_enum = TOX_USER_STATUS_NONE;
             return false;
         }
     }
@@ -165,19 +165,19 @@ bool tox_user_status_unpack(Tox_User_Status *val, Bin_Unpack *bu)
 }
 
 non_null()
-static bool tox_group_privacy_state_from_int(uint32_t value, Tox_Group_Privacy_State *out)
+static bool tox_group_privacy_state_from_int(uint32_t value, Tox_Group_Privacy_State *out_enum)
 {
     switch (value) {
         case TOX_GROUP_PRIVACY_STATE_PUBLIC: {
-            *out = TOX_GROUP_PRIVACY_STATE_PUBLIC;
+            *out_enum = TOX_GROUP_PRIVACY_STATE_PUBLIC;
             return true;
         }
         case TOX_GROUP_PRIVACY_STATE_PRIVATE: {
-            *out = TOX_GROUP_PRIVACY_STATE_PRIVATE;
+            *out_enum = TOX_GROUP_PRIVACY_STATE_PRIVATE;
             return true;
         }
         default: {
-            *out = TOX_GROUP_PRIVACY_STATE_PUBLIC;
+            *out_enum = TOX_GROUP_PRIVACY_STATE_PUBLIC;
             return false;
         }
     }
@@ -189,23 +189,23 @@ bool tox_group_privacy_state_unpack(Tox_Group_Privacy_State *val, Bin_Unpack *bu
            && tox_group_privacy_state_from_int(u32, val);
 }
 non_null()
-static bool tox_group_voice_state_from_int(uint32_t value, Tox_Group_Voice_State *out)
+static bool tox_group_voice_state_from_int(uint32_t value, Tox_Group_Voice_State *out_enum)
 {
     switch (value) {
         case TOX_GROUP_VOICE_STATE_ALL: {
-            *out = TOX_GROUP_VOICE_STATE_ALL;
+            *out_enum = TOX_GROUP_VOICE_STATE_ALL;
             return true;
         }
         case TOX_GROUP_VOICE_STATE_MODERATOR: {
-            *out = TOX_GROUP_VOICE_STATE_MODERATOR;
+            *out_enum = TOX_GROUP_VOICE_STATE_MODERATOR;
             return true;
         }
         case TOX_GROUP_VOICE_STATE_FOUNDER: {
-            *out = TOX_GROUP_VOICE_STATE_FOUNDER;
+            *out_enum = TOX_GROUP_VOICE_STATE_FOUNDER;
             return true;
         }
         default: {
-            *out = TOX_GROUP_VOICE_STATE_ALL;
+            *out_enum = TOX_GROUP_VOICE_STATE_ALL;
             return false;
         }
     }
@@ -218,19 +218,19 @@ bool tox_group_voice_state_unpack(Tox_Group_Voice_State *val, Bin_Unpack *bu)
 }
 
 non_null()
-static bool tox_group_topic_lock_from_int(uint32_t value, Tox_Group_Topic_Lock *out)
+static bool tox_group_topic_lock_from_int(uint32_t value, Tox_Group_Topic_Lock *out_enum)
 {
     switch (value) {
         case TOX_GROUP_TOPIC_LOCK_ENABLED: {
-            *out = TOX_GROUP_TOPIC_LOCK_ENABLED;
+            *out_enum = TOX_GROUP_TOPIC_LOCK_ENABLED;
             return true;
         }
         case TOX_GROUP_TOPIC_LOCK_DISABLED: {
-            *out = TOX_GROUP_TOPIC_LOCK_DISABLED;
+            *out_enum = TOX_GROUP_TOPIC_LOCK_DISABLED;
             return true;
         }
         default: {
-            *out = TOX_GROUP_TOPIC_LOCK_ENABLED;
+            *out_enum = TOX_GROUP_TOPIC_LOCK_ENABLED;
             return false;
         }
     }
@@ -243,23 +243,23 @@ bool tox_group_topic_lock_unpack(Tox_Group_Topic_Lock *val, Bin_Unpack *bu)
 }
 
 non_null()
-static bool tox_group_join_fail_from_int(uint32_t value, Tox_Group_Join_Fail *out)
+static bool tox_group_join_fail_from_int(uint32_t value, Tox_Group_Join_Fail *out_enum)
 {
     switch (value) {
         case TOX_GROUP_JOIN_FAIL_PEER_LIMIT: {
-            *out = TOX_GROUP_JOIN_FAIL_PEER_LIMIT;
+            *out_enum = TOX_GROUP_JOIN_FAIL_PEER_LIMIT;
             return true;
         }
         case TOX_GROUP_JOIN_FAIL_INVALID_PASSWORD: {
-            *out = TOX_GROUP_JOIN_FAIL_INVALID_PASSWORD;
+            *out_enum = TOX_GROUP_JOIN_FAIL_INVALID_PASSWORD;
             return true;
         }
         case TOX_GROUP_JOIN_FAIL_UNKNOWN: {
-            *out = TOX_GROUP_JOIN_FAIL_UNKNOWN;
+            *out_enum = TOX_GROUP_JOIN_FAIL_UNKNOWN;
             return true;
         }
         default: {
-            *out = TOX_GROUP_JOIN_FAIL_PEER_LIMIT;
+            *out_enum = TOX_GROUP_JOIN_FAIL_PEER_LIMIT;
             return false;
         }
     }
@@ -272,27 +272,27 @@ bool tox_group_join_fail_unpack(Tox_Group_Join_Fail *val, Bin_Unpack *bu)
 }
 
 non_null()
-static bool tox_group_mod_event_from_int(uint32_t value, Tox_Group_Mod_Event *out)
+static bool tox_group_mod_event_from_int(uint32_t value, Tox_Group_Mod_Event *out_enum)
 {
     switch (value) {
         case TOX_GROUP_MOD_EVENT_KICK: {
-            *out = TOX_GROUP_MOD_EVENT_KICK;
+            *out_enum = TOX_GROUP_MOD_EVENT_KICK;
             return true;
         }
         case TOX_GROUP_MOD_EVENT_OBSERVER: {
-            *out = TOX_GROUP_MOD_EVENT_OBSERVER;
+            *out_enum = TOX_GROUP_MOD_EVENT_OBSERVER;
             return true;
         }
         case TOX_GROUP_MOD_EVENT_USER: {
-            *out = TOX_GROUP_MOD_EVENT_USER;
+            *out_enum = TOX_GROUP_MOD_EVENT_USER;
             return true;
         }
         case TOX_GROUP_MOD_EVENT_MODERATOR: {
-            *out = TOX_GROUP_MOD_EVENT_MODERATOR;
+            *out_enum = TOX_GROUP_MOD_EVENT_MODERATOR;
             return true;
         }
         default: {
-            *out = TOX_GROUP_MOD_EVENT_KICK;
+            *out_enum = TOX_GROUP_MOD_EVENT_KICK;
             return false;
         }
     }
@@ -305,35 +305,35 @@ bool tox_group_mod_event_unpack(Tox_Group_Mod_Event *val, Bin_Unpack *bu)
 }
 
 non_null()
-static bool tox_group_exit_type_from_int(uint32_t value, Tox_Group_Exit_Type *out)
+static bool tox_group_exit_type_from_int(uint32_t value, Tox_Group_Exit_Type *out_enum)
 {
     switch (value) {
         case TOX_GROUP_EXIT_TYPE_QUIT: {
-            *out = TOX_GROUP_EXIT_TYPE_QUIT;
+            *out_enum = TOX_GROUP_EXIT_TYPE_QUIT;
             return true;
         }
         case TOX_GROUP_EXIT_TYPE_TIMEOUT: {
-            *out = TOX_GROUP_EXIT_TYPE_TIMEOUT;
+            *out_enum = TOX_GROUP_EXIT_TYPE_TIMEOUT;
             return true;
         }
         case TOX_GROUP_EXIT_TYPE_DISCONNECTED: {
-            *out = TOX_GROUP_EXIT_TYPE_DISCONNECTED;
+            *out_enum = TOX_GROUP_EXIT_TYPE_DISCONNECTED;
             return true;
         }
         case TOX_GROUP_EXIT_TYPE_SELF_DISCONNECTED: {
-            *out = TOX_GROUP_EXIT_TYPE_SELF_DISCONNECTED;
+            *out_enum = TOX_GROUP_EXIT_TYPE_SELF_DISCONNECTED;
             return true;
         }
         case TOX_GROUP_EXIT_TYPE_KICK: {
-            *out = TOX_GROUP_EXIT_TYPE_KICK;
+            *out_enum = TOX_GROUP_EXIT_TYPE_KICK;
             return true;
         }
         case TOX_GROUP_EXIT_TYPE_SYNC_ERROR: {
-            *out = TOX_GROUP_EXIT_TYPE_SYNC_ERROR;
+            *out_enum = TOX_GROUP_EXIT_TYPE_SYNC_ERROR;
             return true;
         }
         default: {
-            *out = TOX_GROUP_EXIT_TYPE_QUIT;
+            *out_enum = TOX_GROUP_EXIT_TYPE_QUIT;
             return false;
         }
     }


### PR DESCRIPTION
In preparation for supporting `out` as a type qualifier in parameters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2726)
<!-- Reviewable:end -->
