### PR TITLE
chore: Add static library builds to the deploy scripts.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install build tools
-        run: brew install coreutils ninja yasm
+        run: brew install binutils coreutils ninja yasm
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -171,7 +171,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install build tools
-        run: brew install coreutils ninja yasm
+        run: brew install binutils coreutils ninja yasm
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/other/deploy/build.sh
+++ b/other/deploy/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+INSTALL_PATH="$1"
+
+cmake --build _build
+cmake --install _build
+
+# Need to use GNU ar because the default ar on macOS doesn't support the -M flag.
+export PATH="/opt/homebrew/opt/binutils/bin:/usr/local/opt/binutils/bin:$PATH"
+
+# Merge toxcore, opus, vpx, and sodium into a single static library.
+ar -M <<EOF
+create libtoxcore.a
+addlib $INSTALL_PATH/lib/libtoxcore.a
+addlib prefix/lib/libopus.a
+addlib prefix/lib/libsodium.a
+addlib prefix/lib/libvpx.a
+save
+end
+EOF
+
+# Replace the original toxcore library with the merged one.
+mv libtoxcore.a "$INSTALL_PATH/lib/libtoxcore.a"
+
+# Remove pkg-config directory. It's useless because these libraries aren't
+# meant to be used in a normal pkg-config project.
+rm -rf "$INSTALL_PATH/lib/pkgconfig"

--- a/other/deploy/ios.sh
+++ b/other/deploy/ios.sh
@@ -23,7 +23,7 @@ cmake \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX="$PWD/toxcore-ios-$ARCH" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DENABLE_STATIC=OFF \
+  -DENABLE_STATIC=ON \
   -DENABLE_SHARED=ON \
   -DMUST_BUILD_TOXAV=ON \
   -DDHT_BOOTSTRAP=OFF \
@@ -38,5 +38,4 @@ cmake \
   -DCMAKE_OSX_SYSROOT="$(xcrun --sdk "$XC_SDK" --show-sdk-path)" \
   -DCMAKE_OSX_ARCHITECTURES="$ARCH"
 
-cmake --build _build
-cmake --install _build
+"$SCRIPT_DIR/build.sh" "toxcore-ios-$ARCH"

--- a/other/deploy/linux.sh
+++ b/other/deploy/linux.sh
@@ -15,7 +15,7 @@ cmake \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX="$PWD/toxcore-linux-$ARCH" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DENABLE_STATIC=OFF \
+  -DENABLE_STATIC=ON \
   -DENABLE_SHARED=ON \
   -DMUST_BUILD_TOXAV=ON \
   -DDHT_BOOTSTRAP=OFF \
@@ -24,5 +24,4 @@ cmake \
   -DMIN_LOGGER_LEVEL=TRACE \
   -DEXPERIMENTAL_API=ON
 
-cmake --build _build
-cmake --install _build
+"$SCRIPT_DIR/build.sh" "toxcore-linux-$ARCH"

--- a/other/deploy/macos.sh
+++ b/other/deploy/macos.sh
@@ -15,7 +15,7 @@ cmake \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX="$PWD/toxcore-macos-$ARCH" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DENABLE_STATIC=OFF \
+  -DENABLE_STATIC=ON \
   -DENABLE_SHARED=ON \
   -DMUST_BUILD_TOXAV=ON \
   -DDHT_BOOTSTRAP=OFF \
@@ -25,5 +25,4 @@ cmake \
   -DEXPERIMENTAL_API=ON \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
 
-cmake --build _build
-cmake --install _build
+"$SCRIPT_DIR/build.sh" "toxcore-macos-$ARCH"


### PR DESCRIPTION
We build libraries with all our dependencies inside. Clients should not then also depend on libsodium, opus, or vpx themselves.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2846)
<!-- Reviewable:end -->
