### PR TITLE
fix: friend_connections leak on allocation failure.

### DIFF
--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -1032,6 +1032,11 @@ void kill_friend_connections(Friend_Connections *fr_c)
         kill_friend_connection(fr_c, i);
     }
 
+    // there might be allocated NONE connections
+    if (fr_c->conns != nullptr) {
+        free(fr_c->conns);
+    }
+
     lan_discovery_kill(fr_c->broadcast);
     free(fr_c);
 }


### PR DESCRIPTION
clean up when it only contains connections in the NONE state.
rare in practice, found by fuzzing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2772)
<!-- Reviewable:end -->
