### PR TITLE
cleanup: use typedef for private message ID's in callback

### DIFF
--- a/auto_tests/group_message_test.c
+++ b/auto_tests/group_message_test.c
@@ -19,7 +19,7 @@ typedef struct State {
     bool peer_joined;
     bool message_sent;
     bool message_received;
-    uint32_t pseudo_msg_id;
+    Tox_Group_Message_Id pseudo_msg_id;
     bool private_message_received;
     size_t custom_packets_received;
     size_t custom_private_packets_received;
@@ -287,7 +287,7 @@ static void group_private_message_handler(const Tox_Event_Group_Private_Message 
     const Tox_Message_Type type = tox_event_group_private_message_get_type(event);
     const uint8_t *message = tox_event_group_private_message_get_message(event);
     const size_t length = tox_event_group_private_message_get_message_length(event);
-    const uint32_t pseudo_msg_id = tox_event_group_private_message_get_message_id(event);
+    const Tox_Group_Message_Id pseudo_msg_id = tox_event_group_private_message_get_message_id(event);
 
     ck_assert_msg(length == TEST_PRIVATE_MESSAGE_LEN, "Failed to receive message. Invalid length: %zu\n", length);
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -524,7 +524,7 @@ static void tox_group_password_handler(const Messenger *m, uint32_t group_number
 
 non_null(1, 5) nullable(8)
 static void tox_group_message_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id, unsigned int type,
-                                      const uint8_t *message, size_t length, uint32_t message_id, void *user_data)
+                                      const uint8_t *message, size_t length, Tox_Group_Message_Id message_id, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 
@@ -538,7 +538,7 @@ static void tox_group_message_handler(const Messenger *m, uint32_t group_number,
 
 non_null(1, 5) nullable(8)
 static void tox_group_private_message_handler(const Messenger *m, uint32_t group_number, GC_Peer_Id peer_id,
-        unsigned int type, const uint8_t *message, size_t length, uint32_t message_id, void *user_data)
+        unsigned int type, const uint8_t *message, size_t length, Tox_Group_Message_Id message_id, void *user_data)
 {
     struct Tox_Userdata *tox_data = (struct Tox_Userdata *)user_data;
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -4753,7 +4753,7 @@ void tox_callback_group_message(Tox *tox, tox_group_message_cb *callback);
  */
 typedef void tox_group_private_message_cb(
     Tox *tox, Tox_Group_Number group_number, Tox_Group_Peer_Number peer_id, Tox_Message_Type type,
-    const uint8_t message[], size_t length, uint32_t message_id, void *user_data);
+    const uint8_t message[], size_t length, Tox_Group_Message_Id message_id, void *user_data);
 
 /**
  * Set the callback for the `group_private_message` event. Pass NULL to unset.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2729)
<!-- Reviewable:end -->
