### PR TITLE
cleanup: Use tox memory for bin_unpack and net_strerror.

### DIFF
--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -1,7 +1,5 @@
-#include <stdlib.h>
 #include <string.h>
 
-#include "../testing/misc_tools.h"
 #include "../toxcore/network.h"
 #include "check_compat.h"
 
@@ -34,9 +32,10 @@ static void test_addr_resolv_localhost(void)
     bool res = addr_resolve_or_parse_ip(ns, mem, localhost, &ip, nullptr, true);
 
     int error = net_error();
-    char *strerror = net_new_strerror(error);
+    char *strerror = net_new_strerror(mem, error);
+    ck_assert(strerror != nullptr);
     ck_assert_msg(res, "Resolver failed: %d, %s", error, strerror);
-    net_kill_strerror(strerror);
+    net_kill_strerror(mem, strerror);
 
     Ip_Ntoa ip_str;
     ck_assert_msg(net_family_is_ipv4(ip.family), "Expected family TOX_AF_INET, got %u.", ip.family.value);
@@ -57,9 +56,10 @@ static void test_addr_resolv_localhost(void)
     }
 
     error = net_error();
-    strerror = net_new_strerror(error);
+    strerror = net_new_strerror(mem, error);
+    ck_assert(strerror != nullptr);
     ck_assert_msg(res, "Resolver failed: %d, %s", error, strerror);
-    net_kill_strerror(strerror);
+    net_kill_strerror(mem, strerror);
 
     ck_assert_msg(net_family_is_ipv6(ip.family), "Expected family TOX_AF_INET6 (%d), got %u.", TOX_AF_INET6,
                   ip.family.value);
@@ -80,9 +80,10 @@ static void test_addr_resolv_localhost(void)
     ip_reset(&extra);
     res = addr_resolve_or_parse_ip(ns, mem, localhost, &ip, &extra, true);
     error = net_error();
-    strerror = net_new_strerror(error);
+    strerror = net_new_strerror(mem, error);
+    ck_assert(strerror != nullptr);
     ck_assert_msg(res, "Resolver failed: %d, %s", error, strerror);
-    net_kill_strerror(strerror);
+    net_kill_strerror(mem, strerror);
 
 #if USE_IPV6
     ck_assert_msg(net_family_is_ipv6(ip.family), "Expected family TOX_AF_INET6 (%d), got %u.", TOX_AF_INET6,

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -678,7 +678,7 @@ static uint32_t rtp_random_u32(void)
     return randombytes_random();
 }
 
