### PR TITLE
perf(onion): shared_key_cache and onion_client key caching

### DIFF
--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -1059,7 +1059,7 @@ cc_library(
 
 cc_test(
     name = "onion_client_test",
-    size = "small",
+    size = "medium",
     srcs = ["onion_client_test.cc"],
     deps = [
         ":DHT_test_util",

--- a/toxcore/announce.c
+++ b/toxcore/announce.c
@@ -25,7 +25,7 @@
 #include "timed_auth.h"
 #include "util.h"
 
-// Settings for the shared key cache
+/* Settings for the shared key cache */
 #define MAX_KEYS_PER_SLOT 4
 #define KEYS_TIMEOUT 600
 

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -33,7 +33,7 @@
 
 #define KEY_REFRESH_INTERVAL (2 * 60 * 60)
 
-// Settings for the shared key cache
+/* Settings for the shared key cache */
 #define MAX_KEYS_PER_SLOT 4
 #define KEYS_TIMEOUT 600
 

--- a/toxcore/onion.h
+++ b/toxcore/onion.h
@@ -18,6 +18,10 @@
 #include "network.h"
 #include "shared_key_cache.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef int onion_recv_1_cb(void *_Nullable object, const IP_Port *_Nonnull dest, const uint8_t *_Nonnull data, uint16_t length);
 
 typedef struct Onion {
@@ -143,4 +147,9 @@ void set_callback_handle_recv_1(Onion *_Nonnull onion, onion_recv_1_cb *_Nullabl
 Onion *_Nullable new_onion(const Logger *_Nonnull log, const Memory *_Nonnull mem, const Mono_Time *_Nonnull mono_time, const Random *_Nonnull rng, DHT *_Nonnull dht, Networking_Core *_Nonnull net);
 
 void kill_onion(Onion *_Nullable onion);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #endif /* C_TOXCORE_TOXCORE_ONION_H */

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -135,6 +135,38 @@ int create_announce_request(const Memory *mem, const Random *rng, uint8_t *packe
     return ONION_ANNOUNCE_REQUEST_MIN_SIZE;
 }
 
+int create_announce_request_symmetric(const Memory *mem, const Random *rng, uint8_t *packet, uint16_t max_packet_length,
+                                      const uint8_t *shared_key,
+                                      const uint8_t *public_key, const uint8_t *ping_id, const uint8_t *client_id,
+                                      const uint8_t *data_public_key, uint64_t sendback_data)
+{
+    if (max_packet_length < ONION_ANNOUNCE_REQUEST_MIN_SIZE) {
+        return -1;
+    }
+
+    uint8_t plain[ONION_PING_ID_SIZE + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_PUBLIC_KEY_SIZE +
+                                     ONION_ANNOUNCE_SENDBACK_DATA_LENGTH];
+    memcpy(plain, ping_id, ONION_PING_ID_SIZE);
+    memcpy(plain + ONION_PING_ID_SIZE, client_id, CRYPTO_PUBLIC_KEY_SIZE);
+    memcpy(plain + ONION_PING_ID_SIZE + CRYPTO_PUBLIC_KEY_SIZE, data_public_key, CRYPTO_PUBLIC_KEY_SIZE);
+    memcpy(plain + ONION_PING_ID_SIZE + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_PUBLIC_KEY_SIZE, &sendback_data,
+           sizeof(sendback_data));
+
+    packet[0] = NET_PACKET_ANNOUNCE_REQUEST_OLD;
+    random_nonce(rng, packet + 1);
+
+    const int len = encrypt_data_symmetric(mem, shared_key, packet + 1, plain, sizeof(plain),
+                                           packet + 1 + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE);
+
+    if ((uint32_t)len + 1 + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE != ONION_ANNOUNCE_REQUEST_MIN_SIZE) {
+        return -1;
+    }
+
+    memcpy(packet + 1 + CRYPTO_NONCE_SIZE, public_key, CRYPTO_PUBLIC_KEY_SIZE);
+
+    return ONION_ANNOUNCE_REQUEST_MIN_SIZE;
+}
+
 /** @brief Create an onion data request packet in packet of max_packet_length.
  *
  * Recommended value for max_packet_length is ONION_ANNOUNCE_REQUEST_SIZE.

--- a/toxcore/onion_announce.h
+++ b/toxcore/onion_announce.h
@@ -41,6 +41,10 @@
 #define ONION_DATA_REQUEST_MIN_SIZE (1 + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_MAC_SIZE)
 #define MAX_DATA_REQUEST_SIZE (ONION_MAX_DATA_SIZE - ONION_DATA_REQUEST_MIN_SIZE)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct Onion_Announce Onion_Announce;
 
 /** These two are not public; they are for tests only! */
@@ -65,6 +69,16 @@ void onion_announce_entry_set_time(Onion_Announce *_Nonnull onion_a, uint32_t en
 int create_announce_request(const Memory *_Nonnull mem, const Random *_Nonnull rng, uint8_t *_Nonnull packet, uint16_t max_packet_length, const uint8_t *_Nonnull dest_client_id,
                             const uint8_t *_Nonnull public_key, const uint8_t *_Nonnull secret_key, const uint8_t *_Nonnull ping_id, const uint8_t *_Nonnull client_id, const uint8_t *_Nonnull data_public_key,
                             uint64_t sendback_data);
+
+/** @brief Same as create_announce_request but uses a precomputed shared key for symmetric encryption.
+ *
+ * @param shared_key The shared key derived from the destination's public key and the sender's secret key.
+ */
+int create_announce_request_symmetric(const Memory *_Nonnull mem, const Random *_Nonnull rng, uint8_t *_Nonnull packet,
+                                      uint16_t max_packet_length, const uint8_t *_Nonnull shared_key,
+                                      const uint8_t *_Nonnull public_key, const uint8_t *_Nonnull ping_id,
+                                      const uint8_t *_Nonnull client_id, const uint8_t *_Nonnull data_public_key,
+                                      uint64_t sendback_data);
 
 /** @brief Create an onion data request packet in packet of max_packet_length.
  *
@@ -128,4 +142,9 @@ Onion_Announce *_Nullable new_onion_announce(const Logger *_Nonnull log, const M
         Networking_Core *_Nonnull net);
 
 void kill_onion_announce(Onion_Announce *_Nullable onion_a);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #endif /* C_TOXCORE_TOXCORE_ONION_ANNOUNCE_H */

--- a/toxcore/onion_client_test.cc
+++ b/toxcore/onion_client_test.cc
@@ -7,8 +7,10 @@
 #include <array>
 #include <cstring>
 #include <functional>
+#include <iostream>
 #include <map>
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "../testing/support/public/simulated_environment.hh"
@@ -37,6 +39,8 @@ public:
               [mem = &dht_wrapper_.node().c_memory](Net_Profile *p) { netprof_kill(mem, p); })
         , net_crypto_(nullptr, [](Net_Crypto *c) { kill_net_crypto(c); })
         , onion_client_(nullptr, [](Onion_Client *c) { kill_onion_client(c); })
+        , onion_server_(nullptr, [](Onion *o) { kill_onion(o); })
+        , onion_announce_(nullptr, [](Onion_Announce *a) { kill_onion_announce(a); })
     {
         // Setup NetCrypto
         TCP_Proxy_Info proxy_info = {{0}, TCP_PROXY_NONE};
@@ -49,6 +53,16 @@ public:
         onion_client_.reset(new_onion_client(dht_wrapper_.logger(), &dht_wrapper_.node().c_memory,
             &dht_wrapper_.node().c_random, dht_wrapper_.mono_time(), net_crypto_.get(),
             dht_wrapper_.get_dht(), dht_wrapper_.networking()));
+
+        // Setup Onion Server
+        onion_server_.reset(new_onion(dht_wrapper_.logger(), &dht_wrapper_.node().c_memory,
+            dht_wrapper_.mono_time(), &dht_wrapper_.node().c_random, dht_wrapper_.get_dht(),
+            dht_wrapper_.networking()));
+
+        // Setup Onion Announce
+        onion_announce_.reset(new_onion_announce(dht_wrapper_.logger(),
+            &dht_wrapper_.node().c_memory, &dht_wrapper_.node().c_random, dht_wrapper_.mono_time(),
+            dht_wrapper_.get_dht(), dht_wrapper_.networking()));
     }
 
     Onion_Client *get_onion_client() { return onion_client_.get(); }
@@ -57,15 +71,19 @@ public:
     Logger *get_logger() { return dht_wrapper_.logger(); }
     const uint8_t *dht_public_key() const { return dht_wrapper_.dht_public_key(); }
     const uint8_t *real_public_key() const { return nc_get_self_public_key(net_crypto_.get()); }
+    const uint8_t *dht_secret_key() const { return dht_wrapper_.dht_secret_key(); }
     const Random *get_random() { return &dht_wrapper_.node().c_random; }
 
     IP_Port get_ip_port() const { return dht_wrapper_.get_ip_port(); }
+    tox::test::ScopedToxSystem &node() { return dht_wrapper_.node(); }
+    Onion_Announce *get_onion_announce() { return onion_announce_.get(); }
 
-    void poll()
+    void poll(bool poll_onion = true)
     {
         dht_wrapper_.poll();
         do_net_crypto(net_crypto_.get(), nullptr);
-        do_onion_client(onion_client_.get());
+        if (poll_onion)
+            do_onion_client(onion_client_.get());
     }
 
     ~OnionTestNode();
@@ -75,6 +93,8 @@ private:
     std::unique_ptr<Net_Profile, std::function<void(Net_Profile *)>> net_profile_;
     std::unique_ptr<Net_Crypto, void (*)(Net_Crypto *)> net_crypto_;
     std::unique_ptr<Onion_Client, void (*)(Onion_Client *)> onion_client_;
+    std::unique_ptr<Onion, void (*)(Onion *)> onion_server_;
+    std::unique_ptr<Onion_Announce, void (*)(Onion_Announce *)> onion_announce_;
 };
 
 template <typename DHTWrapper>
@@ -87,6 +107,8 @@ public:
     static void print_log(void *context, Logger_Level level, const char *file, uint32_t line,
         const char *func, const char *message, void *userdata)
     {
+        if (level == LOGGER_LEVEL_TRACE)
+            return;
         fprintf(stderr, "[%d] %s:%u %s: %s\n", level, file, line, func, message);
     }
 
@@ -244,8 +266,12 @@ TEST_F(OnionClientTest, GroupChatHelpers)
 
 TEST_F(OnionClientTest, OOBReadInHandleAnnounceResponse)
 {
+    constexpr bool kEnableLogging = false;
+
     OnionNode alice(env, 33445);
-    logger_callback_log(alice.get_logger(), OnionClientTest::print_log, nullptr, nullptr);
+    if (kEnableLogging) {
+        logger_callback_log(alice.get_logger(), OnionClientTest::print_log, nullptr, nullptr);
+    }
     WrappedDHT bob(env, 12345);
     FakeUdpSocket *bob_socket = bob.node().endpoint;
 
@@ -441,10 +467,16 @@ TEST_F(OnionClientTest, DISABLED_IntegerOverflowNumFriends)
 
 TEST_F(OnionClientTest, OnionAnnounceResponse_TooShort)
 {
+    constexpr bool kEnableLogging = false;
+
     OnionNode alice(env, 33445);
-    logger_callback_log(alice.get_logger(), OnionClientTest::print_log, nullptr, nullptr);
+    if (kEnableLogging) {
+        logger_callback_log(alice.get_logger(), OnionClientTest::print_log, nullptr, nullptr);
+    }
     WrappedDHT bob(env, 12345);
-    logger_callback_log(bob.logger(), OnionClientTest::print_log, nullptr, nullptr);
+    if (kEnableLogging) {
+        logger_callback_log(bob.logger(), OnionClientTest::print_log, nullptr, nullptr);
+    }
     FakeUdpSocket *bob_socket = bob.node().endpoint;
 
     IP_Port bob_ip = bob.get_ip_port();
@@ -574,6 +606,239 @@ TEST_F(OnionClientTest, OnionAnnounceResponse_TooShort)
 
     ASSERT_TRUE(triggered);
     EXPECT_EQ(onion_testonly_get_last_packet_recv(alice.get_onion_client()), initial_recv_time);
+}
+
+TEST_F(OnionClientTest, SharedKeyCacheUseAfterFreeRegression)
+{
+    OnionNode alice(env, 33445);
+    OnionNode bob(env, 33446);
+    OnionNode charlie(env, 33447);
+    OnionNode dave(env, 33448);
+
+    std::vector<OnionNode *> nodes = {&bob, &charlie, &dave};
+
+    // Make everyone know everyone via bootstrap
+    for (auto n1 : nodes) {
+        for (auto n2 : nodes) {
+            if (n1 == n2)
+                continue;
+            IP_Port ip = n2->get_ip_port();
+            dht_bootstrap(n1->get_dht(), &ip, n2->dht_public_key());
+        }
+    }
+
+    for (auto node : nodes) {
+        IP_Port ip = node->get_ip_port();
+        const uint8_t *pk = node->dht_public_key();
+        dht_bootstrap(alice.get_dht(), &ip, pk);
+        onion_add_bs_path_node(alice.get_onion_client(), &ip, pk);
+    }
+
+    Tox_Memory mem_struct = env.fake_memory().get_c_memory();
+    const Memory *mem = &mem_struct;
+
+    int total_decryption_failures = 0;
+    std::set<std::vector<uint8_t>> seen_announcements;
+
+    auto observer = [&](OnionNode *node, const std::vector<uint8_t> &data, const IP_Port &from) {
+        if (data.empty())
+            return;
+        // If it's an onion packet, it will be handled by Onion server.
+        // We want to catch the final hop announce request.
+        if (data[0] == 0x83 || data[0] == 0x87) {
+            // An announce request has 57 bytes of header and 120 bytes of ciphertext.
+            // There's also RETURN_3 appended, but we don't need it for decryption.
+            const size_t kHeaderSize = 1 + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE;
+            const size_t kCiphertextSize = 120;
+
+            if (data.size() < kHeaderSize + kCiphertextSize)
+                return;
+
+            const uint8_t *nonce = data.data() + 1;
+            const uint8_t *sender_pk = data.data() + 1 + CRYPTO_NONCE_SIZE;
+            const uint8_t *ciphertext = sender_pk + CRYPTO_PUBLIC_KEY_SIZE;
+
+            std::vector<uint8_t> plain(kCiphertextSize - CRYPTO_MAC_SIZE);
+            int plen = decrypt_data(mem, sender_pk, node->dht_secret_key(), nonce, ciphertext,
+                kCiphertextSize, plain.data());
+
+            if (plen > 0) {
+                // The real PK (client_id) is in the payload at offset ONION_PING_ID_SIZE (32).
+                const uint8_t *real_pk = plain.data() + 32;
+                seen_announcements.insert(
+                    std::vector<uint8_t>(real_pk, real_pk + CRYPTO_PUBLIC_KEY_SIZE));
+            } else {
+                total_decryption_failures++;
+#if 0
+                fprintf(stderr, "Node %02x%02x... FAILED to decrypt announcement from %02x%02x...
+                (size %zu)\n",
+                       node->dht_public_key()[0], node->dht_public_key()[1], sender_pk[0],
+                       sender_pk[1], data.size());
+#endif
+            }
+        }
+    };
+
+    bob.node().endpoint->set_recv_observer(
+        [&](const std::vector<uint8_t> &data, const IP_Port &from) { observer(&bob, data, from); });
+    charlie.node().endpoint->set_recv_observer(
+        [&](const std::vector<uint8_t> &data, const IP_Port &from) {
+            observer(&charlie, data, from);
+        });
+    dave.node().endpoint->set_recv_observer(
+        [&](const std::vector<uint8_t> &data, const IP_Port &from) {
+            observer(&dave, data, from);
+        });
+
+    // Give Alice time to connect.
+    for (int i = 0; i < 30; ++i) {
+        env.advance_time(500);
+        alice.poll();
+        for (auto node : nodes)
+            node->poll();
+        if (onion_connection_status(alice.get_onion_client()) != ONION_CONNECTION_STATUS_NONE) {
+            break;
+        }
+    }
+
+    ASSERT_NE(onion_connection_status(alice.get_onion_client()), ONION_CONNECTION_STATUS_NONE);
+
+    const int kNumFriends = 2;
+    std::vector<std::vector<uint8_t>> friend_pks;
+
+    for (int i = 0; i < kNumFriends; ++i) {
+        uint8_t pk[CRYPTO_PUBLIC_KEY_SIZE], sk[CRYPTO_SECRET_KEY_SIZE];
+        crypto_new_keypair(alice.get_random(), pk, sk);
+        onion_addfriend(alice.get_onion_client(), pk);
+        friend_pks.push_back(std::vector<uint8_t>(pk, pk + CRYPTO_PUBLIC_KEY_SIZE));
+    }
+
+    // Wait for announcements.
+    for (int i = 0; i < 20; ++i) {
+        env.advance_time(1000);
+        alice.poll();
+        for (auto node : nodes)
+            node->poll();
+
+        // If we've seen most friends announced, we can stop early.
+        int found_count = 0;
+        for (const auto &pk : friend_pks) {
+            if (seen_announcements.count(pk))
+                found_count++;
+        }
+        if (found_count >= kNumFriends) {
+            break;
+        }
+    }
+
+    // On incorrect code, we expect many decryption failures because Alice reuses shared keys.
+    // On correct code, there should be zero decryption failures.
+    EXPECT_EQ(total_decryption_failures, 0) << "Decryption failed at the target node! This "
+                                               "indicates Alice reused a shared key incorrectly.";
+
+    int found_count = 0;
+    for (const auto &pk : friend_pks) {
+        if (seen_announcements.count(pk))
+            found_count++;
+    }
+    EXPECT_GE(found_count, kNumFriends / 2)
+        << "At least some friends should have been announced successfully.";
+}
+
+TEST_F(OnionClientTest, SharedKeyReuseOnEviction)
+{
+    OnionNode alice(env, 33445);
+    const uint8_t *alice_pk = alice.real_public_key();
+
+    // Alice adds a friend
+    uint8_t friend_pk[CRYPTO_PUBLIC_KEY_SIZE];
+    uint8_t friend_sk[CRYPTO_SECRET_KEY_SIZE];
+    crypto_new_keypair(alice.get_random(), friend_pk, friend_sk);
+    onion_addfriend(alice.get_onion_client(), friend_pk);
+
+    // We use 20 nodes to ensure we fill the announcement list (size 12) and trigger evictions.
+    std::vector<std::unique_ptr<OnionNode>> nodes;
+    for (int i = 0; i < 20; ++i) {
+        nodes.push_back(std::make_unique<OnionNode>(env, 33446 + i));
+        IP_Port ip = nodes.back()->get_ip_port();
+        onion_add_bs_path_node(alice.get_onion_client(), &ip, nodes.back()->dht_public_key());
+    }
+
+    // Make everyone know everyone via bootstrap
+    for (auto &n1 : nodes) {
+        // Bootstrap Alice to this node
+        IP_Port ip1 = n1->get_ip_port();
+        dht_bootstrap(alice.get_dht(), &ip1, n1->dht_public_key());
+
+        for (auto &n2 : nodes) {
+            if (n1 == n2)
+                continue;
+            IP_Port ip2 = n2->get_ip_port();
+            dht_bootstrap(n1->get_dht(), &ip2, n2->dht_public_key());
+        }
+    }
+
+    // Alice connects
+    for (int i = 0; i < 20; ++i) {
+        env.advance_time(500);
+        alice.poll();
+        for (auto &n : nodes)
+            n->poll();
+        if (onion_connection_status(alice.get_onion_client()) != ONION_CONNECTION_STATUS_NONE)
+            break;
+    }
+
+    int total_decrypted = 0;
+    int total_failed = 0;
+    Tox_Memory mem_struct = env.fake_memory().get_c_memory();
+    const Memory *mem = &mem_struct;
+
+    auto observer = [&](OnionNode *node, const std::vector<uint8_t> &data) {
+        if (data.size() < 1 + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE)
+            return;
+
+        // Check for announce request (0x83 or 0x87)
+        if (data[0] != 0x83 && data[0] != 0x87)
+            return;
+
+        const uint8_t *nonce = data.data() + 1;
+        const uint8_t *sender_pk = data.data() + 1 + CRYPTO_NONCE_SIZE;
+
+        const uint8_t *ciphertext = sender_pk + CRYPTO_PUBLIC_KEY_SIZE;
+        // The announce request ciphertext is exactly 120 bytes.
+        const size_t kCiphertextSize = 120;
+
+        if (data.size() < (1 + CRYPTO_NONCE_SIZE + CRYPTO_PUBLIC_KEY_SIZE + kCiphertextSize))
+            return;
+
+        std::vector<uint8_t> plain(kCiphertextSize - CRYPTO_MAC_SIZE);
+        int plen = decrypt_data(mem, sender_pk, node->dht_secret_key(), nonce, ciphertext,
+            kCiphertextSize, plain.data());
+
+        if (plen > 0) {
+            total_decrypted++;
+        } else {
+            total_failed++;
+        }
+    };
+
+    for (auto &n : nodes) {
+        n->node().endpoint->set_recv_observer([&, ptr = n.get()](const std::vector<uint8_t> &data,
+                                                  const IP_Port &from) { observer(ptr, data); });
+    }
+
+    // Run for a while to ensure many announcements are sent and some slots are reused.
+    for (int i = 0; i < 30; ++i) {
+        env.advance_time(1000);
+        alice.poll();
+        for (auto &n : nodes)
+            n->poll();
+    }
+
+    EXPECT_GT(total_decrypted, 0);
+    EXPECT_EQ(total_failed, 0)
+        << "Decryption failed! This indicates Alice reused a shared key incorrectly after a node "
+           "slot was evicted and replaced.";
 }
 
 }  // namespace


### PR DESCRIPTION
TODO: `path_nodes_shared_keys` is probably unsafe. I am investigating and trying to produce a conclusive test result in which I can show why it's unsafe.

-----
1. Shared key caching in `Onion_Node` within `onion_client.c`. Allows `client_send_announce_request` to reuse precomputed shared keys when communicating with onion nodes, avoiding expensive Curve25519 `encrypt_precompute` calls on every announce packet.
2. Refactor `shared_key_cache_lookup` in `shared_key_cache.c` for better performance:
    * Use a better hash (XOR of 4 bytes) for bucket distribution.
    * Return immediately upon finding a key (skipping unnecessary housekeeping).
    * Perform housekeeping only on cache misses to evict timed-out keys.
    * Prioritize empty slots over eviction when inserting new keys.
3. Update `create_announce_request` logic to support symmetric encryption via `create_announce_request_symmetric` and pass shared key arguments through the call stack (`do_friend`, `do_announce`, `populate_path_nodes`, `client_send_announce_request`).

### 1. Disconnected Nodes (Major Improvement)

*Optimizing the handling of timed-out or unreachable nodes yields the
largest gains.*

| Benchmark Case | master (ns) | onion-opt-2 (ns) | Delta | Status |
| :--- | :--- | :--- | :--- | :--- |
| **Disconnected/10** | 521,883 | 332,101 | **-36.36%** | 🚀 Huge Win |
| **Disconnected/100** | 3,150,498 | 1,527,138 | **-51.53%** | 🚀 Huge Win |
| **Disconnected/1000** | 22,779,786 | 12,365,778 | **-45.72%** | 🚀 Huge Win |
| **Disconnected/2000** | 41,811,633 | 24,844,111 | **-40.58%** | 🚀 Huge Win |

### 2. Connected Nodes & General Iteration

*Standard operation shows consistent, measurable improvements.*

| Benchmark Case | master (ns) | onion-opt-2 (ns) | Delta | Status |
| :--- | :--- | :--- | :--- | :--- |
| **Connected/10** | 1,446 | 1,341 | **-7.26%** | ✅ Improved |
| **Connected/20** | 2,470 | 2,327 | **-5.79%** | ✅ Improved |
| **Iterate/200** | 2,330 | 2,237 | **-3.99%** | ✅ Improved |
| **Iterate/300** | 3,233 | 3,193 | **-1.24%** | ✅ Improved |
| **Iterate/0** | 243 | 239 | **-1.65%** | ✅ Improved |

### 3. Neutral / Noise

*Results within the margin of error.*

| Benchmark Case | master (ns) | onion-opt-2 (ns) | Delta |
| :--- | :--- | :--- | :--- |
| **Connected/0** | 239 | 239 | 0.00% |
| **Disconnected/0** | 98,053 | 99,186 | +1.16% |
| **Connected/50** | 5,541 | 5,602 | +1.10% |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2970)
<!-- Reviewable:end -->
