### PR TITLE
chore: Update the version-sync script to work in a post-tox.api.h world

### DIFF
--- a/other/version-sync
+++ b/other/version-sync
@@ -25,9 +25,9 @@ update() {
 
 update 'configure.ac' 's/AC_INIT(\[tox\], \[.*\])/AC_INIT([tox], ['"$VER"'])/'
 
-update 'toxcore/tox.api.h' 's/\(const VERSION_MAJOR *= \).*;/\1'"$MAJOR"';/'
-update 'toxcore/tox.api.h' 's/\(const VERSION_MINOR *= \).*;/\1'"$MINOR"';/'
-update 'toxcore/tox.api.h' 's/\(const VERSION_PATCH *= \).*;/\1'"$PATCH"';/'
+update 'toxcore/tox.h' 's/\(#define TOX_VERSION_MAJOR *\).*/\1'"$MAJOR"'/'
+update 'toxcore/tox.h' 's/\(#define TOX_VERSION_MINOR *\).*/\1'"$MINOR"'/'
+update 'toxcore/tox.h' 's/\(#define TOX_VERSION_PATCH *\).*/\1'"$PATCH"'/'
 
 update 'CMakeLists.txt' 's/\(PROJECT_VERSION_MAJOR "\).*"/\1'"$MAJOR"'"/'
 update 'CMakeLists.txt' 's/\(PROJECT_VERSION_MINOR "\).*"/\1'"$MINOR"'"/'


### PR DESCRIPTION
Fixes #2884

```
robin@u:~/code/c-toxcore$ ./tools/update-versions.sh 0.2.21
+ VERSION=0.2.21
++ git rev-parse --show-toplevel
+ GIT_ROOT=/home/robin/code/c-toxcore
+ cd /home/robin/code/c-toxcore
+ VERSION=0.2.21
+ IFS=.
+ read -ra version_parts
+ other/version-sync /home/robin/code/c-toxcore 0 2 21
5c5
< AC_INIT([tox], [0.2.20])
---
> AC_INIT([tox], [0.2.21])
157c157
< #define TOX_VERSION_PATCH              20
---
> #define TOX_VERSION_PATCH              21
47c47
< set(PROJECT_VERSION_PATCH "20")
---
> set(PROJECT_VERSION_PATCH "21")
14c14
< CURRENT=22
---
> CURRENT=23
16c16
< AGE=20
---
> AGE=21

robin@u:~/code/c-toxcore$ git diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 71b1f333..337ad716 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set_source_files_properties(
 # versions in a synchronised way.
 set(PROJECT_VERSION_MAJOR "0")
 set(PROJECT_VERSION_MINOR "2")
-set(PROJECT_VERSION_PATCH "20")
+set(PROJECT_VERSION_PATCH "21")
 set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")

 # set .so library version / following libtool scheme
diff --git a/configure.ac b/configure.ac
index b2869a9c..ee095b1a 100644
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.

 AC_PREREQ([2.65])
-AC_INIT([tox], [0.2.20])
+AC_INIT([tox], [0.2.21])
 AC_CONFIG_AUX_DIR(configure_aux)
 AC_CONFIG_SRCDIR([toxcore/net_crypto.c])
 AM_INIT_AUTOMAKE([foreign 1.10 -Wall -Werror subdir-objects tar-ustar])
diff --git a/so.version b/so.version
index 3415d979..7e5d9222 100644
--- a/so.version
+++ b/so.version
@@ -11,6 +11,6 @@
 # For a full reference see:
 # https://www.gnu.org/software/libtool/manual/libtool.html#Updating-version-info

-CURRENT=22
+CURRENT=23
 REVISION=0
-AGE=20
+AGE=21
diff --git a/toxcore/tox.h b/toxcore/tox.h
index 2235ccfd..f44b8201 100644
--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -154,7 +154,7 @@ uint32_t tox_version_minor(void);
  * Incremented when bugfixes are applied without changing any functionality or
  * API or ABI.
  */
-#define TOX_VERSION_PATCH              20
+#define TOX_VERSION_PATCH              21

 uint32_t tox_version_patch(void);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2885)
<!-- Reviewable:end -->
