### PR TITLE
fix(toxav): fix heap buffer overflow in RTP video packet handling

### DIFF
--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 load("//tools:no_undefined.bzl", "cc_library")
 
 exports_files(
@@ -69,6 +70,20 @@ cc_test(
         "//c-toxcore/toxcore:os_memory",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_fuzz_test(
+    name = "rtp_fuzz_test",
+    size = "small",
+    srcs = ["rtp_fuzz_test.cc"],
+    copts = ["-UNDEBUG"],
+    deps = [
+        ":rtp",
+        "//c-toxcore/testing/fuzzing:fuzz_support",
+        "//c-toxcore/toxcore:logger",
+        "//c-toxcore/toxcore:mono_time",
+        "//c-toxcore/toxcore:os_memory",
     ],
 )
 

--- a/toxav/rtp_fuzz_test.cc
+++ b/toxav/rtp_fuzz_test.cc
@@ -1,0 +1,81 @@
+#include "rtp.h"
+
+#include <cstdlib>
+#include <vector>
+
+#include "../testing/fuzzing/fuzz_support.hh"
+#include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
+#include "../toxcore/os_memory.h"
+
+namespace {
+
+struct MockSessionData { };
+
+static int mock_send_packet(void * /*user_data*/, const uint8_t * /*data*/, uint16_t /*length*/)
+{
+    return 0;
+}
+
+static int mock_m_cb(const Mono_Time * /*mono_time*/, void * /*cs*/, RTPMessage *msg)
+{
+    std::free(msg);
+    return 0;
+}
+
+void fuzz_rtp_receive(Fuzz_Data &input)
+{
+    const Memory *mem = os_memory();
+    struct LoggerDeleter {
+        void operator()(Logger *l) { logger_kill(l); }
+    };
+    std::unique_ptr<Logger, LoggerDeleter> log(logger_new(mem));
+
+    auto time_cb = [](void *) -> uint64_t { return 0; };
+    struct MonoTimeDeleter {
+        const Memory *m;
+        void operator()(Mono_Time *t) { mono_time_free(m, t); }
+    };
+    std::unique_ptr<Mono_Time, MonoTimeDeleter> mono_time(
+        mono_time_new(mem, time_cb, nullptr), MonoTimeDeleter{mem});
+
+    MockSessionData sd;
+
+    CONSUME1_OR_RETURN(uint8_t, payload_type_byte, input);
+    int payload_type = (payload_type_byte % 2 == 0) ? RTP_TYPE_AUDIO : RTP_TYPE_VIDEO;
+
+    struct RtpSessionDeleter {
+        Logger *l;
+        void operator()(RTPSession *s) { rtp_kill(l, s); }
+    };
+    std::unique_ptr<RTPSession, RtpSessionDeleter> session(
+        rtp_new(log.get(), payload_type, mono_time.get(), mock_send_packet, &sd, nullptr, nullptr,
+            nullptr, &sd, mock_m_cb),
+        RtpSessionDeleter{log.get()});
+
+    while (!input.empty()) {
+        CONSUME1_OR_RETURN(uint16_t, len, input);
+
+        if (input.size() < len) {
+            len = input.size();
+        }
+
+        if (len == 0) {
+            break;
+        }
+
+        const uint8_t *pkt_data = input.consume(__func__, len);
+        rtp_receive_packet(session.get(), pkt_data, len);
+    }
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    Fuzz_Data input(data, size);
+    fuzz_rtp_receive(input);
+    return 0;
+}


### PR DESCRIPTION
The `rtp_receive_packet` function (via `fill_data_into_slot`) relied on the `data_length_full` field in the RTP header to allocate the frame buffer, but failed to verify that the actual payload length of the incoming packet fit within this allocated size. A malicious peer could send a packet with a small `data_length_full` but a large payload, causing `memcpy` to write past the end of the buffer.

This PR adds a bounds check to ensure that the packet offset plus the payload length does not exceed the total frame length. Tested via unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2939)
<!-- Reviewable:end -->
