### PR TITLE
refactor: decouple net_crypto from DHT

### DIFF
--- a/auto_tests/auto_test_support.c
+++ b/auto_tests/auto_test_support.c
@@ -8,12 +8,35 @@
 #include "../toxcore/tox_dispatch.h"
 #include "../toxcore/tox_events.h"
 #include "../toxcore/tox_struct.h"
+#include "../toxcore/net_crypto.h"
+#include "../toxcore/DHT.h"
 
 #include "auto_test_support.h"
 
 #ifndef ABORT_ON_LOG_ERROR
 #define ABORT_ON_LOG_ERROR true
 #endif
+
+static const uint8_t *auto_test_nc_dht_get_shared_key_sent_wrapper(void *dht, const uint8_t *public_key)
+{
+    return dht_get_shared_key_sent((DHT *)dht, public_key);
+}
+
+static const uint8_t *auto_test_nc_dht_get_self_public_key_wrapper(const void *dht)
+{
+    return dht_get_self_public_key((const DHT *)dht);
+}
+
+static const uint8_t *auto_test_nc_dht_get_self_secret_key_wrapper(const void *dht)
+{
+    return dht_get_self_secret_key((const DHT *)dht);
+}
+
+const Net_Crypto_DHT_Funcs auto_test_dht_funcs = {
+    auto_test_nc_dht_get_shared_key_sent_wrapper,
+    auto_test_nc_dht_get_self_public_key_wrapper,
+    auto_test_nc_dht_get_self_secret_key_wrapper,
+};
 
 #ifndef USE_IPV6
 #define USE_IPV6 1

--- a/auto_tests/auto_test_support.h
+++ b/auto_tests/auto_test_support.h
@@ -8,6 +8,7 @@
 #include "../toxcore/Messenger.h"
 #include "../toxcore/mono_time.h"
 #include "../toxcore/tox_dispatch.h"
