### PR TITLE
chore: Move one of the 3 freebsd builds to post-submit.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [autotools, clang-tidy, compcert, cppcheck, doxygen, goblint, infer, freebsd, misra, modules, pkgsrc, rpm, slimcc, sparse, tcc, tokstyle]
+        tool: [autotools, clang-tidy, compcert, cppcheck, doxygen, goblint, infer, misra, modules, pkgsrc, rpm, slimcc, sparse, tcc, tokstyle]
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -5,15 +5,19 @@ on:
     branches: [master]
 
 jobs:
-  build-alpine-s390x:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: [alpine-s390x, freebsd]
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker Build
         uses: docker/build-push-action@v5
         with:
-          file: other/docker/alpine-s390x/Dockerfile
+          file: other/docker/${{ matrix.tool }}/${{ matrix.tool }}.Dockerfile
 
   docker-coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This one takes a long time and never fails because we ignore test failures (of which it has many). The other 2 freebsd builds actually check for test failures so are more valuable. We keep this one for now because it's our own freebsd image build, so we at least want to keep it building in case the other 2 freebsd builds break (e.g. Cirrus shuts down or the freebsd vm workflow goes away).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2875)
<!-- Reviewable:end -->
