### PR TITLE
fix(ngc): dont double every message, if we are not directly connected

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -1626,7 +1626,7 @@ int group_packet_wrap(
  * Returns true on success.
  */
 non_null()
-static bool send_lossy_group_packet(const GC_Chat *chat, const GC_Connection *gconn, const uint8_t *data,
+static bool send_lossy_group_packet(const GC_Chat *chat, GC_Connection *gconn, const uint8_t *data,
                                     uint16_t length, uint8_t packet_type)
 {
     assert(length <= MAX_GC_CUSTOM_LOSSY_PACKET_SIZE);
@@ -2236,7 +2236,7 @@ static int handle_gc_invite_response_reject(const GC_Session *c, GC_Chat *chat, 
  * Return true on success.
  */
 non_null()
-static bool send_gc_invite_response_reject(const GC_Chat *chat, const GC_Connection *gconn, uint8_t type)
+static bool send_gc_invite_response_reject(const GC_Chat *chat, GC_Connection *gconn, uint8_t type)
 {
     if (type >= GJ_INVALID) {
         type = GJ_INVITE_FAILED;
@@ -2353,7 +2353,7 @@ static bool send_gc_lossy_packet_all_peers(const GC_Chat *chat, const uint8_t *d
     uint32_t confirmed_peers = 0;
 
     for (uint32_t i = 1; i < chat->numpeers; ++i) {
-        const GC_Connection *gconn = get_gc_connection(chat, i);
+        GC_Connection *gconn = get_gc_connection(chat, i);
 
         assert(gconn != nullptr);
 
@@ -7072,7 +7072,7 @@ static void do_peer_delete(const GC_Session *c, GC_Chat *chat, void *userdata)
  * Return true on success.
  */
 non_null()
-static bool ping_peer(const GC_Chat *chat, const GC_Connection *gconn)
+static bool ping_peer(const GC_Chat *chat, GC_Connection *gconn)
 {
     const uint16_t buf_size = GC_PING_PACKET_MIN_DATA_SIZE + sizeof(IP_Port);
     uint8_t *data = (uint8_t *)mem_balloc(chat->mem, buf_size);

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -115,6 +115,7 @@ typedef struct GC_Connection {
     uint64_t    last_sent_tcp_relays_time;  /* the last time we attempted to send this peer our tcp relays */
     uint16_t    tcp_relay_share_index;
     uint64_t    last_received_direct_time;   /* the last time we received a direct UDP packet from this connection */
+    uint64_t    last_sent_direct_try_time;   /* the last time we tried sending a direct UDP packet */
     uint64_t    last_sent_ip_time;  /* the last time we sent our ip info to this peer in a ping packet */
 
     Node_format connected_tcp_relays[MAX_FRIEND_TCP_CONNECTIONS];

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -135,6 +135,10 @@ void gcc_make_session_shared_key(GC_Connection *gconn, const uint8_t *sender_pk)
 non_null()
 bool gcc_conn_is_direct(const Mono_Time *mono_time, const GC_Connection *gconn);
 
+/** @brief Return true if we can try a direct connection with `gconn` again. */
+non_null()
+bool gcc_conn_should_try_direct(const Mono_Time *mono_time, const GC_Connection *gconn);
+
 /** @brief Return true if a direct UDP connection is possible with `gconn`. */
 non_null()
 bool gcc_direct_conn_is_possible(const GC_Chat *chat, const GC_Connection *gconn);
@@ -146,7 +150,7 @@ bool gcc_direct_conn_is_possible(const GC_Chat *chat, const GC_Connection *gconn
  * Return true on success.
  */
 non_null()
-bool gcc_send_packet(const GC_Chat *chat, const GC_Connection *gconn, const uint8_t *packet, uint16_t length);
+bool gcc_send_packet(const GC_Chat *chat, GC_Connection *gconn, const uint8_t *packet, uint16_t length);
 
 /** @brief Sends a lossless packet to `gconn` comprised of `data` of size `length`.
  *
@@ -184,7 +188,7 @@ bool gcc_send_lossless_packet_fragments(const GC_Chat *chat, GC_Connection *gcon
  * Return -2 if the packet fails to send.
  */
 non_null(1, 2) nullable(3)
-int gcc_encrypt_and_send_lossless_packet(const GC_Chat *chat, const GC_Connection *gconn, const uint8_t *data,
+int gcc_encrypt_and_send_lossless_packet(const GC_Chat *chat, GC_Connection *gconn, const uint8_t *data,
         uint16_t length, uint64_t message_id, uint8_t packet_type);
 
 /** @brief Called when a peer leaves the group. */


### PR DESCRIPTION
but we and the other peer would support direct.

Recreation of #2894 , since the ci is acting funny there.

---

All hail the network profiler.

![image](https://github.com/user-attachments/assets/ba8f3370-ae64-4e24-b34e-b952e72983f3)
(missing returning udp traffic)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2905)
<!-- Reviewable:end -->