+#include "../toxcore/net_crypto.h"
 
 typedef struct AutoTox {
     Tox *tox;
@@ -65,5 +66,7 @@ void print_debug_logger(void *context, Logger_Level level, const char *file, uin
 
 Tox *tox_new_log(struct Tox_Options *options, Tox_Err_New *err, void *log_user_data);
 Tox *tox_new_log_lan(struct Tox_Options *options, Tox_Err_New *err, void *log_user_data, bool lan_discovery);
+
+extern const Net_Crypto_DHT_Funcs auto_test_dht_funcs;
 
 #endif

--- a/auto_tests/forwarding_test.c
+++ b/auto_tests/forwarding_test.c
@@ -132,7 +132,7 @@ static Forwarding_Subtox *new_forwarding_subtox(const Memory *mem, bool no_udp, 
     ck_assert(subtox->tcp_np != nullptr);
 
     const TCP_Proxy_Info inf = {{{{0}}}};
-    subtox->c = new_net_crypto(subtox->log, mem, rng, ns, subtox->mono_time, subtox->net, subtox->dht, &inf, subtox->tcp_np);
+    subtox->c = new_net_crypto(subtox->log, mem, rng, ns, subtox->mono_time, subtox->net, subtox->dht, &auto_test_dht_funcs, &inf, subtox->tcp_np);
 
     subtox->forwarding = new_forwarding(subtox->log, mem, rng, subtox->mono_time, subtox->dht, subtox->net);
     ck_assert(subtox->forwarding != nullptr);

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -492,7 +492,7 @@ static Onions *new_onions(const Memory *mem, const Random *rng, uint16_t port, u
     }
 
     TCP_Proxy_Info inf = {{{{0}}}};
-    on->nc = new_net_crypto(on->log, mem, rng, ns, on->mono_time, net, dht, &inf, on->tcp_np);
+    on->nc = new_net_crypto(on->log, mem, rng, ns, on->mono_time, net, dht, &auto_test_dht_funcs, &inf, on->tcp_np);
     on->onion_c = new_onion_client(on->log, mem, rng, on->mono_time, on->nc, dht, net);
 
     if (!on->onion_c) {

--- a/toxav/msi.h
+++ b/toxav/msi.h
@@ -6,6 +6,7 @@
 #define C_TOXCORE_TOXAV_MSI_H
 
 #include <pthread.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "../toxcore/logger.h"

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -47,6 +47,30 @@ static_assert(MAX_CONCURRENT_FILE_PIPES <= UINT8_MAX + 1,
 
 static const Friend empty_friend = {{0}};
 
+static const uint8_t *_Nullable nc_dht_get_shared_key_sent_wrapper(void *_Nonnull obj, const uint8_t *_Nonnull public_key)
+{
+    DHT *dht = (DHT *)obj;
+    return dht_get_shared_key_sent(dht, public_key);
+}
+
+static const uint8_t *_Nonnull nc_dht_get_self_public_key_wrapper(const void *_Nonnull obj)
+{
+    const DHT *dht = (const DHT *)obj;
+    return dht_get_self_public_key(dht);
+}
+
+static const uint8_t *_Nonnull nc_dht_get_self_secret_key_wrapper(const void *_Nonnull obj)
+{
+    const DHT *dht = (const DHT *)obj;
+    return dht_get_self_secret_key(dht);
+}
+
+static const Net_Crypto_DHT_Funcs m_dht_funcs = {
+    nc_dht_get_shared_key_sent_wrapper,
+    nc_dht_get_self_public_key_wrapper,
+    nc_dht_get_self_secret_key_wrapper,
+};
+
 /**
  * Determines if the friendnumber passed is valid in the Messenger object.
  *
@@ -3443,7 +3467,7 @@ Messenger *new_messenger(Mono_Time *mono_time, const Memory *mem, const Random *
         return nullptr;
     }
 
-    m->net_crypto = new_net_crypto(m->log, m->mem, m->rng, m->ns, m->mono_time, m->net, m->dht, &options->proxy_info, m->tcp_np);
+    m->net_crypto = new_net_crypto(m->log, m->mem, m->rng, m->ns, m->mono_time, m->net, m->dht, &m_dht_funcs, &options->proxy_info, m->tcp_np);
 
     if (m->net_crypto == nullptr) {
         LOGGER_WARNING(m->log, "net_crypto initialisation failed");

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -9,7 +9,7 @@
 #ifndef C_TOXCORE_TOXCORE_NET_CRYPTO_H
 #define C_TOXCORE_TOXCORE_NET_CRYPTO_H
 
-#include "DHT.h"
+#include "DHT.h" // Node_format
 #include "TCP_client.h"
 #include "TCP_connection.h"
 #include "attributes.h"
@@ -23,6 +23,16 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef const uint8_t *_Nullable nc_dht_get_shared_key_sent_cb(void *_Nonnull obj, const uint8_t *_Nonnull public_key);
+typedef const uint8_t *_Nonnull nc_dht_get_self_public_key_cb(const void *_Nonnull obj);
+typedef const uint8_t *_Nonnull nc_dht_get_self_secret_key_cb(const void *_Nonnull obj);
+
+typedef struct Net_Crypto_DHT_Funcs {
+    nc_dht_get_shared_key_sent_cb *_Nonnull get_shared_key_sent;
+    nc_dht_get_self_public_key_cb *_Nonnull get_self_public_key;
+    nc_dht_get_self_secret_key_cb *_Nonnull get_self_secret_key;
+} Net_Crypto_DHT_Funcs;
 
 /*** Crypto payloads. */
 
@@ -369,7 +379,7 @@ void load_secret_key(Net_Crypto *_Nonnull c, const uint8_t *_Nonnull sk);
  * Sets all the global connection variables to their default values.
  */
 Net_Crypto *_Nullable new_net_crypto(const Logger *_Nonnull log, const Memory *_Nonnull mem, const Random *_Nonnull rng, const Network *_Nonnull ns, Mono_Time *_Nonnull mono_time,
-                                     Networking_Core *_Nonnull net, DHT *_Nonnull dht,
+                                     Networking_Core *_Nonnull net, void *_Nonnull dht, const Net_Crypto_DHT_Funcs *_Nonnull dht_funcs,
                                      const TCP_Proxy_Info *_Nonnull proxy_info, Net_Profile *_Nonnull tcp_np);
 
 /** return the optimal interval in ms for running do_net_crypto. */


### PR DESCRIPTION
This introduces a vtable interface for the DHT dependency in net_crypto, allowing us to break the dependency and make testing/mocking/fuzzing easier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2949)
<!-- Reviewable:end -->
