### PR TITLE
chore: Move most cirrus jobs to circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,12 @@ workflows:
     jobs:
       - bazel-asan
       - bazel-dbg
+      - bazel-msan
       - bazel-opt
       - clang-analyze
       - cpplint
       - static-analysis
+      - cimple
       - cimplefmt
       - generate-events
 
@@ -34,6 +36,16 @@ jobs:
       - checkout
       - run: .circleci/bazel-test
           //c-toxcore/...
+
+  bazel-msan:
+    working_directory: /tmp/cirrus-ci-build
+    docker:
+      - image: toxchat/toktok-stack:latest-msan
+
+    steps:
+      - checkout
+      - run: .circleci/bazel-test
+          //c-toxcore/auto_tests:lossless_packet_test
 
   bazel-opt:
     working_directory: /tmp/cirrus-ci-build
@@ -105,6 +117,22 @@ jobs:
       - checkout
       - run: git submodule update --init --recursive
       - run: other/analysis/run-cpplint
+
+  cimple:
+    working_directory: /tmp/cirrus-ci-build
+    docker:
+      - image: toxchat/toktok-stack:latest-release
+
+    steps:
+      - checkout
+      - run: git submodule update --init --recursive
+      - run: cd /src/workspace &&
+          bazel test
+            -k
+            --build_tag_filters=haskell
+            --test_tag_filters=haskell
+            --
+            //c-toxcore/...
 
   cimplefmt:
     working_directory: ~/work

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,100 +1,33 @@
----
-bazel-opt_task:
-  timeout_in: 10m
-  container:
-    image: toxchat/toktok-stack:latest-release
-    cpu: 8
-    memory: 2G
-  configure_script:
-    - git submodule update --init --recursive
-    - /src/workspace/tools/inject-repo c-toxcore
-  test_all_script:
-    - cd /src/workspace && tools/retry 5 bazel
-        test -k
-        --build_tag_filters=-haskell
-        --test_tag_filters=-haskell
-        --
-        //c-toxcore/...
-        -//c-toxcore/auto_tests:tcp_relay_test # Cirrus doesn't allow external network connections.
-
-bazel-dbg_task:
-  timeout_in: 10m
-  container:
-    image: toxchat/toktok-stack:latest-debug
-    cpu: 8
-    memory: 2G
-  configure_script:
-    - git submodule update --init --recursive
-    - /src/workspace/tools/inject-repo c-toxcore
-  test_all_script:
-    - cd /src/workspace && tools/retry 5 bazel
-        test -k
-        --build_tag_filters=-haskell
-        --test_tag_filters=-haskell
-        --
-        //c-toxcore/...
-        -//c-toxcore/auto_tests:tcp_relay_test # Cirrus doesn't allow external network connections.
-
-bazel-msan_task:
-  timeout_in: 10m
-  container:
-    image: toxchat/toktok-stack:latest-msan
-    cpu: 4
-    memory: 2G
-  configure_script:
-    - git submodule update --init --recursive
-    - /src/workspace/tools/inject-repo c-toxcore
-  test_all_script:
-    - cd /src/workspace && tools/retry 5 bazel
-        test -k
-        --
-        //c-toxcore/auto_tests:lossless_packet_test
-
-cimple_task:
-  timeout_in: 5m
-  container:
-    image: toxchat/toktok-stack:latest-release
-    cpu: 2
-    memory: 4G
-  configure_script:
-    - git submodule update --init --recursive
-    - /src/workspace/tools/inject-repo c-toxcore
-  test_all_script:
-    - cd /src/workspace && bazel
-        test -k
-        --build_tag_filters=haskell
-        --test_tag_filters=haskell
-        --
-        //c-toxcore/...
-
-freebsd_task:
-  timeout_in: 5m
-  freebsd_instance:
-    image_family: freebsd-14-1
-  configure_script:
-    - PAGER=cat ASSUME_ALWAYS_YES=YES pkg install
-        cmake
-        git
-        gmake
-        googletest
-        libconfig
-        libsodium
-        libvpx
-        ninja
-        opus
-        pkgconf
-    - git submodule update --init --recursive
-  test_all_script:
-    - |
-      # TODO(iphydf): Investigate FreeBSD failures on these tests.
-      sed -Ei -e '/\(dht_getnodes_api\)/s/^/#/' auto_tests/CMakeLists.txt
-      cmake . \
-        -DMIN_LOGGER_LEVEL=TRACE \
-        -DMUST_BUILD_TOXAV=ON \
-        -DNON_HERMETIC_TESTS=OFF \
-        -DTEST_TIMEOUT_SECONDS=50 \
-        -DUSE_IPV6=OFF \
-        -DAUTOTEST=ON \
-        -GNinja
-      cmake --build . --target install
-      ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:3 || ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:3
+# TODO(iphydf): Reactivate when we have quota again in February 2025.
+# ---
+# freebsd_task:
+#   timeout_in: 5m
+#   freebsd_instance:
+#     image_family: freebsd-14-1
+#   configure_script:
+#     - PAGER=cat ASSUME_ALWAYS_YES=YES pkg install
+#         cmake
+#         git
+#         gmake
+#         googletest
+#         libconfig
+#         libsodium
+#         libvpx
+#         ninja
+#         opus
+#         pkgconf
+#     - git submodule update --init --recursive
+#   test_all_script:
+#     - |
+#       # TODO(iphydf): Investigate FreeBSD failures on these tests.
+#       sed -Ei -e '/\(dht_getnodes_api\)/s/^/#/' auto_tests/CMakeLists.txt
+#       cmake . \
+#         -DMIN_LOGGER_LEVEL=TRACE \
+#         -DMUST_BUILD_TOXAV=ON \
+#         -DNON_HERMETIC_TESTS=OFF \
+#         -DTEST_TIMEOUT_SECONDS=50 \
+#         -DUSE_IPV6=OFF \
+#         -DAUTOTEST=ON \
+#         -GNinja
+#       cmake --build . --target install
+#       ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:3 || ctest -j50 --output-on-failure --rerun-failed --repeat until-pass:3


### PR DESCRIPTION
Cirrus is very expensive now. We need to make our builds cheaper before we can use it more. For now, only the build that can't move out will stay, i.e. the FreeBSD VM one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2838)
<!-- Reviewable:end -->
