### PR TITLE
refactor: Move tox_log_level out into its own file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,8 @@ set(toxcore_SOURCES
   toxcore/tox_events.c
   toxcore/tox_events.h
   toxcore/tox.h
+  toxcore/tox_log_level.c
+  toxcore/tox_log_level.h
   toxcore/tox_private.c
   toxcore/tox_private.h
   toxcore/tox_pack.c
@@ -363,8 +365,9 @@ endif()
 set(toxcore_PKGCONFIG_REQUIRES ${toxcore_PKGCONFIG_REQUIRES} libsodium)
 set(toxcore_API_HEADERS
   ${toxcore_SOURCE_DIR}/toxcore/tox.h^tox
+  ${toxcore_SOURCE_DIR}/toxcore/tox_dispatch.h^tox
   ${toxcore_SOURCE_DIR}/toxcore/tox_events.h^tox
-  ${toxcore_SOURCE_DIR}/toxcore/tox_dispatch.h^tox)
+  ${toxcore_SOURCE_DIR}/toxcore/tox_log_level.h^tox)
 if(EXPERIMENTAL_API)
   set(toxcore_API_HEADERS ${toxcore_API_HEADERS}
     ${toxcore_SOURCE_DIR}/toxcore/tox_private.h^tox)

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 exports_files(
     srcs = [
         "tox.h",
+        "tox_log_level.h",
         "tox_private.h",
     ],
     visibility = ["//c-toxcore:__subpackages__"],
@@ -977,6 +978,13 @@ cc_library(
         ":state",
         ":util",
     ],
+)
+
+cc_library(
+    name = "tox_log_level",
+    srcs = ["tox_log_level.c"],
+    hdrs = ["tox_log_level.h"],
+    visibility = ["//c-toxcore:__subpackages__"],
 )
 
 cc_library(

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -95,6 +95,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "tox_log_level.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -437,40 +439,6 @@ typedef enum Tox_Savedata_Type {
 } Tox_Savedata_Type;
 
 const char *tox_savedata_type_to_string(Tox_Savedata_Type value);
-
-/**
- * @brief Severity level of log messages.
- */
-typedef enum Tox_Log_Level {
-
-    /**
-     * Very detailed traces including all network activity.
-     */
-    TOX_LOG_LEVEL_TRACE,
-
-    /**
-     * Debug messages such as which port we bind to.
-     */
-    TOX_LOG_LEVEL_DEBUG,
-
-    /**
-     * Informational log messages such as video call status changes.
-     */
-    TOX_LOG_LEVEL_INFO,
-
-    /**
-     * Warnings about internal inconsistency or logic errors.
-     */
-    TOX_LOG_LEVEL_WARNING,
-
-    /**
-     * Severe unexpected errors caused by external or internal inconsistency.
-     */
-    TOX_LOG_LEVEL_ERROR,
-
-} Tox_Log_Level;
-
-const char *tox_log_level_to_string(Tox_Log_Level value);
 
 /**
  * @brief This event is triggered when Tox logs an internal message.

--- a/toxcore/tox_api.c
+++ b/toxcore/tox_api.c
@@ -378,27 +378,6 @@ const char *tox_savedata_type_to_string(Tox_Savedata_Type value)
 
     return "<invalid Tox_Savedata_Type>";
 }
-const char *tox_log_level_to_string(Tox_Log_Level value)
-{
-    switch (value) {
-        case TOX_LOG_LEVEL_TRACE:
-            return "TOX_LOG_LEVEL_TRACE";
-
-        case TOX_LOG_LEVEL_DEBUG:
-            return "TOX_LOG_LEVEL_DEBUG";
-
-        case TOX_LOG_LEVEL_INFO:
-            return "TOX_LOG_LEVEL_INFO";
-
-        case TOX_LOG_LEVEL_WARNING:
-            return "TOX_LOG_LEVEL_WARNING";
-
-        case TOX_LOG_LEVEL_ERROR:
-            return "TOX_LOG_LEVEL_ERROR";
-    }
-
-    return "<invalid Tox_Log_Level>";
-}
 const char *tox_err_options_new_to_string(Tox_Err_Options_New value)
 {
     switch (value) {

--- a/toxcore/tox_log_level.c
+++ b/toxcore/tox_log_level.c
@@ -1,0 +1,23 @@
+#include "tox_log_level.h"
+
+const char *tox_log_level_to_string(Tox_Log_Level value)
+{
+    switch (value) {
+    case TOX_LOG_LEVEL_TRACE:
+        return "TOX_LOG_LEVEL_TRACE";
+
+    case TOX_LOG_LEVEL_DEBUG:
+        return "TOX_LOG_LEVEL_DEBUG";
+
+    case TOX_LOG_LEVEL_INFO:
+        return "TOX_LOG_LEVEL_INFO";
+
+    case TOX_LOG_LEVEL_WARNING:
+        return "TOX_LOG_LEVEL_WARNING";
+
+    case TOX_LOG_LEVEL_ERROR:
+        return "TOX_LOG_LEVEL_ERROR";
+    }
+
+    return "<invalid Tox_Log_Level>";
+}

--- a/toxcore/tox_log_level.h
+++ b/toxcore/tox_log_level.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022-2024 The TokTok team.
+ */
+
+#ifndef C_TOXCORE_TOXCORE_TOX_LOG_LEVEL_H
+#define C_TOXCORE_TOXCORE_TOX_LOG_LEVEL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Severity level of log messages.
+ */
+typedef enum Tox_Log_Level {
+
+    /**
+     * Very detailed traces including all network activity.
+     */
+    TOX_LOG_LEVEL_TRACE,
+
+    /**
+     * Debug messages such as which port we bind to.
+     */
+    TOX_LOG_LEVEL_DEBUG,
+
+    /**
+     * Informational log messages such as video call status changes.
+     */
+    TOX_LOG_LEVEL_INFO,
+
+    /**
+     * Warnings about internal inconsistency or logic errors.
+     */
+    TOX_LOG_LEVEL_WARNING,
+
+    /**
+     * Severe unexpected errors caused by external or internal inconsistency.
+     */
+    TOX_LOG_LEVEL_ERROR,
+
+} Tox_Log_Level;
+
+const char *tox_log_level_to_string(Tox_Log_Level value);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* C_TOXCORE_TOXCORE_TOX_LOG_LEVEL_H */


### PR DESCRIPTION
Perhaps we can reuse it in the logger.