### PR TITLE
refactor: Make Tox_Options own the passed proxy host and savedata.

### DIFF
--- a/auto_tests/file_saving_test.c
+++ b/auto_tests/file_saving_test.c
@@ -13,6 +13,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../toxcore/ccompat.h"
+#include "../toxcore/tox.h"
 #include "auto_test_support.h"
 #include "check_compat.h"
 
@@ -71,11 +73,12 @@ static void load_data_decrypted(void)
     int64_t size = ftell(f);
     fseek(f, 0, SEEK_SET);
 
-    ck_assert_msg(0 <= size && size <= UINT_MAX, "file size out of range");
+    ck_assert_msg(TOX_PASS_ENCRYPTION_EXTRA_LENGTH <= size && size <= UINT_MAX, "file size out of range");
 
     uint8_t *cipher = (uint8_t *)malloc(size);
     ck_assert(cipher != nullptr);
-    uint8_t *clear = (uint8_t *)malloc(size - TOX_PASS_ENCRYPTION_EXTRA_LENGTH);
+    const size_t clear_size = size - TOX_PASS_ENCRYPTION_EXTRA_LENGTH;
+    uint8_t *clear = (uint8_t *)malloc(clear_size);
     ck_assert(clear != nullptr);
     size_t read_value = fread(cipher, sizeof(*cipher), size, f);
     printf("Read read_value = %u of %u\n", (unsigned)read_value, (unsigned)size);
@@ -88,9 +91,10 @@ static void load_data_decrypted(void)
     struct Tox_Options *options = tox_options_new(nullptr);
     ck_assert(options != nullptr);
 
+    tox_options_set_experimental_owned_data(options, true);
     tox_options_set_savedata_type(options, TOX_SAVEDATA_TYPE_TOX_SAVE);
-
-    tox_options_set_savedata_data(options, clear, size);
+    ck_assert(tox_options_set_savedata_data(options, clear, clear_size));
+    free(clear);
 
     Tox_Err_New err;
 
@@ -107,7 +111,6 @@ static void load_data_decrypted(void)
                   "name returned by tox_self_get_name does not match expected result");
 
     tox_kill(t);
-    free(clear);
     free(cipher);
     free(readname);
     fclose(f);

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -574,7 +574,7 @@ struct Tox_Options {
      * TOX_PROXY_TYPE_NONE.
      *
      * The data pointed at by this member is owned by the user, so must
-     * outlive the options object.
+     * outlive the options object (unless experimental_owned_data is set).
      */
     const char *proxy_host;
 
@@ -629,10 +629,10 @@ struct Tox_Options {
     Tox_Savedata_Type savedata_type;
 
     /**
-     * The savedata.
+     * The savedata (either a Tox save or a secret key) to load from.
      *
-     * The data pointed at by this member is owned by the user, so must outlive
-     * the options object.
+     * The data pointed at by this member is owned by the user, so must
+     * outlive the options object (unless experimental_owned_data is set).
      */
     const uint8_t *savedata_data;
 
@@ -694,6 +694,34 @@ struct Tox_Options {
      * Default: false. May become true in the future (0.3.0).
      */
     bool experimental_disable_dns;
+
+    /**
+     * @brief Whether the savedata data is owned by the Tox_Options object.
+     *
+     * If true, the setters for savedata and proxy_host try to copy the string.
+     * If that fails, the value is not copied and the member is set to the
+     * user-provided pointer. In that case, the user must not free the string
+     * until the Tox_Options object is freed. Client code can check whether
+     * allocation succeeded by checking the returned bool. If
+     * experimental_owned_data is false, it will always return true. If set to
+     * true, the return value will be false on allocation failure.
+     *
+     * If set to true, this must be set before any other member that allocates
+     * memory is set.
+     */
+    bool experimental_owned_data;
+
+    /**
+     * @brief Owned pointer to the savedata data.
+     * @private
+     */
+    uint8_t *owned_savedata_data;
+
+    /**
+     * @brief Owned pointer to the proxy host.
+     * @private
+     */
+    char *owned_proxy_host;
 };
 #endif /* TOX_HIDE_DEPRECATED */
 
@@ -719,7 +747,7 @@ void tox_options_set_proxy_type(Tox_Options *options, Tox_Proxy_Type proxy_type)
 
 const char *tox_options_get_proxy_host(const Tox_Options *options);
 
-void tox_options_set_proxy_host(Tox_Options *options, const char *proxy_host);
+bool tox_options_set_proxy_host(Tox_Options *options, const char *proxy_host);
 
 uint16_t tox_options_get_proxy_port(const Tox_Options *options);
 
@@ -747,7 +775,7 @@ void tox_options_set_savedata_type(Tox_Options *options, Tox_Savedata_Type saved
 
 const uint8_t *tox_options_get_savedata_data(const Tox_Options *options);
 
-void tox_options_set_savedata_data(Tox_Options *options, const uint8_t savedata_data[], size_t length);
+bool tox_options_set_savedata_data(Tox_Options *options, const uint8_t savedata_data[], size_t length);
 
 size_t tox_options_get_savedata_length(const Tox_Options *options);
 
@@ -760,6 +788,10 @@ void tox_options_set_log_callback(Tox_Options *options, tox_log_cb *log_callback
 void *tox_options_get_log_user_data(const Tox_Options *options);
 
 void tox_options_set_log_user_data(Tox_Options *options, void *log_user_data);
+
+bool tox_options_get_experimental_owned_data(const Tox_Options *options);
+
+void tox_options_set_experimental_owned_data(Tox_Options *options, bool experimental_owned_data);
 
 bool tox_options_get_experimental_thread_safety(const Tox_Options *options);
 


### PR DESCRIPTION
This way, client code can immediately free their data after the options setter returns true.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2819)
<!-- Reviewable:end -->
