### PR TITLE
chore: Remove bazel-dbg CI check.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,28 +7,11 @@ bazel-opt_task:
   configure_script:
     - git submodule update --init --recursive
     - /src/workspace/tools/inject-repo c-toxcore
-    - sed -i -e 's/build --config=remote/#&/' /src/workspace/.bazelrc.local
   test_all_script:
     - cd /src/workspace && bazel test -k
+        --remote_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --build_tag_filters=-haskell
         --test_tag_filters=-haskell
-        --
-        //c-toxcore/...
-        -//c-toxcore/auto_tests:tcp_relay_test # Cirrus doesn't allow external network connections.
-
-bazel-dbg_task:
-  container:
-    image: toxchat/toktok-stack:latest-debug
-    cpu: 2
-    memory: 2G
-  configure_script:
-    - git submodule update --init --recursive
-    - /src/workspace/tools/inject-repo c-toxcore
-  test_all_script:
-    - cd /src/workspace && bazel test -k
-        --build_tag_filters=-haskell
-        --test_tag_filters=-haskell
-        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --
         //c-toxcore/...
         -//c-toxcore/auto_tests:tcp_relay_test # Cirrus doesn't allow external network connections.
@@ -41,9 +24,9 @@ cimple_task:
   configure_script:
     - git submodule update --init --recursive
     - /src/workspace/tools/inject-repo c-toxcore
-    - sed -i -e 's/build --config=remote/#&/' /src/workspace/.bazelrc.local
   test_all_script:
     - cd /src/workspace && bazel test -k
+        --remote_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --build_tag_filters=haskell
         --test_tag_filters=haskell
         --


### PR DESCRIPTION
This has never helped catch errors, and takes a lot of time without working remote cache.

Also removed the `sed` to disable remote cache. It's disabled globally for now in toktok-stack.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2776)
<!-- Reviewable:end -->
