### PR TITLE
feat: Add `to_string` functions for toxencryptsave errors.

### DIFF
--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -89,3 +89,10 @@ cc_binary(
         "//c-toxcore/toxcore:mono_time",
     ],
 )
+
+cc_binary(
+    name = "decrypt_save",
+    testonly = 1,
+    srcs = ["decrypt_save.c"],
+    deps = ["//c-toxcore/toxencryptsave"],
+)

--- a/testing/decrypt_save.c
+++ b/testing/decrypt_save.c
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2025 The TokTok team.
+ */
+#include "../toxencryptsave/toxencryptsave.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ./decrypt_save <password> <encrypted input> <decrypted output>
+int main(int argc, char *argv[])
+{
+    if (argc != 4) {
+        printf("Usage: %s <password> <encrypted input> <decrypted output>\n", argv[0]);
+        return 1;
+    }
+    FILE *fp = fopen(argv[2], "rb");
+    if (!fp) {
+        printf("Could not open %s\n", argv[2]);
+        return 1;
+    }
+    fseek(fp, 0, SEEK_END);
+    size_t len = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    uint8_t *data = (uint8_t *)malloc(len);
+    if (!data) {
+        printf("Could not allocate memory\n");
+        fclose(fp);
+        return 1;
+    }
+
+    if (fread(data, 1, len, fp) != len) {
+        printf("Could not read %s\n", argv[2]);
+        free(data);
+        fclose(fp);
+        return 1;
+    }
+    fclose(fp);
+
+    uint8_t *plaintext = (uint8_t *)malloc(len);
+    if (!plaintext) {
+        printf("Could not allocate memory\n");
+        free(data);
+        return 1;
+    }
+    Tox_Err_Decryption error;
+    if (!tox_pass_decrypt(data, len, (uint8_t *)argv[1], strlen(argv[1]), plaintext, &error)) {
+        printf("Could not decrypt: %s\n", tox_err_decryption_to_string(error));
+        free(data);
+        free(plaintext);
+        return 1;
+    }
+    fp = fopen(argv[3], "wb");
+    if (!fp) {
+        printf("Could not open %s\n", argv[3]);
+        free(data);
+        free(plaintext);
+        return 1;
+    }
+    if (fwrite(plaintext, 1, len - TOX_PASS_ENCRYPTION_EXTRA_LENGTH, fp) != len - TOX_PASS_ENCRYPTION_EXTRA_LENGTH) {
+        printf("Could not write %s\n", argv[3]);
+        free(data);
+        free(plaintext);
+        fclose(fp);
+        return 1;
+    }
+    free(data);
+    free(plaintext);
+    fclose(fp);
+
+    return 0;
+}

--- a/toxencryptsave/toxencryptsave.c
+++ b/toxencryptsave/toxencryptsave.c
@@ -395,3 +395,63 @@ bool tox_is_data_encrypted(const uint8_t data[TOX_PASS_ENCRYPTION_EXTRA_LENGTH])
 {
     return memcmp(data, TOX_ENC_SAVE_MAGIC_NUMBER, TOX_ENC_SAVE_MAGIC_LENGTH) == 0;
 }
+
+const char *tox_err_key_derivation_to_string(Tox_Err_Key_Derivation error)
+{
+    switch (error) {
+        case TOX_ERR_KEY_DERIVATION_OK:
+            return "TOX_ERR_KEY_DERIVATION_OK";
+        case TOX_ERR_KEY_DERIVATION_NULL:
+            return "TOX_ERR_KEY_DERIVATION_NULL";
+        case TOX_ERR_KEY_DERIVATION_FAILED:
+            return "TOX_ERR_KEY_DERIVATION_FAILED";
+    }
+    return "<invalid Tox_Err_Key_Derivation>";
+}
+
+const char *tox_err_encryption_to_string(Tox_Err_Encryption error)
+{
+    switch (error) {
+        case TOX_ERR_ENCRYPTION_OK:
+            return "TOX_ERR_ENCRYPTION_OK";
+        case TOX_ERR_ENCRYPTION_NULL:
+            return "TOX_ERR_ENCRYPTION_NULL";
+        case TOX_ERR_ENCRYPTION_KEY_DERIVATION_FAILED:
+            return "TOX_ERR_ENCRYPTION_KEY_DERIVATION_FAILED";
+        case TOX_ERR_ENCRYPTION_FAILED:
+            return "TOX_ERR_ENCRYPTION_FAILED";
+    }
+    return "<invalid Tox_Err_Encryption>";
+}
+
+const char *tox_err_decryption_to_string(Tox_Err_Decryption error)
+{
+    switch (error) {
+        case TOX_ERR_DECRYPTION_OK:
+            return "TOX_ERR_DECRYPTION_OK";
+        case TOX_ERR_DECRYPTION_NULL:
+            return "TOX_ERR_DECRYPTION_NULL";
+        case TOX_ERR_DECRYPTION_INVALID_LENGTH:
+            return "TOX_ERR_DECRYPTION_INVALID_LENGTH";
+        case TOX_ERR_DECRYPTION_BAD_FORMAT:
+            return "TOX_ERR_DECRYPTION_BAD_FORMAT";
+        case TOX_ERR_DECRYPTION_KEY_DERIVATION_FAILED:
+            return "TOX_ERR_DECRYPTION_KEY_DERIVATION_FAILED";
+        case TOX_ERR_DECRYPTION_FAILED:
+            return "TOX_ERR_DECRYPTION_FAILED";
+    }
+    return "<invalid Tox_Err_Decryption>";
+}
+
+const char *tox_err_get_salt_to_string(Tox_Err_Get_Salt error)
+{
+    switch (error) {
+        case TOX_ERR_GET_SALT_OK:
+            return "TOX_ERR_GET_SALT_OK";
+        case TOX_ERR_GET_SALT_NULL:
+            return "TOX_ERR_GET_SALT_NULL";
+        case TOX_ERR_GET_SALT_BAD_FORMAT:
+            return "TOX_ERR_GET_SALT_BAD_FORMAT";
+    }
+    return "<invalid Tox_Err_Get_Salt>";
+}

--- a/toxencryptsave/toxencryptsave.h
+++ b/toxencryptsave/toxencryptsave.h
@@ -88,6 +88,8 @@ typedef enum Tox_Err_Key_Derivation {
 
 } Tox_Err_Key_Derivation;
 
+const char *tox_err_key_derivation_to_string(Tox_Err_Key_Derivation error);
+
 typedef enum Tox_Err_Encryption {
 
     /**
@@ -113,6 +115,8 @@ typedef enum Tox_Err_Encryption {
     TOX_ERR_ENCRYPTION_FAILED,
 
 } Tox_Err_Encryption;
+
+const char *tox_err_encryption_to_string(Tox_Err_Encryption error);
 
 typedef enum Tox_Err_Decryption {
 
@@ -151,6 +155,8 @@ typedef enum Tox_Err_Decryption {
     TOX_ERR_DECRYPTION_FAILED,
 
 } Tox_Err_Decryption;
+
+const char *tox_err_decryption_to_string(Tox_Err_Decryption error);
 
 /*******************************************************************************
  *
@@ -312,6 +318,8 @@ typedef enum Tox_Err_Get_Salt {
     TOX_ERR_GET_SALT_BAD_FORMAT,
 
 } Tox_Err_Get_Salt;
+
+const char *tox_err_get_salt_to_string(Tox_Err_Get_Salt error);
 
 /**
  * Retrieves the salt used to encrypt the given data.


### PR DESCRIPTION
Also added a tox save decryption tool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2824)
<!-- Reviewable:end -->
