### PR TITLE
docs: Output the error code string instead of int in toxav logging

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,6 @@ bazel-opt_task:
     - cd /src/workspace && bazel
         --max_idle_secs=5
         test -k
-        --remote_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --build_tag_filters=-haskell
         --test_tag_filters=-haskell
         --
@@ -52,7 +51,6 @@ cimple_task:
     - cd /src/workspace && bazel
         --max_idle_secs=5
         test -k
-        --remote_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --build_tag_filters=haskell
         --test_tag_filters=haskell
         --

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -780,8 +780,8 @@ static void rtp_send_piece(const Logger *log, Tox *tox, uint32_t friend_number, 
 
     if (error != TOX_ERR_FRIEND_CUSTOM_PACKET_OK) {
         char *netstrerror = net_new_strerror(net_error());
-        LOGGER_WARNING(log, "RTP send failed (len: %d)! tox error: %d, net error: %s",
-                       length + RTP_HEADER_SIZE + 1, error, netstrerror);
+        LOGGER_WARNING(log, "RTP send failed (len: %d)! tox error: %s, net error: %s",
+                       length + RTP_HEADER_SIZE + 1, tox_err_friend_custom_packet_to_string(error), netstrerror);
         net_kill_strerror(netstrerror);
     }
 }


### PR DESCRIPTION
"tox error: 7" is less useful than "tox error:
TOX_ERR_FRIEND_CUSTOM_PACKET_SENDQ".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2812)
<!-- Reviewable:end -->
