### PR TITLE
test: Fix crypto_test to initialise its plain text buffer.

### DIFF
--- a/auto_tests/crypto_test.c
+++ b/auto_tests/crypto_test.c
@@ -301,6 +301,8 @@ static void test_very_large_data(void)
     ck_assert(plain != nullptr);
     ck_assert(encrypted != nullptr);
 
+    memset(plain, 0, plain_size);
+
     encrypt_data(mem, pk, sk, nonce, plain, plain_size, encrypted);
 
     free(encrypted);


### PR DESCRIPTION
msan caught this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2804)
<!-- Reviewable:end -->
