### PR TITLE
refactor: TCP connection netprof objects are now owned by Messenger

### DIFF
--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -1058,6 +1058,7 @@ cc_library(
         ":mem",
         ":mono_time",
         ":net_crypto",
+        ":net_profile",
         ":network",
         ":onion",
         ":onion_announce",

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -25,6 +25,7 @@
 #include "mem.h"
 #include "mono_time.h"
 #include "net_crypto.h"
+#include "net_profile.h"
 #include "network.h"
 #include "onion.h"
 #include "onion_announce.h"
@@ -248,6 +249,7 @@ struct Messenger {
 
     Networking_Core *net;
     Net_Crypto *net_crypto;
+    Net_Profile *tcp_np;
     DHT *dht;
 
     Forwarding *forwarding;

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -1596,7 +1596,7 @@ int set_tcp_onion_status(TCP_Connections *tcp_c, bool status)
  * Returns NULL on failure.
  */
 TCP_Connections *new_tcp_connections(const Logger *logger, const Memory *mem, const Random *rng, const Network *ns,
-                                     Mono_Time *mono_time, const uint8_t *secret_key, const TCP_Proxy_Info *proxy_info)
+                                     Mono_Time *mono_time, const uint8_t *secret_key, const TCP_Proxy_Info *proxy_info, Net_Profile *tcp_np)
 {
     assert(logger != nullptr);
     assert(mem != nullptr);
@@ -1614,14 +1614,7 @@ TCP_Connections *new_tcp_connections(const Logger *logger, const Memory *mem, co
         return nullptr;
     }
 
-    Net_Profile *np = netprof_new(logger, mem);
-
-    if (np == nullptr) {
-        mem_delete(mem, temp);
-        return nullptr;
-    }
-
-    temp->net_profile = np;
+    temp->net_profile = tcp_np;
     temp->logger = logger;
     temp->mem = mem;
     temp->rng = rng;
@@ -1736,17 +1729,8 @@ void kill_tcp_connections(TCP_Connections *tcp_c)
 
     crypto_memzero(tcp_c->self_secret_key, sizeof(tcp_c->self_secret_key));
 
-    netprof_kill(tcp_c->mem, tcp_c->net_profile);
     mem_delete(tcp_c->mem, tcp_c->tcp_connections);
     mem_delete(tcp_c->mem, tcp_c->connections);
     mem_delete(tcp_c->mem, tcp_c);
 }
 
-const Net_Profile *tcp_connection_get_client_net_profile(const TCP_Connections *tcp_c)
-{
-    if (tcp_c == nullptr) {
-        return nullptr;
-    }
-
-    return tcp_c->net_profile;
-}

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -307,7 +307,7 @@ uint32_t tcp_copy_connected_relays_index(const TCP_Connections *tcp_c, Node_form
  */
 non_null()
 TCP_Connections *new_tcp_connections(const Logger *logger, const Memory *mem, const Random *rng, const Network *ns,
-                                     Mono_Time *mono_time, const uint8_t *secret_key, const TCP_Proxy_Info *proxy_info);
+                                     Mono_Time *mono_time, const uint8_t *secret_key, const TCP_Proxy_Info *proxy_info, Net_Profile *tcp_np);
 
 non_null()
 int kill_tcp_relay_connection(TCP_Connections *tcp_c, int tcp_connections_number);
@@ -317,12 +317,5 @@ void do_tcp_connections(const Logger *logger, TCP_Connections *tcp_c, void *user
 
 nullable(1)
 void kill_tcp_connections(TCP_Connections *tcp_c);
-
-/** @brief a pointer to the tcp client net profile associated with tcp_c.
- *
- * @retval null if tcp_c is null.
- */
-non_null()
-const Net_Profile *tcp_connection_get_client_net_profile(const TCP_Connections *tcp_c);
 
 #endif /* C_TOXCORE_TOXCORE_TCP_CONNECTION_H */

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -7418,7 +7418,7 @@ static bool init_gc_tcp_connection(const GC_Session *c, GC_Chat *chat)
     const Messenger *m = c->messenger;
 
     chat->tcp_conn = new_tcp_connections(chat->log, chat->mem, chat->rng, m->ns, chat->mono_time, chat->self_secret_key.enc,
-                                         &m->options.proxy_info);
+                                         &m->options.proxy_info, c->tcp_np);
 
     if (chat->tcp_conn == nullptr) {
         return false;
@@ -8274,6 +8274,7 @@ GC_Session *new_dht_groupchats(Messenger *m)
 
     c->messenger = m;
     c->announces_list = m->group_announce;
+    c->tcp_np = m->tcp_np;
 
     networking_registerhandler(m->net, NET_PACKET_GC_LOSSLESS, &handle_gc_udp_packet, m);
     networking_registerhandler(m->net, NET_PACKET_GC_LOSSY, &handle_gc_udp_packet, m);

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -20,6 +20,7 @@
 #include "logger.h"
 #include "mem.h"
 #include "mono_time.h"
+#include "net_profile.h"
 #include "network.h"
 
 #define MAX_GC_PART_MESSAGE_SIZE 128
@@ -377,6 +378,7 @@ typedef void gc_rejected_cb(const Messenger *m, uint32_t group_number, unsigned 
 typedef struct GC_Session {
     Messenger                 *messenger;
     GC_Chat                   *chats;
+    Net_Profile               *tcp_np;
     struct GC_Announces_List  *announces_list;
 
     uint32_t     chats_index;

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2988,7 +2988,7 @@ void load_secret_key(Net_Crypto *c, const uint8_t *sk)
  * Sets all the global connection variables to their default values.
  */
 Net_Crypto *new_net_crypto(const Logger *log, const Memory *mem, const Random *rng, const Network *ns,
-                           Mono_Time *mono_time, DHT *dht, const TCP_Proxy_Info *proxy_info)
+                           Mono_Time *mono_time, DHT *dht, const TCP_Proxy_Info *proxy_info, Net_Profile *tcp_np)
 {
     if (dht == nullptr) {
         return nullptr;
@@ -3006,7 +3006,7 @@ Net_Crypto *new_net_crypto(const Logger *log, const Memory *mem, const Random *r
     temp->mono_time = mono_time;
     temp->ns = ns;
 
-    temp->tcp_c = new_tcp_connections(log, mem, rng, ns, mono_time, dht_get_self_secret_key(dht), proxy_info);
+    temp->tcp_c = new_tcp_connections(log, mem, rng, ns, mono_time, dht_get_self_secret_key(dht), proxy_info, tcp_np);
 
     if (temp->tcp_c == nullptr) {
         mem_delete(mem, temp);
@@ -3097,19 +3097,4 @@ void kill_net_crypto(Net_Crypto *c)
     networking_registerhandler(dht_get_net(c->dht), NET_PACKET_CRYPTO_DATA, nullptr, nullptr);
     crypto_memzero(c, sizeof(Net_Crypto));
     mem_delete(mem, c);
-}
-
-const Net_Profile *nc_get_tcp_client_net_profile(const Net_Crypto *c)
-{
-    if (c == nullptr) {
-        return nullptr;
-    }
-
-    const TCP_Connections *tcp_c = nc_get_tcp_c(c);
-
-    if (tcp_c == nullptr) {
-        return nullptr;
-    }
-
-    return tcp_connection_get_client_net_profile(tcp_c);
 }

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -406,7 +406,7 @@ void load_secret_key(Net_Crypto *c, const uint8_t *sk);
  */
 non_null()
 Net_Crypto *new_net_crypto(const Logger *log, const Memory *mem, const Random *rng, const Network *ns,
-                           Mono_Time *mono_time, DHT *dht, const TCP_Proxy_Info *proxy_info);
+                           Mono_Time *mono_time, DHT *dht, const TCP_Proxy_Info *proxy_info, Net_Profile *tcp_np);
 
 /** return the optimal interval in ms for running do_net_crypto. */
 non_null()
@@ -418,13 +418,6 @@ void do_net_crypto(Net_Crypto *c, void *userdata);
 
 nullable(1)
 void kill_net_crypto(Net_Crypto *c);
-
-/**
- * Returns a pointer to the net profile object for the TCP client associated with `c`.
- * Returns null if `c` is null or the TCP_Connections associated with `c` is null.
- */
-non_null()
-const Net_Profile *nc_get_tcp_client_net_profile(const Net_Crypto *c);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/toxcore/net_profile.h
+++ b/toxcore/net_profile.h
@@ -15,6 +15,10 @@
 #include "logger.h"
 #include "mem.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The max number of packet ID's (must fit inside one byte) */
 #define NET_PROF_MAX_PACKET_IDS 256
 
@@ -69,5 +73,9 @@ Net_Profile *netprof_new(const Logger *log, const Memory *mem);
  */
 non_null(1) nullable(2)
 void netprof_kill(const Memory *mem, Net_Profile *net_profile);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif  /* C_TOXCORE_TOXCORE_NET_PROFILE_H */

--- a/toxcore/tox_private.c
+++ b/toxcore/tox_private.c
@@ -237,7 +237,7 @@ uint64_t tox_netprof_get_packet_id_count(const Tox *tox, Tox_Netprof_Packet_Type
 
     tox_lock(tox);
 
-    const Net_Profile *tcp_c_profile = nc_get_tcp_client_net_profile(tox->m->net_crypto);
+    const Net_Profile *tcp_c_profile = tox->m->tcp_np;
     const Net_Profile *tcp_s_profile = tcp_server_get_net_profile(tox->m->tcp_server);
 
     const Packet_Direction dir = (Packet_Direction) direction;
@@ -286,7 +286,7 @@ uint64_t tox_netprof_get_packet_total_count(const Tox *tox, Tox_Netprof_Packet_T
 
     tox_lock(tox);
 
-    const Net_Profile *tcp_c_profile = nc_get_tcp_client_net_profile(tox->m->net_crypto);
+    const Net_Profile *tcp_c_profile = tox->m->tcp_np;
     const Net_Profile *tcp_s_profile = tcp_server_get_net_profile(tox->m->tcp_server);
 
     const Packet_Direction dir = (Packet_Direction) direction;
@@ -335,7 +335,7 @@ uint64_t tox_netprof_get_packet_id_bytes(const Tox *tox, Tox_Netprof_Packet_Type
 
     tox_lock(tox);
 
-    const Net_Profile *tcp_c_profile = nc_get_tcp_client_net_profile(tox->m->net_crypto);
+    const Net_Profile *tcp_c_profile = tox->m->tcp_np;
     const Net_Profile *tcp_s_profile = tcp_server_get_net_profile(tox->m->tcp_server);
 
     const Packet_Direction dir = (Packet_Direction) direction;
@@ -384,7 +384,7 @@ uint64_t tox_netprof_get_packet_total_bytes(const Tox *tox, Tox_Netprof_Packet_T
 
     tox_lock(tox);
 
-    const Net_Profile *tcp_c_profile = nc_get_tcp_client_net_profile(tox->m->net_crypto);
+    const Net_Profile *tcp_c_profile = tox->m->tcp_np;
     const Net_Profile *tcp_s_profile = tcp_server_get_net_profile(tox->m->tcp_server);
 
     const Packet_Direction dir = (Packet_Direction) direction;


### PR DESCRIPTION
This allows us to have a single netprof object for all TCP client connections, which makes it easier to query and keep track of TCP network data for groupchats. Previously we were not properly querying groupchat TCP network data via the netprof API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2893)
<!-- Reviewable:end -->
