### PR TITLE
fix: Return an error instead of crashing on nullptr args in NGC.

### DIFF
--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -2551,6 +2551,12 @@ uint32_t tox_conference_join(Tox *tox, uint32_t friend_number, const uint8_t *co
                              Tox_Err_Conference_Join *error)
 {
     assert(tox != nullptr);
+
+    if (cookie == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_CONFERENCE_JOIN_NULL);
+        return UINT32_MAX;
+    }
+
     tox_lock(tox);
     const int ret = join_groupchat(tox->m->conferences_object, friend_number, GROUPCHAT_TYPE_TEXT, cookie, length);
     tox_unlock(tox);
@@ -4262,6 +4268,11 @@ uint32_t tox_group_invite_accept(Tox *tox, uint32_t friend_number, const uint8_t
                                  size_t password_length, Tox_Err_Group_Invite_Accept *error)
 {
     assert(tox != nullptr);
+
+    if (invite_data == nullptr || name == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_INVITE_ACCEPT_NULL);
+        return UINT32_MAX;
+    }
 
     tox_lock(tox);
     const int ret = gc_accept_invite(tox->m->group_handler, friend_number, invite_data, length, name, name_length, password,

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -2891,6 +2891,11 @@ typedef enum Tox_Err_Conference_Join {
      */
     TOX_ERR_CONFERENCE_JOIN_FAIL_SEND,
 
+    /**
+     * The cookie passed was NULL.
+     */
+    TOX_ERR_CONFERENCE_JOIN_NULL,
+
 } Tox_Err_Conference_Join;
 
 const char *tox_err_conference_join_to_string(Tox_Err_Conference_Join value);
@@ -4994,6 +4999,11 @@ typedef enum Tox_Err_Group_Invite_Accept {
      * Packet failed to send.
      */
     TOX_ERR_GROUP_INVITE_ACCEPT_FAIL_SEND,
+
+    /**
+     * Invite data or name is NULL.
+     */
+    TOX_ERR_GROUP_INVITE_ACCEPT_NULL,
 
 } Tox_Err_Group_Invite_Accept;
 

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -887,6 +887,9 @@ const char *tox_err_conference_join_to_string(Tox_Err_Conference_Join value)
 
         case TOX_ERR_CONFERENCE_JOIN_FAIL_SEND:
             return "TOX_ERR_CONFERENCE_JOIN_FAIL_SEND";
+
+        case TOX_ERR_CONFERENCE_JOIN_NULL:
+            return "TOX_ERR_CONFERENCE_JOIN_NULL";
     }
 
     return "<invalid Tox_Err_Conference_Join>";
@@ -1448,6 +1451,9 @@ const char *tox_err_group_invite_accept_to_string(Tox_Err_Group_Invite_Accept va
 
         case TOX_ERR_GROUP_INVITE_ACCEPT_FAIL_SEND:
             return "TOX_ERR_GROUP_INVITE_ACCEPT_FAIL_SEND";
+
+        case TOX_ERR_GROUP_INVITE_ACCEPT_NULL:
+            return "TOX_ERR_GROUP_INVITE_ACCEPT_NULL";
     }
 
     return "<invalid Tox_Err_Group_Invite_Accept>";


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2783)
<!-- Reviewable:end -->
