### PR TITLE
cleanup: Align internal logger with external on type of source line.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ workflows:
   circleci:
     jobs:
       - bazel-asan
+      - bazel-dbg
+      - bazel-opt
       - clang-analyze
       - cpplint
       - static-analysis
@@ -17,6 +19,26 @@ jobs:
     working_directory: /tmp/cirrus-ci-build
     docker:
       - image: toxchat/toktok-stack:latest-asan
+
+    steps:
+      - checkout
+      - run: .circleci/bazel-test
+          //c-toxcore/...
+
+  bazel-dbg:
+    working_directory: /tmp/cirrus-ci-build
+    docker:
+      - image: toxchat/toktok-stack:latest-debug
+
+    steps:
+      - checkout
+      - run: .circleci/bazel-test
+          //c-toxcore/...
+
+  bazel-opt:
+    working_directory: /tmp/cirrus-ci-build
+    docker:
+      - image: toxchat/toktok-stack:latest-release
 
     steps:
       - checkout

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,15 +1,15 @@
 ---
 bazel-opt_task:
-  timeout_in: 5m
+  timeout_in: 10m
   container:
     image: toxchat/toktok-stack:latest-release
-    cpu: 2
+    cpu: 8
     memory: 2G
   configure_script:
     - git submodule update --init --recursive
     - /src/workspace/tools/inject-repo c-toxcore
   test_all_script:
-    - cd /src/workspace && bazel
+    - cd /src/workspace && tools/retry 5 bazel
         test -k
         --build_tag_filters=-haskell
         --test_tag_filters=-haskell
@@ -18,16 +18,16 @@ bazel-opt_task:
         -//c-toxcore/auto_tests:tcp_relay_test # Cirrus doesn't allow external network connections.
 
 bazel-dbg_task:
-  timeout_in: 5m
+  timeout_in: 10m
   container:
     image: toxchat/toktok-stack:latest-debug
-    cpu: 2
+    cpu: 8
     memory: 2G
   configure_script:
     - git submodule update --init --recursive
     - /src/workspace/tools/inject-repo c-toxcore
   test_all_script:
-    - cd /src/workspace && bazel
+    - cd /src/workspace && tools/retry 5 bazel
         test -k
         --build_tag_filters=-haskell
         --test_tag_filters=-haskell
@@ -36,7 +36,7 @@ bazel-dbg_task:
         -//c-toxcore/auto_tests:tcp_relay_test # Cirrus doesn't allow external network connections.
 
 bazel-msan_task:
-  timeout_in: 5m
+  timeout_in: 10m
   container:
     image: toxchat/toktok-stack:latest-msan
     cpu: 2
@@ -45,7 +45,7 @@ bazel-msan_task:
     - git submodule update --init --recursive
     - /src/workspace/tools/inject-repo c-toxcore
   test_all_script:
-    - cd /src/workspace && bazel
+    - cd /src/workspace && tools/retry 5 bazel
         test -k
         --
         //c-toxcore/auto_tests:lossless_packet_test
@@ -97,4 +97,4 @@ freebsd_task:
         -DAUTOTEST=ON \
         -GNinja
       cmake --build . --target install
-      ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:6
+      ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:3 || ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:3

--- a/auto_tests/auto_test_support.c
+++ b/auto_tests/auto_test_support.c
@@ -444,9 +444,9 @@ void print_debug_log(Tox *m, Tox_Log_Level level, const char *file, uint32_t lin
     }
 }
 
-void print_debug_logger(void *context, Logger_Level level, const char *file, int line, const char *func, const char *message, void *userdata)
+void print_debug_logger(void *context, Logger_Level level, const char *file, uint32_t line, const char *func, const char *message, void *userdata)
 {
-    print_debug_log(nullptr, (Tox_Log_Level) level, file, (uint32_t) line, func, message, userdata);
+    print_debug_log(nullptr, (Tox_Log_Level) level, file, line, func, message, userdata);
 }
 
 Tox *tox_new_log_lan(struct Tox_Options *options, Tox_Err_New *err, void *log_user_data, bool lan_discovery)

