### PR TITLE
test(toxcore): fix incorrect mutex in tox_scenario_get_time

### DIFF
--- a/auto_tests/scenarios/framework/framework.c
+++ b/auto_tests/scenarios/framework/framework.c
@@ -638,9 +638,9 @@ Tox_Dispatch *tox_node_get_dispatch(const ToxNode *node)
 
 uint64_t tox_scenario_get_time(ToxScenario *s)
 {
-    pthread_mutex_lock(&s->mutex);
+    pthread_mutex_lock(&s->clock_mutex);
     uint64_t time = s->virtual_clock;
-    pthread_mutex_unlock(&s->mutex);
+    pthread_mutex_unlock(&s->clock_mutex);
     return time;
 }
 


### PR DESCRIPTION
Fixes CID 1668103 and CID 1668102 by protecting `s->virtual_clock` with `s->clock_mutex` instead of `s->mutex`, consistent with other usages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2963)
<!-- Reviewable:end -->