-RTPSession *rtp_new(const Logger *log, int payload_type, Tox *tox, ToxAV *toxav, uint32_t friendnumber,
+RTPSession *rtp_new(const Logger *log, const Memory *mem, int payload_type, Tox *tox, ToxAV *toxav, uint32_t friendnumber,
                     BWController *bwc, void *cs, rtp_m_cb *mcb)
 {
     assert(mcb != nullptr);
@@ -704,6 +704,8 @@ RTPSession *rtp_new(const Logger *log, int payload_type, Tox *tox, ToxAV *toxav,
 
     session->ssrc = payload_type == RTP_TYPE_VIDEO ? 0 : rtp_random_u32(); // Zoff: what is this??
     session->payload_type = payload_type;
+    session->log = log;
+    session->mem = mem;
     session->tox = tox;
     session->toxav = toxav;
     session->friend_number = friendnumber;
@@ -773,18 +775,18 @@ void rtp_stop_receiving(Tox *tox)
  * @param error the error from rtp_send_custom_lossy_packet.
  * @param rdata_size The package length to be shown in the log.
  */
-static void rtp_report_error_maybe(const Logger *log, Tox_Err_Friend_Custom_Packet error, uint16_t rdata_size)
+static void rtp_report_error_maybe(const Logger *log, const Memory *mem, Tox_Err_Friend_Custom_Packet error, uint16_t rdata_size)
 {
     if (error != TOX_ERR_FRIEND_CUSTOM_PACKET_OK) {
-        char *netstrerror = net_new_strerror(net_error());
+        char *netstrerror = net_new_strerror(mem, net_error());
         const char *toxerror = tox_err_friend_custom_packet_to_string(error);
         LOGGER_WARNING(log, "RTP send failed (len: %u)! tox error: %s net error: %s",
                        rdata_size, toxerror, netstrerror);
-        net_kill_strerror(netstrerror);
+        net_kill_strerror(mem, netstrerror);
     }
 }
 
-static void rtp_send_piece(const Logger *log, Tox *tox, uint32_t friend_number, const struct RTPHeader *header,
+static void rtp_send_piece(const Logger *log, const Memory *mem, Tox *tox, uint32_t friend_number, const struct RTPHeader *header,
                            const uint8_t *data, uint8_t *rdata, uint16_t length)
 {
     rtp_header_pack(rdata + 1, header);
@@ -795,7 +797,7 @@ static void rtp_send_piece(const Logger *log, Tox *tox, uint32_t friend_number, 
     Tox_Err_Friend_Custom_Packet error;
     tox_friend_send_lossy_packet(tox, friend_number, rdata, rdata_size, &error);
 
-    rtp_report_error_maybe(log, error, rdata_size);
+    rtp_report_error_maybe(log, mem, error, rdata_size);
 }
 
 static struct RTPHeader rtp_default_header(const RTPSession *session, uint32_t length, bool is_keyframe)
@@ -868,7 +870,7 @@ int rtp_send_data(const Logger *log, RTPSession *session, const uint8_t *data, u
          * Send the packet in single piece.
          */
         assert(length < UINT16_MAX);
-        rtp_send_piece(log, session->tox, session->friend_number, &header, data, rdata, length);
+        rtp_send_piece(log, session->mem, session->tox, session->friend_number, &header, data, rdata, length);
     } else {
         /*
          * The length is greater than the maximum allowed length (including header)
@@ -878,7 +880,7 @@ int rtp_send_data(const Logger *log, RTPSession *session, const uint8_t *data, u
         uint16_t piece = MAX_CRYPTO_DATA_SIZE - (RTP_HEADER_SIZE + 1);
 
         while ((length - sent) + RTP_HEADER_SIZE + 1 > MAX_CRYPTO_DATA_SIZE) {
-            rtp_send_piece(log, session->tox, session->friend_number, &header, data + sent, rdata, piece);
+            rtp_send_piece(log, session->mem, session->tox, session->friend_number, &header, data + sent, rdata, piece);
 
             sent += piece;
             header.offset_lower = sent;
@@ -889,7 +891,7 @@ int rtp_send_data(const Logger *log, RTPSession *session, const uint8_t *data, u
         piece = length - sent;
 
         if (piece != 0) {
-            rtp_send_piece(log, session->tox, session->friend_number, &header, data + sent, rdata, piece);
+            rtp_send_piece(log, session->mem, session->tox, session->friend_number, &header, data + sent, rdata, piece);
         }
     }
 

--- a/toxav/rtp.h
+++ b/toxav/rtp.h
@@ -162,6 +162,7 @@ typedef struct RTPSession {
     struct RTPWorkBufferList *work_buffer_list;
     uint8_t  first_packets_counter; /* dismiss first few lost video packets */
     const Logger *log;
+    const Memory *mem;
     Tox *tox;
     ToxAV *toxav;
     uint32_t friend_number;
@@ -192,7 +193,7 @@ size_t rtp_header_pack(uint8_t *rdata, const struct RTPHeader *header);
  */
 size_t rtp_header_unpack(const uint8_t *data, struct RTPHeader *header);
 
-RTPSession *rtp_new(const Logger *log, int payload_type, Tox *tox, ToxAV *toxav, uint32_t friendnumber,
+RTPSession *rtp_new(const Logger *log, const Memory *mem, int payload_type, Tox *tox, ToxAV *toxav, uint32_t friendnumber,
                     BWController *bwc, void *cs, rtp_m_cb *mcb);
 void rtp_kill(const Logger *log, RTPSession *session);
 void rtp_allow_receiving_mark(RTPSession *session);

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -192,6 +192,7 @@ cc_library(
     deps = [
         ":attributes",
         ":ccompat",
+        ":mem",
         "//c-toxcore/third_party:cmp",
     ],
 )
@@ -204,6 +205,7 @@ cc_test(
         ":bin_pack",
         ":bin_unpack",
         ":logger",
+        ":mem",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -3171,7 +3171,7 @@ static bool handle_groups_load(void *obj, Bin_Unpack *bu)
 non_null()
 static State_Load_Status groups_load(Messenger *m, const uint8_t *data, uint32_t length)
 {
-    if (!bin_unpack_obj(handle_groups_load, m, data, length)) {
+    if (!bin_unpack_obj(m->mem, handle_groups_load, m, data, length)) {
         LOGGER_ERROR(m->log, "msgpack failed to unpack groupchats array");
         return STATE_LOAD_STATUS_ERROR;
     }

--- a/toxcore/TCP_common.c
+++ b/toxcore/TCP_common.c
@@ -35,7 +35,7 @@ int send_pending_data_nonpriority(const Logger *logger, TCP_Connection *con)
     }
 
     const uint16_t left = con->last_packet_length - con->last_packet_sent;
-    const int len = net_send(con->ns, logger, con->sock, con->last_packet + con->last_packet_sent, left, &con->ip_port,
+    const int len = net_send(con->ns, con->mem, logger, con->sock, con->last_packet + con->last_packet_sent, left, &con->ip_port,
                              con->net_profile);
 
     if (len <= 0) {
@@ -67,7 +67,7 @@ int send_pending_data(const Logger *logger, TCP_Connection *con)
 
     while (p != nullptr) {
         const uint16_t left = p->size - p->sent;
-        const int len = net_send(con->ns, logger, con->sock, p->data + p->sent, left, &con->ip_port, con->net_profile);
+        const int len = net_send(con->ns, con->mem, logger, con->sock, p->data + p->sent, left, &con->ip_port, con->net_profile);
 
         if (len != left) {
             if (len > 0) {
@@ -165,7 +165,7 @@ int write_packet_tcp_secure_connection(const Logger *logger, TCP_Connection *con
     }
 
     if (priority) {
-        len = sendpriority ? net_send(con->ns, logger, con->sock, packet, packet_size, &con->ip_port,
+        len = sendpriority ? net_send(con->ns, con->mem, logger, con->sock, packet, packet_size, &con->ip_port,
                                       con->net_profile) : 0;
 
         if (len <= 0) {
@@ -181,7 +181,7 @@ int write_packet_tcp_secure_connection(const Logger *logger, TCP_Connection *con
         return add_priority(con, packet, packet_size, len) ? 1 : 0;
     }
 
-    len = net_send(con->ns, logger, con->sock, packet, packet_size, &con->ip_port, con->net_profile);
+    len = net_send(con->ns, con->mem, logger, con->sock, packet, packet_size, &con->ip_port, con->net_profile);
 
     if (len <= 0) {
         return 0;
@@ -218,7 +218,7 @@ int read_tcp_packet(
         return -1;
     }
 
-    const int len = net_recv(ns, logger, sock, data, length, ip_port);
+    const int len = net_recv(ns, mem, logger, sock, data, length, ip_port);
 
     if (len != length) {
         LOGGER_ERROR(logger, "FAIL recv packet");
@@ -242,7 +242,7 @@ static uint16_t read_tcp_length(const Logger *logger, const Memory *mem, const N
 
     if (count >= sizeof(uint16_t)) {
         uint8_t length_buf[sizeof(uint16_t)];
-        const int len = net_recv(ns, logger, sock, length_buf, sizeof(length_buf), ip_port);
+        const int len = net_recv(ns, mem, logger, sock, length_buf, sizeof(length_buf), ip_port);
 
         if (len != sizeof(uint16_t)) {
             LOGGER_ERROR(logger, "FAIL recv packet");

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -362,7 +362,7 @@ static int handle_tcp_handshake(const Logger *logger, TCP_Secure_Connection *con
 
     const IP_Port ipp = {{{0}}};
 
-    if (TCP_SERVER_HANDSHAKE_SIZE != net_send(con->con.ns, logger, con->con.sock, response, TCP_SERVER_HANDSHAKE_SIZE, &ipp, con->con.net_profile)) {
+    if (TCP_SERVER_HANDSHAKE_SIZE != net_send(con->con.ns, con->con.mem, logger, con->con.sock, response, TCP_SERVER_HANDSHAKE_SIZE, &ipp, con->con.net_profile)) {
         crypto_memzero(shared_key, sizeof(shared_key));
         return -1;
     }
@@ -920,7 +920,7 @@ static int accept_connection(TCP_Server *tcp_server, Socket sock)
 }
 
 non_null()
-static Socket new_listening_tcp_socket(const Logger *logger, const Network *ns, Family family, uint16_t port)
+static Socket new_listening_tcp_socket(const Logger *logger, const Memory *mem, const Network *ns, Family family, uint16_t port)
 {
     const Socket sock = net_socket(ns, family, TOX_SOCK_STREAM, TOX_PROTO_TCP);
 
@@ -942,10 +942,10 @@ static Socket new_listening_tcp_socket(const Logger *logger, const Network *ns, 
     ok = ok && bind_to_port(ns, sock, family, port) && (net_listen(ns, sock, TCP_MAX_BACKLOG) == 0);
 
     if (!ok) {
-        char *const error = net_new_strerror(net_error());
+        char *const error = net_new_strerror(mem, net_error());
         LOGGER_WARNING(logger, "could not bind to TCP port %d (family = %d): %s",
                        port, family.value, error != nullptr ? error : "(null)");
-        net_kill_strerror(error);
+        net_kill_strerror(mem, error);
         kill_sock(ns, sock);
         return net_invalid_socket();
     }
@@ -1015,7 +1015,7 @@ TCP_Server *new_tcp_server(const Logger *logger, const Memory *mem, const Random
     const Family family = ipv6_enabled ? net_family_ipv6() : net_family_ipv4();
 
     for (uint32_t i = 0; i < num_sockets; ++i) {
-        const Socket sock = new_listening_tcp_socket(logger, ns, family, ports[i]);
+        const Socket sock = new_listening_tcp_socket(logger, mem, ns, family, ports[i]);
 
         if (!sock_valid(sock)) {
             continue;

--- a/toxcore/bin_unpack.c
+++ b/toxcore/bin_unpack.c
@@ -5,14 +5,16 @@
 #include "bin_unpack.h"
 
 #include <assert.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "../third_party/cmp/cmp.h"
 #include "attributes.h"
 #include "ccompat.h"
+#include "mem.h"
 
 struct Bin_Unpack {
+    const Memory *mem;
+
     const uint8_t *bytes;
     uint32_t bytes_size;
     cmp_ctx_t ctx;
@@ -54,17 +56,18 @@ static size_t null_writer(cmp_ctx_t *ctx, const void *data, size_t count)
 }
 
 non_null()
-static void bin_unpack_init(Bin_Unpack *bu, const uint8_t *buf, uint32_t buf_size)
+static void bin_unpack_init(Bin_Unpack *bu, const Memory *mem, const uint8_t *buf, uint32_t buf_size)
 {
+    bu->mem = mem;
     bu->bytes = buf;
     bu->bytes_size = buf_size;
     cmp_init(&bu->ctx, bu, buf_reader, buf_skipper, null_writer);
 }
 
-bool bin_unpack_obj(bin_unpack_cb *callback, void *obj, const uint8_t *buf, uint32_t buf_size)
+bool bin_unpack_obj(const Memory *mem, bin_unpack_cb *callback, void *obj, const uint8_t *buf, uint32_t buf_size)
 {
     Bin_Unpack bu;
-    bin_unpack_init(&bu, buf, buf_size);
+    bin_unpack_init(&bu, mem, buf, buf_size);
     return callback(obj, &bu);
 }
 
@@ -120,10 +123,10 @@ bool bin_unpack_bin(Bin_Unpack *bu, uint8_t **data_ptr, uint32_t *data_length_pt
         // There aren't as many bytes as this bin claims to want to allocate.
         return false;
     }
-    uint8_t *const data = (uint8_t *)malloc(bin_size);
+    uint8_t *const data = (uint8_t *)mem_balloc(bu->mem, bin_size);
 
     if (!bin_unpack_bin_b(bu, data, bin_size)) {
-        free(data);
+        mem_delete(bu->mem, data);
         return false;
     }
 

--- a/toxcore/bin_unpack.h
+++ b/toxcore/bin_unpack.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "attributes.h"
+#include "mem.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +47,7 @@ typedef bool bin_unpack_cb(void *obj, Bin_Unpack *bu);
  * @retval false if an error occurred (e.g. buffer overrun).
  */
 non_null()
-bool bin_unpack_obj(bin_unpack_cb *callback, void *obj, const uint8_t *buf, uint32_t buf_size);
+bool bin_unpack_obj(const Memory *mem, bin_unpack_cb *callback, void *obj, const uint8_t *buf, uint32_t buf_size);
 
 /** @brief Start unpacking a MessagePack array.
  *

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -877,19 +877,19 @@ static const char *net_packet_type_name(Net_Packet_Type type)
 }
 
 non_null()
-static void loglogdata(const Logger *log, const char *message, const uint8_t *buffer,
+static void loglogdata(const Logger *log, const Memory *mem, const char *message, const uint8_t *buffer,
                        uint16_t buflen, const IP_Port *ip_port, long res)
 {
     if (res < 0) { /* Windows doesn't necessarily know `%zu` */
         Ip_Ntoa ip_str;
         const int error = net_error();
-        char *strerror = net_new_strerror(error);
+        char *strerror = net_new_strerror(mem, error);
         LOGGER_TRACE(log, "[%02x = %-21s] %s %3u%c %s:%u (%u: %s) | %08x%08x...%02x",
                      buffer[0], net_packet_type_name((Net_Packet_Type)buffer[0]), message,
                      min_u16(buflen, 999), 'E',
                      net_ip_ntoa(&ip_port->ip, &ip_str), net_ntohs(ip_port->port), error,
                      strerror, data_0(buflen, buffer), data_1(buflen, buffer), buffer[buflen - 1]);
-        net_kill_strerror(strerror);
+        net_kill_strerror(mem, strerror);
     } else if ((res > 0) && ((size_t)res <= buflen)) {
         Ip_Ntoa ip_str;
         LOGGER_TRACE(log, "[%02x = %-21s] %s %3u%c %s:%u (%u: %s) | %08x%08x...%02x",
@@ -907,7 +907,7 @@ static void loglogdata(const Logger *log, const char *message, const uint8_t *bu
     }
 }
 
-int net_send(const Network *ns, const Logger *log,
+int net_send(const Network *ns, const Memory *mem, const Logger *log,
              Socket sock, const uint8_t *buf, size_t len, const IP_Port *ip_port, Net_Profile *net_profile)
 {
     const int res = ns->funcs->send(ns->obj, sock, buf, len);
@@ -916,7 +916,7 @@ int net_send(const Network *ns, const Logger *log,
         netprof_record_packet(net_profile, buf[0], res, PACKET_DIRECTION_SEND);
     }
 
-    loglogdata(log, "T=>", buf, len, ip_port, res);
+    loglogdata(log, mem, "T=>", buf, len, ip_port, res);
     return res;
 }
 
@@ -928,11 +928,11 @@ static int net_sendto(
     return ns->funcs->sendto(ns->obj, sock, buf, len, addr);
 }
 
-int net_recv(const Network *ns, const Logger *log,
+int net_recv(const Network *ns, const Memory *mem, const Logger *log,
              Socket sock, uint8_t *buf, size_t len, const IP_Port *ip_port)
 {
     const int res = ns->funcs->recv(ns->obj, sock, buf, len);
-    loglogdata(log, "=>T", buf, len, ip_port, res);
+    loglogdata(log, mem, "=>T", buf, len, ip_port, res);
     return res;
 }
 
@@ -1103,7 +1103,7 @@ int send_packet(const Networking_Core *net, const IP_Port *ip_port, Packet packe
     }
 
     const long res = net_sendto(net->ns, net->sock, packet.data, packet.length, &addr, &ipp_copy);
-    loglogdata(net->log, "O=>", packet.data, packet.length, ip_port, res);
+    loglogdata(net->log, net->mem, "O=>", packet.data, packet.length, ip_port, res);
 
     assert(res <= INT_MAX);
 
@@ -1144,9 +1144,9 @@ static int receivepacket(const Network *ns, const Memory *mem, const Logger *log
         const int error = net_error();
 
         if (!should_ignore_recv_error(error)) {
-            char *strerror = net_new_strerror(error);
+            char *strerror = net_new_strerror(mem, error);
             LOGGER_ERROR(log, "unexpected error reading from socket: %u, %s", error, strerror);
-            net_kill_strerror(strerror);
+            net_kill_strerror(mem, strerror);
         }
 
         return -1; /* Nothing received. */
@@ -1188,7 +1188,7 @@ static int receivepacket(const Network *ns, const Memory *mem, const Logger *log
         return -1;
     }
 
-    loglogdata(log, "=>O", data, MAX_UDP_PACKET_SIZE, ip_port, *length);
+    loglogdata(log, mem, "=>O", data, MAX_UDP_PACKET_SIZE, ip_port, *length);
 
     return 0;
 }
@@ -1298,9 +1298,9 @@ Networking_Core *new_networking_ex(
     /* Check for socket error. */
     if (!sock_valid(temp->sock)) {
         const int neterror = net_error();
-        char *strerror = net_new_strerror(neterror);
+        char *strerror = net_new_strerror(mem, neterror);
         LOGGER_ERROR(log, "failed to get a socket?! %d, %s", neterror, strerror);
-        net_kill_strerror(strerror);
+        net_kill_strerror(mem, strerror);
         netprof_kill(mem, temp->udp_net_profile);
         mem_delete(mem, temp);
 
@@ -1402,7 +1402,7 @@ Networking_Core *new_networking_ex(
         const int res = net_setsockopt(ns, temp->sock, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
 
         const int neterror = net_error();
-        char *strerror = net_new_strerror(neterror);
+        char *strerror = net_new_strerror(mem, neterror);
 
         if (res < 0) {
             LOGGER_INFO(log, "Failed to activate local multicast membership in FF02::1. (%d, %s)", neterror, strerror);
@@ -1410,7 +1410,7 @@ Networking_Core *new_networking_ex(
             LOGGER_TRACE(log, "Local multicast group joined successfully. (%d, %s)", neterror, strerror);
         }
 
-        net_kill_strerror(strerror);
+        net_kill_strerror(mem, strerror);
 #endif /* ESP_PLATFORM */
     }
 
@@ -1468,10 +1468,10 @@ Networking_Core *new_networking_ex(
 
     Ip_Ntoa ip_str;
     const int neterror = net_error();
-    char *strerror = net_new_strerror(neterror);
+    char *strerror = net_new_strerror(mem, neterror);
     LOGGER_ERROR(log, "failed to bind socket: %d, %s IP: %s port_from: %u port_to: %u",
                  neterror, strerror, net_ip_ntoa(ip, &ip_str), port_from, port_to);
-    net_kill_strerror(strerror);
+    net_kill_strerror(mem, strerror);
     kill_networking(temp);
 
     if (error != nullptr) {
@@ -2097,10 +2097,10 @@ bool net_connect(const Network *ns, const Memory *mem, const Logger *log, Socket
 
         // Non-blocking socket: "Operation in progress" means it's connecting.
         if (!should_ignore_connect_error(error)) {
-            char *net_strerror = net_new_strerror(error);
+            char *net_strerror = net_new_strerror(mem, error);
             LOGGER_WARNING(log, "failed to connect to %s:%d: %d (%s)",
                            net_ip_ntoa(&ip_port->ip, &ip_str), net_ntohs(ip_port->port), error, net_strerror);
-            net_kill_strerror(net_strerror);
+            net_kill_strerror(mem, net_strerror);
             *err = NET_ERR_CONNECT_FAILED;
             return false;
         }
@@ -2367,7 +2367,7 @@ int net_error(void)
 }
 
 #ifdef OS_WIN32
-char *net_new_strerror(int error)
+char *net_new_strerror(const Memory *mem, int error)
 {
     char *str = nullptr;
     // Windows API is weird. The 5th function arg is of char* type, but we
@@ -2407,7 +2407,7 @@ static const char *net_strerror_r(int error, char *tmp, size_t tmp_size)
     return tmp;
 }
 #endif /* GNU */
-char *net_new_strerror(int error)
+char *net_new_strerror(const Memory *mem, int error)
 {
     char tmp[256];
 
@@ -2416,7 +2416,7 @@ char *net_new_strerror(int error)
     const char *retstr = net_strerror_r(error, tmp, sizeof(tmp));
     const size_t retstr_len = strlen(retstr);
 
-    char *str = (char *)malloc(retstr_len + 1);
+    char *str = (char *)mem_balloc(mem, retstr_len + 1);
 
     if (str == nullptr) {
         return nullptr;
@@ -2428,12 +2428,12 @@ char *net_new_strerror(int error)
 }
 #endif /* OS_WIN32 */
 
-void net_kill_strerror(char *strerror)
+void net_kill_strerror(const Memory *mem, char *strerror)
 {
 #ifdef OS_WIN32
     LocalFree((char *)strerror);
 #else
-    free(strerror);
+    mem_delete(mem, strerror);
 #endif /* OS_WIN32 */
 }
 

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -236,15 +236,32 @@ Socket net_invalid_socket(void);
 
 /**
  * Calls send(sockfd, buf, len, MSG_NOSIGNAL).
+ *
+ * @param ns System network object.
+ * @param mem Memory object, only used for logging.
+ * @param log Logger object.
+ * @param sock Socket to send data with.
+ * @param buf Data to send.
+ * @param len Length of data.
+ * @param ip_port IP and port to send data to.
+ * @param net_profile Network profile to record the packet.
  */
-non_null(1, 2, 4, 6) nullable(7)
-int net_send(const Network *ns, const Logger *log, Socket sock, const uint8_t *buf, size_t len, const IP_Port *ip_port,
+non_null(1, 2, 3, 5, 7) nullable(8)
+int net_send(const Network *ns, const Memory *mem, const Logger *log, Socket sock, const uint8_t *buf, size_t len, const IP_Port *ip_port,
              Net_Profile *net_profile);
 /**
  * Calls recv(sockfd, buf, len, MSG_NOSIGNAL).
+ *
+ * @param ns System network object.
+ * @param mem Memory object, only used for logging.
+ * @param log Logger object.
+ * @param sock Socket to receive data with.
+ * @param buf Buffer to store received data.
+ * @param len Length of buffer.
+ * @param ip_port IP and port of the sender.
  */
 non_null()
-int net_recv(const Network *ns, const Logger *log, Socket sock, uint8_t *buf, size_t len, const IP_Port *ip_port);
+int net_recv(const Network *ns, const Memory *mem, const Logger *log, Socket sock, uint8_t *buf, size_t len, const IP_Port *ip_port);
 /**
  * Calls listen(sockfd, backlog).
  */
@@ -594,14 +611,15 @@ int net_error(void);
  * return pointer to a NULL-terminated string describing the error code on
  * success. The returned string must be freed using `net_kill_strerror()`.
  */
-char *net_new_strerror(int error);
+non_null()
+char *net_new_strerror(const Memory *mem, int error);
 
 /** @brief Frees the string returned by `net_new_strerror()`.
  * It's valid to pass NULL as the argument, the function does nothing in this
  * case.
  */
-nullable(1)
-void net_kill_strerror(char *strerror);
+non_null(1) nullable(2)
+void net_kill_strerror(const Memory *mem, char *strerror);
 
 /** @brief Initialize networking.
  * Bind to ip and port.

--- a/toxcore/tox_events.c
+++ b/toxcore/tox_events.c
@@ -173,7 +173,7 @@ Tox_Events *tox_events_load(const Tox_System *sys, const uint8_t *bytes, uint32_
     };
     events->mem = sys->mem;
 
-    if (!bin_unpack_obj(tox_events_unpack_handler, events, bytes, bytes_size)) {
+    if (!bin_unpack_obj(sys->mem, tox_events_unpack_handler, events, bytes, bytes_size)) {
         tox_events_free(events);
         return nullptr;
     }


### PR DESCRIPTION
Some of the last places where we use malloc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2833)
<!-- Reviewable:end -->
