### PR TITLE
fix(toxencryptsave): Wipe salt and passkey after usage.

### DIFF
--- a/toxencryptsave/toxencryptsave.c
+++ b/toxencryptsave/toxencryptsave.c
@@ -55,6 +55,13 @@ struct Tox_Pass_Key {
 
 void tox_pass_key_free(Tox_Pass_Key *key)
 {
+    if (key == NULL) {
+        return;
+    }
+
+    /* wipe sensitive state */
+    crypto_memzero(key->salt, TOX_PASS_SALT_LENGTH);
+    crypto_memzero(key->key, TOX_PASS_KEY_LENGTH);
     free(key);
 }
 


### PR DESCRIPTION
fixes #2925

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2926)
<!-- Reviewable:end -->
