### PR TITLE
refactor(toxcore): use Tox_Memory in generated events

### DIFF
--- a/toxcore/events/conference_connected.c
+++ b/toxcore/events/conference_connected.c
@@ -124,11 +124,8 @@ bool tox_event_conference_connected_unpack(
     return tox_event_conference_connected_unpack_into(*event, bu);
 }
 
-static Tox_Event_Conference_Connected *tox_event_conference_connected_alloc(void *_Nonnull user_data)
+static Tox_Event_Conference_Connected *tox_event_conference_connected_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -153,7 +150,8 @@ void tox_events_handle_conference_connected(
     Tox *tox, uint32_t conference_number,
     void *user_data)
 {
-    Tox_Event_Conference_Connected *conference_connected = tox_event_conference_connected_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Conference_Connected *conference_connected = tox_event_conference_connected_alloc(state);
 
     if (conference_connected == nullptr) {
         return;

--- a/toxcore/events/conference_message.c
+++ b/toxcore/events/conference_message.c
@@ -67,11 +67,11 @@ Tox_Message_Type tox_event_conference_message_get_type(const Tox_Event_Conferenc
 }
 
 static bool tox_event_conference_message_set_message(Tox_Event_Conference_Message *_Nonnull conference_message,
-        const uint8_t *_Nullable message, uint32_t message_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable message, uint32_t message_length)
 {
     assert(conference_message != nullptr);
     if (conference_message->message != nullptr) {
-        free(conference_message->message);
+        mem_delete(mem, conference_message->message);
         conference_message->message = nullptr;
         conference_message->message_length = 0;
     }
@@ -81,7 +81,7 @@ static bool tox_event_conference_message_set_message(Tox_Event_Conference_Messag
         return true;
     }
 
-    uint8_t *message_copy = (uint8_t *)malloc(message_length);
+    uint8_t *message_copy = (uint8_t *)mem_balloc(mem, message_length);
 
     if (message_copy == nullptr) {
         return false;
@@ -111,7 +111,7 @@ static void tox_event_conference_message_construct(Tox_Event_Conference_Message 
 }
 static void tox_event_conference_message_destruct(Tox_Event_Conference_Message *_Nonnull conference_message, const Memory *_Nonnull mem)
 {
-    free(conference_message->message);
+    mem_delete(mem, conference_message->message);
 }
 
 bool tox_event_conference_message_pack(
@@ -202,11 +202,8 @@ bool tox_event_conference_message_unpack(
     return tox_event_conference_message_unpack_into(*event, bu);
 }
 
-static Tox_Event_Conference_Message *tox_event_conference_message_alloc(void *_Nonnull user_data)
+static Tox_Event_Conference_Message *tox_event_conference_message_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -231,7 +228,8 @@ void tox_events_handle_conference_message(
     Tox *tox, uint32_t conference_number, uint32_t peer_number, Tox_Message_Type type, const uint8_t *message, size_t length,
     void *user_data)
 {
-    Tox_Event_Conference_Message *conference_message = tox_event_conference_message_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Conference_Message *conference_message = tox_event_conference_message_alloc(state);
 
     if (conference_message == nullptr) {
         return;
@@ -240,5 +238,5 @@ void tox_events_handle_conference_message(
     tox_event_conference_message_set_conference_number(conference_message, conference_number);
     tox_event_conference_message_set_peer_number(conference_message, peer_number);
     tox_event_conference_message_set_type(conference_message, type);
-    tox_event_conference_message_set_message(conference_message, message, length);
+    tox_event_conference_message_set_message(conference_message, state->mem, message, length);
 }

--- a/toxcore/events/conference_peer_list_changed.c
+++ b/toxcore/events/conference_peer_list_changed.c
@@ -124,11 +124,8 @@ bool tox_event_conference_peer_list_changed_unpack(
     return tox_event_conference_peer_list_changed_unpack_into(*event, bu);
 }
 
-static Tox_Event_Conference_Peer_List_Changed *tox_event_conference_peer_list_changed_alloc(void *_Nonnull user_data)
+static Tox_Event_Conference_Peer_List_Changed *tox_event_conference_peer_list_changed_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -153,7 +150,8 @@ void tox_events_handle_conference_peer_list_changed(
     Tox *tox, uint32_t conference_number,
     void *user_data)
 {
-    Tox_Event_Conference_Peer_List_Changed *conference_peer_list_changed = tox_event_conference_peer_list_changed_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Conference_Peer_List_Changed *conference_peer_list_changed = tox_event_conference_peer_list_changed_alloc(state);
 
     if (conference_peer_list_changed == nullptr) {
         return;

--- a/toxcore/events/conference_title.c
+++ b/toxcore/events/conference_title.c
@@ -53,11 +53,11 @@ uint32_t tox_event_conference_title_get_peer_number(const Tox_Event_Conference_T
 }
 
 static bool tox_event_conference_title_set_title(Tox_Event_Conference_Title *_Nonnull conference_title,
-        const uint8_t *_Nullable title, uint32_t title_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable title, uint32_t title_length)
 {
     assert(conference_title != nullptr);
     if (conference_title->title != nullptr) {
-        free(conference_title->title);
+        mem_delete(mem, conference_title->title);
         conference_title->title = nullptr;
         conference_title->title_length = 0;
     }
@@ -67,7 +67,7 @@ static bool tox_event_conference_title_set_title(Tox_Event_Conference_Title *_No
         return true;
     }
 
-    uint8_t *title_copy = (uint8_t *)malloc(title_length);
+    uint8_t *title_copy = (uint8_t *)mem_balloc(mem, title_length);
 
     if (title_copy == nullptr) {
         return false;
@@ -97,7 +97,7 @@ static void tox_event_conference_title_construct(Tox_Event_Conference_Title *_No
 }
 static void tox_event_conference_title_destruct(Tox_Event_Conference_Title *_Nonnull conference_title, const Memory *_Nonnull mem)
 {
-    free(conference_title->title);
+    mem_delete(mem, conference_title->title);
 }
 
 bool tox_event_conference_title_pack(
@@ -186,11 +186,8 @@ bool tox_event_conference_title_unpack(
     return tox_event_conference_title_unpack_into(*event, bu);
 }
 
-static Tox_Event_Conference_Title *tox_event_conference_title_alloc(void *_Nonnull user_data)
+static Tox_Event_Conference_Title *tox_event_conference_title_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -215,7 +212,8 @@ void tox_events_handle_conference_title(
     Tox *tox, uint32_t conference_number, uint32_t peer_number, const uint8_t *title, size_t length,
     void *user_data)
 {
-    Tox_Event_Conference_Title *conference_title = tox_event_conference_title_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Conference_Title *conference_title = tox_event_conference_title_alloc(state);
 
     if (conference_title == nullptr) {
         return;
@@ -223,5 +221,5 @@ void tox_events_handle_conference_title(
 
     tox_event_conference_title_set_conference_number(conference_title, conference_number);
     tox_event_conference_title_set_peer_number(conference_title, peer_number);
-    tox_event_conference_title_set_title(conference_title, title, length);
+    tox_event_conference_title_set_title(conference_title, state->mem, title, length);
 }

--- a/toxcore/events/file_chunk_request.c
+++ b/toxcore/events/file_chunk_request.c
@@ -171,11 +171,8 @@ bool tox_event_file_chunk_request_unpack(
     return tox_event_file_chunk_request_unpack_into(*event, bu);
 }
 
-static Tox_Event_File_Chunk_Request *tox_event_file_chunk_request_alloc(void *_Nonnull user_data)
+static Tox_Event_File_Chunk_Request *tox_event_file_chunk_request_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -200,7 +197,8 @@ void tox_events_handle_file_chunk_request(
     Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, size_t length,
     void *user_data)
 {
-    Tox_Event_File_Chunk_Request *file_chunk_request = tox_event_file_chunk_request_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_File_Chunk_Request *file_chunk_request = tox_event_file_chunk_request_alloc(state);
 
     if (file_chunk_request == nullptr) {
         return;

--- a/toxcore/events/file_recv_chunk.c
+++ b/toxcore/events/file_recv_chunk.c
@@ -65,11 +65,11 @@ uint64_t tox_event_file_recv_chunk_get_position(const Tox_Event_File_Recv_Chunk 
 }
 
 static bool tox_event_file_recv_chunk_set_data(Tox_Event_File_Recv_Chunk *_Nonnull file_recv_chunk,
-        const uint8_t *_Nullable data, uint32_t data_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable data, uint32_t data_length)
 {
     assert(file_recv_chunk != nullptr);
     if (file_recv_chunk->data != nullptr) {
-        free(file_recv_chunk->data);
+        mem_delete(mem, file_recv_chunk->data);
         file_recv_chunk->data = nullptr;
         file_recv_chunk->data_length = 0;
     }
@@ -79,7 +79,7 @@ static bool tox_event_file_recv_chunk_set_data(Tox_Event_File_Recv_Chunk *_Nonnu
         return true;
     }
 
-    uint8_t *data_copy = (uint8_t *)malloc(data_length);
+    uint8_t *data_copy = (uint8_t *)mem_balloc(mem, data_length);
 
     if (data_copy == nullptr) {
         return false;
@@ -109,7 +109,7 @@ static void tox_event_file_recv_chunk_construct(Tox_Event_File_Recv_Chunk *_Nonn
 }
 static void tox_event_file_recv_chunk_destruct(Tox_Event_File_Recv_Chunk *_Nonnull file_recv_chunk, const Memory *_Nonnull mem)
 {
-    free(file_recv_chunk->data);
+    mem_delete(mem, file_recv_chunk->data);
 }
 
 bool tox_event_file_recv_chunk_pack(
@@ -200,11 +200,8 @@ bool tox_event_file_recv_chunk_unpack(
     return tox_event_file_recv_chunk_unpack_into(*event, bu);
 }
 
-static Tox_Event_File_Recv_Chunk *tox_event_file_recv_chunk_alloc(void *_Nonnull user_data)
+static Tox_Event_File_Recv_Chunk *tox_event_file_recv_chunk_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -229,7 +226,8 @@ void tox_events_handle_file_recv_chunk(
     Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, const uint8_t *data, size_t length,
     void *user_data)
 {
-    Tox_Event_File_Recv_Chunk *file_recv_chunk = tox_event_file_recv_chunk_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_File_Recv_Chunk *file_recv_chunk = tox_event_file_recv_chunk_alloc(state);
 
     if (file_recv_chunk == nullptr) {
         return;
@@ -238,5 +236,5 @@ void tox_events_handle_file_recv_chunk(
     tox_event_file_recv_chunk_set_friend_number(file_recv_chunk, friend_number);
     tox_event_file_recv_chunk_set_file_number(file_recv_chunk, file_number);
     tox_event_file_recv_chunk_set_position(file_recv_chunk, position);
-    tox_event_file_recv_chunk_set_data(file_recv_chunk, data, length);
+    tox_event_file_recv_chunk_set_data(file_recv_chunk, state->mem, data, length);
 }

--- a/toxcore/events/file_recv_control.c
+++ b/toxcore/events/file_recv_control.c
@@ -159,11 +159,8 @@ bool tox_event_file_recv_control_unpack(
     return tox_event_file_recv_control_unpack_into(*event, bu);
 }
 
-static Tox_Event_File_Recv_Control *tox_event_file_recv_control_alloc(void *_Nonnull user_data)
+static Tox_Event_File_Recv_Control *tox_event_file_recv_control_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -188,7 +185,8 @@ void tox_events_handle_file_recv_control(
     Tox *tox, uint32_t friend_number, uint32_t file_number, Tox_File_Control control,
     void *user_data)
 {
-    Tox_Event_File_Recv_Control *file_recv_control = tox_event_file_recv_control_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_File_Recv_Control *file_recv_control = tox_event_file_recv_control_alloc(state);
 
     if (file_recv_control == nullptr) {
         return;

--- a/toxcore/events/friend_connection_status.c
+++ b/toxcore/events/friend_connection_status.c
@@ -145,11 +145,8 @@ bool tox_event_friend_connection_status_unpack(
     return tox_event_friend_connection_status_unpack_into(*event, bu);
 }
 
-static Tox_Event_Friend_Connection_Status *tox_event_friend_connection_status_alloc(void *_Nonnull user_data)
+static Tox_Event_Friend_Connection_Status *tox_event_friend_connection_status_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -174,7 +171,8 @@ void tox_events_handle_friend_connection_status(
     Tox *tox, uint32_t friend_number, Tox_Connection connection_status,
     void *user_data)
 {
-    Tox_Event_Friend_Connection_Status *friend_connection_status = tox_event_friend_connection_status_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Friend_Connection_Status *friend_connection_status = tox_event_friend_connection_status_alloc(state);
 
     if (friend_connection_status == nullptr) {
         return;

--- a/toxcore/events/friend_lossless_packet.c
+++ b/toxcore/events/friend_lossless_packet.c
@@ -41,11 +41,11 @@ uint32_t tox_event_friend_lossless_packet_get_friend_number(const Tox_Event_Frie
 }
 
 static bool tox_event_friend_lossless_packet_set_data(Tox_Event_Friend_Lossless_Packet *_Nonnull friend_lossless_packet,
-        const uint8_t *_Nullable data, uint32_t data_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable data, uint32_t data_length)
 {
     assert(friend_lossless_packet != nullptr);
     if (friend_lossless_packet->data != nullptr) {
-        free(friend_lossless_packet->data);
+        mem_delete(mem, friend_lossless_packet->data);
         friend_lossless_packet->data = nullptr;
         friend_lossless_packet->data_length = 0;
     }
@@ -55,7 +55,7 @@ static bool tox_event_friend_lossless_packet_set_data(Tox_Event_Friend_Lossless_
         return true;
     }
 
-    uint8_t *data_copy = (uint8_t *)malloc(data_length);
+    uint8_t *data_copy = (uint8_t *)mem_balloc(mem, data_length);
 
     if (data_copy == nullptr) {
         return false;
@@ -85,7 +85,7 @@ static void tox_event_friend_lossless_packet_construct(Tox_Event_Friend_Lossless
 }
 static void tox_event_friend_lossless_packet_destruct(Tox_Event_Friend_Lossless_Packet *_Nonnull friend_lossless_packet, const Memory *_Nonnull mem)
 {
-    free(friend_lossless_packet->data);
+    mem_delete(mem, friend_lossless_packet->data);
 }
 
 bool tox_event_friend_lossless_packet_pack(
@@ -172,11 +172,8 @@ bool tox_event_friend_lossless_packet_unpack(
     return tox_event_friend_lossless_packet_unpack_into(*event, bu);
 }
 
-static Tox_Event_Friend_Lossless_Packet *tox_event_friend_lossless_packet_alloc(void *_Nonnull user_data)
+static Tox_Event_Friend_Lossless_Packet *tox_event_friend_lossless_packet_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -201,12 +198,13 @@ void tox_events_handle_friend_lossless_packet(
     Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
     void *user_data)
 {
-    Tox_Event_Friend_Lossless_Packet *friend_lossless_packet = tox_event_friend_lossless_packet_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Friend_Lossless_Packet *friend_lossless_packet = tox_event_friend_lossless_packet_alloc(state);
 
     if (friend_lossless_packet == nullptr) {
         return;
     }
 
     tox_event_friend_lossless_packet_set_friend_number(friend_lossless_packet, friend_number);
-    tox_event_friend_lossless_packet_set_data(friend_lossless_packet, data, length);
+    tox_event_friend_lossless_packet_set_data(friend_lossless_packet, state->mem, data, length);
 }

--- a/toxcore/events/friend_lossy_packet.c
+++ b/toxcore/events/friend_lossy_packet.c
@@ -41,11 +41,11 @@ uint32_t tox_event_friend_lossy_packet_get_friend_number(const Tox_Event_Friend_
 }
 
 static bool tox_event_friend_lossy_packet_set_data(Tox_Event_Friend_Lossy_Packet *_Nonnull friend_lossy_packet,
-        const uint8_t *_Nullable data, uint32_t data_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable data, uint32_t data_length)
 {
     assert(friend_lossy_packet != nullptr);
     if (friend_lossy_packet->data != nullptr) {
-        free(friend_lossy_packet->data);
+        mem_delete(mem, friend_lossy_packet->data);
         friend_lossy_packet->data = nullptr;
         friend_lossy_packet->data_length = 0;
     }
@@ -55,7 +55,7 @@ static bool tox_event_friend_lossy_packet_set_data(Tox_Event_Friend_Lossy_Packet
         return true;
     }
 
-    uint8_t *data_copy = (uint8_t *)malloc(data_length);
+    uint8_t *data_copy = (uint8_t *)mem_balloc(mem, data_length);
 
     if (data_copy == nullptr) {
         return false;
@@ -85,7 +85,7 @@ static void tox_event_friend_lossy_packet_construct(Tox_Event_Friend_Lossy_Packe
 }
 static void tox_event_friend_lossy_packet_destruct(Tox_Event_Friend_Lossy_Packet *_Nonnull friend_lossy_packet, const Memory *_Nonnull mem)
 {
-    free(friend_lossy_packet->data);
+    mem_delete(mem, friend_lossy_packet->data);
 }
 
 bool tox_event_friend_lossy_packet_pack(
@@ -172,11 +172,8 @@ bool tox_event_friend_lossy_packet_unpack(
     return tox_event_friend_lossy_packet_unpack_into(*event, bu);
 }
 
-static Tox_Event_Friend_Lossy_Packet *tox_event_friend_lossy_packet_alloc(void *_Nonnull user_data)
+static Tox_Event_Friend_Lossy_Packet *tox_event_friend_lossy_packet_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -201,12 +198,13 @@ void tox_events_handle_friend_lossy_packet(
     Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
     void *user_data)
 {
-    Tox_Event_Friend_Lossy_Packet *friend_lossy_packet = tox_event_friend_lossy_packet_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Friend_Lossy_Packet *friend_lossy_packet = tox_event_friend_lossy_packet_alloc(state);
 
     if (friend_lossy_packet == nullptr) {
         return;
     }
 
     tox_event_friend_lossy_packet_set_friend_number(friend_lossy_packet, friend_number);
-    tox_event_friend_lossy_packet_set_data(friend_lossy_packet, data, length);
+    tox_event_friend_lossy_packet_set_data(friend_lossy_packet, state->mem, data, length);
 }

--- a/toxcore/events/friend_read_receipt.c
+++ b/toxcore/events/friend_read_receipt.c
@@ -143,11 +143,8 @@ bool tox_event_friend_read_receipt_unpack(
     return tox_event_friend_read_receipt_unpack_into(*event, bu);
 }
 
-static Tox_Event_Friend_Read_Receipt *tox_event_friend_read_receipt_alloc(void *_Nonnull user_data)
+static Tox_Event_Friend_Read_Receipt *tox_event_friend_read_receipt_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -172,7 +169,8 @@ void tox_events_handle_friend_read_receipt(
     Tox *tox, uint32_t friend_number, uint32_t message_id,
     void *user_data)
 {
-    Tox_Event_Friend_Read_Receipt *friend_read_receipt = tox_event_friend_read_receipt_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Friend_Read_Receipt *friend_read_receipt = tox_event_friend_read_receipt_alloc(state);
 
     if (friend_read_receipt == nullptr) {
         return;

--- a/toxcore/events/friend_status.c
+++ b/toxcore/events/friend_status.c
@@ -145,11 +145,8 @@ bool tox_event_friend_status_unpack(
     return tox_event_friend_status_unpack_into(*event, bu);
 }
 
-static Tox_Event_Friend_Status *tox_event_friend_status_alloc(void *_Nonnull user_data)
+static Tox_Event_Friend_Status *tox_event_friend_status_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -174,7 +171,8 @@ void tox_events_handle_friend_status(
     Tox *tox, uint32_t friend_number, Tox_User_Status status,
     void *user_data)
 {
-    Tox_Event_Friend_Status *friend_status = tox_event_friend_status_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Friend_Status *friend_status = tox_event_friend_status_alloc(state);
 
     if (friend_status == nullptr) {
         return;

--- a/toxcore/events/friend_typing.c
+++ b/toxcore/events/friend_typing.c
@@ -143,11 +143,8 @@ bool tox_event_friend_typing_unpack(
     return tox_event_friend_typing_unpack_into(*event, bu);
 }
 
-static Tox_Event_Friend_Typing *tox_event_friend_typing_alloc(void *_Nonnull user_data)
+static Tox_Event_Friend_Typing *tox_event_friend_typing_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -172,7 +169,8 @@ void tox_events_handle_friend_typing(
     Tox *tox, uint32_t friend_number, bool typing,
     void *user_data)
 {
-    Tox_Event_Friend_Typing *friend_typing = tox_event_friend_typing_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Friend_Typing *friend_typing = tox_event_friend_typing_alloc(state);
 
     if (friend_typing == nullptr) {
         return;

--- a/toxcore/events/group_custom_packet.c
+++ b/toxcore/events/group_custom_packet.c
@@ -53,11 +53,11 @@ uint32_t tox_event_group_custom_packet_get_peer_id(const Tox_Event_Group_Custom_
 }
 
 static bool tox_event_group_custom_packet_set_data(Tox_Event_Group_Custom_Packet *_Nonnull group_custom_packet,
-        const uint8_t *_Nullable data, uint32_t data_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable data, uint32_t data_length)
 {
     assert(group_custom_packet != nullptr);
     if (group_custom_packet->data != nullptr) {
-        free(group_custom_packet->data);
+        mem_delete(mem, group_custom_packet->data);
         group_custom_packet->data = nullptr;
         group_custom_packet->data_length = 0;
     }
@@ -67,7 +67,7 @@ static bool tox_event_group_custom_packet_set_data(Tox_Event_Group_Custom_Packet
         return true;
     }
 
-    uint8_t *data_copy = (uint8_t *)malloc(data_length);
+    uint8_t *data_copy = (uint8_t *)mem_balloc(mem, data_length);
 
     if (data_copy == nullptr) {
         return false;
@@ -97,7 +97,7 @@ static void tox_event_group_custom_packet_construct(Tox_Event_Group_Custom_Packe
 }
 static void tox_event_group_custom_packet_destruct(Tox_Event_Group_Custom_Packet *_Nonnull group_custom_packet, const Memory *_Nonnull mem)
 {
-    free(group_custom_packet->data);
+    mem_delete(mem, group_custom_packet->data);
 }
 
 bool tox_event_group_custom_packet_pack(
@@ -186,11 +186,8 @@ bool tox_event_group_custom_packet_unpack(
     return tox_event_group_custom_packet_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Custom_Packet *tox_event_group_custom_packet_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Custom_Packet *tox_event_group_custom_packet_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -215,7 +212,8 @@ void tox_events_handle_group_custom_packet(
     Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data, size_t data_length,
     void *user_data)
 {
-    Tox_Event_Group_Custom_Packet *group_custom_packet = tox_event_group_custom_packet_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Custom_Packet *group_custom_packet = tox_event_group_custom_packet_alloc(state);
 
     if (group_custom_packet == nullptr) {
         return;
@@ -223,5 +221,5 @@ void tox_events_handle_group_custom_packet(
 
     tox_event_group_custom_packet_set_group_number(group_custom_packet, group_number);
     tox_event_group_custom_packet_set_peer_id(group_custom_packet, peer_id);
-    tox_event_group_custom_packet_set_data(group_custom_packet, data, data_length);
+    tox_event_group_custom_packet_set_data(group_custom_packet, state->mem, data, data_length);
 }

--- a/toxcore/events/group_custom_private_packet.c
+++ b/toxcore/events/group_custom_private_packet.c
@@ -53,11 +53,11 @@ uint32_t tox_event_group_custom_private_packet_get_peer_id(const Tox_Event_Group
 }
 
 static bool tox_event_group_custom_private_packet_set_data(Tox_Event_Group_Custom_Private_Packet *_Nonnull group_custom_private_packet,
-        const uint8_t *_Nullable data, uint32_t data_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable data, uint32_t data_length)
 {
     assert(group_custom_private_packet != nullptr);
     if (group_custom_private_packet->data != nullptr) {
-        free(group_custom_private_packet->data);
+        mem_delete(mem, group_custom_private_packet->data);
         group_custom_private_packet->data = nullptr;
         group_custom_private_packet->data_length = 0;
     }
@@ -67,7 +67,7 @@ static bool tox_event_group_custom_private_packet_set_data(Tox_Event_Group_Custo
         return true;
     }
 
-    uint8_t *data_copy = (uint8_t *)malloc(data_length);
+    uint8_t *data_copy = (uint8_t *)mem_balloc(mem, data_length);
 
     if (data_copy == nullptr) {
         return false;
@@ -97,7 +97,7 @@ static void tox_event_group_custom_private_packet_construct(Tox_Event_Group_Cust
 }
 static void tox_event_group_custom_private_packet_destruct(Tox_Event_Group_Custom_Private_Packet *_Nonnull group_custom_private_packet, const Memory *_Nonnull mem)
 {
-    free(group_custom_private_packet->data);
+    mem_delete(mem, group_custom_private_packet->data);
 }
 
 bool tox_event_group_custom_private_packet_pack(
@@ -186,11 +186,8 @@ bool tox_event_group_custom_private_packet_unpack(
     return tox_event_group_custom_private_packet_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Custom_Private_Packet *tox_event_group_custom_private_packet_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Custom_Private_Packet *tox_event_group_custom_private_packet_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -215,7 +212,8 @@ void tox_events_handle_group_custom_private_packet(
     Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data, size_t data_length,
     void *user_data)
 {
-    Tox_Event_Group_Custom_Private_Packet *group_custom_private_packet = tox_event_group_custom_private_packet_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Custom_Private_Packet *group_custom_private_packet = tox_event_group_custom_private_packet_alloc(state);
 
     if (group_custom_private_packet == nullptr) {
         return;
@@ -223,5 +221,5 @@ void tox_events_handle_group_custom_private_packet(
 
     tox_event_group_custom_private_packet_set_group_number(group_custom_private_packet, group_number);
     tox_event_group_custom_private_packet_set_peer_id(group_custom_private_packet, peer_id);
-    tox_event_group_custom_private_packet_set_data(group_custom_private_packet, data, data_length);
+    tox_event_group_custom_private_packet_set_data(group_custom_private_packet, state->mem, data, data_length);
 }

--- a/toxcore/events/group_invite.c
+++ b/toxcore/events/group_invite.c
@@ -43,11 +43,11 @@ uint32_t tox_event_group_invite_get_friend_number(const Tox_Event_Group_Invite *
 }
 
 static bool tox_event_group_invite_set_invite_data(Tox_Event_Group_Invite *_Nonnull group_invite,
-        const uint8_t *_Nullable invite_data, uint32_t invite_data_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable invite_data, uint32_t invite_data_length)
 {
     assert(group_invite != nullptr);
     if (group_invite->invite_data != nullptr) {
-        free(group_invite->invite_data);
+        mem_delete(mem, group_invite->invite_data);
         group_invite->invite_data = nullptr;
         group_invite->invite_data_length = 0;
     }
@@ -57,7 +57,7 @@ static bool tox_event_group_invite_set_invite_data(Tox_Event_Group_Invite *_Nonn
         return true;
     }
 
-    uint8_t *invite_data_copy = (uint8_t *)malloc(invite_data_length);
+    uint8_t *invite_data_copy = (uint8_t *)mem_balloc(mem, invite_data_length);
 
     if (invite_data_copy == nullptr) {
         return false;
@@ -80,11 +80,11 @@ const uint8_t *tox_event_group_invite_get_invite_data(const Tox_Event_Group_Invi
 }
 
 static bool tox_event_group_invite_set_group_name(Tox_Event_Group_Invite *_Nonnull group_invite,
-        const uint8_t *_Nullable group_name, uint32_t group_name_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable group_name, uint32_t group_name_length)
 {
     assert(group_invite != nullptr);
     if (group_invite->group_name != nullptr) {
-        free(group_invite->group_name);
+        mem_delete(mem, group_invite->group_name);
         group_invite->group_name = nullptr;
         group_invite->group_name_length = 0;
     }
@@ -94,7 +94,7 @@ static bool tox_event_group_invite_set_group_name(Tox_Event_Group_Invite *_Nonnu
         return true;
     }
 
-    uint8_t *group_name_copy = (uint8_t *)malloc(group_name_length);
+    uint8_t *group_name_copy = (uint8_t *)mem_balloc(mem, group_name_length);
 
     if (group_name_copy == nullptr) {
         return false;
@@ -124,8 +124,8 @@ static void tox_event_group_invite_construct(Tox_Event_Group_Invite *_Nonnull gr
 }
 static void tox_event_group_invite_destruct(Tox_Event_Group_Invite *_Nonnull group_invite, const Memory *_Nonnull mem)
 {
-    free(group_invite->invite_data);
-    free(group_invite->group_name);
+    mem_delete(mem, group_invite->invite_data);
+    mem_delete(mem, group_invite->group_name);
 }
 
 bool tox_event_group_invite_pack(
@@ -214,11 +214,8 @@ bool tox_event_group_invite_unpack(
     return tox_event_group_invite_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Invite *tox_event_group_invite_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Invite *tox_event_group_invite_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -243,13 +240,14 @@ void tox_events_handle_group_invite(
     Tox *tox, uint32_t friend_number, const uint8_t *invite_data, size_t invite_data_length, const uint8_t *group_name, size_t group_name_length,
     void *user_data)
 {
-    Tox_Event_Group_Invite *group_invite = tox_event_group_invite_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Invite *group_invite = tox_event_group_invite_alloc(state);
 
     if (group_invite == nullptr) {
         return;
     }
 
     tox_event_group_invite_set_friend_number(group_invite, friend_number);
-    tox_event_group_invite_set_invite_data(group_invite, invite_data, invite_data_length);
-    tox_event_group_invite_set_group_name(group_invite, group_name, group_name_length);
+    tox_event_group_invite_set_invite_data(group_invite, state->mem, invite_data, invite_data_length);
+    tox_event_group_invite_set_group_name(group_invite, state->mem, group_name, group_name_length);
 }

--- a/toxcore/events/group_join_fail.c
+++ b/toxcore/events/group_join_fail.c
@@ -145,11 +145,8 @@ bool tox_event_group_join_fail_unpack(
     return tox_event_group_join_fail_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Join_Fail *tox_event_group_join_fail_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Join_Fail *tox_event_group_join_fail_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -174,7 +171,8 @@ void tox_events_handle_group_join_fail(
     Tox *tox, uint32_t group_number, Tox_Group_Join_Fail fail_type,
     void *user_data)
 {
-    Tox_Event_Group_Join_Fail *group_join_fail = tox_event_group_join_fail_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Join_Fail *group_join_fail = tox_event_group_join_fail_alloc(state);
 
     if (group_join_fail == nullptr) {
         return;

--- a/toxcore/events/group_message.c
+++ b/toxcore/events/group_message.c
@@ -68,11 +68,11 @@ Tox_Message_Type tox_event_group_message_get_message_type(const Tox_Event_Group_
 }
 
 static bool tox_event_group_message_set_message(Tox_Event_Group_Message *_Nonnull group_message,
-        const uint8_t *_Nullable message, uint32_t message_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable message, uint32_t message_length)
 {
     assert(group_message != nullptr);
     if (group_message->message != nullptr) {
-        free(group_message->message);
+        mem_delete(mem, group_message->message);
         group_message->message = nullptr;
         group_message->message_length = 0;
     }
@@ -82,7 +82,7 @@ static bool tox_event_group_message_set_message(Tox_Event_Group_Message *_Nonnul
         return true;
     }
 
-    uint8_t *message_copy = (uint8_t *)malloc(message_length);
+    uint8_t *message_copy = (uint8_t *)mem_balloc(mem, message_length);
 
     if (message_copy == nullptr) {
         return false;
@@ -123,7 +123,7 @@ static void tox_event_group_message_construct(Tox_Event_Group_Message *_Nonnull 
 }
 static void tox_event_group_message_destruct(Tox_Event_Group_Message *_Nonnull group_message, const Memory *_Nonnull mem)
 {
-    free(group_message->message);
+    mem_delete(mem, group_message->message);
 }
 
 bool tox_event_group_message_pack(
@@ -216,11 +216,8 @@ bool tox_event_group_message_unpack(
     return tox_event_group_message_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Message *tox_event_group_message_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Message *tox_event_group_message_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -245,7 +242,8 @@ void tox_events_handle_group_message(
     Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Message_Type message_type, const uint8_t *message, size_t message_length, uint32_t message_id,
     void *user_data)
 {
-    Tox_Event_Group_Message *group_message = tox_event_group_message_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Message *group_message = tox_event_group_message_alloc(state);
 
     if (group_message == nullptr) {
         return;
@@ -254,6 +252,6 @@ void tox_events_handle_group_message(
     tox_event_group_message_set_group_number(group_message, group_number);
     tox_event_group_message_set_peer_id(group_message, peer_id);
     tox_event_group_message_set_message_type(group_message, message_type);
-    tox_event_group_message_set_message(group_message, message, message_length);
+    tox_event_group_message_set_message(group_message, state->mem, message, message_length);
     tox_event_group_message_set_message_id(group_message, message_id);
 }

--- a/toxcore/events/group_moderation.c
+++ b/toxcore/events/group_moderation.c
@@ -173,11 +173,8 @@ bool tox_event_group_moderation_unpack(
     return tox_event_group_moderation_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Moderation *tox_event_group_moderation_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Moderation *tox_event_group_moderation_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -202,7 +199,8 @@ void tox_events_handle_group_moderation(
     Tox *tox, uint32_t group_number, uint32_t source_peer_id, uint32_t target_peer_id, Tox_Group_Mod_Event mod_type,
     void *user_data)
 {
-    Tox_Event_Group_Moderation *group_moderation = tox_event_group_moderation_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Moderation *group_moderation = tox_event_group_moderation_alloc(state);
 
     if (group_moderation == nullptr) {
         return;

--- a/toxcore/events/group_peer_exit.c
+++ b/toxcore/events/group_peer_exit.c
@@ -69,11 +69,11 @@ Tox_Group_Exit_Type tox_event_group_peer_exit_get_exit_type(const Tox_Event_Grou
 }
 
 static bool tox_event_group_peer_exit_set_name(Tox_Event_Group_Peer_Exit *_Nonnull group_peer_exit,
-        const uint8_t *_Nullable name, uint32_t name_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable name, uint32_t name_length)
 {
     assert(group_peer_exit != nullptr);
     if (group_peer_exit->name != nullptr) {
-        free(group_peer_exit->name);
+        mem_delete(mem, group_peer_exit->name);
         group_peer_exit->name = nullptr;
         group_peer_exit->name_length = 0;
     }
@@ -83,7 +83,7 @@ static bool tox_event_group_peer_exit_set_name(Tox_Event_Group_Peer_Exit *_Nonnu
         return true;
     }
 
-    uint8_t *name_copy = (uint8_t *)malloc(name_length);
+    uint8_t *name_copy = (uint8_t *)mem_balloc(mem, name_length);
 
     if (name_copy == nullptr) {
         return false;
@@ -106,11 +106,11 @@ const uint8_t *tox_event_group_peer_exit_get_name(const Tox_Event_Group_Peer_Exi
 }
 
 static bool tox_event_group_peer_exit_set_part_message(Tox_Event_Group_Peer_Exit *_Nonnull group_peer_exit,
-        const uint8_t *_Nullable part_message, uint32_t part_message_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable part_message, uint32_t part_message_length)
 {
     assert(group_peer_exit != nullptr);
     if (group_peer_exit->part_message != nullptr) {
-        free(group_peer_exit->part_message);
+        mem_delete(mem, group_peer_exit->part_message);
         group_peer_exit->part_message = nullptr;
         group_peer_exit->part_message_length = 0;
     }
@@ -120,7 +120,7 @@ static bool tox_event_group_peer_exit_set_part_message(Tox_Event_Group_Peer_Exit
         return true;
     }
 
-    uint8_t *part_message_copy = (uint8_t *)malloc(part_message_length);
+    uint8_t *part_message_copy = (uint8_t *)mem_balloc(mem, part_message_length);
 
     if (part_message_copy == nullptr) {
         return false;
@@ -150,8 +150,8 @@ static void tox_event_group_peer_exit_construct(Tox_Event_Group_Peer_Exit *_Nonn
 }
 static void tox_event_group_peer_exit_destruct(Tox_Event_Group_Peer_Exit *_Nonnull group_peer_exit, const Memory *_Nonnull mem)
 {
-    free(group_peer_exit->name);
-    free(group_peer_exit->part_message);
+    mem_delete(mem, group_peer_exit->name);
+    mem_delete(mem, group_peer_exit->part_message);
 }
 
 bool tox_event_group_peer_exit_pack(
@@ -244,11 +244,8 @@ bool tox_event_group_peer_exit_unpack(
     return tox_event_group_peer_exit_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Peer_Exit *tox_event_group_peer_exit_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Peer_Exit *tox_event_group_peer_exit_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -273,7 +270,8 @@ void tox_events_handle_group_peer_exit(
     Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Group_Exit_Type exit_type, const uint8_t *name, size_t name_length, const uint8_t *part_message, size_t part_message_length,
     void *user_data)
 {
-    Tox_Event_Group_Peer_Exit *group_peer_exit = tox_event_group_peer_exit_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Peer_Exit *group_peer_exit = tox_event_group_peer_exit_alloc(state);
 
     if (group_peer_exit == nullptr) {
         return;
@@ -282,6 +280,6 @@ void tox_events_handle_group_peer_exit(
     tox_event_group_peer_exit_set_group_number(group_peer_exit, group_number);
     tox_event_group_peer_exit_set_peer_id(group_peer_exit, peer_id);
     tox_event_group_peer_exit_set_exit_type(group_peer_exit, exit_type);
-    tox_event_group_peer_exit_set_name(group_peer_exit, name, name_length);
-    tox_event_group_peer_exit_set_part_message(group_peer_exit, part_message, part_message_length);
+    tox_event_group_peer_exit_set_name(group_peer_exit, state->mem, name, name_length);
+    tox_event_group_peer_exit_set_part_message(group_peer_exit, state->mem, part_message, part_message_length);
 }

--- a/toxcore/events/group_peer_join.c
+++ b/toxcore/events/group_peer_join.c
@@ -143,11 +143,8 @@ bool tox_event_group_peer_join_unpack(
     return tox_event_group_peer_join_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Peer_Join *tox_event_group_peer_join_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Peer_Join *tox_event_group_peer_join_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -172,7 +169,8 @@ void tox_events_handle_group_peer_join(
     Tox *tox, uint32_t group_number, uint32_t peer_id,
     void *user_data)
 {
-    Tox_Event_Group_Peer_Join *group_peer_join = tox_event_group_peer_join_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Peer_Join *group_peer_join = tox_event_group_peer_join_alloc(state);
 
     if (group_peer_join == nullptr) {
         return;

--- a/toxcore/events/group_peer_limit.c
+++ b/toxcore/events/group_peer_limit.c
@@ -143,11 +143,8 @@ bool tox_event_group_peer_limit_unpack(
     return tox_event_group_peer_limit_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Peer_Limit *tox_event_group_peer_limit_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Peer_Limit *tox_event_group_peer_limit_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -172,7 +169,8 @@ void tox_events_handle_group_peer_limit(
     Tox *tox, uint32_t group_number, uint32_t peer_limit,
     void *user_data)
 {
-    Tox_Event_Group_Peer_Limit *group_peer_limit = tox_event_group_peer_limit_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Peer_Limit *group_peer_limit = tox_event_group_peer_limit_alloc(state);
 
     if (group_peer_limit == nullptr) {
         return;

--- a/toxcore/events/group_peer_status.c
+++ b/toxcore/events/group_peer_status.c
@@ -159,11 +159,8 @@ bool tox_event_group_peer_status_unpack(
     return tox_event_group_peer_status_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Peer_Status *tox_event_group_peer_status_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Peer_Status *tox_event_group_peer_status_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -188,7 +185,8 @@ void tox_events_handle_group_peer_status(
     Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_User_Status status,
     void *user_data)
 {
-    Tox_Event_Group_Peer_Status *group_peer_status = tox_event_group_peer_status_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Peer_Status *group_peer_status = tox_event_group_peer_status_alloc(state);
 
     if (group_peer_status == nullptr) {
         return;

--- a/toxcore/events/group_privacy_state.c
+++ b/toxcore/events/group_privacy_state.c
@@ -145,11 +145,8 @@ bool tox_event_group_privacy_state_unpack(
     return tox_event_group_privacy_state_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Privacy_State *tox_event_group_privacy_state_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Privacy_State *tox_event_group_privacy_state_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -174,7 +171,8 @@ void tox_events_handle_group_privacy_state(
     Tox *tox, uint32_t group_number, Tox_Group_Privacy_State privacy_state,
     void *user_data)
 {
-    Tox_Event_Group_Privacy_State *group_privacy_state = tox_event_group_privacy_state_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Privacy_State *group_privacy_state = tox_event_group_privacy_state_alloc(state);
 
     if (group_privacy_state == nullptr) {
         return;

--- a/toxcore/events/group_private_message.c
+++ b/toxcore/events/group_private_message.c
@@ -68,11 +68,11 @@ Tox_Message_Type tox_event_group_private_message_get_message_type(const Tox_Even
 }
 
 static bool tox_event_group_private_message_set_message(Tox_Event_Group_Private_Message *_Nonnull group_private_message,
-        const uint8_t *_Nullable message, uint32_t message_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable message, uint32_t message_length)
 {
     assert(group_private_message != nullptr);
     if (group_private_message->message != nullptr) {
-        free(group_private_message->message);
+        mem_delete(mem, group_private_message->message);
         group_private_message->message = nullptr;
         group_private_message->message_length = 0;
     }
@@ -82,7 +82,7 @@ static bool tox_event_group_private_message_set_message(Tox_Event_Group_Private_
         return true;
     }
 
-    uint8_t *message_copy = (uint8_t *)malloc(message_length);
+    uint8_t *message_copy = (uint8_t *)mem_balloc(mem, message_length);
 
     if (message_copy == nullptr) {
         return false;
@@ -123,7 +123,7 @@ static void tox_event_group_private_message_construct(Tox_Event_Group_Private_Me
 }
 static void tox_event_group_private_message_destruct(Tox_Event_Group_Private_Message *_Nonnull group_private_message, const Memory *_Nonnull mem)
 {
-    free(group_private_message->message);
+    mem_delete(mem, group_private_message->message);
 }
 
 bool tox_event_group_private_message_pack(
@@ -216,11 +216,8 @@ bool tox_event_group_private_message_unpack(
     return tox_event_group_private_message_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Private_Message *tox_event_group_private_message_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Private_Message *tox_event_group_private_message_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -245,7 +242,8 @@ void tox_events_handle_group_private_message(
     Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Message_Type message_type, const uint8_t *message, size_t message_length, uint32_t message_id,
     void *user_data)
 {
-    Tox_Event_Group_Private_Message *group_private_message = tox_event_group_private_message_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Private_Message *group_private_message = tox_event_group_private_message_alloc(state);
 
     if (group_private_message == nullptr) {
         return;
@@ -254,6 +252,6 @@ void tox_events_handle_group_private_message(
     tox_event_group_private_message_set_group_number(group_private_message, group_number);
     tox_event_group_private_message_set_peer_id(group_private_message, peer_id);
     tox_event_group_private_message_set_message_type(group_private_message, message_type);
-    tox_event_group_private_message_set_message(group_private_message, message, message_length);
+    tox_event_group_private_message_set_message(group_private_message, state->mem, message, message_length);
     tox_event_group_private_message_set_message_id(group_private_message, message_id);
 }

--- a/toxcore/events/group_self_join.c
+++ b/toxcore/events/group_self_join.c
@@ -124,11 +124,8 @@ bool tox_event_group_self_join_unpack(
     return tox_event_group_self_join_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Self_Join *tox_event_group_self_join_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Self_Join *tox_event_group_self_join_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -153,7 +150,8 @@ void tox_events_handle_group_self_join(
     Tox *tox, uint32_t group_number,
     void *user_data)
 {
-    Tox_Event_Group_Self_Join *group_self_join = tox_event_group_self_join_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Self_Join *group_self_join = tox_event_group_self_join_alloc(state);
 
     if (group_self_join == nullptr) {
         return;

--- a/toxcore/events/group_topic.c
+++ b/toxcore/events/group_topic.c
@@ -53,11 +53,11 @@ uint32_t tox_event_group_topic_get_peer_id(const Tox_Event_Group_Topic *group_to
 }
 
 static bool tox_event_group_topic_set_topic(Tox_Event_Group_Topic *_Nonnull group_topic,
-        const uint8_t *_Nullable topic, uint32_t topic_length)
+        const Memory *_Nonnull mem, const uint8_t *_Nullable topic, uint32_t topic_length)
 {
     assert(group_topic != nullptr);
     if (group_topic->topic != nullptr) {
-        free(group_topic->topic);
+        mem_delete(mem, group_topic->topic);
         group_topic->topic = nullptr;
         group_topic->topic_length = 0;
     }
@@ -67,7 +67,7 @@ static bool tox_event_group_topic_set_topic(Tox_Event_Group_Topic *_Nonnull grou
         return true;
     }
 
-    uint8_t *topic_copy = (uint8_t *)malloc(topic_length);
+    uint8_t *topic_copy = (uint8_t *)mem_balloc(mem, topic_length);
 
     if (topic_copy == nullptr) {
         return false;
@@ -97,7 +97,7 @@ static void tox_event_group_topic_construct(Tox_Event_Group_Topic *_Nonnull grou
 }
 static void tox_event_group_topic_destruct(Tox_Event_Group_Topic *_Nonnull group_topic, const Memory *_Nonnull mem)
 {
-    free(group_topic->topic);
+    mem_delete(mem, group_topic->topic);
 }
 
 bool tox_event_group_topic_pack(
@@ -186,11 +186,8 @@ bool tox_event_group_topic_unpack(
     return tox_event_group_topic_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Topic *tox_event_group_topic_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Topic *tox_event_group_topic_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -215,7 +212,8 @@ void tox_events_handle_group_topic(
     Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *topic, size_t topic_length,
     void *user_data)
 {
-    Tox_Event_Group_Topic *group_topic = tox_event_group_topic_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Topic *group_topic = tox_event_group_topic_alloc(state);
 
     if (group_topic == nullptr) {
         return;
@@ -223,5 +221,5 @@ void tox_events_handle_group_topic(
 
     tox_event_group_topic_set_group_number(group_topic, group_number);
     tox_event_group_topic_set_peer_id(group_topic, peer_id);
-    tox_event_group_topic_set_topic(group_topic, topic, topic_length);
+    tox_event_group_topic_set_topic(group_topic, state->mem, topic, topic_length);
 }

--- a/toxcore/events/group_topic_lock.c
+++ b/toxcore/events/group_topic_lock.c
@@ -145,11 +145,8 @@ bool tox_event_group_topic_lock_unpack(
     return tox_event_group_topic_lock_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Topic_Lock *tox_event_group_topic_lock_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Topic_Lock *tox_event_group_topic_lock_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -174,7 +171,8 @@ void tox_events_handle_group_topic_lock(
     Tox *tox, uint32_t group_number, Tox_Group_Topic_Lock topic_lock,
     void *user_data)
 {
-    Tox_Event_Group_Topic_Lock *group_topic_lock = tox_event_group_topic_lock_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Topic_Lock *group_topic_lock = tox_event_group_topic_lock_alloc(state);
 
     if (group_topic_lock == nullptr) {
         return;

--- a/toxcore/events/group_voice_state.c
+++ b/toxcore/events/group_voice_state.c
@@ -145,11 +145,8 @@ bool tox_event_group_voice_state_unpack(
     return tox_event_group_voice_state_unpack_into(*event, bu);
 }
 
-static Tox_Event_Group_Voice_State *tox_event_group_voice_state_alloc(void *_Nonnull user_data)
+static Tox_Event_Group_Voice_State *tox_event_group_voice_state_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -174,7 +171,8 @@ void tox_events_handle_group_voice_state(
     Tox *tox, uint32_t group_number, Tox_Group_Voice_State voice_state,
     void *user_data)
 {
-    Tox_Event_Group_Voice_State *group_voice_state = tox_event_group_voice_state_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Group_Voice_State *group_voice_state = tox_event_group_voice_state_alloc(state);
 
     if (group_voice_state == nullptr) {
         return;

--- a/toxcore/events/self_connection_status.c
+++ b/toxcore/events/self_connection_status.c
@@ -126,11 +126,8 @@ bool tox_event_self_connection_status_unpack(
     return tox_event_self_connection_status_unpack_into(*event, bu);
 }
 
-static Tox_Event_Self_Connection_Status *tox_event_self_connection_status_alloc(void *_Nonnull user_data)
+static Tox_Event_Self_Connection_Status *tox_event_self_connection_status_alloc(Tox_Events_State *_Nonnull state)
 {
-    Tox_Events_State *state = tox_events_alloc(user_data);
-    assert(state != nullptr);
-
     if (state->events == nullptr) {
         return nullptr;
     }
@@ -155,7 +152,8 @@ void tox_events_handle_self_connection_status(
     Tox *tox, Tox_Connection connection_status,
     void *user_data)
 {
-    Tox_Event_Self_Connection_Status *self_connection_status = tox_event_self_connection_status_alloc(user_data);
+    Tox_Events_State *state = tox_events_alloc(user_data);
+    Tox_Event_Self_Connection_Status *self_connection_status = tox_event_self_connection_status_alloc(state);
 
     if (self_connection_status == nullptr) {
         return;


### PR DESCRIPTION
Update event generator to use mem_balloc/mem_delete for byte arrays in events, ensuring consistency with Tox memory management. Also fix struct initialization to use compound literals compliant with tokstyle.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2964)
<!-- Reviewable:end -->
