### PR TITLE
fix: Limit memory allocation by MAX_CRYPTO_DATA_SIZE

### DIFF
--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -804,13 +804,8 @@ int rtp_send_data(RTPSession *session, const uint8_t *data, uint32_t length,
     if (is_keyframe) {
         header.flags |= RTP_KEY_FRAME;
     }
-    const uint16_t rdata_size = length_safe + RTP_HEADER_SIZE + 1 > MAX_CRYPTO_DATA_SIZE? MAX_CRYPTO_DATA_SIZE : length_safe + RTP_HEADER_SIZE + 1;
+    const uint16_t rdata_size = length_safe + RTP_HEADER_SIZE + 1 > MAX_CRYPTO_DATA_SIZE ? MAX_CRYPTO_DATA_SIZE : length_safe + RTP_HEADER_SIZE + 1;
     VLA(uint8_t, rdata, rdata_size);
-    const uint16_t rdata_allocated = sizeof(rdata) / sizeof(uint8_t);
-    if (rdata_allocated < rdata_size){
-        LOGGER_ERROR(log, "Unable to allocate %d bytes, only %d bytes were allocated.", rdata_size, rdata_allocated);
-        return -1;
-    }
     memset(rdata, 0, rdata_size);
     rdata[0] = session->payload_type;  // packet id == payload_type
 

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -792,8 +792,8 @@ int rtp_send_data(RTPSession *session, const uint8_t *data, uint32_t length,
 
     uint16_t length_safe = (uint16_t)length;
 
-    if (length > UINT16_MAX) {
-        length_safe = UINT16_MAX;
+    if (length > UINT16_MAX - RTP_HEADER_SIZE - 1) {
+        length_safe = UINT16_MAX - RTP_HEADER_SIZE - 1;
     }
 
     header.data_length_lower = length_safe;


### PR DESCRIPTION
This PR is intended to fix the issue, when shiny object is shown to the camera during the call. In this scenario camera creates big frames, for which toxcore tries to allocate memory and if the frame is big enough, it may fail, resulting in overflow error.

In this fix we limit the allocation size to `MAX_CRYPTO_DATA_SIZE` and, limit the frame size to `UINT16_MAX` (we use `length_safe` instead of `length` variable). 

I have tested the fix on qTox client.

See [issue](https://github.com/TokTok/c-toxcore/issues/2767)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2766)
<!-- Reviewable:end -->
