### PR TITLE
chore: Update the pkgsrc versions in the update-versions tool

### DIFF
--- a/other/version-sync
+++ b/other/version-sync
@@ -33,6 +33,12 @@ update 'CMakeLists.txt' 's/\(PROJECT_VERSION_MAJOR "\).*"/\1'"$MAJOR"'"/'
 update 'CMakeLists.txt' 's/\(PROJECT_VERSION_MINOR "\).*"/\1'"$MINOR"'"/'
 update 'CMakeLists.txt' 's/\(PROJECT_VERSION_PATCH "\).*"/\1'"$PATCH"'"/'
 
+update 'other/docker/pkgsrc/pkgsrc.Dockerfile' 's/\(COPY . \/work\/c-toxcore-\).*/\1'"$VER"'/'
+update 'other/docker/pkgsrc/pkgsrc.Dockerfile' 's/\(tar", "zcf", "c-toxcore.tar.gz", "c-toxcore-\).*/\1'"$VER"'"]/'
+
+update 'other/docker/pkgsrc/pkgsrc.patch' 's/\(+DISTNAME=\ttoxcore-\).*/\1'"$VER"'/'
+update 'other/docker/pkgsrc/pkgsrc.patch' 's/\(+lib\/libtoxcore.so.\).*/\1'"$MINOR.$PATCH.0"'/'
+
 #
 # calculating the SO version
 #


### PR DESCRIPTION
```
robin@0:~/code/c-toxcore$ ./tools/update-versions.sh 0.2.22
+ VERSION=0.2.22
++ git rev-parse --show-toplevel
+ GIT_ROOT=/home/robin/code/c-toxcore
+ cd /home/robin/code/c-toxcore
+ VERSION=0.2.22
+ IFS=.
+ read -ra version_parts
+ other/version-sync /home/robin/code/c-toxcore 0 2 22
5c5
< AC_INIT([tox], [0.2.20])
---
> AC_INIT([tox], [0.2.22])
157c157
< #define TOX_VERSION_PATCH              20
---
> #define TOX_VERSION_PATCH              22
47c47
< set(PROJECT_VERSION_PATCH "20")
---
> set(PROJECT_VERSION_PATCH "22")
4c4
< COPY . /work/c-toxcore-0.2.20
---
> COPY . /work/c-toxcore-0.2.22
5c5
< RUN ["tar", "zcf", "c-toxcore.tar.gz", "c-toxcore-0.2.20"]
---
> RUN ["tar", "zcf", "c-toxcore.tar.gz", "c-toxcore-0.2.22"]
9c9
< +DISTNAME=    toxcore-0.2.20
---
> +DISTNAME=    toxcore-0.2.22
29c29
< +lib/libtoxcore.so.2.20.0
---
> +lib/libtoxcore.so.2.22.0
14c14
< CURRENT=22
---
> CURRENT=24
16c16
< AGE=20
---
> AGE=22
```

```diff
robin@0:~/code/c-toxcore$ git diff other/docker/pkgsrc/
diff --git a/other/docker/pkgsrc/pkgsrc.Dockerfile b/other/docker/pkgsrc/pkgsrc.Dockerfile
index 58dd3ed7..b55cf4d2 100644
--- a/other/docker/pkgsrc/pkgsrc.Dockerfile
+++ b/other/docker/pkgsrc/pkgsrc.Dockerfile
@@ -1,8 +1,8 @@
 FROM toxchat/pkgsrc:latest

 WORKDIR /work
-COPY . /work/c-toxcore-0.2.20
-RUN ["tar", "zcf", "c-toxcore.tar.gz", "c-toxcore-0.2.20"]
+COPY . /work/c-toxcore-0.2.22
+RUN ["tar", "zcf", "c-toxcore.tar.gz", "c-toxcore-0.2.22"]

 WORKDIR /work/pkgsrc
 COPY other/docker/pkgsrc/pkgsrc.patch /tmp/pkgsrc.patch
diff --git a/other/docker/pkgsrc/pkgsrc.patch b/other/docker/pkgsrc/pkgsrc.patch
index 4d2dba1f..8eb03423 100644
--- a/other/docker/pkgsrc/pkgsrc.patch
+++ b/other/docker/pkgsrc/pkgsrc.patch
@@ -6,7 +6,7 @@ index 70466704d..53a08ad08 100644
  # $NetBSD: Makefile,v 1.6 2024/01/22 13:16:56 ryoon Exp $

 -DISTNAME=     toxcore-0.2.18
-+DISTNAME=     toxcore-0.2.20
++DISTNAME=     toxcore-0.2.22
  PKGREVISION=  2
  CATEGORIES=   chat
  MASTER_SITES= ${MASTER_SITE_GITHUB:=TokTok/}
@@ -26,6 +26,6 @@ index f0a5e4f04..4122b0867 100644
  lib/libtoxcore.so
  lib/libtoxcore.so.2
 -lib/libtoxcore.so.2.18.0
-+lib/libtoxcore.so.2.20.0
++lib/libtoxcore.so.2.22.0
  lib/pkgconfig/toxcore.pc
  share/bash-completion/completions/tox-bootstrapd
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2886)
<!-- Reviewable:end -->
