### PR TITLE
fix: Memory leak in the bootstrap daemon

### DIFF
--- a/other/bootstrap_daemon/src/config.c
+++ b/other/bootstrap_daemon/src/config.c
@@ -200,6 +200,8 @@ bool get_general_config(const char *cfg_file_path, char **pid_file_path, char **
     *keys_file_path = (char *)malloc(keys_file_path_len);
     if (*keys_file_path == nullptr) {
         log_write(LOG_LEVEL_ERROR, "Allocation failure.\n");
+        free(*pid_file_path);
+        *pid_file_path = nullptr;
         return false;
     }
     memcpy(*keys_file_path, tmp_keys_file, keys_file_path_len);


### PR DESCRIPTION
[Found by `clang-analyze`](https://app.circleci.com/pipelines/github/TokTok/c-toxcore/7318/workflows/1459b40e-eb05-4a37-89d3-593016088728/jobs/61053?invite=true#step-104-10510_130).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2747)
<!-- Reviewable:end -->
