### PR TITLE
refactor: Use IP string length from ip_ntoa instead of strlen.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@
 #   test_all_script:
 #     - |
 #       # TODO(iphydf): Investigate FreeBSD failures on these tests.
-#       sed -Ei -e '/\(dht_getnodes_api\)/s/^/#/' auto_tests/CMakeLists.txt
+#       sed -Ei -e '/\(dht_nodes_request_api\)/s/^/#/' auto_tests/CMakeLists.txt
 #       cmake . \
 #         -DMIN_LOGGER_LEVEL=TRACE \
 #         -DMUST_BUILD_TOXAV=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
           run: |
             # TODO(iphydf): Investigate NetBSD failures on these tests.
-            sed -Ei -e '/\((TCP|dht_getnodes_api)\)/s/^/#/' auto_tests/CMakeLists.txt
+            sed -Ei -e '/\((TCP|dht_nodes_request_api)\)/s/^/#/' auto_tests/CMakeLists.txt
             cmake . \
               -DMIN_LOGGER_LEVEL=TRACE \
               -DMUST_BUILD_TOXAV=ON \
@@ -160,7 +160,7 @@ jobs:
 
           run: |
             # TODO(iphydf): Investigate FreeBSD failures on these tests.
-            sed -Ei -e '/\(dht_getnodes_api\)/s/^/#/' auto_tests/CMakeLists.txt
+            sed -Ei -e '/\(dht_nodes_request_api\)/s/^/#/' auto_tests/CMakeLists.txt
             cmake . \
               -DMIN_LOGGER_LEVEL=TRACE \
               -DMUST_BUILD_TOXAV=ON \

--- a/auto_tests/CMakeLists.txt
+++ b/auto_tests/CMakeLists.txt
@@ -48,7 +48,7 @@ auto_test(conference_simple)
 auto_test(conference_two)
 auto_test(crypto)
 #auto_test(dht)  # Doesn't work with UNITY_BUILD.
-auto_test(dht_getnodes_api)
+auto_test(dht_nodes_response_api)
 auto_test(encryptsave)
 auto_test(file_saving)
 auto_test(file_streaming)

--- a/auto_tests/dht_nodes_response_api_test.c
+++ b/auto_tests/dht_nodes_response_api_test.c
@@ -6,7 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 
 #include "../toxcore/tox.h"
 #include "../toxcore/tox_private.h"

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -13,6 +13,7 @@
 #include "rtp.h"
 #include "toxav_hacks.h"
 
+#include "../toxcore/Messenger.h"
 #include "../toxcore/ccompat.h"
 #include "../toxcore/logger.h"
 #include "../toxcore/mono_time.h"

--- a/toxcore/events/dht_nodes_response.c
+++ b/toxcore/events/dht_nodes_response.c
@@ -51,13 +51,13 @@ static bool tox_event_dht_nodes_response_set_ip(Tox_Event_Dht_Nodes_Response *dh
         dht_nodes_response->ip_length = 0;
     }
 
-    uint8_t *ip_tmp = (uint8_t *)mem_balloc(mem, ip_length);
+    uint8_t *ip_tmp = (uint8_t *)mem_balloc(mem, ip_length + 1);
 
     if (ip_tmp == nullptr) {
         return false;
     }
 
-    memcpy(ip_tmp, ip, ip_length);
+    memcpy(ip_tmp, ip, ip_length + 1);
     dht_nodes_response->ip = ip_tmp;
     dht_nodes_response->ip_length = ip_length;
     return true;
@@ -206,7 +206,7 @@ static Tox_Event_Dht_Nodes_Response *tox_event_dht_nodes_response_alloc(void *us
 
 void tox_events_handle_dht_nodes_response(
     Tox *tox, const uint8_t public_key[TOX_PUBLIC_KEY_SIZE],
-    const char *ip, uint16_t port, void *user_data)
+    const char *ip, uint32_t ip_length, uint16_t port, void *user_data)
 {
     Tox_Event_Dht_Nodes_Response *dht_nodes_response = tox_event_dht_nodes_response_alloc(user_data);
 
@@ -214,14 +214,9 @@ void tox_events_handle_dht_nodes_response(
         return;
     }
 
-    const size_t ip_length = strlen(ip);
-    if (ip_length >= UINT32_MAX) {
-        return;
-    }
-
     const Tox_System *sys = tox_get_system(tox);
 
     tox_event_dht_nodes_response_set_public_key(dht_nodes_response, public_key);
-    tox_event_dht_nodes_response_set_ip(dht_nodes_response, ip, ip_length + 1, sys->mem);
+    tox_event_dht_nodes_response_set_ip(dht_nodes_response, ip, ip_length, sys->mem);
     tox_event_dht_nodes_response_set_port(dht_nodes_response, port);
 }

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -373,9 +373,11 @@ static void tox_dht_nodes_response_handler(const DHT *dht, const Node_format *no
     }
 
     Ip_Ntoa ip_str;
+    net_ip_ntoa(&node->ip_port.ip, &ip_str);
+
     tox_unlock(tox_data->tox);
     tox_data->tox->dht_nodes_response_callback(
-        tox_data->tox, node->public_key, net_ip_ntoa(&node->ip_port.ip, &ip_str), net_ntohs(node->ip_port.port),
+        tox_data->tox, node->public_key, ip_str.buf, ip_str.length, net_ntohs(node->ip_port.port),
         tox_data->user_data);
     tox_lock(tox_data->tox);
 }

--- a/toxcore/tox_events.c
+++ b/toxcore/tox_events.c
@@ -17,7 +17,7 @@
 #include "tox.h"
 #include "tox_event.h"
 #include "tox_private.h"
-#include "tox_struct.h"
+#include "tox_struct.h" // IWYU pragma: keep
 
 /*****************************************************
  *

--- a/toxcore/tox_private.c
+++ b/toxcore/tox_private.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 
 #include "DHT.h"
+#include "Messenger.h"
 #include "TCP_server.h"
 #include "ccompat.h"
 #include "crypto_core.h"

--- a/toxcore/tox_private.h
+++ b/toxcore/tox_private.h
@@ -93,8 +93,9 @@ uint32_t tox_dht_node_public_key_size(void);
  * @param ip The node's IP address, represented as a NUL-terminated C string.
  * @param port The node's port.
  */
-typedef void tox_dht_nodes_response_cb(Tox *tox, const uint8_t *public_key, const char *ip, uint16_t port,
-                                       void *user_data);
+typedef void tox_dht_nodes_response_cb(
+    Tox *tox, const uint8_t *public_key, const char *ip, uint32_t ip_length,
+    uint16_t port, void *user_data);
 
 /**
  * Set the callback for the `dht_nodes_response` event. Pass NULL to unset.

--- a/toxcore/tox_struct.h
+++ b/toxcore/tox_struct.h
@@ -8,7 +8,6 @@
 
 #include <pthread.h>
 
-#include "Messenger.h"
 #include "mono_time.h"
 #include "tox.h"
 #include "tox_options.h" // tox_log_cb
@@ -19,7 +18,7 @@ extern "C" {
 #endif
 
 struct Tox {
-    Messenger *m;
+    struct Messenger *m;
     Mono_Time *mono_time;
     Tox_System sys;
     pthread_mutex_t *mutex;


### PR DESCRIPTION
Saves us a strlen and is slightly safer. Also, changed the event length to not include the terminating NUL byte. Adding it is just confusing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2861)
<!-- Reviewable:end -->
