### PR TITLE
refactor: Observers/ignored peers can now send and receive custom packets

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -5067,10 +5067,6 @@ int gc_send_custom_private_packet(const GC_Chat *chat, bool lossless, GC_Peer_Id
         return -3;
     }
 
-    if (gc_get_self_role(chat) >= GR_OBSERVER) {
-        return -4;
-    }
-
     bool ret;
 
     if (lossless) {
@@ -5079,7 +5075,7 @@ int gc_send_custom_private_packet(const GC_Chat *chat, bool lossless, GC_Peer_Id
         ret = send_lossy_group_packet(chat, gconn, message, length, GP_CUSTOM_PRIVATE_PACKET);
     }
 
-    return ret ? 0 : -5;
+    return ret ? 0 : -4;
 }
 
 /** @brief Handles a custom private packet.
@@ -5099,10 +5095,6 @@ static int handle_gc_custom_private_packet(const GC_Session *c, const GC_Chat *c
         return -1;
     }
 
-    if (peer->ignore || peer->role >= GR_OBSERVER) {
-        return 0;
-    }
-
     if (c->custom_private_packet != nullptr) {
         c->custom_private_packet(c->messenger, chat->group_number, peer->peer_id, data, length, userdata);
     }
@@ -5120,10 +5112,6 @@ int gc_send_custom_packet(const GC_Chat *chat, bool lossless, const uint8_t *dat
         return -2;
     }
 
-    if (gc_get_self_role(chat) >= GR_OBSERVER) {
-        return -3;
-    }
-
     bool success;
 
     if (lossless) {
@@ -5132,7 +5120,7 @@ int gc_send_custom_packet(const GC_Chat *chat, bool lossless, const uint8_t *dat
         success = send_gc_lossy_packet_all_peers(chat, data, length, GP_CUSTOM_PACKET);
     }
 
-    return success ? 0 : -4;
+    return success ? 0 : -3;
 }
 
 /** @brief Handles a custom packet.
@@ -5150,10 +5138,6 @@ static int handle_gc_custom_packet(const GC_Session *c, const GC_Chat *chat, con
 
     if (data == nullptr || length == 0) {
         return -1;
-    }
-
-    if (peer->ignore || peer->role >= GR_OBSERVER) {
-        return 0;
     }
 
     if (c->custom_packet != nullptr) {

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -192,8 +192,7 @@ int gc_send_private_message(const GC_Chat *chat, GC_Peer_Id peer_id, uint8_t typ
  * Returns 0 on success.
  * Returns -1 if the message is too long.
  * Returns -2 if the message pointer is NULL or length is zero.
- * Returns -3 if the sender has the observer role.
- * Returns -4 if the packet did not successfully send to any peer.
+ * Returns -3 if the packet did not successfully send to any peer.
  */
 non_null()
 int gc_send_custom_packet(const GC_Chat *chat, bool lossless, const uint8_t *data, uint16_t length);
@@ -206,8 +205,7 @@ int gc_send_custom_packet(const GC_Chat *chat, bool lossless, const uint8_t *dat
  * @retval -1 if the message is too long.
  * @retval -2 if the message pointer is NULL or length is zero.
  * @retval -3 if the supplied peer_id does not designate a valid peer.
- * @retval -4 if the sender has the observer role.
- * @retval -5 if the packet fails to send.
+ * @retval -4 if the packet fails to send.
  */
 non_null()
 int gc_send_custom_private_packet(const GC_Chat *chat, bool lossless, GC_Peer_Id peer_id, const uint8_t *message,

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -4100,11 +4100,6 @@ bool tox_group_send_custom_packet(const Tox *tox, uint32_t group_number, bool lo
         }
 
         case -3: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SEND_CUSTOM_PACKET_PERMISSIONS);
-            return false;
-        }
-
-        case -4: {
             SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SEND_CUSTOM_PACKET_FAIL_SEND);
             return false;
         }
@@ -4162,11 +4157,6 @@ bool tox_group_send_custom_private_packet(const Tox *tox, uint32_t group_number,
         }
 
         case -4: {
-            SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_PERMISSIONS);
-            return false;
-        }
-
-        case -5: {
             SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_FAIL_SEND);
             return false;
         }

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -4605,11 +4605,6 @@ typedef enum Tox_Err_Group_Send_Custom_Packet {
     TOX_ERR_GROUP_SEND_CUSTOM_PACKET_EMPTY,
 
     /**
-     * The caller does not have the required permissions to send group messages.
-     */
-    TOX_ERR_GROUP_SEND_CUSTOM_PACKET_PERMISSIONS,
-
-    /**
      * The group is disconnected.
      */
     TOX_ERR_GROUP_SEND_CUSTOM_PACKET_DISCONNECTED,
@@ -4681,11 +4676,6 @@ typedef enum Tox_Err_Group_Send_Custom_Private_Packet {
      * The peer ID passed did no designate a valid peer.
      */
     TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_PEER_NOT_FOUND,
-
-    /**
-     * The caller does not have the required permissions to send group messages.
-     */
-    TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_PERMISSIONS,
 
     /**
      * The packet failed to send.

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -1370,9 +1370,6 @@ const char *tox_err_group_send_custom_packet_to_string(Tox_Err_Group_Send_Custom
         case TOX_ERR_GROUP_SEND_CUSTOM_PACKET_EMPTY:
             return "TOX_ERR_GROUP_SEND_CUSTOM_PACKET_EMPTY";
 
-        case TOX_ERR_GROUP_SEND_CUSTOM_PACKET_PERMISSIONS:
-            return "TOX_ERR_GROUP_SEND_CUSTOM_PACKET_PERMISSIONS";
-
         case TOX_ERR_GROUP_SEND_CUSTOM_PACKET_DISCONNECTED:
             return "TOX_ERR_GROUP_SEND_CUSTOM_PACKET_DISCONNECTED";
 
@@ -1399,9 +1396,6 @@ const char *tox_err_group_send_custom_private_packet_to_string(Tox_Err_Group_Sen
 
         case TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_PEER_NOT_FOUND:
             return "TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_PEER_NOT_FOUND";
-
-        case TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_PERMISSIONS:
-            return "TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_PERMISSIONS";
 
         case TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_FAIL_SEND:
             return "TOX_ERR_GROUP_SEND_CUSTOM_PRIVATE_PACKET_FAIL_SEND";


### PR DESCRIPTION
The Observer role was intended to prevent peers from being disruptive and/or interacting with other peers in the group. It wasn't intended to cripple custom protocols running on-top of the groups such as file sharing and message syncing.

In cases where it might be undesirable for observers to use custom packets (e.g. starting a file transfer) the client will still have the ability to decide whether or not to allow it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2728)
<!-- Reviewable:end -->
