### PR TITLE
cleanup: Use tox_attributes.h in tox_private.h and install it.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,6 +18,7 @@ genrule(
     outs = [
         "tox/toxav.h",
         "tox/tox.h",
+        "tox/tox_attributes.h",
         "tox/tox_dispatch.h",
         "tox/tox_events.h",
         "tox/tox_log_level.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,7 @@ set(toxcore_API_HEADERS
   ${toxcore_SOURCE_DIR}/toxcore/tox_options.h^tox)
 if(EXPERIMENTAL_API)
   set(toxcore_API_HEADERS ${toxcore_API_HEADERS}
+    ${toxcore_SOURCE_DIR}/toxcore/tox_attributes.h^tox
     ${toxcore_SOURCE_DIR}/toxcore/tox_dispatch.h^tox
     ${toxcore_SOURCE_DIR}/toxcore/tox_events.h^tox
     ${toxcore_SOURCE_DIR}/toxcore/tox_private.h^tox

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 exports_files(
     srcs = [
         "tox.h",
+        "tox_attributes.h",
         "tox_dispatch.h",
         "tox_events.h",
         "tox_log_level.h",
@@ -1318,6 +1319,7 @@ cc_library(
         ":os_memory",
         ":os_random",
         ":state",
+        ":tox_attributes",
         ":tox_log_level",
         ":tox_options",
         ":util",

--- a/toxcore/tox_attributes.h
+++ b/toxcore/tox_attributes.h
@@ -1,12 +1,9 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later
- * Copyright © 2022-2025 The TokTok team.
+ * Copyright © 2022-2026 The TokTok team.
  */
 
 /**
  * nonnull attributes for GCC/Clang and Cimple.
- *
- * This file is a modified version of c-toxcore/toxcore/attributes.h with a
- * `tox_` prefix added to the macros to avoid conflicts with client code.
  */
 #ifndef C_TOXCORE_TOXCORE_TOX_ATTRIBUTES_H
 #define C_TOXCORE_TOXCORE_TOX_ATTRIBUTES_H
@@ -18,12 +15,6 @@
 #ifndef __clang__
 #define _Nonnull
 #define _Nullable
-#endif
-
-#ifdef SPARSE
-#define tox_bitwise __attribute__((bitwise))
-#else
-#define tox_bitwise
 #endif
 
 //!TOKSTYLE+

--- a/toxcore/tox_private.h
+++ b/toxcore/tox_private.h
@@ -10,8 +10,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "attributes.h"
 #include "tox.h"
+#include "tox_attributes.h"
 #include "tox_options.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Only when using experimental APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2972)
<!-- Reviewable:end -->
