### PR TITLE
chore(toxav): use realtime deadline for vp8 encoder

### DIFF
--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -24,18 +24,7 @@
 #include "../toxcore/tox_struct.h"  // IWYU pragma: keep
 #include "../toxcore/util.h"
 
-// TODO(zoff99): don't hardcode this, let the application choose it
-// VPX Info: Time to spend encoding, in microseconds (it's a *soft* deadline)
-#define WANTED_MAX_ENCODER_FPS 40
-#define MAX_ENCODE_TIME_US (1000000 / WANTED_MAX_ENCODER_FPS) // to allow x fps
-
 #define VIDEO_SEND_X_KEYFRAMES_FIRST 7 // force the first n frames to be keyframes!
-
-/*
- * VPX_DL_REALTIME       (1)       deadline parameter analogous to VPx REALTIME mode.
- * VPX_DL_GOOD_QUALITY   (1000000) deadline parameter analogous to VPx GOOD QUALITY mode.
- * VPX_DL_BEST_QUALITY   (0)       deadline parameter analogous to VPx BEST QUALITY mode.
- */
 
 // iteration interval that is used when no call is active
 #define IDLE_ITERATION_INTERVAL_MS 200
@@ -1086,8 +1075,11 @@ bool toxav_video_send_frame(ToxAV *av, uint32_t friend_number, uint16_t width, u
         memcpy(img.planes[VPX_PLANE_U], u, (width / 2) * (height / 2));
         memcpy(img.planes[VPX_PLANE_V], v, (width / 2) * (height / 2));
 
+        // TODO(zoff99): don't hardcode this, let the application choose it
+        const vpx_enc_deadline_t deadline = VPX_DL_REALTIME;
+
         const vpx_codec_err_t vrc = vpx_codec_encode(call->video->encoder, &img,
-                                    call->video->frame_counter, 1, vpx_encode_flags, MAX_ENCODE_TIME_US);
+                                    call->video->frame_counter, 1, vpx_encode_flags, deadline);
 
         vpx_img_free(&img);
 

--- a/toxav/video.c
+++ b/toxav/video.c
@@ -16,27 +16,6 @@
 #include "../toxcore/mono_time.h"
 
 /**
- * Soft deadline the decoder should attempt to meet, in "us" (microseconds).
- * Set to zero for unlimited.
- *
- * By convention, the value 1 is used to mean "return as fast as possible."
- */
-// TODO(zoff99): don't hardcode this, let the application choose it
-#define WANTED_MAX_DECODER_FPS 40
-
-/**
- * VPX_DL_REALTIME       (1)
- * deadline parameter analogous to VPx REALTIME mode.
- *
- * VPX_DL_GOOD_QUALITY   (1000000)
- * deadline parameter analogous to VPx GOOD QUALITY mode.
- *
- * VPX_DL_BEST_QUALITY   (0)
- * deadline parameter analogous to VPx BEST QUALITY mode.
- */
-#define MAX_DECODE_TIME_US (1000000 / WANTED_MAX_DECODER_FPS) // to allow x fps
-
-/**
  * Codec control function to set encoder internal speed settings. Changes in
  * this value influences, among others, the encoder's selection of motion
  * estimation methods. Values greater than 0 will increase encoder speed at the
@@ -320,7 +299,7 @@ void vc_iterate(VCSession *vc)
 
     LOGGER_DEBUG(vc->log, "vc_iterate: rb_read p->len=%d p->header.xe=%d", (int)full_data_len, p->header.xe);
     LOGGER_DEBUG(vc->log, "vc_iterate: rb_read rb size=%d", (int)log_rb_size);
-    const vpx_codec_err_t rc = vpx_codec_decode(vc->decoder, p->data, full_data_len, nullptr, MAX_DECODE_TIME_US);
+    const vpx_codec_err_t rc = vpx_codec_decode(vc->decoder, p->data, full_data_len, nullptr, 0);
     free(p);
 
     if (rc != VPX_CODEC_OK) {


### PR DESCRIPTION
Technically all this does is choose a quality based on frame duration, which we always set to 1, and as such is always realtime. (In same timebase as pts, which we use as a frame counter...)

Also no deadline for decoder. (documentation tells us it's ignored)