### PR TITLE
chore: Fix Circle CI build failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,9 +141,7 @@ jobs:
       - run: *apt_install
       - run:
           apt-get install -y --no-install-recommends
-            ca-certificates
-            python3-pip
+            cpplint
       - checkout
       - run: git submodule update --init --recursive
-      - run: pip install cpplint
       - run: other/analysis/run-cpplint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: &apt_install
           apt-get update &&
           DEBIAN_FRONTEND=noninteractive
-          apt-get install -y --no-install-recommends
+          apt-get install -y
             ca-certificates
             clang
             cmake

--- a/.github/scripts/flags-clang.sh
+++ b/.github/scripts/flags-clang.sh
@@ -39,12 +39,17 @@ add_flag -Wno-reserved-id-macro
 # TODO(iphydf): Clean these up. They are likely not bugs, but still
 # potential issues and probably confusing.
 add_flag -Wno-sign-compare
+# We don't want to have default cases, we want to explicitly define all cases
+add_flag -Wno-switch-default
 # __attribute__((nonnull)) causes this warning on defensive null checks.
 add_flag -Wno-tautological-pointer-compare
 # Our use of mutexes results in a false positive, see 1bbe446.
 add_flag -Wno-thread-safety-analysis
 # File transfer code has this.
 add_flag -Wno-type-limits
+# Generates false positives in toxcore similar to
+# https://github.com/llvm/llvm-project/issues/64646
+add_flag -Wno-unsafe-buffer-usage
 # Callbacks often don't use all their parameters.
 add_flag -Wno-unused-parameter
 # cimple does this better

--- a/other/analysis/run-clang
+++ b/other/analysis/run-clang
@@ -28,8 +28,10 @@ run() {
     -Wno-old-style-cast \
     -Wno-padded \
     -Wno-sign-compare \
+    -Wno-switch-default \
     -Wno-tautological-pointer-compare \
     -Wno-unreachable-code-return \
+    -Wno-unsafe-buffer-usage \
     -Wno-unused-parameter \
     -Wno-used-but-marked-unused \
     -Wno-source-uses-openmp

--- a/toxcore/bin_pack_test.cc
+++ b/toxcore/bin_pack_test.cc
@@ -32,7 +32,7 @@ TEST(BinPack, PackedUint64CanBeUnpacked)
         },
         &orig, nullptr, buf.data(), buf.size()));
 
-    uint64_t unpacked;
+    uint64_t unpacked = 0;
     EXPECT_TRUE(bin_unpack_obj(
         [](void *obj, Bin_Unpack *bu) {
             return bin_unpack_u64_b(bu, static_cast<uint64_t *>(obj));
@@ -51,7 +51,7 @@ TEST(BinPack, MsgPackedUint8CanBeUnpackedAsUint32)
         },
         &orig, nullptr, buf.data(), buf.size()));
 
-    uint32_t unpacked;
+    uint32_t unpacked = 0;
     EXPECT_TRUE(bin_unpack_obj(
         [](void *obj, Bin_Unpack *bu) { return bin_unpack_u32(bu, static_cast<uint32_t *>(obj)); },
         &unpacked, buf.data(), buf.size()));
@@ -68,7 +68,7 @@ TEST(BinPack, MsgPackedUint32CanBeUnpackedAsUint8IfSmallEnough)
         },
         &orig, nullptr, buf.data(), buf.size()));
 
-    uint8_t unpacked;
+    uint8_t unpacked = 0;
     EXPECT_TRUE(bin_unpack_obj(
         [](void *obj, Bin_Unpack *bu) { return bin_unpack_u08(bu, static_cast<uint8_t *>(obj)); },
         &unpacked, buf.data(), buf.size()));
@@ -86,7 +86,7 @@ TEST(BinPack, LargeMsgPackedUint32CannotBeUnpackedAsUint8)
         },
         &orig, nullptr, buf.data(), buf.size()));
 
-    uint8_t unpacked;
+    uint8_t unpacked = 0;
     EXPECT_FALSE(bin_unpack_obj(
         [](void *obj, Bin_Unpack *bu) { return bin_unpack_u08(bu, static_cast<uint8_t *>(obj)); },
         &unpacked, buf.data(), buf.size()));


### PR DESCRIPTION
Circle CI's image got updated to use Ubuntu 24.04 (Noble Numbat), which:

- Changed a bit how clang is packaged -- `libclang_rt.ubsan_standalone-x86_64.a` is no longer getting installed
- Includes a newer clang with more enabled warnings in one the umbrella flags like -Weverything, -Wall, etc., like `-Wswitch-default` and `-Wunsafe-buffer-usage`:
  - We actually do not want a default in our switches, we want to explicitly handle every case and get warned when we don't, so `-Wswitch-default` should be disables
  - `-Wunsafe-buffer-usage` seems to be broken, it warns on things that are perfectly ok, like doing `foo[1] = 0;` where `uint32_t foo[4];`, e.g.

    warning:

    ```bash
    /root/work/toxcore/network.c:966:9: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
      966 |         ip6.uint32[1] = 0;
          |         ^~~~~~~~~~
    ```

    on:

    https://github.com/TokTok/c-toxcore/blob/da438763d5b8e071de6e061a1dcaddd2177dff7d/toxcore/network.c#L966
    
    where `uint32` is:
    
    https://github.com/TokTok/c-toxcore/blob/da438763d5b8e071de6e061a1dcaddd2177dff7d/toxcore/network.h#L200

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2755)
<!-- Reviewable:end -->
