### PR TITLE
fix(autotools): add tox_log_level.h to public headers list

### DIFF
--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -2,6 +2,7 @@ lib_LTLIBRARIES += libtoxcore.la
 
 libtoxcore_la_include_HEADERS = \
                         ../toxcore/tox.h \
+                        ../toxcore/tox_log_level.h \
                         ../toxcore/tox_options.h
 
 libtoxcore_la_includedir = $(includedir)/tox


### PR DESCRIPTION
The tox_log_level.h header file was added as a public API header in
version 0.2.21, but was not included in the libtoxcore_la_include_HEADERS
variable in toxcore/Makefile.inc. This caused the header to not be
installed when building with autotools, leading to compilation errors
for applications that include tox_options.h (which depends on
tox_log_level.h, like qTox).

This patch adds tox_log_level.h to the list of installed headers,
matching the behavior of the CMake build system.

Commit: c8344726378e3be2277e82734ffd39c40c15d2e4
Fixes: compilation error "tox_log_level.h: No such file or directory"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2928)
<!-- Reviewable:end -->
