### PR TITLE
fix(group_moderation): allow validating unsorted sanction list signatures

### DIFF
--- a/toxcore/group_moderation.c
+++ b/toxcore/group_moderation.c
@@ -439,7 +439,7 @@ int sanctions_list_unpack(Mod_Sanction *_Nonnull sanctions, Mod_Sanction_Creds *
  * Return true on success.
  */
 static bool sanctions_list_make_hash(const Memory *_Nonnull mem, const Mod_Sanction *_Nullable sanctions, uint32_t new_version, uint16_t num_sanctions,
-                                     uint8_t *_Nonnull hash)
+                                     bool sort, uint8_t *_Nonnull hash)
 {
     if (num_sanctions == 0 || sanctions == nullptr) {
         memzero(hash, MOD_SANCTION_HASH_SIZE);
@@ -464,7 +464,9 @@ static bool sanctions_list_make_hash(const Memory *_Nonnull mem, const Mod_Sanct
         memcpy(&data[i * SIGNATURE_SIZE], sanctions[i].signature, SIGNATURE_SIZE);
     }
 
-    qsort(data, num_sanctions, SIGNATURE_SIZE, compare_signatures);
+    if (sort) {
+        qsort(data, num_sanctions, SIGNATURE_SIZE, compare_signatures);
+    }
 
     memcpy(&data[sig_data_size], &new_version, sizeof(uint32_t));
     crypto_sha256(hash, data, data_buf_size);
@@ -524,7 +526,7 @@ bool sanctions_list_make_creds(Moderation *_Nonnull moderation)
     uint8_t hash[MOD_SANCTION_HASH_SIZE];
 
     if (!sanctions_list_make_hash(moderation->mem, moderation->sanctions, moderation->sanctions_creds.version,
-                                  moderation->num_sanctions, hash)) {
+                                  moderation->num_sanctions, true, hash)) {
         moderation->sanctions_creds = old_creds;
         return false;
     }
@@ -563,15 +565,23 @@ static bool sanctions_creds_validate(const Moderation *_Nonnull moderation, cons
 
     uint8_t hash[MOD_SANCTION_HASH_SIZE];
 
-    if (!sanctions_list_make_hash(moderation->mem, sanctions, creds->version, num_sanctions, hash)) {
+    if (!sanctions_list_make_hash(moderation->mem, sanctions, creds->version, num_sanctions, true, hash)) {
         return false;
     }
 
     if (memcmp(hash, creds->hash, MOD_SANCTION_HASH_SIZE) != 0) {
-        LOGGER_WARNING(moderation->log, "Invalid credentials hash");
-        return false;
-    }
+        /* Some older/other clients might not sort the signatures.
+         * Try calculating the hash without sorting.
+         */
+        if (!sanctions_list_make_hash(moderation->mem, sanctions, creds->version, num_sanctions, false, hash)) {
+            return false;
+        }
 
+        if (memcmp(hash, creds->hash, MOD_SANCTION_HASH_SIZE) != 0) {
+            LOGGER_WARNING(moderation->log, "Invalid credentials hash");
+            return false;
+        }
+    }
     if (creds->checksum != sanctions_creds_get_checksum(creds)) {
         LOGGER_WARNING(moderation->log, "Invalid credentials checksum");
         return false;


### PR DESCRIPTION
Some clients might send the sanctions list signatures unsorted, which causes the credentials hash validation to fail because the hash is sensitive to the order of signatures.

This updates the validation logic to verify the credentials hash against both the sorted (default) and unsorted signature list. If the sorted check fails but the unsorted check succeeds, the credentials are accepted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2955)
<!-- Reviewable:end -->
