### PR TITLE
chore(ci): update azure runner image to windows-2022

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: "windows-2019"
+  vmImage: "windows-2022"
 jobs:
   - job: "vcpkg"
     strategy:


### PR DESCRIPTION
windows-2019 is EOL

https://github.com/actions/runner-images/issues/12045

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2930)
<!-- Reviewable:end -->
