### PR TITLE
fix: reduce memory usage in group chats by 75%

### DIFF
--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -52,7 +52,7 @@
 #define MAX_GC_PACKET_SIZE (MAX_GC_PACKET_CHUNK_SIZE * 100)
 
 /* Max number of messages to store in the send/recv arrays */
-#define GCC_BUFFER_SIZE 8192
+#define GCC_BUFFER_SIZE 2048
 
 /** Self UDP status. Must correspond to return values from `ipport_self_copy()`. */
 typedef enum Self_UDP_Status {


### PR DESCRIPTION
Significantly reduced the memory usage of groups since all message slots are preallocated for every peer for send and receive buffers of buffer size (hundreds of MiB **peak** when save contained a lot of peers to try to connect to)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2801)
<!-- Reviewable:end -->