--- a/auto_tests/auto_test_support.h
+++ b/auto_tests/auto_test_support.h
@@ -60,7 +60,7 @@ void print_debug_log(Tox *m, Tox_Log_Level level, const char *file, uint32_t lin
                      const char *message, void *user_data);
 
 // Use this function when setting the log callback on a Logger object
-void print_debug_logger(void *context, Logger_Level level, const char *file, int line,
+void print_debug_logger(void *context, Logger_Level level, const char *file, uint32_t line,
                         const char *func, const char *message, void *userdata);
 
 Tox *tox_new_log(struct Tox_Options *options, Tox_Err_New *err, void *log_user_data);

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -117,10 +117,10 @@ static const char *strlevel(Logger_Level level)
     }
 }
 
-static void print_log(void *context, Logger_Level level, const char *file, int line,
+static void print_log(void *context, Logger_Level level, const char *file, uint32_t line,
                       const char *func, const char *message, void *userdata)
 {
-    fprintf(stderr, "[%s] %s:%d(%s) %s\n", strlevel(level), file, line, func, message);
+    fprintf(stderr, "[%s] %s:%u(%s) %s\n", strlevel(level), file, line, func, message);
 }
 
 int main(int argc, char *argv[])

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -200,10 +200,10 @@ static LOG_LEVEL logger_level_to_log_level(Logger_Level level)
     }
 }
 
-static void toxcore_logger_callback(void *context, Logger_Level level, const char *file, int line,
+static void toxcore_logger_callback(void *context, Logger_Level level, const char *file, uint32_t line,
                                     const char *func, const char *message, void *userdata)
 {
-    log_write(logger_level_to_log_level(level), "%s:%d(%s) %s\n", file, line, func, message);
+    log_write(logger_level_to_log_level(level), "%s:%u(%s) %s\n", file, line, func, message);
 }
 
 static volatile sig_atomic_t caught_signal = 0;

--- a/toxcore/logger.c
+++ b/toxcore/logger.c
@@ -57,7 +57,7 @@ void logger_callback_log(Logger *log, logger_cb *function, void *context, void *
     log->userdata = userdata;
 }
 
-void logger_write(const Logger *log, Logger_Level level, const char *file, int line, const char *func,
+void logger_write(const Logger *log, Logger_Level level, const char *file, uint32_t line, const char *func,
                   const char *format, ...)
 {
     if (log == nullptr) {

--- a/toxcore/logger.h
+++ b/toxcore/logger.h
@@ -33,7 +33,7 @@ typedef enum Logger_Level {
 
 typedef struct Logger Logger;
 
-typedef void logger_cb(void *context, Logger_Level level, const char *file, int line,
+typedef void logger_cb(void *context, Logger_Level level, const char *file, uint32_t line,
                        const char *func, const char *message, void *userdata);
 
 /**
@@ -66,7 +66,7 @@ void logger_callback_log(Logger *log, logger_cb *function, void *context, void *
  */
 non_null(3, 5, 6) nullable(1) GNU_PRINTF(6, 7)
 void logger_write(
-    const Logger *log, Logger_Level level, const char *file, int line, const char *func,
+    const Logger *log, Logger_Level level, const char *file, uint32_t line, const char *func,
     const char *format, ...);
 
 /* @brief Terminate the program with a signal. */

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -79,7 +79,7 @@ struct Tox_Userdata {
 
 static logger_cb tox_log_handler;
 non_null(1, 3, 5, 6) nullable(7)
-static void tox_log_handler(void *context, Logger_Level level, const char *file, int line, const char *func,
+static void tox_log_handler(void *context, Logger_Level level, const char *file, uint32_t line, const char *func,
                             const char *message, void *userdata)
 {
     Tox *tox = (Tox *)context;


### PR DESCRIPTION
We use `uint32_t` everywhere now. It's easier that way, and line numbers are never negative.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2820)
<!-- Reviewable:end -->
