### PR TITLE
chore(ci): new minimum for all android versions is 21

### DIFF
--- a/.github/scripts/cmake-android
+++ b/.github/scripts/cmake-android
@@ -10,7 +10,7 @@ ABI=${1:-"armeabi-v7a"}
 case $ABI in
   armeabi-v7a)
     TARGET=armv7a-linux-androideabi
-    NDK_API=19
+    NDK_API=21
     ;;
   arm64-v8a)
     TARGET=aarch64-linux-android
@@ -18,7 +18,7 @@ case $ABI in
     ;;
   x86)
     TARGET=i686-linux-android
-    NDK_API=19
+    NDK_API=21
     ;;
   x86_64)
     TARGET=x86_64-linux-android


### PR DESCRIPTION
see #2390 for a previous update

ndk mentioning the removal of 19+20: https://github.com/android/ndk/releases/tag/r26

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2769)
<!-- Reviewable:end -->
