### PR TITLE
fix(toxav): fix multiple bugs in bandwidth controller and add tests

### DIFF
--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -73,6 +73,34 @@ cc_test(
 )
 
 cc_library(
+    name = "bwcontroller",
+    srcs = ["bwcontroller.c"],
+    hdrs = ["bwcontroller.h"],
+    deps = [
+        ":ring_buffer",
+        "//c-toxcore/toxcore:ccompat",
+        "//c-toxcore/toxcore:logger",
+        "//c-toxcore/toxcore:mono_time",
+        "//c-toxcore/toxcore:network",
+        "//c-toxcore/toxcore:util",
+    ],
+)
+
+cc_test(
+    name = "bwcontroller_test",
+    size = "small",
+    srcs = ["bwcontroller_test.cc"],
+    deps = [
+        ":bwcontroller",
+        "//c-toxcore/toxcore:logger",
+        "//c-toxcore/toxcore:mono_time",
+        "//c-toxcore/toxcore:os_memory",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "toxav",
     srcs = glob(
         [
@@ -83,11 +111,14 @@ cc_library(
             "toxav.h",
             "rtp.c",
             "rtp.h",
+            "bwcontroller.c",
+            "bwcontroller.h",
         ],
     ),
     hdrs = ["toxav.h"],
     visibility = ["//c-toxcore:__subpackages__"],
     deps = [
+        ":bwcontroller",
         ":rtp",
         "//c-toxcore/toxcore:Messenger",
         "//c-toxcore/toxcore:ccompat",

--- a/toxav/bwcontroller.h
+++ b/toxav/bwcontroller.h
@@ -6,23 +6,37 @@
 #define C_TOXCORE_TOXAV_BWCONTROLLER_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 #include "../toxcore/logger.h"
 #include "../toxcore/mono_time.h"
-#include "../toxcore/tox.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BWC_PACKET_ID 196
 
 typedef struct BWController BWController;
 
-typedef void m_cb(BWController *bwc, uint32_t friend_number, float loss, void *user_data);
+typedef void bwc_loss_report_cb(BWController *bwc, uint32_t friend_number, float loss, void *user_data);
 
-BWController *bwc_new(const Logger *log, Tox *tox, uint32_t friendnumber,
-                      m_cb *mcb, void *mcb_user_data, Mono_Time *bwc_mono_time);
+typedef int bwc_send_packet_cb(void *user_data, const uint8_t *data, uint16_t length);
+
+BWController *bwc_new(const Logger *log, uint32_t friendnumber,
+                      bwc_loss_report_cb *mcb, void *mcb_user_data,
+                      bwc_send_packet_cb *send_packet, void *send_packet_user_data,
+                      Mono_Time *bwc_mono_time);
 
 void bwc_kill(BWController *bwc);
 
 void bwc_add_lost(BWController *bwc, uint32_t bytes_lost);
 void bwc_add_recv(BWController *bwc, uint32_t recv_bytes);
-void bwc_allow_receiving(Tox *tox);
-void bwc_stop_receiving(Tox *tox);
+
+void bwc_handle_packet(BWController *bwc, const uint8_t *data, size_t length);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* C_TOXCORE_TOXAV_BWCONTROLLER_H */

--- a/toxav/bwcontroller_test.cc
+++ b/toxav/bwcontroller_test.cc
@@ -1,0 +1,390 @@
+#include "bwcontroller.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
+#include "../toxcore/network.h"
+#include "../toxcore/os_memory.h"
+
+namespace {
+
+struct BwcTimeMock {
+    uint64_t t;
+};
+
+uint64_t mock_time_cb(void *ud) { return static_cast<BwcTimeMock *>(ud)->t; }
+
+struct MockBwcData {
+    std::vector<std::vector<uint8_t>> sent_packets;
+    std::vector<float> reported_losses;
+    uint32_t friend_number = 0;
+
+    static int send_packet(void *user_data, const uint8_t *data, uint16_t length)
+    {
+        auto *sd = static_cast<MockBwcData *>(user_data);
+        if (sd->fail_send) {
+            return -1;
+        }
+        sd->sent_packets.emplace_back(data, data + length);
+        return 0;
+    }
+
+    static void loss_report(
+        BWController * /*bwc*/, uint32_t friend_number, float loss, void *user_data)
+    {
+        auto *sd = static_cast<MockBwcData *>(user_data);
+        sd->friend_number = friend_number;
+        sd->reported_losses.push_back(loss);
+    }
+
+    bool fail_send = false;
+};
+
+class BwcTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        const Memory *mem = os_memory();
+        log = logger_new(mem);
+        tm.t = 1000;
+        mono_time = mono_time_new(mem, mock_time_cb, &tm);
+        mono_time_update(mono_time);
+    }
+
+    void TearDown() override
+    {
+        const Memory *mem = os_memory();
+        mono_time_free(mem, mono_time);
+        logger_kill(log);
+    }
+
+    Logger *log;
+    Mono_Time *mono_time;
+    BwcTimeMock tm;
+};
+
+TEST_F(BwcTest, BasicNewKill)
+{
+    MockBwcData sd;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+    ASSERT_NE(bwc, nullptr);
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, SendUpdate)
+{
+    MockBwcData sd;
+    uint32_t friend_number = 123;
+    BWController *bwc = bwc_new(log, friend_number, MockBwcData::loss_report, &sd,
+        MockBwcData::send_packet, &sd, mono_time);
+    ASSERT_NE(bwc, nullptr);
+
+    // BWC_AVG_LOSS_OVER_CYCLES_COUNT is 30
+    // BWC_SEND_INTERVAL_MS is 950
+
+    // Add some received and lost bytes
+    for (int i = 0; i < 30; ++i) {
+        bwc_add_recv(bwc, 1000);
+    }
+    bwc_add_lost(bwc, 500);
+
+    // Should not have sent anything yet because interval not reached
+    EXPECT_EQ(sd.sent_packets.size(), 0);
+
+    // Advance time
+    tm.t += 1000;
+    mono_time_update(mono_time);
+
+    // Trigger another update
+    bwc_add_recv(bwc, 1000);
+
+    ASSERT_EQ(sd.sent_packets.size(), 1);
+    EXPECT_EQ(sd.sent_packets[0][0], BWC_PACKET_ID);
+
+    // Packet contains lost (4 bytes) and recv (4 bytes)
+    uint32_t lost, recv;
+    net_unpack_u32(sd.sent_packets[0].data() + 1, &lost);
+    net_unpack_u32(sd.sent_packets[0].data() + 5, &recv);
+
+    EXPECT_EQ(lost, 500);
+    EXPECT_EQ(recv, 30 * 1000 + 1000);
+
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, HandlePacket)
+{
+    MockBwcData sd;
+    uint32_t friend_number = 123;
+    BWController *bwc = bwc_new(log, friend_number, MockBwcData::loss_report, &sd,
+        MockBwcData::send_packet, &sd, mono_time);
+    ASSERT_NE(bwc, nullptr);
+
+    uint8_t packet[9];
+    packet[0] = BWC_PACKET_ID;
+    net_pack_u32(packet + 1, 100);  // lost
+    net_pack_u32(packet + 5, 900);  // recv
+
+    bwc_handle_packet(bwc, packet, sizeof(packet));
+
+    ASSERT_EQ(sd.reported_losses.size(), 1);
+    EXPECT_EQ(sd.friend_number, friend_number);
+    EXPECT_FLOAT_EQ(sd.reported_losses[0], 100.0f / (100.0f + 900.0f));
+
+    // Try sending another update too soon
+    bwc_handle_packet(bwc, packet, sizeof(packet));
+    EXPECT_EQ(sd.reported_losses.size(), 1);
+
+    // Advance time
+    tm.t += 1000;
+    mono_time_update(mono_time);
+
+    bwc_handle_packet(bwc, packet, sizeof(packet));
+    EXPECT_EQ(sd.reported_losses.size(), 2);
+
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, NullArgs)
+{
+    // These should just return without crashing
+    bwc_kill(nullptr);
+    bwc_add_lost(nullptr, 100);
+    bwc_add_recv(nullptr, 100);
+    bwc_handle_packet(nullptr, nullptr, 0);
+
+    MockBwcData sd;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+    bwc_add_recv(bwc, 0);  // Should return early
+    bwc_add_lost(bwc, 0);  // Should return early
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, InvalidPacketSize)
+{
+    MockBwcData sd;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+    uint8_t packet[10] = {0};
+
+    // Correct size is 9
+    bwc_handle_packet(bwc, packet, 8);
+    bwc_handle_packet(bwc, packet, 10);
+    EXPECT_EQ(sd.reported_losses.size(), 0);
+
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, SendFailure)
+{
+    MockBwcData sd;
+    sd.fail_send = true;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+
+    for (int i = 0; i < 31; ++i) {
+        bwc_add_recv(bwc, 1000);
+    }
+    bwc_add_lost(bwc, 500);
+    tm.t += 1000;
+    mono_time_update(mono_time);
+    bwc_add_recv(bwc, 1000);
+
+    // Send should have failed (logged, but doesn't crash)
+    EXPECT_EQ(sd.sent_packets.size(), 0);
+
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, NullCallback)
+{
+    MockBwcData sd;
+    // Pass NULL for the loss report callback
+    BWController *bwc
+        = bwc_new(log, 123, nullptr, nullptr, MockBwcData::send_packet, &sd, mono_time);
+
+    uint8_t packet[9];
+    packet[0] = BWC_PACKET_ID;
+    net_pack_u32(packet + 1, 100);  // lost
+    net_pack_u32(packet + 5, 900);  // recv
+
+    bwc_handle_packet(bwc, packet, sizeof(packet));
+
+    // Should not crash, and no loss should be reported
+    EXPECT_EQ(sd.reported_losses.size(), 0);
+
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, ZeroLoss)
+{
+    MockBwcData sd;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+
+    // 1. Peer sends update with zero loss
+    uint8_t packet[9];
+    packet[0] = BWC_PACKET_ID;
+    net_pack_u32(packet + 1, 0);  // lost
+    net_pack_u32(packet + 5, 1000);  // recv
+
+    bwc_handle_packet(bwc, packet, sizeof(packet));
+    EXPECT_EQ(sd.reported_losses.size(), 0);
+
+    // 2. We have zero loss to report
+    for (int i = 0; i < 31; ++i) {
+        bwc_add_recv(bwc, 1000);
+    }
+    // No bwc_add_lost called
+    tm.t += 1000;
+    mono_time_update(mono_time);
+    bwc_add_recv(bwc, 1000);
+
+    // Should NOT send update if loss is 0
+    EXPECT_EQ(sd.sent_packets.size(), 0);
+
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, Overflow)
+{
+    MockBwcData sd;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+
+    // Set lost/recv to near max to check for overflow (though they are just added)
+    bwc_add_lost(bwc, 0xFFFFFFFF);
+    bwc_add_recv(bwc, 0xFFFFFFFF);
+
+    // Trigger update
+    for (int i = 0; i < 32; ++i) {
+        bwc_add_recv(bwc, 1);
+    }
+    tm.t += 1000;
+    mono_time_update(mono_time);
+    bwc_add_recv(bwc, 1);
+
+    ASSERT_EQ(sd.sent_packets.size(), 1);
+    uint32_t lost, recv;
+    net_unpack_u32(sd.sent_packets[0].data() + 1, &lost);
+    net_unpack_u32(sd.sent_packets[0].data() + 5, &recv);
+
+    // 0xFFFFFFFF + 32 + 1 should wrap to 32
+    EXPECT_EQ(lost, 0xFFFFFFFF);
+    EXPECT_EQ(recv, 32);
+
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, CycleCountThreshold)
+{
+    MockBwcData sd;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+
+    // BWC_AVG_LOSS_OVER_CYCLES_COUNT is 30.
+    // We need more than 30 cycles AND the time interval to pass.
+
+    tm.t += 2000;  // Time is sufficient
+    mono_time_update(mono_time);
+
+    for (int i = 0; i < 30; ++i) {
+        bwc_add_recv(bwc, 100);
+        bwc_add_lost(bwc, 1);
+        ASSERT_EQ(sd.sent_packets.size(), 0) << "Should not send at cycle " << i;
+    }
+
+    // 31st call to bwc_add_recv (or bwc_add_lost)
+    bwc_add_recv(bwc, 100);
+    EXPECT_EQ(sd.sent_packets.size(), 1);
+
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, TimeIntervalStrict)
+{
+    MockBwcData sd;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+
+    // Enough cycles
+    for (int i = 0; i < 40; ++i) {
+        bwc_add_recv(bwc, 100);
+    }
+    bwc_add_lost(bwc, 10);
+    EXPECT_EQ(sd.sent_packets.size(), 0);  // Time not advanced
+
+    // Advance just below 950ms
+    tm.t += 949;
+    mono_time_update(mono_time);
+    bwc_add_recv(bwc, 100);
+    EXPECT_EQ(sd.sent_packets.size(), 0);
+
+    // Advance to 951ms (Total > 950)
+    tm.t += 2;
+    mono_time_update(mono_time);
+    bwc_add_recv(bwc, 100);
+    EXPECT_EQ(sd.sent_packets.size(), 1);
+
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, RecvPlusLostOverflowBug)
+{
+    MockBwcData sd;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+    uint8_t packet[9];
+    packet[0] = BWC_PACKET_ID;
+    net_pack_u32(packet + 1, 1);
+    net_pack_u32(packet + 5, 0xFFFFFFFF);
+    bwc_handle_packet(bwc, packet, sizeof(packet));
+    ASSERT_EQ(sd.reported_losses.size(), 1);
+    // Loss should be very small, but if it's inf or > 1.0, it's a bug
+    EXPECT_LE(sd.reported_losses[0], 1.0f);
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, RateLimitBypassBug)
+{
+    MockBwcData sd;
+    BWController *bwc = bwc_new(
+        log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
+    tm.t = 0xFFFFFFF0;
+    mono_time_update(mono_time);
+    uint8_t packet[9];
+    packet[0] = BWC_PACKET_ID;
+    net_pack_u32(packet + 1, 1);
+    net_pack_u32(packet + 5, 100);
+    bwc_handle_packet(bwc, packet, sizeof(packet));
+    EXPECT_EQ(sd.reported_losses.size(), 1);
+
+    // Only 5ms passed, should be rejected
+    tm.t = 0xFFFFFFF5;
+    mono_time_update(mono_time);
+    bwc_handle_packet(bwc, packet, sizeof(packet));
+    EXPECT_EQ(sd.reported_losses.size(), 1);
+    bwc_kill(bwc);
+}
+
+TEST_F(BwcTest, NoCrashOnNullSendPacket)
+{
+    BWController *bwc = bwc_new(log, 123, nullptr, nullptr, nullptr, nullptr, mono_time);
+    for (int i = 0; i < 31; ++i) {
+        bwc_add_recv(bwc, 100);
+    }
+    bwc_add_lost(bwc, 10);
+    tm.t += 1000;
+    mono_time_update(mono_time);
+    // This should no longer crash
+    bwc_add_recv(bwc, 100);
+    bwc_kill(bwc);
+}
+
+}  // namespace


### PR DESCRIPTION
- Fix rate limiting logic to be wrap-around safe for timestamps.
- Fix potential division-by-zero/sum-overflow in percentage calculation by using double precision.
- Fix NULL callback dereference in send_update.
- Add unit tests covering edge cases and bug scenarios.
- Refactor BWController to be more testable and independent of toxcore by injecting a packet sending callback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2934)
<!-- Reviewable:end -->
