### PR TITLE
fix(toxav): harden video processing and fix large frame handling

### DIFF
--- a/auto_tests/BUILD.bazel
+++ b/auto_tests/BUILD.bazel
@@ -39,7 +39,7 @@ extra_data = {
 
 [cc_test(
     name = src[:-2],
-    size = "small",
+    timeout = "moderate",
     srcs = [src],
     args = ["$(location %s)" % src] + extra_args.get(
         src[:-2],

--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -132,6 +132,36 @@ cc_test(
 )
 
 cc_library(
+    name = "video",
+    srcs = ["video.c"],
+    hdrs = ["video.h"],
+    deps = [
+        ":ring_buffer",
+        ":rtp",
+        "//c-toxcore/toxcore:ccompat",
+        "//c-toxcore/toxcore:logger",
+        "//c-toxcore/toxcore:mono_time",
+        "//c-toxcore/toxcore:util",
+        "@libvpx",
+    ],
+)
+
+cc_test(
+    name = "video_test",
+    timeout = "moderate",
+    srcs = ["video_test.cc"],
+    deps = [
+        ":rtp",
+        ":video",
+        "//c-toxcore/toxcore:logger",
+        "//c-toxcore/toxcore:mono_time",
+        "//c-toxcore/toxcore:os_memory",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "toxav",
     srcs = glob(
         [
@@ -146,6 +176,8 @@ cc_library(
             "bwcontroller.h",
             "audio.c",
             "audio.h",
+            "video.c",
+            "video.h",
         ],
     ),
     hdrs = ["toxav.h"],
@@ -154,6 +186,7 @@ cc_library(
         ":audio",
         ":bwcontroller",
         ":rtp",
+        ":video",
         "//c-toxcore/toxcore:Messenger",
         "//c-toxcore/toxcore:ccompat",
         "//c-toxcore/toxcore:group",
@@ -164,7 +197,6 @@ cc_library(
         "//c-toxcore/toxcore:tox",
         "//c-toxcore/toxcore:util",
         "@libsodium",
-        "@libvpx",
         "@opus",
     ],
 )

--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -194,7 +194,7 @@ void ac_iterate(ACSession *ac)
             }
         } else {
             const uint8_t *msg_data = rtp_message_data(msg);
-            const uint16_t msg_length = rtp_message_len(msg);
+            const uint32_t msg_length = rtp_message_len(msg);
 
             if (msg_length <= 4) {
                 LOGGER_WARNING(ac->log, "Packet too short: %u", msg_length);

--- a/toxav/audio_test.cc
+++ b/toxav/audio_test.cc
@@ -38,14 +38,14 @@ struct AudioTestData {
     }
 };
 
-struct RtpMock {
+struct AudioRtpMock {
     RTPSession *recv_session = nullptr;
     std::vector<std::vector<uint8_t>> captured_packets;
     bool auto_forward = true;
 
     static int send_packet(void *user_data, const uint8_t *data, uint16_t length)
     {
-        auto *self = static_cast<RtpMock *>(user_data);
+        auto *self = static_cast<AudioRtpMock *>(user_data);
         self->captured_packets.push_back(std::vector<uint8_t>(data, data + length));
         if (self->auto_forward && self->recv_session) {
             rtp_receive_packet(self->recv_session, data, length);
@@ -96,11 +96,11 @@ TEST_F(AudioTest, EncodeDecodeLoop)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    AudioRtpMock rtp_mock;
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     uint32_t sampling_rate = 48000;
@@ -184,12 +184,12 @@ TEST_F(AudioTest, QueueInvalidMessage)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     // Create a video RTP session but try to queue to audio session
-    RTPSession *video_rtp = rtp_new(log, RTP_TYPE_VIDEO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *audio_recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet,
-        &rtp_mock, nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *video_rtp = rtp_new(log, RTP_TYPE_VIDEO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *audio_recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = audio_recv_rtp;
 
     std::vector<uint8_t> dummy_video(100, 0);
@@ -212,12 +212,12 @@ TEST_F(AudioTest, JitterBufferDuplicate)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     rtp_mock.auto_forward = false;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     uint8_t dummy_data[100] = {0};
@@ -253,12 +253,12 @@ TEST_F(AudioTest, JitterBufferOutOfOrder)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     rtp_mock.auto_forward = false;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     uint8_t dummy_data[100] = {0};
@@ -300,12 +300,12 @@ TEST_F(AudioTest, PacketLossConcealment)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     rtp_mock.auto_forward = false;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     uint8_t dummy_data[100] = {0};
@@ -346,12 +346,12 @@ TEST_F(AudioTest, JitterBufferReset)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     rtp_mock.auto_forward = false;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     uint8_t dummy_data[100] = {0};
@@ -391,12 +391,12 @@ TEST_F(AudioTest, DecoderReconfigureCooldown)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     rtp_mock.auto_forward = false;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     uint8_t dummy_data[100] = {0};
@@ -452,12 +452,12 @@ TEST_F(AudioTest, QueueDummyMessage)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     // RTP_TYPE_AUDIO + 2 is the dummy type
-    RTPSession *dummy_rtp = rtp_new(log, RTP_TYPE_AUDIO + 2, mono_time, RtpMock::send_packet,
-        &rtp_mock, nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *audio_recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet,
-        &rtp_mock, nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *dummy_rtp = rtp_new(log, RTP_TYPE_AUDIO + 2, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *audio_recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = audio_recv_rtp;
 
     std::vector<uint8_t> dummy_payload(100, 0);
@@ -480,12 +480,12 @@ TEST_F(AudioTest, LatePacketReset)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     rtp_mock.auto_forward = false;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     uint8_t dummy_data[100] = {0};
@@ -531,12 +531,12 @@ TEST_F(AudioTest, InvalidSamplingRate)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     rtp_mock.auto_forward = false;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     // 1. Send a packet with an absurdly large sampling rate.
@@ -578,12 +578,12 @@ TEST_F(AudioTest, ShortPacket)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     rtp_mock.auto_forward = false;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     // 1. Send a packet that is too short (only sampling rate, no Opus data).
@@ -610,12 +610,12 @@ TEST_F(AudioTest, JitterBufferWrapAround)
     ACSession *ac = ac_new(mono_time, log, 123, AudioTestData::receive_frame, &data);
     ASSERT_NE(ac, nullptr);
 
-    RtpMock rtp_mock;
+    AudioRtpMock rtp_mock;
     rtp_mock.auto_forward = false;
-    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
-    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, RtpMock::send_packet, &rtp_mock,
-        nullptr, nullptr, nullptr, ac, RtpMock::audio_cb);
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, AudioRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, ac, AudioRtpMock::audio_cb);
     rtp_mock.recv_session = recv_rtp;
 
     uint8_t dummy_data[100] = {0};

--- a/toxav/msi.h
+++ b/toxav/msi.h
@@ -13,6 +13,11 @@
 
 #include "../toxcore/logger.h"
 
+#ifndef TOX_DEFINED
+#define TOX_DEFINED
+typedef struct Tox Tox;
+#endif /* !TOX_DEFINED */
+
 /**
  * Error codes.
  */

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -71,7 +71,7 @@ struct RTPMessage {
      * record the number of bytes received so far in a multi-part message. The
      * multi-part message in the old code is stored in `RTPSession::mp`.
      */
-    uint16_t len;
+    uint32_t len;
 
     struct RTPHeader header;
     uint8_t data[];
@@ -136,7 +136,7 @@ const uint8_t *rtp_message_data(const RTPMessage *msg)
     return msg->data;
 }
 
-uint16_t rtp_message_len(const RTPMessage *msg)
+uint32_t rtp_message_len(const RTPMessage *msg)
 {
     return msg->len;
 }
@@ -363,7 +363,8 @@ static struct RTPMessage *process_frame(const Logger *log, struct RTPWorkBufferL
     struct RTPWorkBuffer *const slot = &wkbl->work_buffer[slot_id];
 
     // Move ownership of the frame out of the slot into m_new.
-    struct RTPMessage *const m_new = slot->buf;
+    struct RTPMessage *msg = slot->buf;
+    msg->len = msg->header.data_length_full;
     slot->buf = nullptr;
 
     assert(wkbl->next_free_entry >= 1 && wkbl->next_free_entry <= USED_RTP_WORKBUFFER_COUNT);
@@ -385,7 +386,7 @@ static struct RTPMessage *process_frame(const Logger *log, struct RTPWorkBufferL
     wkbl->work_buffer[wkbl->next_free_entry] = empty;
 
     // Move ownership of the frame to the caller.
-    return m_new;
+    return msg;
 }
 
 /**

--- a/toxav/rtp.h
+++ b/toxav/rtp.h
@@ -57,7 +57,7 @@ typedef struct RTPSession RTPSession;
 
 /* RTPMessage accessors */
 const uint8_t *rtp_message_data(const RTPMessage *msg);
-uint16_t rtp_message_len(const RTPMessage *msg);
+uint32_t rtp_message_len(const RTPMessage *msg);
 uint8_t rtp_message_pt(const RTPMessage *msg);
 uint16_t rtp_message_sequnum(const RTPMessage *msg);
 uint64_t rtp_message_flags(const RTPMessage *msg);

--- a/toxav/toxav_hacks.h
+++ b/toxav/toxav_hacks.h
@@ -9,6 +9,11 @@
 #include "msi.h"
 #include "rtp.h"
 
+#ifndef TOXAV_DEFINED
+#define TOXAV_DEFINED
+typedef struct ToxAV ToxAV;
+#endif /* TOXAV_DEFINED */
+
 #ifndef TOXAV_CALL_DEFINED
 #define TOXAV_CALL_DEFINED
 typedef struct ToxAVCall ToxAVCall;

--- a/toxav/video.c
+++ b/toxav/video.c
@@ -4,6 +4,13 @@
  */
 #include "video.h"
 
+#include <vpx/vpx_decoder.h>
+#include <vpx/vpx_encoder.h>
+#include <vpx/vpx_image.h>
+
+#include <vpx/vp8cx.h>
+#include <vpx/vp8dx.h>
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,6 +21,31 @@
 #include "../toxcore/ccompat.h"
 #include "../toxcore/logger.h"
 #include "../toxcore/mono_time.h"
+#include "../toxcore/util.h"
+
+struct VCSession {
+    /* encoding */
+    vpx_codec_ctx_t encoder[1];
+    uint32_t frame_counter;
+
+    /* decoding */
+    vpx_codec_ctx_t decoder[1];
+    struct RingBuffer *vbuf_raw; /* Un-decoded data */
+
+    uint64_t linfts; /* Last received frame time stamp */
+    uint32_t lcfd; /* Last calculated frame duration for incoming video payload */
+
+    uint32_t friend_number;
+
+    /* Video frame receive callback */
+    vc_video_receive_frame_cb *vcb;
+    void *user_data;
+
+    pthread_mutex_t queue_mutex[1];
+    const Logger *log;
+
+    vpx_codec_iter_t iter;
+};
 
 /**
  * Codec control function to set encoder internal speed settings. Changes in
@@ -32,6 +64,12 @@
  */
 #define VIDEO_BITRATE_INITIAL_VALUE 5000
 #define VIDEO_DECODE_BUFFER_SIZE 5 // this buffer has normally max. 1 entry
+
+/**
+ * Security limits to prevent resource exhaustion.
+ */
+#define VIDEO_MAX_FRAME_SIZE (10 * 1024 * 1024)
+#define VIDEO_MAX_RESOLUTION_LIMIT 4096
 
 static vpx_codec_iface_t *video_codec_decoder_interface(void)
 {
@@ -120,9 +158,13 @@ static void vc_init_encoder_cfg(const Logger *log, vpx_codec_enc_cfg_t *cfg, int
 #endif /* 0 */
 }
 
-VCSession *vc_new(const Logger *log, const Mono_Time *mono_time, ToxAV *av, uint32_t friend_number,
-                  toxav_video_receive_frame_cb *cb, void *cb_data)
+VCSession *vc_new(const Logger *log, const Mono_Time *mono_time, uint32_t friend_number,
+                  vc_video_receive_frame_cb *cb, void *user_data)
 {
+    if (mono_time == nullptr) {
+        return nullptr;
+    }
+
     VCSession *vc = (VCSession *)calloc(1, sizeof(VCSession));
     vpx_codec_err_t rc;
 
@@ -231,9 +273,8 @@ VCSession *vc_new(const Logger *log, const Mono_Time *mono_time, ToxAV *av, uint
     vc->linfts = current_time_monotonic(mono_time);
     vc->lcfd = 60;
     vc->vcb = cb;
-    vc->vcb_user_data = cb_data;
+    vc->user_data = user_data;
     vc->friend_number = friend_number;
-    vc->av = av;
     vc->log = log;
     return vc;
 
@@ -290,13 +331,23 @@ void vc_iterate(VCSession *vc)
 
     if ((rtp_message_flags(p) & RTP_LARGE_FRAME) != 0) {
         full_data_len = rtp_message_data_length_full(p);
-        LOGGER_DEBUG(vc->log, "vc_iterate:001:full_data_len=%d", (int)full_data_len);
+        LOGGER_DEBUG(vc->log, "vc_iterate:001:full_data_len=%u", full_data_len);
     } else {
         full_data_len = rtp_message_len(p);
         LOGGER_DEBUG(vc->log, "vc_iterate:002");
     }
 
-    LOGGER_DEBUG(vc->log, "vc_iterate: rb_read p->len=%d", (int)full_data_len);
+    /* Security check: Ensure the reported full data length does not exceed the actual buffer size.
+     * rtp_message_len(p) returns the actual allocated payload size.
+     */
+    if (full_data_len > rtp_message_len(p)) {
+        LOGGER_ERROR(vc->log, "vc_iterate: Malicious packet detected! Lying length: %u actual: %u",
+                     full_data_len, (uint32_t)rtp_message_len(p));
+        free(p);
+        return;
+    }
+
+    LOGGER_DEBUG(vc->log, "vc_iterate: rb_read p->len=%u", full_data_len);
     LOGGER_DEBUG(vc->log, "vc_iterate: rb_read rb size=%d", (int)log_rb_size);
     const vpx_codec_err_t rc = vpx_codec_decode(vc->decoder, rtp_message_data(p), full_data_len, nullptr, 0);
     free(p);
@@ -313,12 +364,10 @@ void vc_iterate(VCSession *vc)
             dest != nullptr;
             dest = vpx_codec_get_frame(vc->decoder, &iter)) {
         if (vc->vcb != nullptr) {
-            vc->vcb(vc->av, vc->friend_number, dest->d_w, dest->d_h,
+            vc->vcb(vc->friend_number, dest->d_w, dest->d_h,
                     dest->planes[0], dest->planes[1], dest->planes[2],
-                    dest->stride[0], dest->stride[1], dest->stride[2], vc->vcb_user_data);
+                    dest->stride[0], dest->stride[1], dest->stride[2], vc->user_data);
         }
-
-        vpx_img_free(dest); // is this needed? none of the VPx examples show that
     }
 }
 
@@ -348,6 +397,13 @@ int vc_queue_message(const Mono_Time *mono_time, void *cs, struct RTPMessage *ms
         return -1;
     }
 
+    /* Security check: Sanitize message size to prevent memory exhaustion */
+    if (rtp_message_data_length_full(msg) > VIDEO_MAX_FRAME_SIZE) {
+        LOGGER_ERROR(vc->log, "Message too large! size=%u", (uint32_t)rtp_message_data_length_full(msg));
+        free(msg);
+        return -1;
+    }
+
     pthread_mutex_lock(vc->queue_mutex);
 
     if ((rtp_message_flags(msg) & RTP_LARGE_FRAME) != 0 && rtp_message_pt(msg) == RTP_TYPE_VIDEO % 128) {
@@ -367,6 +423,12 @@ int vc_queue_message(const Mono_Time *mono_time, void *cs, struct RTPMessage *ms
 int vc_reconfigure_encoder(VCSession *vc, uint32_t bit_rate, uint16_t width, uint16_t height, int16_t kf_max_dist)
 {
     if (vc == nullptr) {
+        return -1;
+    }
+
+    /* Security check: Sanitize resolution to prevent resource exhaustion */
+    if (width == 0 || height == 0 || width > VIDEO_MAX_RESOLUTION_LIMIT || height > VIDEO_MAX_RESOLUTION_LIMIT) {
+        LOGGER_ERROR(vc->log, "Invalid resolution requested: %ux%u", (uint32_t)width, (uint32_t)height);
         return -1;
     }
 
@@ -391,15 +453,16 @@ int vc_reconfigure_encoder(VCSession *vc, uint32_t bit_rate, uint16_t width, uin
          * reconfiguring encoder to use resolutions greater than initially set.
          */
         LOGGER_DEBUG(vc->log, "Have to reinitialize vpx encoder on session %p", (void *)vc);
-        vpx_codec_ctx_t new_c;
         vpx_codec_enc_cfg_t  cfg;
         vc_init_encoder_cfg(vc->log, &cfg, kf_max_dist);
         cfg.rc_target_bitrate = bit_rate;
         cfg.g_w = width;
         cfg.g_h = height;
 
+        /* Atomic reconfiguration: Initialize new encoder first */
+        vpx_codec_ctx_t new_encoder;
         LOGGER_DEBUG(vc->log, "Using VP8 codec for encoder");
-        vpx_codec_err_t rc = vpx_codec_enc_init(&new_c, video_codec_encoder_interface(), &cfg, VPX_CODEC_USE_FRAME_THREADING);
+        vpx_codec_err_t rc = vpx_codec_enc_init(&new_encoder, video_codec_encoder_interface(), &cfg, VPX_CODEC_USE_FRAME_THREADING);
 
         if (rc != VPX_CODEC_OK) {
             LOGGER_ERROR(vc->log, "Failed to initialize encoder: %s", vpx_codec_err_to_string(rc));
@@ -408,17 +471,90 @@ int vc_reconfigure_encoder(VCSession *vc, uint32_t bit_rate, uint16_t width, uin
 
         const int cpu_used_value = VP8E_SET_CPUUSED_VALUE;
 
-        rc = vpx_codec_control(&new_c, VP8E_SET_CPUUSED, cpu_used_value);
+        rc = vpx_codec_control(&new_encoder, VP8E_SET_CPUUSED, cpu_used_value);
 
         if (rc != VPX_CODEC_OK) {
             LOGGER_ERROR(vc->log, "Failed to set encoder control setting: %s", vpx_codec_err_to_string(rc));
-            vpx_codec_destroy(&new_c);
+            vpx_codec_destroy(&new_encoder);
             return -1;
         }
 
+        /* Swap only on success */
         vpx_codec_destroy(vc->encoder);
-        memcpy(vc->encoder, &new_c, sizeof(new_c));
+        *vc->encoder = new_encoder;
+        return 0;
     }
 
     return 0;
+}
+
+int vc_encode(VCSession *vc, uint16_t width, uint16_t height, const uint8_t *y,
+              const uint8_t *u, const uint8_t *v, int encode_flags)
+{
+    vpx_image_t img;
+
+    if (vpx_img_alloc(&img, VPX_IMG_FMT_I420, width, height, 0) == nullptr) {
+        LOGGER_ERROR(vc->log, "Could not allocate image for frame");
+        return -1;
+    }
+
+    /* I420 "It comprises an NxM Y plane followed by (N/2)x(M/2) V and U planes."
+     * http://fourcc.org/yuv.php#IYUV
+     */
+    memcpy(img.planes[VPX_PLANE_Y], y, width * height);
+    memcpy(img.planes[VPX_PLANE_U], u, (width / 2) * (height / 2));
+    memcpy(img.planes[VPX_PLANE_V], v, (width / 2) * (height / 2));
+
+    int vpx_flags = 0;
+
+    if ((encode_flags & VC_EFLAG_FORCE_KF) != 0) {
+        vpx_flags |= VPX_EFLAG_FORCE_KF;
+    }
+
+    const vpx_codec_err_t vrc = vpx_codec_encode(vc->encoder, &img,
+                                vc->frame_counter, 1, vpx_flags, VPX_DL_REALTIME);
+
+    vpx_img_free(&img);
+
+    if (vrc != VPX_CODEC_OK) {
+        LOGGER_ERROR(vc->log, "Could not encode video frame: %s", vpx_codec_err_to_string(vrc));
+        return -1;
+    }
+
+    vc->iter = nullptr;
+    return 0;
+}
+
+int vc_get_cx_data(VCSession *vc, uint8_t **data, uint32_t *size, bool *is_keyframe)
+{
+    const vpx_codec_cx_pkt_t *pkt = vpx_codec_get_cx_data(vc->encoder, &vc->iter);
+
+    while (pkt != nullptr && pkt->kind != VPX_CODEC_CX_FRAME_PKT) {
+        pkt = vpx_codec_get_cx_data(vc->encoder, &vc->iter);
+    }
+
+    if (pkt == nullptr) {
+        return 0;
+    }
+
+    *data = (uint8_t *)pkt->data.frame.buf;
+    *size = (uint32_t)pkt->data.frame.sz;
+    *is_keyframe = (pkt->data.frame.flags & VPX_FRAME_IS_KEY) != 0;
+
+    return 1;
+}
+
+uint32_t vc_get_lcfd(const VCSession *vc)
+{
+    return vc->lcfd;
+}
+
+pthread_mutex_t *vc_get_queue_mutex(VCSession *vc)
+{
+    return &vc->queue_mutex[0];
+}
+
+void vc_increment_frame_counter(VCSession *vc)
+{
+    ++vc->frame_counter;
 }

--- a/toxav/video.h
+++ b/toxav/video.h
@@ -5,50 +5,46 @@
 #ifndef C_TOXCORE_TOXAV_VIDEO_H
 #define C_TOXCORE_TOXAV_VIDEO_H
 
-#include <vpx/vpx_decoder.h>
-#include <vpx/vpx_encoder.h>
-#include <vpx/vpx_image.h>
-
-#include <vpx/vp8cx.h>
-#include <vpx/vp8dx.h>
-
 #include <pthread.h>
-
-#include "toxav.h"
+#include <stdint.h>
 
 #include "../toxcore/logger.h"
-#include "../toxcore/util.h"
-#include "ring_buffer.h"
-#include "rtp.h"
+#include "../toxcore/mono_time.h"
 
-typedef struct VCSession {
-    /* encoding */
-    vpx_codec_ctx_t encoder[1];
-    uint32_t frame_counter;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-    /* decoding */
-    vpx_codec_ctx_t decoder[1];
-    struct RingBuffer *vbuf_raw; /* Un-decoded data */
+typedef void vc_video_receive_frame_cb(uint32_t friend_number, uint16_t width, uint16_t height,
+                                       const uint8_t *y, const uint8_t *u, const uint8_t *v,
+                                       int32_t ystride, int32_t ustride, int32_t vstride,
+                                       void *user_data);
 
-    uint64_t linfts; /* Last received frame time stamp */
-    uint32_t lcfd; /* Last calculated frame duration for incoming video payload */
+typedef struct VCSession VCSession;
 
-    ToxAV *av;
-    uint32_t friend_number;
+#define VC_EFLAG_NONE 0
+#define VC_EFLAG_FORCE_KF (1 << 0)
 
-    /* Video frame receive callback */
-    toxav_video_receive_frame_cb *vcb;
-    void *vcb_user_data;
+struct RTPMessage;
 
-    pthread_mutex_t queue_mutex[1];
-    const Logger *log;
-} VCSession;
-
-VCSession *vc_new(const Logger *log, const Mono_Time *mono_time, ToxAV *av, uint32_t friend_number,
-                  toxav_video_receive_frame_cb *cb, void *cb_data);
+VCSession *vc_new(const Logger *log, const Mono_Time *mono_time, uint32_t friend_number,
+                  vc_video_receive_frame_cb *cb, void *user_data);
 void vc_kill(VCSession *vc);
 void vc_iterate(VCSession *vc);
+
 int vc_queue_message(const Mono_Time *mono_time, void *cs, struct RTPMessage *msg);
 int vc_reconfigure_encoder(VCSession *vc, uint32_t bit_rate, uint16_t width, uint16_t height, int16_t kf_max_dist);
+
+int vc_encode(VCSession *vc, uint16_t width, uint16_t height, const uint8_t *y,
+              const uint8_t *u, const uint8_t *v, int encode_flags);
+
+int vc_get_cx_data(VCSession *vc, uint8_t **data, uint32_t *size, bool *is_keyframe);
+uint32_t vc_get_lcfd(const VCSession *vc);
+pthread_mutex_t *vc_get_queue_mutex(VCSession *vc);
+void vc_increment_frame_counter(VCSession *vc);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* C_TOXCORE_TOXAV_VIDEO_H */

--- a/toxav/video_test.cc
+++ b/toxav/video_test.cc
@@ -1,0 +1,412 @@
+#include "video.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
+#include "../toxcore/network.h"
+#include "../toxcore/os_memory.h"
+#include "rtp.h"
+
+namespace {
+
+struct VideoTimeMock {
+    uint64_t t;
+};
+
+uint64_t video_mock_time_cb(void *ud) { return static_cast<VideoTimeMock *>(ud)->t; }
+
+void test_logger_cb(void *context, Logger_Level level, const char *file, uint32_t line,
+    const char *func, const char *message, void *userdata)
+{
+    (void)context;
+    (void)userdata;
+    const char *level_str = "UNKNOWN";
+    switch (level) {
+    case LOGGER_LEVEL_TRACE:
+        level_str = "TRACE";
+        break;
+    case LOGGER_LEVEL_DEBUG:
+        level_str = "DEBUG";
+        break;
+    case LOGGER_LEVEL_INFO:
+        level_str = "INFO";
+        break;
+    case LOGGER_LEVEL_WARNING:
+        level_str = "WARN";
+        break;
+    case LOGGER_LEVEL_ERROR:
+        level_str = "ERROR";
+        break;
+    }
+    printf("[%s] %s:%u %s: %s\n", level_str, file, line, func, message);
+}
+
+struct VideoTestData {
+    uint32_t friend_number = 0;
+    uint16_t width = 0;
+    uint16_t height = 0;
+    std::vector<uint8_t> y, u, v;
+    int32_t ystride = 0, ustride = 0, vstride = 0;
+
+    VideoTestData();
+    ~VideoTestData();
+
+    static void receive_frame(uint32_t friend_number, uint16_t width, uint16_t height,
+        const uint8_t *y, const uint8_t *u, const uint8_t *v, int32_t ystride, int32_t ustride,
+        int32_t vstride, void *user_data)
+    {
+        auto *self = static_cast<VideoTestData *>(user_data);
+        self->friend_number = friend_number;
+        self->width = width;
+        self->height = height;
+        self->ystride = ystride;
+        self->ustride = ustride;
+        self->vstride = vstride;
+
+        self->y.assign(y, y + static_cast<size_t>(std::abs(ystride)) * height);
+        self->u.assign(u, u + static_cast<size_t>(std::abs(ustride)) * (height / 2));
+        self->v.assign(v, v + static_cast<size_t>(std::abs(vstride)) * (height / 2));
+    }
+};
+
+VideoTestData::VideoTestData() = default;
+VideoTestData::~VideoTestData() = default;
+
+struct VideoRtpMock {
+    RTPSession *recv_session = nullptr;
+    std::vector<std::vector<uint8_t>> captured_packets;
+    bool auto_forward = true;
+
+    static int send_packet(void *user_data, const uint8_t *data, uint16_t length)
+    {
+        auto *self = static_cast<VideoRtpMock *>(user_data);
+        self->captured_packets.push_back(std::vector<uint8_t>(data, data + length));
+        if (self->auto_forward && self->recv_session) {
+            rtp_receive_packet(self->recv_session, data, length);
+        }
+        return 0;
+    }
+
+    static int video_cb(const Mono_Time *mono_time, void *cs, RTPMessage *msg)
+    {
+        return vc_queue_message(mono_time, cs, msg);
+    }
+};
+
+class VideoTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        const Memory *mem = os_memory();
+        log = logger_new(mem);
+        logger_callback_log(log, test_logger_cb, nullptr, nullptr);
+        tm.t = 1000;
+        mono_time = mono_time_new(mem, video_mock_time_cb, &tm);
+        mono_time_update(mono_time);
+    }
+
+    void TearDown() override
+    {
+        const Memory *mem = os_memory();
+        mono_time_free(mem, mono_time);
+        logger_kill(log);
+    }
+
+    Logger *log;
+    Mono_Time *mono_time;
+    VideoTimeMock tm;
+};
+
+TEST_F(VideoTest, BasicNewKill)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+    vc_kill(vc);
+}
+
+TEST_F(VideoTest, EncodeDecodeLoop)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+
+    VideoRtpMock rtp_mock;
+    RTPSession *send_rtp = rtp_new(log, RTP_TYPE_VIDEO, mono_time, VideoRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, vc, VideoRtpMock::video_cb);
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_VIDEO, mono_time, VideoRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, vc, VideoRtpMock::video_cb);
+    rtp_mock.recv_session = recv_rtp;
+
+    uint16_t width = 320;
+    uint16_t height = 240;
+    uint32_t bitrate = 500;
+
+    ASSERT_EQ(vc_reconfigure_encoder(vc, bitrate, width, height, -1), 0);
+
+    std::vector<uint8_t> y(width * height, 128);
+    std::vector<uint8_t> u((width / 2) * (height / 2), 64);
+    std::vector<uint8_t> v((width / 2) * (height / 2), 192);
+
+    ASSERT_EQ(vc_encode(vc, width, height, y.data(), u.data(), v.data(), VC_EFLAG_FORCE_KF), 0);
+    vc_increment_frame_counter(vc);
+
+    uint8_t *pkt_data;
+    uint32_t pkt_size;
+    bool is_keyframe;
+
+    while (vc_get_cx_data(vc, &pkt_data, &pkt_size, &is_keyframe)) {
+        int rc = rtp_send_data(log, send_rtp, pkt_data, pkt_size, is_keyframe);
+        ASSERT_EQ(rc, 0);
+    }
+
+    vc_iterate(vc);
+
+    ASSERT_EQ(data.friend_number, 123u);
+    ASSERT_EQ(data.width, width);
+    ASSERT_EQ(data.height, height);
+    ASSERT_FALSE(data.y.empty());
+
+    rtp_kill(log, send_rtp);
+    rtp_kill(log, recv_rtp);
+    vc_kill(vc);
+}
+
+TEST_F(VideoTest, ReconfigureEncoder)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+
+    // Initial reconfigure
+    ASSERT_EQ(vc_reconfigure_encoder(vc, 500, 320, 240, -1), 0);
+
+    // Change bitrate and resolution
+    ASSERT_EQ(vc_reconfigure_encoder(vc, 1000, 640, 480, -1), 0);
+
+    std::vector<uint8_t> y(640 * 480, 128);
+    std::vector<uint8_t> u(320 * 240, 64);
+    std::vector<uint8_t> v(320 * 240, 192);
+
+    ASSERT_EQ(vc_encode(vc, 640, 480, y.data(), u.data(), v.data(), VC_EFLAG_NONE), 0);
+
+    vc_kill(vc);
+}
+
+TEST_F(VideoTest, GetLcfd)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+
+    // Default lcfd is 60 in video.c
+    EXPECT_EQ(vc_get_lcfd(vc), 60u);
+
+    vc_kill(vc);
+}
+
+TEST_F(VideoTest, QueueInvalidMessage)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+
+    VideoRtpMock rtp_mock;
+    // Create an audio RTP session but try to queue to video session
+    RTPSession *audio_rtp = rtp_new(log, RTP_TYPE_AUDIO, mono_time, VideoRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, vc, VideoRtpMock::video_cb);
+    RTPSession *video_recv_rtp = rtp_new(log, RTP_TYPE_VIDEO, mono_time, VideoRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, vc, VideoRtpMock::video_cb);
+    rtp_mock.recv_session = video_recv_rtp;
+
+    std::vector<uint8_t> dummy_audio(100, 0);
+    int rc = rtp_send_data(
+        log, audio_rtp, dummy_audio.data(), static_cast<uint32_t>(dummy_audio.size()), false);
+    ASSERT_EQ(rc, 0);
+
+    // Iterate should NOT trigger callback because payload type was wrong
+    vc_iterate(vc);
+    EXPECT_EQ(data.width, 0u);
+
+    rtp_kill(log, audio_rtp);
+    rtp_kill(log, video_recv_rtp);
+    vc_kill(vc);
+}
+
+TEST_F(VideoTest, ReconfigureOptimizations)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+
+    // 1. Reconfigure with same values (should do nothing)
+    // vc_new initializes encoder with 800x600 and 5000 bitrate.
+    EXPECT_EQ(vc_reconfigure_encoder(vc, 5000, 800, 600, -1), 0);
+
+    // 2. Reconfigure with only bitrate change
+    EXPECT_EQ(vc_reconfigure_encoder(vc, 2000, 800, 600, -1), 0);
+
+    // 3. Reconfigure with kf_max_dist > 1 (triggers re-init and kf_max_dist branch)
+    EXPECT_EQ(vc_reconfigure_encoder(vc, 2000, 800, 600, 60), 0);
+
+    vc_kill(vc);
+}
+
+TEST_F(VideoTest, LcfdAndSpecialPackets)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+
+    VideoRtpMock rtp_mock;
+    RTPSession *video_recv_rtp = rtp_new(log, RTP_TYPE_VIDEO, mono_time, VideoRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, vc, VideoRtpMock::video_cb);
+    rtp_mock.recv_session = video_recv_rtp;
+
+    // 1. Test lcfd update
+    tm.t += 50;  // Advance time by 50ms
+    mono_time_update(mono_time);
+    std::vector<uint8_t> dummy_frame(10, 0);
+    rtp_send_data(
+        log, video_recv_rtp, dummy_frame.data(), static_cast<uint32_t>(dummy_frame.size()), true);
+
+    // lcfd should be updated. Initial linfts was set at vc_new (tm.t=1000).
+    // Now tm.t is 1050. t_lcfd = 1050 - 1000 = 50.
+    EXPECT_EQ(vc_get_lcfd(vc), 50u);
+
+    // 2. Test lcfd threshold (t_lcfd > 100 should be ignored)
+    tm.t += 200;
+    mono_time_update(mono_time);
+    rtp_send_data(
+        log, video_recv_rtp, dummy_frame.data(), static_cast<uint32_t>(dummy_frame.size()), true);
+    EXPECT_EQ(vc_get_lcfd(vc), 50u);  // Should still be 50
+
+    // 3. Test dummy packet PT = (RTP_TYPE_VIDEO + 2) % 128
+    RTPSession *dummy_rtp = rtp_new(log, (RTP_TYPE_VIDEO + 2), mono_time, VideoRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, vc, VideoRtpMock::video_cb);
+    rtp_mock.recv_session = dummy_rtp;
+    rtp_send_data(
+        log, dummy_rtp, dummy_frame.data(), static_cast<uint32_t>(dummy_frame.size()), false);
+    // Should return 0 but do nothing (logged as "Got dummy!")
+
+    // 4. Test GetQueueMutex
+    EXPECT_NE(vc_get_queue_mutex(vc), nullptr);
+
+    rtp_kill(log, video_recv_rtp);
+    rtp_kill(log, dummy_rtp);
+    vc_kill(vc);
+}
+
+TEST_F(VideoTest, MultiReconfigureEncode)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+
+    for (int i = 0; i < 5; ++i) {
+        uint16_t w = static_cast<uint16_t>(160 + (i * 16));
+        uint16_t h = static_cast<uint16_t>(120 + (i * 16));
+        std::vector<uint8_t> y(static_cast<size_t>(w) * h, 128);
+        std::vector<uint8_t> u((static_cast<size_t>(w) / 2) * (h / 2), 64);
+        std::vector<uint8_t> v((static_cast<size_t>(w) / 2) * (h / 2), 192);
+
+        ASSERT_EQ(vc_reconfigure_encoder(vc, 1000, w, h, -1), 0);
+        ASSERT_EQ(vc_encode(vc, w, h, y.data(), u.data(), v.data(), VC_EFLAG_NONE), 0);
+    }
+
+    vc_kill(vc);
+}
+
+TEST_F(VideoTest, NewWithNullMonoTime)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, nullptr, 123, VideoTestData::receive_frame, &data);
+    EXPECT_EQ(vc, nullptr);
+}
+
+TEST_F(VideoTest, ReconfigureFailDoS)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+
+    // Trigger failure by passing invalid resolution (0)
+    // This currently destroys the encoder.
+    ASSERT_EQ(vc_reconfigure_encoder(vc, 1000, 0, 0, -1), -1);
+
+    // Attempt to encode. This is expected to crash because vc->encoder is destroyed.
+    std::vector<uint8_t> y(320 * 240, 128);
+    std::vector<uint8_t> u(160 * 120, 64);
+    std::vector<uint8_t> v(160 * 120, 192);
+    // This call will crash in the current unfixed code.
+    vc_encode(vc, 320, 240, y.data(), u.data(), v.data(), VC_EFLAG_NONE);
+
+    vc_kill(vc);
+}
+
+TEST_F(VideoTest, LyingLengthOOB)
+{
+    VideoTestData data;
+    VCSession *vc = vc_new(log, mono_time, 123, VideoTestData::receive_frame, &data);
+    ASSERT_NE(vc, nullptr);
+
+    VideoRtpMock rtp_mock;
+    RTPSession *recv_rtp = rtp_new(log, RTP_TYPE_VIDEO, mono_time, VideoRtpMock::send_packet,
+        &rtp_mock, nullptr, nullptr, nullptr, vc, VideoRtpMock::video_cb);
+    rtp_mock.recv_session = recv_rtp;
+
+    // Craft a malicious RTP packet
+    uint16_t payload_len = 10;
+    uint8_t packet[RTP_HEADER_SIZE + 11];  // +1 for Tox ID
+    memset(packet, 0, sizeof(packet));
+
+    // Tox ID
+    packet[0] = static_cast<uint8_t>(RTP_TYPE_VIDEO);
+
+    auto pack_u16 = [](uint8_t *p, uint16_t v) {
+        p[0] = static_cast<uint8_t>(v >> 8);
+        p[1] = static_cast<uint8_t>(v & 0xff);
+    };
+    auto pack_u32 = [](uint8_t *p, uint32_t v) {
+        p[0] = static_cast<uint8_t>(v >> 24);
+        p[1] = static_cast<uint8_t>((v >> 16) & 0xff);
+        p[2] = static_cast<uint8_t>((v >> 8) & 0xff);
+        p[3] = static_cast<uint8_t>(v & 0xff);
+    };
+    auto pack_u64 = [&](uint8_t *p, uint64_t v) {
+        pack_u32(p, static_cast<uint32_t>(v >> 32));
+        pack_u32(p + 4, static_cast<uint32_t>(v & 0xffffffff));
+    };
+
+    // RTP Header starts at packet[1]
+    packet[1] = 2 << 6;  // ve = 2
+    packet[2] = static_cast<uint8_t>(RTP_TYPE_VIDEO % 128);
+
+    pack_u16(packet + 3, 1);  // sequnum
+    pack_u32(packet + 5, 1000);  // timestamp
+    pack_u32(packet + 9, 0x12345678);  // ssrc
+    pack_u64(packet + 13, RTP_LARGE_FRAME);  // flags
+    pack_u32(packet + 21, 0);  // offset_full
+    pack_u32(packet + 25, 1000);  // data_length_full (LYING! Actual is 10)
+    pack_u32(packet + 29, 0);  // received_length_full
+
+    // Skip padding fields (11 * 4 = 44 bytes)
+    pack_u16(packet + 77, 0);  // offset_lower
+    pack_u16(packet + 79, payload_len);  // data_length_lower
+
+    // Send the malicious packet
+    rtp_receive_packet(recv_rtp, packet, sizeof(packet));
+
+    // Trigger vc_iterate. This will call vpx_codec_decode with length 1000.
+    // This is expected to cause OOB read.
+    vc_iterate(vc);
+
+    rtp_kill(log, recv_rtp);
+    vc_kill(vc);
+}
+
+}  // namespace


### PR DESCRIPTION
- Remove invalid vpx_img_free call in vc_iterate.
- Make vc_reconfigure_encoder atomic and add resolution limits.
- Support 32-bit RTPMessage lengths to correctly handle large frames.
- Ensure len is correctly set for assembled video frames.
- Add security checks for incoming frame sizes and resolutions.
- Clean up VCSession structure and improve internal API consistency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2936)
<!-- Reviewable:end -->
