### PR TITLE
docs: Update the docs for group join functions

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -7797,10 +7797,6 @@ int gc_group_join(GC_Session *c, const uint8_t *chat_id, const uint8_t *nick, si
         return ret != 0 ? -6 : ret;
     }
 
-    if (getfriend_id(c->messenger, chat_id) != -1) {
-        return -2;
-    }
-
     const int group_number = create_new_group(c->messenger->mem, c, nick, nick_length, false, GI_PUBLIC);
 
     if (group_number == -1) {

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -650,7 +650,7 @@ int gc_group_add(GC_Session *c, Group_Privacy_State privacy_state, const uint8_t
  *
  * Return group_number on success.
  * Return -1 if the group object fails to initialize.
- * Return -2 if chat_id is NULL or a group with chat_id already exists in the chats array.
+ * Return -2 if chat_id is NULL.
  * Return -3 if nick is too long.
  * Return -4 if nick is empty or nick length is zero.
  * Return -5 if there is an error setting the group password.

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -3698,9 +3698,7 @@ typedef enum Tox_Err_Group_Join {
     TOX_ERR_GROUP_JOIN_INIT,
 
     /**
-     * The chat_id pointer is set to NULL or a group with chat_id already
-     * exists. This usually happens if the client attempts to create multiple
-     * sessions for the same group.
+     * The chat_id pointer is set to NULL.
      */
     TOX_ERR_GROUP_JOIN_BAD_CHAT_ID,
 


### PR DESCRIPTION
The docs now reflect the changes made in commit fc06506. The getfriend_id check was also removed as it no longer serves a purpose. It previously would indicate that the group already existed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2808)
<!-- Reviewable:end -->
