### PR TITLE
fix: Allow peers to reconnect to group chats using a password

### DIFF
--- a/auto_tests/group_general_test.c
+++ b/auto_tests/group_general_test.c
@@ -392,9 +392,9 @@ static void group_announce_test(AutoTox *autotoxes)
     ck_assert(s_err == TOX_ERR_GROUP_SELF_STATUS_SET_OK);
 
     fprintf(stderr, "Peer 0 reconnecting...\n");
-    Tox_Err_Group_Reconnect r_err;
-    tox_group_reconnect(tox0, groupnumber, &r_err);
-    ck_assert(r_err == TOX_ERR_GROUP_RECONNECT_OK);
+    Tox_Err_Group_Join err_rejoin;
+    tox_group_join(tox0, chat_id, (const uint8_t *)PEER0_NICK, PEER0_NICK_LEN, nullptr, 0, &err_rejoin);
+    ck_assert(err_rejoin == TOX_ERR_GROUP_JOIN_OK);
 
     while (state1->peer_joined_count != 2 && state0->self_joined_count == 2) {
         iterate_all_wait(autotoxes, NUM_GROUP_TOXES, ITERATION_INTERVAL);

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -676,8 +676,8 @@ bool gc_disconnect_from_group(const GC_Session *c, GC_Chat *chat);
  * Returns -1 if the group handler object or chat object is null.
  * Returns -2 if the Messenger friend connection fails to initialize.
  */
-non_null()
-int gc_rejoin_group(GC_Session *c, GC_Chat *chat);
+non_null(1, 2) nullable(3)
+int gc_rejoin_group(GC_Session *c, GC_Chat *chat, const uint8_t *passwd, uint16_t passwd_len);
 
 /** @brief Joins a group using the invite data received in a friend's group invite.
  *

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -3249,7 +3249,7 @@ bool tox_group_reconnect(Tox *tox, uint32_t group_number, Tox_Err_Group_Reconnec
         return false;
     }
 
-    const int ret = gc_rejoin_group(tox->m->group_handler, chat);
+    const int ret = gc_rejoin_group(tox->m->group_handler, chat, nullptr, 0);
     tox_unlock(tox);
 
     switch (ret) {

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -3717,11 +3717,14 @@ typedef enum Tox_Err_Group_Join {
 const char *tox_err_group_join_to_string(Tox_Err_Group_Join value);
 
 /**
- * Joins a group chat with specified Chat ID.
+ * Joins a group chat with specified Chat ID or reconnects to an existing group.
  *
  * This function creates a new group chat object, adds it to the chats array,
  * and sends a DHT announcement to find peers in the group associated with
  * chat_id. Once a peer has been found a join attempt will be initiated.
+ *
+ * If a group with the specified Chat ID already exists, this function will attempt
+ * to reconnect to the group.
  *
  * @param chat_id The Chat ID of the group you wish to join. This must be
  *   TOX_GROUP_CHAT_ID_SIZE bytes.
@@ -3827,6 +3830,8 @@ const char *tox_err_group_reconnect_to_string(Tox_Err_Group_Reconnect value);
  * @param group_number The group number of the group we wish to reconnect to.
  *
  * @return true on success.
+ *
+ * @deprecated Use `tox_group_join` instead.
  */
 bool tox_group_reconnect(Tox *tox, Tox_Group_Number group_number, Tox_Err_Group_Reconnect *error);
 


### PR DESCRIPTION
This commit deprecates the tox_group_reconnect groupchat API function and modifies the tox_group_join function to automatically reconnect to groups when it's called with a chat_id that designates a group that it's already a member of.

This allows clients to implement group rejoin functionality that lets peers rejoin/reconnect to groups with a passed password argument, which may be necessary if the group password changes while a peer is offline. This fixes the bug described in #2806.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2807)
<!-- Reviewable:end -->
