### PR TITLE
refactor: use `crypto_verify_32` for `pk_equal` except where it's safe

### DIFF
--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -142,12 +142,21 @@ bool crypto_memunlock(void *data, size_t length)
 
 bool pk_equal(const uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE], const uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE])
 {
+#if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
     return memcmp(pk1, pk2, CRYPTO_PUBLIC_KEY_SIZE) == 0;
+#else
+    return crypto_verify_32(pk1, pk2) == 0;
+#endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
 }
 
 void pk_copy(uint8_t dest[CRYPTO_PUBLIC_KEY_SIZE], const uint8_t src[CRYPTO_PUBLIC_KEY_SIZE])
 {
     memcpy(dest, src, CRYPTO_PUBLIC_KEY_SIZE);
+}
+
+bool pk_equal_fast(const uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE], const uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE])
+{
+    return memcmp(pk1, pk2, CRYPTO_PUBLIC_KEY_SIZE) == 0;
 }
 
 bool crypto_sha512_eq(const uint8_t cksum1[CRYPTO_SHA512_SIZE], const uint8_t cksum2[CRYPTO_SHA512_SIZE])
@@ -162,7 +171,20 @@ bool crypto_sha512_eq(const uint8_t cksum1[CRYPTO_SHA512_SIZE], const uint8_t ck
 
 bool crypto_sha256_eq(const uint8_t cksum1[CRYPTO_SHA256_SIZE], const uint8_t cksum2[CRYPTO_SHA256_SIZE])
 {
+#if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
     return memcmp(cksum1, cksum2, CRYPTO_SHA256_SIZE) == 0;
+#else
+    return crypto_verify_32(cksum1, cksum2) == 0;
+#endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
+}
+
+int crypto_memcmp(const uint8_t *p1, const uint8_t *p2, size_t length)
+{
+#if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
+    return memcmp(p1, p2, length);
+#else
+    return sodium_memcmp(p1, p2, length);
+#endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
 }
 
 uint8_t random_u08(const Random *rng)

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -175,6 +175,17 @@ bool pk_equal(const uint8_t pk1[_Nonnull CRYPTO_PUBLIC_KEY_SIZE], const uint8_t 
 void pk_copy(uint8_t dest[_Nonnull CRYPTO_PUBLIC_KEY_SIZE], const uint8_t src[_Nonnull CRYPTO_PUBLIC_KEY_SIZE]);
 
 /**
+ * @brief Compare 2 public keys of length @ref CRYPTO_PUBLIC_KEY_SIZE.
+ *
+ * Warning: This function is not constant time and should not be used for verification
+ * of secrets or where timing side-channels matters.
+ *
+ * @retval true if both mem locations of length are equal
+ * @retval false if they are not
+ */
+bool pk_equal_fast(const uint8_t pk1[_Nonnull CRYPTO_PUBLIC_KEY_SIZE], const uint8_t pk2[_Nonnull CRYPTO_PUBLIC_KEY_SIZE]);
+
+/**
  * @brief Compare 2 SHA512 checksums of length CRYPTO_SHA512_SIZE, not vulnerable to
  *   timing attacks.
  *
@@ -189,6 +200,13 @@ bool crypto_sha512_eq(const uint8_t cksum1[_Nonnull CRYPTO_SHA512_SIZE], const u
  * @return true if both mem locations of length are equal, false if they are not.
  */
 bool crypto_sha256_eq(const uint8_t cksum1[_Nonnull CRYPTO_SHA256_SIZE], const uint8_t cksum2[_Nonnull CRYPTO_SHA256_SIZE]);
+
+/**
+ * @brief Compare 2 memory locations of length @p length, not vulnerable to timing attacks.
+ *
+ * @return 0 if both mem locations of length are equal, -1 if they are not.
+ */
+int crypto_memcmp(const uint8_t *_Nonnull p1, const uint8_t *_Nonnull p2, size_t length);
 
 /**
  * @brief Shorter internal name for the RNG type.

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -218,7 +218,7 @@ const Mono_Time *g_mono_time(const Group_Chats *g_c)
 
 static bool group_id_eq(const uint8_t *_Nonnull a, const uint8_t *_Nonnull b)
 {
-    return pk_equal(a, b);
+    return pk_equal_fast(a, b);
 }
 
 static bool g_title_eq(const Group_c *_Nonnull g, const uint8_t *_Nonnull title, uint8_t title_len)

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -543,7 +543,7 @@ static bool validate_password(const GC_Chat *_Nonnull chat, const uint8_t *_Nonn
         return false;
     }
 
-    return memcmp(chat->shared_state.password, password, length) == 0;
+    return crypto_memcmp(chat->shared_state.password, password, length) == 0;
 }
 
 /** @brief Returns the chat object that contains a peer with a public key equal to `id`.
@@ -3826,11 +3826,6 @@ static bool handle_gc_topic_validate(const GC_Chat *_Nonnull chat, const GC_Peer
         }
 
         if (topic_info->version == chat->shared_state.topic_lock) {
-            // always accept topic on initial connection
-            if (!mono_time_is_timeout(chat->mono_time, chat->time_connected, GC_PING_TIMEOUT)) {
-                return true;
-            }
-
             return true;
         }
 


### PR DESCRIPTION
This is taking a bit more conservative approach. We're using the fast version `pk_equal_fast` only where the information compared is definitely publicly retrievable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2948)
<!-- Reviewable:end -->
