### PR TITLE
refactor(toxav): decouple networking and create toxav_core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,7 +418,9 @@ if(BUILD_TOXAV)
     toxav/rtp.h
     toxav/toxav.c
     toxav/toxav.h
+    toxav/toxav_compat.c
     toxav/toxav_old.c
+    toxav/toxav_private.h
     toxav/video.c
     toxav/video.h)
   set(toxcore_API_HEADERS ${toxcore_API_HEADERS}

--- a/toxav/BUILD.bazel
+++ b/toxav/BUILD.bazel
@@ -262,21 +262,54 @@ cc_test(
 )
 
 cc_library(
-    name = "toxav",
-    srcs = [
-        "groupav.c",
-        "groupav.h",
-        "toxav.c",
-        "toxav_old.c",
+    name = "toxav_core",
+    srcs = ["toxav.c"],
+    hdrs = [
+        "toxav.h",
+        "toxav_private.h",
     ],
-    hdrs = ["toxav.h"],
-    visibility = ["//c-toxcore:__subpackages__"],
     deps = [
         ":audio",
         ":bwcontroller",
         ":msi",
         ":rtp",
         ":video",
+        "//c-toxcore/toxcore:Messenger",
+        "//c-toxcore/toxcore:ccompat",
+        "//c-toxcore/toxcore:logger",
+        "//c-toxcore/toxcore:mono_time",
+        "//c-toxcore/toxcore:net_crypto",
+        "//c-toxcore/toxcore:network",
+        "//c-toxcore/toxcore:tox",
+        "//c-toxcore/toxcore:util",
+        "@libsodium",
+        "@opus",
+    ],
+)
+
+cc_test(
+    name = "toxav_test",
+    size = "small",
+    srcs = ["toxav_test.cc"],
+    deps = [
+        ":av_test_support",
+        ":toxav_core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "toxav",
+    srcs = [
+        "groupav.c",
+        "groupav.h",
+        "toxav_compat.c",
+        "toxav_old.c",
+    ],
+    hdrs = ["toxav.h"],
+    visibility = ["//c-toxcore:__subpackages__"],
+    deps = [
+        ":toxav_core",
         "//c-toxcore/toxcore:Messenger",
         "//c-toxcore/toxcore:ccompat",
         "//c-toxcore/toxcore:group",
@@ -298,4 +331,21 @@ sh_library(
         "*.h",
     ]),
     visibility = ["//c-toxcore/testing:__pkg__"],
+)
+
+cc_fuzz_test(
+    name = "toxav_fuzz_test",
+    srcs = ["toxav_fuzz_test.cc"],
+    copts = ["-UNDEBUG"],
+    # corpus = ["//tools/toktok-fuzzer/corpus:toxav_fuzz_test"],
+    deps = [
+        ":toxav_core",
+        "//c-toxcore/testing/fuzzing:fuzz_support",
+    ],
+)
+
+cc_binary(
+    name = "toxav_fuzz_seed_gen",
+    srcs = ["toxav_fuzz_seed_gen.cc"],
+    visibility = ["//visibility:public"],
 )

--- a/toxav/Makefile.inc
+++ b/toxav/Makefile.inc
@@ -20,7 +20,9 @@ libtoxav_la_SOURCES = ../toxav/rtp.h \
                     ../toxav/ring_buffer.c \
                     ../toxav/toxav.h \
                     ../toxav/toxav.c \
-                    ../toxav/toxav_old.c
+                    ../toxav/toxav_compat.c \
+                    ../toxav/toxav_old.c \
+                    ../toxav/toxav_private.h
 
 libtoxav_la_CFLAGS = -I../toxcore \
                     -I../toxav \

--- a/toxav/av_test_support.cc
+++ b/toxav/av_test_support.cc
@@ -50,6 +50,10 @@ int RtpMock::noop_cb(const Mono_Time * /*mono_time*/, void * /*cs*/, RTPMessage 
 void fill_audio_frame(uint32_t sampling_rate, uint8_t channels, int frame_index,
     size_t sample_count, std::vector<int16_t> &pcm)
 {
+    if (pcm.size() < sample_count * channels) {
+        pcm.resize(sample_count * channels);
+    }
+
     const double pi = std::acos(-1.0);
     double amplitude = 10000.0;
 
@@ -68,6 +72,10 @@ void fill_audio_frame(uint32_t sampling_rate, uint8_t channels, int frame_index,
 
 void fill_silent_frame(uint8_t channels, size_t sample_count, std::vector<int16_t> &pcm)
 {
+    if (pcm.size() < sample_count * channels) {
+        pcm.resize(sample_count * channels);
+    }
+
     for (size_t i = 0; i < sample_count * channels; ++i) {
         // Very low amplitude white noise (simulating silence with background hiss)
         pcm[i] = (std::rand() % 21) - 10;
@@ -92,6 +100,16 @@ void AudioTestData::receive_frame(uint32_t friend_number, const int16_t *pcm, si
 void fill_video_frame(uint16_t width, uint16_t height, int frame_index, std::vector<uint8_t> &y,
     std::vector<uint8_t> &u, std::vector<uint8_t> &v)
 {
+    size_t y_size = static_cast<size_t>(width) * height;
+    size_t uv_size = y_size / 4;
+
+    if (y.size() < y_size)
+        y.resize(y_size);
+    if (u.size() < uv_size)
+        u.resize(uv_size);
+    if (v.size() < uv_size)
+        v.resize(uv_size);
+
     // Background (dark gray)
     std::fill(y.begin(), y.end(), 32);
     std::fill(u.begin(), u.end(), 128);

--- a/toxav/msi.h
+++ b/toxav/msi.h
@@ -6,6 +6,7 @@
 #define C_TOXCORE_TOXAV_MSI_H
 
 #include <pthread.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "../toxcore/logger.h"

--- a/toxav/toxav_compat.c
+++ b/toxav/toxav_compat.c
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2016-2025 The TokTok team.
+ * Copyright © 2013-2015 Tox project.
+ */
+#include "toxav.h"
+#include "toxav_private.h"
+
+#include <stdlib.h>
+
+#include "../toxcore/ccompat.h"
+#include "../toxcore/tox.h"
+#include "../toxcore/tox_private.h"
+#include "../toxcore/tox_struct.h"
+#include "../toxcore/Messenger.h" // For PACKET_ID_MSI if needed, but we use numeric or define
+#include "../toxcore/net_crypto.h" // For PACKET_ID_MSI
+
+Tox *toxav_get_tox(const ToxAV *av)
+{
+    return av->tox;
+}
+
+static bool legacy_send_lossy(uint32_t friend_number, const uint8_t *data, size_t length, void *user_data)
+{
+    Tox *tox = (Tox *)user_data;
+    Tox_Err_Friend_Custom_Packet error;
+    tox_friend_send_lossy_packet(tox, friend_number, data, length, &error);
+    return error == TOX_ERR_FRIEND_CUSTOM_PACKET_OK;
+}
+
+static bool legacy_send_lossless(uint32_t friend_number, const uint8_t *data, size_t length, void *user_data)
+{
+    Tox *tox = (Tox *)user_data;
+    Tox_Err_Friend_Custom_Packet error;
+    tox_friend_send_lossless_packet(tox, friend_number, data, length, &error);
+    return error == TOX_ERR_FRIEND_CUSTOM_PACKET_OK;
+}
+
+static bool legacy_friend_exists(uint32_t friend_number, void *user_data)
+{
+    const Tox *tox = (const Tox *)user_data;
+    return tox_friend_exists(tox, friend_number);
+}
+
+static bool legacy_friend_connected(uint32_t friend_number, void *user_data)
+{
+    const Tox *tox = (const Tox *)user_data;
+    Tox_Err_Friend_Query error;
+    return tox_friend_get_connection_status(tox, friend_number, &error) != TOX_CONNECTION_NONE;
+}
+
+static void legacy_handle_rtp_packet(Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length, void *user_data)
+{
+    ToxAV *av = (ToxAV *)tox_get_av_object(tox);
+    if (av != nullptr) {
+        toxav_receive_packet(av, friend_number, data, length);
+    }
+}
+
+static void legacy_handle_msi_packet(Tox *tox, Tox_Friend_Number friend_number, const uint8_t *data, size_t length, void *user_data)
+{
+    ToxAV *av = (ToxAV *)tox_get_av_object(tox);
+    if (av != nullptr) {
+        toxav_receive_packet(av, friend_number, data, length);
+    }
+}
+
+ToxAV *toxav_new(Tox *tox, Toxav_Err_New *error)
+{
+    if (tox == nullptr) {
+        if (error) {
+            *error = TOXAV_ERR_NEW_NULL;
+        }
+        return nullptr;
+    }
+
+    const ToxAV_IO io = {
+        legacy_send_lossy,
+        legacy_send_lossless,
+        legacy_friend_exists,
+        legacy_friend_connected,
+    };
+
+    ToxAV *av = toxav_new_custom(&io, tox, error);
+    if (av == nullptr) {
+        return nullptr;
+    }
+
+    av->tox = tox;
+    // We access internal toxcore structs here, which is allowed for compat/legacy layer
+    av->mem = tox->sys.mem;
+    logger_kill(av->log);
+    av->log = tox->m->log;
+
+    // Register callbacks
+    tox_callback_friend_lossy_packet_per_pktid(av->tox, legacy_handle_rtp_packet, RTP_TYPE_AUDIO);
+    tox_callback_friend_lossy_packet_per_pktid(av->tox, legacy_handle_rtp_packet, RTP_TYPE_VIDEO);
+    tox_callback_friend_lossy_packet_per_pktid(av->tox, legacy_handle_rtp_packet, BWC_PACKET_ID);
+    tox_callback_friend_lossless_packet_per_pktid(av->tox, legacy_handle_msi_packet, PACKET_ID_MSI);
+
+    tox_set_av_object(av->tox, av);
+    return av;
+}

--- a/toxav/toxav_fuzz_seed_gen.cc
+++ b/toxav/toxav_fuzz_seed_gen.cc
@@ -1,0 +1,236 @@
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+// Helper to construct fuzzer input
+class SeedBuilder {
+    std::vector<uint8_t> data;
+
+public:
+    void add_byte(uint8_t b) { data.push_back(b); }
+
+    void add_u16(uint16_t v)
+    {
+        data.push_back(v & 0xFF);
+        data.push_back((v >> 8) & 0xFF);
+    }
+
+    void add_u32(uint32_t v)
+    {
+        data.push_back(v & 0xFF);
+        data.push_back((v >> 8) & 0xFF);
+        data.push_back((v >> 16) & 0xFF);
+        data.push_back((v >> 24) & 0xFF);
+    }
+
+    void add_bytes(const void *ptr, size_t size)
+    {
+        const uint8_t *p = static_cast<const uint8_t *>(ptr);
+        data.insert(data.end(), p, p + size);
+    }
+
+    void add_zeros(size_t count) { data.insert(data.end(), count, 0); }
+
+    void save(const std::string &filename)
+    {
+        std::string path = filename;
+        const char *workspace_dir = std::getenv("BUILD_WORKSPACE_DIRECTORY");
+        if (workspace_dir) {
+            path = std::string(workspace_dir) + "/" + filename;
+        }
+        std::ofstream out(path, std::ios::binary);
+        if (out) {
+            out.write(reinterpret_cast<const char *>(data.data()), data.size());
+            std::cout << "Generated seed file: " << path << " (" << data.size() << " bytes)"
+                      << std::endl;
+        } else {
+            std::cerr << "Failed to write to " << path << std::endl;
+        }
+    }
+
+    // Actions matching toxav_fuzz_test.cc
+
+    void set_header(uint8_t mode)
+    {
+        // First byte is mode (multithreaded if % 2 != 0)
+        add_byte(mode);
+    }
+
+    void iterate() { add_byte(0); }
+
+    void call(uint8_t friend_num, uint32_t audio_br, uint32_t video_br)
+    {
+        add_byte(1);
+        add_byte(friend_num);
+        add_u32(audio_br);
+        add_u32(video_br);
+    }
+
+    void answer(uint8_t friend_num, uint32_t audio_br, uint32_t video_br)
+    {
+        add_byte(2);
+        add_byte(friend_num);
+        add_u32(audio_br);
+        add_u32(video_br);
+    }
+
+    void call_control(uint8_t friend_num, uint8_t control)
+    {
+        add_byte(3);
+        add_byte(friend_num);
+        add_byte(control);
+    }
+
+    void audio_send_frame(uint8_t friend_num, uint16_t samples, uint8_t channels, uint32_t rate)
+    {
+        add_byte(4);
+        add_byte(friend_num);
+        add_u16(samples);
+        add_byte(channels);
+        add_u32(rate);
+        // data needs to be added manually or zeros
+        size_t pcm_size = samples * channels * sizeof(int16_t);
+        add_zeros(pcm_size);
+    }
+
+    void video_send_frame(uint8_t friend_num, uint16_t w, uint16_t h)
+    {
+        add_byte(5);
+        add_byte(friend_num);
+        add_u16(w);
+        add_u16(h);
+
+        size_t y_size = w * h;
+        size_t u_size = (w / 2) * (h / 2);
+        size_t v_size = u_size;
+
+        add_zeros(y_size + u_size + v_size);
+    }
+
+    void receive_packet(uint8_t friend_num, const std::vector<uint8_t> &packet, uint8_t bias)
+    {
+        add_byte(6);
+        add_byte(friend_num);
+        add_u16(packet.size());
+        add_byte(bias);
+        add_bytes(packet.data(), packet.size());
+    }
+
+    void set_audio_bit_rate(uint8_t friend_num, uint32_t br)
+    {
+        add_byte(7);
+        add_byte(friend_num);
+        add_u32(br);
+    }
+
+    void set_video_bit_rate(uint8_t friend_num, uint32_t br)
+    {
+        add_byte(8);
+        add_byte(friend_num);
+        add_u32(br);
+    }
+
+    void advance_time(uint16_t ms)
+    {
+        add_byte(9);
+        add_u16(ms);
+    }
+
+    void toggle_connected() { add_byte(10); }
+
+    void toggle_send_success() { add_byte(11); }
+};
+
+int main()
+{
+    SeedBuilder b;
+
+    // 0 = Single Threaded
+    b.set_header(0);
+
+    // Initial state: connected, send success = true
+
+    // 1. Advance time a bit to simulate startup
+    b.advance_time(100);
+    b.iterate();
+
+    // 2. Start a call to friend 0
+    // Audio 48k, Video 0 (Audio only)
+    b.call(0, 48, 0);
+    b.iterate();
+
+    // 3. Advance time while ringing
+    b.advance_time(50);
+    b.iterate();
+
+    // 4. Simulate receiving a packet (e.g. MSI or just noise with correct ID)
+    // Bias 0 = MSI (69)
+    std::vector<uint8_t> dummy_pkt(10, 0xAA);
+    b.receive_packet(0, dummy_pkt, 0);
+    b.iterate();
+
+    // 5. Send some audio frames
+    // 960 samples, 1 channel, 48000 Hz = 20ms
+    for (int i = 0; i < 5; ++i) {
+        b.audio_send_frame(0, 960, 1, 48000);
+        b.advance_time(20);
+        b.iterate();
+    }
+
+    // 6. Set bitrate
+    b.set_audio_bit_rate(0, 64);
+    b.iterate();
+
+    // 7. Answer (invalid state since we called, but good for fuzzing coverage)
+    b.answer(0, 48, 0);
+    b.iterate();
+
+    // 8. Call Control: Pause
+    // TOXAV_CALL_CONTROL_PAUSE = 1
+    b.call_control(0, 1);
+    b.iterate();
+
+    // 9. Advance time
+    b.advance_time(1000);
+    b.iterate();
+
+    // 10. Resume
+    // TOXAV_CALL_CONTROL_RESUME = 0
+    b.call_control(0, 0);
+    b.iterate();
+
+    // 11. Send Video Frame (even though we didn't enable it, check error handling)
+    b.video_send_frame(0, 320, 240);
+    b.iterate();
+
+    // 12. Set video bitrate
+    b.set_video_bit_rate(0, 1000);
+    b.iterate();
+
+    // 13. Toggle connected (simulate disconnect)
+    b.toggle_connected();
+    b.iterate();
+    b.advance_time(50);
+    b.iterate();
+
+    // Toggle connected (simulate reconnect)
+    b.toggle_connected();
+    b.iterate();
+
+    // 14. Toggle send success (simulate send failure)
+    b.toggle_send_success();
+    // Try sending frame which should fail
+    b.audio_send_frame(0, 960, 1, 48000);
+    b.iterate();
+
+    // Toggle send success (simulate recovery)
+    b.toggle_send_success();
+    b.iterate();
+
+    b.save("toxav_call_cycle.bin");
+
+    return 0;
+}

--- a/toxav/toxav_fuzz_test.cc
+++ b/toxav/toxav_fuzz_test.cc
@@ -1,0 +1,275 @@
+#include "toxav.h"
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "../testing/fuzzing/fuzz_support.hh"
+
+namespace {
+
+constexpr bool kEnableDebug = false;
+
+template <typename... Args>
+void fuzz_log(const char *fmt, Args &&...args)
+{
+    if constexpr (kEnableDebug) {
+        fprintf(stderr, fmt, std::forward<Args>(args)...);
+    }
+}
+
+struct FuzzContext {
+    uint64_t current_time_ms = 1000000;
+    bool friend_connected = true;
+    bool send_success = true;
+};
+
+// Mock IO callbacks
+static bool mock_send_lossy(
+    uint32_t friend_number, const uint8_t *data, size_t length, void *user_data)
+{
+    return static_cast<FuzzContext *>(user_data)->send_success;
+}
+
+static bool mock_send_lossless(
+    uint32_t friend_number, const uint8_t *data, size_t length, void *user_data)
+{
+    return static_cast<FuzzContext *>(user_data)->send_success;
+}
+
+static bool mock_friend_exists(uint32_t friend_number, void *user_data) { return true; }
+
+static bool mock_friend_connected(uint32_t friend_number, void *user_data)
+{
+    return static_cast<FuzzContext *>(user_data)->friend_connected;
+}
+
+static uint64_t mock_current_time(void *user_data)
+{
+    return static_cast<FuzzContext *>(user_data)->current_time_ms;
+}
+
+// Callbacks for ToxAV events (just to avoid crashes if they are called)
+static void on_call(ToxAV *av, uint32_t friend_number, bool audio, bool video, void *user_data) { }
+static void on_call_state(ToxAV *av, uint32_t friend_number, uint32_t state, void *user_data) { }
+static void on_audio_frame(ToxAV *av, uint32_t friend_number, const int16_t *pcm,
+    size_t sample_count, uint8_t channels, uint32_t sampling_rate, void *user_data)
+{
+}
+static void on_video_frame(ToxAV *av, uint32_t friend_number, uint16_t width, uint16_t height,
+    const uint8_t *y, const uint8_t *u, const uint8_t *v, int32_t ystride, int32_t ustride,
+    int32_t vstride, void *user_data)
+{
+}
+static void on_audio_bit_rate(
+    ToxAV *av, uint32_t friend_number, uint32_t audio_bit_rate, void *user_data)
+{
+}
+static void on_video_bit_rate(
+    ToxAV *av, uint32_t friend_number, uint32_t video_bit_rate, void *user_data)
+{
+}
+
+void fuzz_toxav_custom(Fuzz_Data &input)
+{
+    FuzzContext ctx;
+    CONSUME1_OR_RETURN(uint8_t, mode, input);
+    bool multithreaded = mode % 2;
+
+    ToxAV_IO *io = toxav_io_new();
+    toxav_io_callback_send_lossy(io, mock_send_lossy);
+    toxav_io_callback_send_lossless(io, mock_send_lossless);
+    toxav_io_callback_friend_exists(io, mock_friend_exists);
+    toxav_io_callback_friend_connected(io, mock_friend_connected);
+    toxav_io_callback_time_current(io, mock_current_time);
+
+    Toxav_Err_New err_new;
+    struct ToxAVDeleter {
+        void operator()(ToxAV *av) { toxav_kill(av); }
+    };
+    std::unique_ptr<ToxAV, ToxAVDeleter> av(toxav_new_custom(io, &ctx, &err_new));
+    toxav_io_kill(io);
+
+    if (err_new != TOXAV_ERR_NEW_OK) {
+        return;
+    }
+
+    // Register callbacks
+    toxav_callback_call(av.get(), on_call, nullptr);
+    toxav_callback_call_state(av.get(), on_call_state, nullptr);
+    toxav_callback_audio_receive_frame(av.get(), on_audio_frame, nullptr);
+    toxav_callback_video_receive_frame(av.get(), on_video_frame, nullptr);
+    toxav_callback_audio_bit_rate(av.get(), on_audio_bit_rate, nullptr);
+    toxav_callback_video_bit_rate(av.get(), on_video_bit_rate, nullptr);
+
+    fuzz_log("Starting fuzz_toxav_custom (size=%zu, mode=%s)\n", input.size(),
+        multithreaded ? "MT" : "ST");
+
+    while (!input.empty()) {
+        CONSUME1_OR_RETURN(uint8_t, action, input);
+        action %= 12;
+
+        switch (action) {
+        case 0: {  // iterate
+            fuzz_log("iterate\n");
+            if (multithreaded) {
+                toxav_audio_iterate(av.get());
+                toxav_video_iterate(av.get());
+            } else {
+                toxav_iterate(av.get());
+            }
+            break;
+        }
+        case 1: {  // call
+            CONSUME1_OR_RETURN(uint8_t, friend_number, input);
+            CONSUME1_OR_RETURN(uint32_t, audio_br, input);
+            CONSUME1_OR_RETURN(uint32_t, video_br, input);
+            fuzz_log("call(friend=%d, abr=%u, vbr=%u)\n", friend_number, audio_br, video_br);
+            Toxav_Err_Call err;
+            toxav_call(av.get(), friend_number, audio_br, video_br, &err);
+            break;
+        }
+        case 2: {  // answer
+            CONSUME1_OR_RETURN(uint8_t, friend_number, input);
+            CONSUME1_OR_RETURN(uint32_t, audio_br, input);
+            CONSUME1_OR_RETURN(uint32_t, video_br, input);
+            fuzz_log("answer(friend=%d, abr=%u, vbr=%u)\n", friend_number, audio_br, video_br);
+            Toxav_Err_Answer err;
+            toxav_answer(av.get(), friend_number, audio_br, video_br, &err);
+            break;
+        }
+        case 3: {  // call_control
+            CONSUME1_OR_RETURN(uint8_t, friend_number, input);
+            CONSUME1_OR_RETURN(uint8_t, control_val, input);
+            Toxav_Call_Control control = static_cast<Toxav_Call_Control>(control_val % 7);
+            fuzz_log("call_control(friend=%d, ctrl=%d)\n", friend_number, control);
+            Toxav_Err_Call_Control err;
+            toxav_call_control(av.get(), friend_number, control, &err);
+            break;
+        }
+        case 4: {  // audio_send_frame
+            CONSUME1_OR_RETURN(uint8_t, friend_number, input);
+            CONSUME1_OR_RETURN(uint16_t, sample_count, input);
+            CONSUME1_OR_RETURN(uint8_t, channels, input);
+            CONSUME1_OR_RETURN(uint32_t, sampling_rate, input);
+
+            // Limit allocation size to prevent OOM in fuzzer
+            if (sample_count > 5760 || channels > 2)
+                break;
+
+            size_t size = static_cast<size_t>(sample_count) * channels;
+            if (input.size() < size * sizeof(int16_t))
+                break;
+
+            std::vector<int16_t> pcm(size);
+            for (size_t i = 0; i < size; ++i) {
+                pcm[i] = input.consume1("pcm");
+            }
+
+            fuzz_log("audio_send_frame(friend=%d, samples=%u)\n", friend_number, sample_count);
+
+            Toxav_Err_Send_Frame err;
+            toxav_audio_send_frame(
+                av.get(), friend_number, pcm.data(), sample_count, channels, sampling_rate, &err);
+            break;
+        }
+        case 5: {  // video_send_frame
+            CONSUME1_OR_RETURN(uint8_t, friend_number, input);
+            CONSUME1_OR_RETURN(uint16_t, width, input);
+            CONSUME1_OR_RETURN(uint16_t, height, input);
+
+            // Limit dimensions
+            if (width > 1280 || height > 720)
+                break;
+
+            size_t y_size = static_cast<size_t>(width) * height;
+            size_t u_size = static_cast<size_t>(width / 2) * (height / 2);
+            size_t v_size = u_size;
+
+            if (input.size() < y_size + u_size + v_size)
+                break;
+
+            // We'll just point to fuzzer data if possible to avoid copy, but api takes const
+            // uint8_t* so we can consume directly.
+            const uint8_t *y = input.consume("y", y_size);
+            const uint8_t *u = input.consume("u", u_size);
+            const uint8_t *v = input.consume("v", v_size);
+
+            fuzz_log("video_send_frame(friend=%d, %dx%d)\n", friend_number, width, height);
+
+            Toxav_Err_Send_Frame err;
+            toxav_video_send_frame(av.get(), friend_number, width, height, y, u, v, &err);
+            break;
+        }
+        case 6: {  // receive_packet
+            CONSUME1_OR_RETURN(uint8_t, friend_number, input);
+            CONSUME1_OR_RETURN(uint16_t, len, input);
+            CONSUME1_OR_RETURN(uint8_t, bias, input);
+
+            if (input.size() < len)
+                len = input.size();
+
+            if (len == 0)
+                break;
+
+            const uint8_t *data = input.consume("packet", len);
+            std::vector<uint8_t> packet(data, data + len);
+
+            if (bias < 4) {
+                static const uint8_t ids[] = {69, 192, 193, 196};
+                packet[0] = ids[bias];
+            }
+
+            fuzz_log("receive_packet(friend=%d, len=%u, bias=%d)\n", friend_number, len, bias);
+
+            toxav_receive_packet(av.get(), friend_number, packet.data(), len);
+            break;
+        }
+        case 7: {  // set_audio_bit_rate
+            CONSUME1_OR_RETURN(uint8_t, friend_number, input);
+            CONSUME1_OR_RETURN(uint32_t, br, input);
+            fuzz_log("set_audio_bit_rate(friend=%d, br=%u)\n", friend_number, br);
+            Toxav_Err_Bit_Rate_Set err;
+            toxav_audio_set_bit_rate(av.get(), friend_number, br, &err);
+            break;
+        }
+        case 8: {  // set_video_bit_rate
+            CONSUME1_OR_RETURN(uint8_t, friend_number, input);
+            CONSUME1_OR_RETURN(uint32_t, br, input);
+            fuzz_log("set_video_bit_rate(friend=%d, br=%u)\n", friend_number, br);
+            Toxav_Err_Bit_Rate_Set err;
+            toxav_video_set_bit_rate(av.get(), friend_number, br, &err);
+            break;
+        }
+        case 9: {  // advance time
+            CONSUME1_OR_RETURN(uint16_t, inc, input);
+            fuzz_log("advance_time(inc=%u)\n", inc);
+            ctx.current_time_ms += inc;
+            break;
+        }
+        case 10: {  // toggle connected
+            fuzz_log("toggle_connected\n");
+            ctx.friend_connected = !ctx.friend_connected;
+            break;
+        }
+        case 11: {  // toggle send success
+            fuzz_log("toggle_send_success\n");
+            ctx.send_success = !ctx.send_success;
+            break;
+        }
+        }
+    }
+    fuzz_log("Finished fuzz_toxav_custom\n");
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    Fuzz_Data input(data, size);
+    fuzz_toxav_custom(input);
+    return 0;
+}

--- a/toxav/toxav_private.h
+++ b/toxav/toxav_private.h
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2016-2025 The TokTok team.
+ * Copyright © 2013-2015 Tox project.
+ */
+#ifndef C_TOXCORE_TOXAV_TOXAV_PRIVATE_H
+#define C_TOXCORE_TOXAV_TOXAV_PRIVATE_H
+
+#include <pthread.h>
+
+#include "toxav.h"
+#include "audio.h"
+#include "video.h"
+#include "bwcontroller.h"
+#include "rtp.h"
+#include "msi.h"
+
+#include "../toxcore/logger.h"
+#include "../toxcore/mono_time.h"
+
+typedef struct ToxAVCall ToxAVCall;
+
+struct ToxAV_IO {
+    toxav_send_lossy_cb *send_lossy;
+    toxav_send_lossless_cb *send_lossless;
+    toxav_friend_exists_cb *friend_exists;
+    toxav_friend_connected_cb *friend_connected;
+    toxav_time_cb *current_time;
+};
+
+struct ToxAVCall {
+    ToxAV *av;
+
+    pthread_mutex_t mutex_audio[1];
+    RTPSession *audio_rtp;
+    ACSession *audio;
+
+    pthread_mutex_t mutex_video[1];
+    RTPSession *video_rtp;
+    VCSession *video;
+
+    BWController *bwc;
+
+    bool active;
+    MSICall *msi_call;
+    Tox_Friend_Number friend_number;
+
+    uint32_t audio_bit_rate; /* Sending audio bit rate */
+    uint32_t video_bit_rate; /* Sending video bit rate */
+
+    /** Required for monitoring changes in states */
+    uint8_t previous_self_capabilities;
+
+    toxav_audio_receive_frame_cb *acb;
+    void *acb_user_data;
+
+    pthread_mutex_t toxav_call_mutex[1];
+
+    struct ToxAVCall *prev;
+    struct ToxAVCall *next;
+};
+
+/** Decode time statistics */
+typedef struct DecodeTimeStats {
+    /** Measure count */
+    int32_t count;
+    /** Last cycle total */
+    int32_t total;
+    /** Average decoding time in ms */
+    int32_t average;
+
+    /** Calculated iteration interval */
+    uint32_t interval;
+} DecodeTimeStats;
+
+/* Forward declaration for Tox if needed, but we try to avoid it in core.
+ * However, struct ToxAV has `Tox *` for legacy support. */
+#ifndef TOX_DEFINED
+#define TOX_DEFINED
+typedef struct Tox Tox;
+#endif /* TOX_DEFINED */
+
+struct ToxAV {
+    const struct Tox_Memory *mem;
+    Logger *log;
+    Tox *tox;
+    MSISession *msi;
+
+    ToxAV_IO io;
+    void *io_user_data;
+
+    /* Two-way storage: first is array of calls and second is list of calls with head and tail */
+    ToxAVCall **calls;
+    uint32_t calls_tail;
+    uint32_t calls_head;
+    pthread_mutex_t mutex[1];
+
+    /* Call callback */
+    toxav_call_cb *ccb;
+    void *ccb_user_data;
+    /* Call state callback */
+    toxav_call_state_cb *scb;
+    void *scb_user_data;
+    /* Audio frame receive callback */
+    toxav_audio_receive_frame_cb *acb;
+    void *acb_user_data;
+    /* Video frame receive callback */
+    toxav_video_receive_frame_cb *vcb;
+    void *vcb_user_data;
+    /* Bit rate control callback */
+    toxav_audio_bit_rate_cb *abcb;
+    void *abcb_user_data;
+    /* Bit rate control callback */
+    toxav_video_bit_rate_cb *vbcb;
+    void *vbcb_user_data;
+
+    /* keep track of decode times for audio and video */
+    DecodeTimeStats audio_stats;
+    DecodeTimeStats video_stats;
+
+    Mono_Time *toxav_mono_time; // ToxAV's own mono_time instance
+};
+
+#endif /* C_TOXCORE_TOXAV_TOXAV_PRIVATE_H */

--- a/toxav/toxav_test.cc
+++ b/toxav/toxav_test.cc
@@ -1,0 +1,392 @@
+#include "toxav.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <vector>
+
+#include "av_test_support.hh"
+
+class VirtualNetwork {
+public:
+    void connect(ToxAV *alice, ToxAV *bob)
+    {
+        alice_ = alice;
+        bob_ = bob;
+    }
+
+    static bool alice_send_lossy_cb(
+        uint32_t friend_number, const uint8_t *data, size_t length, void *user_data)
+    {
+        return static_cast<VirtualNetwork *>(user_data)->send(true, data, length);
+    }
+    static bool alice_send_lossless_cb(
+        uint32_t friend_number, const uint8_t *data, size_t length, void *user_data)
+    {
+        return static_cast<VirtualNetwork *>(user_data)->send(true, data, length);
+    }
+
+    static bool bob_send_lossy_cb(
+        uint32_t friend_number, const uint8_t *data, size_t length, void *user_data)
+    {
+        return static_cast<VirtualNetwork *>(user_data)->send(false, data, length);
+    }
+    static bool bob_send_lossless_cb(
+        uint32_t friend_number, const uint8_t *data, size_t length, void *user_data)
+    {
+        return static_cast<VirtualNetwork *>(user_data)->send(false, data, length);
+    }
+
+    static bool friend_exists_cb(uint32_t friend_number, void *user_data) { return true; }
+    static bool friend_connected_cb(uint32_t friend_number, void *user_data) { return true; }
+
+    void process()
+    {
+        while (true) {
+            QueuedPacket pkt;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                if (queue_.empty())
+                    break;
+                pkt = queue_.front();
+                queue_.pop_front();
+            }
+            ToxAV *target = pkt.from_alice ? bob_ : alice_;
+            if (target) {
+                toxav_receive_packet(target, 0, pkt.data.data(), pkt.data.size());
+            }
+        }
+    }
+
+private:
+    struct QueuedPacket {
+        bool from_alice;
+        std::vector<uint8_t> data;
+    };
+
+    bool send(bool from_alice, const uint8_t *data, size_t length)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        QueuedPacket pkt;
+        pkt.from_alice = from_alice;
+        pkt.data.assign(data, data + length);
+        queue_.push_back(pkt);
+        return true;
+    }
+
+    ToxAV *alice_ = nullptr;
+    ToxAV *bob_ = nullptr;
+    std::deque<QueuedPacket> queue_;
+    std::mutex mutex_;
+};
+
+class ToxAVCustomTest : public ::testing::Test {
+protected:
+    ToxAV *alice = nullptr;
+    ToxAV *bob = nullptr;
+    VirtualNetwork network;
+    ToxAV_IO *alice_io = nullptr;
+    ToxAV_IO *bob_io = nullptr;
+
+    bool bob_invited = false;
+    uint32_t alice_state = 0;
+    uint32_t bob_state = 0;
+    int bob_audio_frames = 0;
+    int bob_video_frames = 0;
+    int alice_audio_frames = 0;
+    int alice_video_frames = 0;
+
+    static void on_call(ToxAV *av, uint32_t friend_number, bool audio, bool video, void *user_data)
+    {
+        static_cast<ToxAVCustomTest *>(user_data)->bob_invited = true;
+    }
+
+    static void on_call_state(ToxAV *av, uint32_t friend_number, uint32_t state, void *user_data)
+    {
+        ToxAVCustomTest *test = static_cast<ToxAVCustomTest *>(user_data);
+        if (av == test->alice)
+            test->alice_state = state;
+        if (av == test->bob)
+            test->bob_state = state;
+    }
+
+    static void on_audio_frame(ToxAV *av, uint32_t friend_number, const int16_t *pcm,
+        size_t sample_count, uint8_t channels, uint32_t sampling_rate, void *user_data)
+    {
+        ToxAVCustomTest *test = static_cast<ToxAVCustomTest *>(user_data);
+        if (av == test->bob)
+            test->bob_audio_frames++;
+        if (av == test->alice)
+            test->alice_audio_frames++;
+    }
+
+    static void on_video_frame(ToxAV *av, uint32_t friend_number, uint16_t width, uint16_t height,
+        const uint8_t *y, const uint8_t *u, const uint8_t *v, int32_t ystride, int32_t ustride,
+        int32_t vstride, void *user_data)
+    {
+        ToxAVCustomTest *test = static_cast<ToxAVCustomTest *>(user_data);
+        if (av == test->bob)
+            test->bob_video_frames++;
+        if (av == test->alice)
+            test->alice_video_frames++;
+    }
+
+    void SetUp() override;
+    void TearDown() override;
+};
+
+void ToxAVCustomTest::SetUp()
+{
+    alice_io = toxav_io_new();
+    toxav_io_callback_send_lossy(alice_io, VirtualNetwork::alice_send_lossy_cb);
+    toxav_io_callback_send_lossless(alice_io, VirtualNetwork::alice_send_lossless_cb);
+    toxav_io_callback_friend_exists(alice_io, VirtualNetwork::friend_exists_cb);
+    toxav_io_callback_friend_connected(alice_io, VirtualNetwork::friend_connected_cb);
+
+    bob_io = toxav_io_new();
+    toxav_io_callback_send_lossy(bob_io, VirtualNetwork::bob_send_lossy_cb);
+    toxav_io_callback_send_lossless(bob_io, VirtualNetwork::bob_send_lossless_cb);
+    toxav_io_callback_friend_exists(bob_io, VirtualNetwork::friend_exists_cb);
+    toxav_io_callback_friend_connected(bob_io, VirtualNetwork::friend_connected_cb);
+
+    Toxav_Err_New err;
+    alice = toxav_new_custom(alice_io, &network, &err);
+    ASSERT_EQ(err, TOXAV_ERR_NEW_OK);
+    bob = toxav_new_custom(bob_io, &network, &err);
+    ASSERT_EQ(err, TOXAV_ERR_NEW_OK);
+
+    toxav_io_kill(alice_io);
+    toxav_io_kill(bob_io);
+
+    network.connect(alice, bob);
+
+    toxav_callback_call_state(alice, on_call_state, this);
+    toxav_callback_call_state(bob, on_call_state, this);
+    toxav_callback_call(bob, on_call, this);
+    toxav_callback_audio_receive_frame(bob, on_audio_frame, this);
+    toxav_callback_video_receive_frame(bob, on_video_frame, this);
+    // Alice needs callbacks too for the call to be established (call_prepare_transmission
+    // requirement)
+    toxav_callback_audio_receive_frame(alice, on_audio_frame, this);
+    toxav_callback_video_receive_frame(alice, on_video_frame, this);
+}
+void ToxAVCustomTest::TearDown()
+{
+    if (alice)
+        toxav_kill(alice);
+    if (bob)
+        toxav_kill(bob);
+}
+
+TEST_F(ToxAVCustomTest, AudioVideoCall)
+{
+    Toxav_Err_Call call_err;
+    bool res = toxav_call(alice, 0, 48, 1000, &call_err);
+    ASSERT_TRUE(res);
+    ASSERT_EQ(call_err, TOXAV_ERR_CALL_OK);
+
+    // Process packets to deliver invite
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_TRUE(bob_invited);
+
+    Toxav_Err_Answer answer_err;
+    res = toxav_answer(bob, 0, 48, 1000, &answer_err);
+    ASSERT_TRUE(res);
+    ASSERT_EQ(answer_err, TOXAV_ERR_ANSWER_OK);
+
+    // Process packets to deliver answer
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_NE(alice_state, 0) << "Alice call state is 0 (not connected?)";
+
+    // Send Audio
+    std::vector<int16_t> pcm(960 * 1);
+    fill_audio_frame(48000, 1, 0, 960, pcm);  // 20ms frame
+    Toxav_Err_Send_Frame send_err;
+    res = toxav_audio_send_frame(alice, 0, pcm.data(), 960, 1, 48000, &send_err);
+    ASSERT_TRUE(res) << "toxav_audio_send_frame failed with error: " << send_err;
+
+    // Process packets
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_GT(bob_audio_frames, 0);
+
+    // Send Video
+    std::vector<uint8_t> y, u, v;
+    fill_video_frame(640, 480, 0, y, u, v);
+    res = toxav_video_send_frame(alice, 0, 640, 480, y.data(), u.data(), v.data(), &send_err);
+    ASSERT_TRUE(res);
+    ASSERT_EQ(send_err, TOXAV_ERR_SEND_FRAME_OK);
+
+    // Process packets
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_GT(bob_video_frames, 0);
+
+    // Hangup
+    Toxav_Err_Call_Control cc_err;
+    toxav_call_control(alice, 0, TOXAV_CALL_CONTROL_CANCEL, &cc_err);
+    ASSERT_EQ(cc_err, TOXAV_ERR_CALL_CONTROL_OK);
+
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_EQ(bob_state, TOXAV_FRIEND_CALL_STATE_FINISHED);
+}
+
+TEST_F(ToxAVCustomTest, BidirectionalCall)
+{
+    Toxav_Err_Call call_err;
+    ASSERT_TRUE(toxav_call(alice, 0, 48, 1000, &call_err));
+    ASSERT_EQ(call_err, TOXAV_ERR_CALL_OK);
+
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_TRUE(bob_invited);
+
+    Toxav_Err_Answer answer_err;
+    ASSERT_TRUE(toxav_answer(bob, 0, 48, 1000, &answer_err));
+    ASSERT_EQ(answer_err, TOXAV_ERR_ANSWER_OK);
+
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    // Process potentially queued state changes
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_NE(alice_state, 0);
+
+    // Alice -> Bob Audio
+    std::vector<int16_t> pcm(960 * 1);
+    fill_audio_frame(48000, 1, 0, 960, pcm);
+    Toxav_Err_Send_Frame send_err;
+    ASSERT_TRUE(toxav_audio_send_frame(alice, 0, pcm.data(), 960, 1, 48000, &send_err));
+
+    // Bob -> Alice Audio
+    ASSERT_TRUE(toxav_audio_send_frame(bob, 0, pcm.data(), 960, 1, 48000, &send_err));
+
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_GT(bob_audio_frames, 0);
+    ASSERT_GT(alice_audio_frames, 0);
+
+    // Alice -> Bob Video
+    std::vector<uint8_t> y, u, v;
+    fill_video_frame(640, 480, 0, y, u, v);
+    ASSERT_TRUE(
+        toxav_video_send_frame(alice, 0, 640, 480, y.data(), u.data(), v.data(), &send_err));
+
+    // Bob -> Alice Video
+    ASSERT_TRUE(toxav_video_send_frame(bob, 0, 640, 480, y.data(), u.data(), v.data(), &send_err));
+
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_GT(bob_video_frames, 0);
+    ASSERT_GT(alice_video_frames, 0);
+}
+
+TEST_F(ToxAVCustomTest, BobMutesAlice)
+{
+    Toxav_Err_Call call_err;
+    ASSERT_TRUE(toxav_call(alice, 0, 48, 1000, &call_err));
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    Toxav_Err_Answer answer_err;
+    ASSERT_TRUE(toxav_answer(bob, 0, 48, 1000, &answer_err));
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    // Extra process for state
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    // Initial Send
+    std::vector<int16_t> pcm(960 * 1);
+    fill_audio_frame(48000, 1, 0, 960, pcm);
+    Toxav_Err_Send_Frame send_err;
+    ASSERT_TRUE(toxav_audio_send_frame(alice, 0, pcm.data(), 960, 1, 48000, &send_err));
+
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    ASSERT_EQ(bob_audio_frames, 1);
+
+    // Bob Mutes Alice
+    Toxav_Err_Call_Control cc_err;
+    ASSERT_TRUE(toxav_call_control(bob, 0, TOXAV_CALL_CONTROL_MUTE_AUDIO, &cc_err));
+    ASSERT_EQ(cc_err, TOXAV_ERR_CALL_CONTROL_OK);
+
+    network.process();
+    toxav_iterate(alice);
+    toxav_iterate(bob);
+
+    // Alice sends again
+    bool res = toxav_audio_send_frame(alice, 0, pcm.data(), 960, 1, 48000, &send_err);
+    if (!res) {
+        ASSERT_EQ(send_err, TOXAV_ERR_SEND_FRAME_PAYLOAD_TYPE_DISABLED);
+    } else {
+        network.process();
+        toxav_iterate(alice);
+        toxav_iterate(bob);
+
+        // Should still be 1
+        ASSERT_EQ(bob_audio_frames, 1);
+    }
+}
+
+TEST(ToxAVManualTest, CallInsertionInMiddle)
+{
+    ToxAV_IO *io = toxav_io_new();
+    toxav_io_callback_friend_exists(io, [](uint32_t, void *) { return true; });
+    toxav_io_callback_friend_connected(io, [](uint32_t, void *) { return true; });
+    toxav_io_callback_time_current(io, [](void *) { return static_cast<uint64_t>(1000000); });
+
+    Toxav_Err_New err_new;
+    struct ToxAVDeleter {
+        void operator()(ToxAV *av) { toxav_kill(av); }
+    };
+    std::unique_ptr<ToxAV, ToxAVDeleter> av(toxav_new_custom(io, nullptr, &err_new));
+    toxav_io_kill(io);
+
+    ASSERT_NE(av, nullptr);
+    ASSERT_EQ(err_new, TOXAV_ERR_NEW_OK);
+
+    Toxav_Err_Call err;
+
+    // Create call 10 (Head)
+    toxav_call(av.get(), 10, 0, 0, &err);
+    ASSERT_EQ(err, TOXAV_ERR_CALL_OK);
+    // Create call 30 (Tail)
+    toxav_call(av.get(), 30, 0, 0, &err);
+    ASSERT_EQ(err, TOXAV_ERR_CALL_OK);
+
+    // Create call 20 (Middle) - This triggers the bug
+    toxav_call(av.get(), 20, 0, 0, &err);
+    ASSERT_EQ(err, TOXAV_ERR_CALL_OK);
+}


### PR DESCRIPTION
Introduces a new `ToxAV_IO` interface to decouple `toxav` from the `toxcore` networking stack. This allows `toxav` to be used with alternative transports or for testing without a full `Tox` instance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2944)
<!-- Reviewable:end -->
