### PR TITLE
refactor: Use `std::` prefixes more consistently in C++ code.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,6 +8,7 @@ genrule(
     srcs = [
         "//c-toxcore/toxav:toxav.h",
         "//c-toxcore/toxcore:tox.h",
+        "//c-toxcore/toxcore:tox_attributes.h",
         "//c-toxcore/toxcore:tox_dispatch.h",
         "//c-toxcore/toxcore:tox_events.h",
         "//c-toxcore/toxcore:tox_log_level.h",
@@ -29,6 +30,7 @@ genrule(
     cmd = """
         cp $(location //c-toxcore/toxav:toxav.h) $(GENDIR)/c-toxcore/tox/toxav.h
         cp $(location //c-toxcore/toxcore:tox.h) $(GENDIR)/c-toxcore/tox/tox.h
+        cp $(location //c-toxcore/toxcore:tox_attributes.h) $(GENDIR)/c-toxcore/tox/tox_attributes.h
         cp $(location //c-toxcore/toxcore:tox_dispatch.h) $(GENDIR)/c-toxcore/tox/tox_dispatch.h
         cp $(location //c-toxcore/toxcore:tox_events.h) $(GENDIR)/c-toxcore/tox/tox_events.h
         cp $(location //c-toxcore/toxcore:tox_log_level.h) $(GENDIR)/c-toxcore/tox/tox_log_level.h

--- a/other/docker/modules/check
+++ b/other/docker/modules/check
@@ -9,92 +9,59 @@ from typing import Any
 from typing import Dict
 from typing import List
 
-STD_MODULE = """module std [system] {
-  textual header "/usr/include/alloca.h"
-  textual header "/usr/include/assert.h"
-  textual header "/usr/include/c++/14.2.0/algorithm"
-  textual header "/usr/include/c++/14.2.0/array"
-  textual header "/usr/include/c++/14.2.0/atomic"
-  textual header "/usr/include/c++/14.2.0/cassert"
-  textual header "/usr/include/c++/14.2.0/cerrno"
-  textual header "/usr/include/c++/14.2.0/chrono"
-  textual header "/usr/include/c++/14.2.0/climits"
-  textual header "/usr/include/c++/14.2.0/compare"
-  textual header "/usr/include/c++/14.2.0/condition_variable"
-  textual header "/usr/include/c++/14.2.0/cstddef"
-  textual header "/usr/include/c++/14.2.0/cstdint"
-  textual header "/usr/include/c++/14.2.0/cstdio"
-  textual header "/usr/include/c++/14.2.0/cstdlib"
-  textual header "/usr/include/c++/14.2.0/cstring"
-  textual header "/usr/include/c++/14.2.0/deque"
-  textual header "/usr/include/c++/14.2.0/functional"
-  textual header "/usr/include/c++/14.2.0/future"
-  textual header "/usr/include/c++/14.2.0/iomanip"
-  textual header "/usr/include/c++/14.2.0/iosfwd"
-  textual header "/usr/include/c++/14.2.0/iostream"
-  textual header "/usr/include/c++/14.2.0/limits"
-  textual header "/usr/include/c++/14.2.0/map"
-  textual header "/usr/include/c++/14.2.0/memory"
-  textual header "/usr/include/c++/14.2.0/mutex"
-  textual header "/usr/include/c++/14.2.0/new"
-  textual header "/usr/include/c++/14.2.0/optional"
-  textual header "/usr/include/c++/14.2.0/ostream"
-  textual header "/usr/include/c++/14.2.0/queue"
-  textual header "/usr/include/c++/14.2.0/random"
-  textual header "/usr/include/c++/14.2.0/set"
-  textual header "/usr/include/c++/14.2.0/stdlib.h"
-  textual header "/usr/include/c++/14.2.0/string"
-  textual header "/usr/include/c++/14.2.0/thread"
-  textual header "/usr/include/c++/14.2.0/type_traits"
-  textual header "/usr/include/c++/14.2.0/vector"
-  textual header "/usr/include/errno.h"
-  textual header "/usr/include/fortify/stdio.h"
-  textual header "/usr/include/fortify/string.h"
-  textual header "/usr/include/fortify/unistd.h"
-  textual header "/usr/include/limits.h"
-  textual header "/usr/include/stdarg.h"
-  textual header "/usr/include/stdbool.h"
-  textual header "/usr/include/stddef.h"
-  textual header "/usr/include/stdint.h"
-  textual header "/usr/include/sys/time.h"
-  textual header "/usr/include/sys/types.h"
-  textual header "/usr/include/time.h"
+# We no longer define 'std' or 'musl' manually.
+# We rely on -fimplicit-module-maps to find the system-provided ones.
+# We only define modules for our project and third-party libraries.
+EXTRA_MODULES = """
+module "_benchmark" [system] {
+  header "/usr/include/benchmark/benchmark.h"
+  export *
 }
-module "c_toxcore_third_party_cmp" {
-  header "third_party/cmp/cmp.h"
-  use std
+module "_com_google_googletest___gtest" [system] {
+  header "/usr/include/gtest/gtest.h"
+  header "/usr/include/gmock/gmock.h"
+  export *
 }
-module "c_toxcore_toxencryptsave_defines" {
-  header "toxencryptsave/defines.h"
+module "_com_google_googletest___gtest_main" [system] {
+    use _com_google_googletest___gtest
+    export *
 }
-module "_benchmark" {
-  textual header "/usr/include/benchmark/benchmark.h"
-  use std
+module "_libsodium" [system] {
+  header "/usr/include/sodium.h"
+  export *
 }
-module "_com_google_googletest___gtest" {
-  textual header "/usr/include/gmock/gmock.h"
-  textual header "/usr/include/gtest/gtest.h"
-  use std
+module "_c_std" [system] {
+  header "/usr/include/stdint.h"
+  header "/usr/include/stdbool.h"
+  header "/usr/include/stddef.h"
+  header "/usr/include/stdio.h"
+  header "/usr/include/stdlib.h"
+  header "/usr/include/string.h"
+  header "/usr/include/inttypes.h"
+  export *
 }
-module "_com_google_googletest___gtest_main" {
-    // Dummy module for gtest_main, assuming it links but headers are in gtest
-    use "_com_google_googletest___gtest"
+module "_pthread" [system] {
+  header "/usr/include/pthread.h"
+  use _c_std
+  export _c_std
+  export *
 }
-module "_libsodium" {
-  textual header "/usr/include/sodium.h"
-}
-module "_pthread" {
-  textual header "/usr/include/pthread.h"
-}
-module "_psocket" {
-  textual header "/usr/include/arpa/inet.h"
-  textual header "/usr/include/fcntl.h"
-  textual header "/usr/include/fortify/sys/socket.h"
-  textual header "/usr/include/linux/if.h"
-  textual header "/usr/include/netdb.h"
-  textual header "/usr/include/netinet/in.h"
-  textual header "/usr/include/sys/epoll.h"
-  textual header "/usr/include/sys/ioctl.h"
+module "_psocket" [system] {
+  header "/usr/include/arpa/inet.h"
+  header "/usr/include/fcntl.h"
+  header "/usr/include/fortify/sys/socket.h"
+  header "/usr/include/linux/if.h"
+  header "/usr/include/netdb.h"
+  header "/usr/include/netinet/in.h"
+  header "/usr/include/sys/epoll.h"
+  header "/usr/include/sys/ioctl.h"
+  header "/usr/include/sys/socket.h"
+  header "/usr/include/sys/stat.h"
+  header "/usr/include/sys/types.h"
+  header "/usr/include/unistd.h"
+  use _c_std
+  export _c_std
+  export *
 }
 """
 
@@ -235,21 +202,33 @@ def main() -> None:
             )
 
     with open("module.modulemap", "w") as f:
-        f.write(STD_MODULE)
+        f.write(EXTRA_MODULES)
         for t in TARGETS:
             f.write(f'module "{t.label}" {{\n')
             for hdr in t.hdrs:
+                # Proper modular header
                 f.write(f'  header "{os.path.join(t.package, hdr)}"\n')
-            f.write("  use std\n")
+
+            # Export all dependencies
             for dep in t.deps:
                 mod_name = resolve_module_name(dep, t.package)
-                # Export all dependencies to ensure visibility of types used in headers
                 f.write(f"  use {mod_name}\n")
                 f.write(f"  export {mod_name}\n")
+
+            # Basic system modules used everywhere
+            f.write("  use std\n")
+            f.write("  use _c_std\n")
+            f.write("  use _psocket\n")
+            f.write("  use _pthread\n")
+            f.write("  use _libsodium\n")
+            f.write("  export *\n")
+
             f.write("}\n")
 
-    # with open("module.modulemap", "r") as f:
-    #     print(f.read(), file=sys.stderr)
+    with open("module.modulemap", "r") as f:
+        print("--- Generated module.modulemap ---", file=sys.stderr)
+        print(f.read(), file=sys.stderr)
+        print("----------------------------------", file=sys.stderr)
 
     src_to_module = {}
     for t in TARGETS:
@@ -257,8 +236,8 @@ def main() -> None:
             full_src = os.path.join(t.package, src)
             src_to_module[full_src] = t.label
 
-    # Sort for deterministic output
     all_srcs = sorted(src_to_module.keys())
+    os.makedirs("/tmp/clang-modules", exist_ok=True)
 
     for src in all_srcs:
         print(f"Validating {src}", file=sys.stderr)
@@ -269,6 +248,7 @@ def main() -> None:
                 "clang",
                 "-fsyntax-only",
                 "-xc++",
+                "-stdlib=libc++",
                 "-Wall",
                 "-Werror",
                 "-Wno-missing-braces",
@@ -276,7 +256,9 @@ def main() -> None:
                 "-std=c++23",
                 "-fdiagnostics-color=always",
                 "-fmodules",
-                "-fmodules-strict-decluse",
+                "-fimplicit-module-maps",
+                "-fbuiltin-module-map",
+                "-fmodules-cache-path=/tmp/clang-modules",
                 "-fmodule-map-file=module.modulemap",
                 f"-fmodule-name={module_name}",
                 "-I.",

--- a/other/docker/modules/modules.Dockerfile
+++ b/other/docker/modules/modules.Dockerfile
@@ -1,10 +1,12 @@
-FROM alpine:3.21.0
+FROM alpine:3.23.0
 
 RUN ["apk", "add", "--no-cache", \
  "bash", \
  "benchmark-dev", \
  "clang", \
  "gtest-dev", \
+ "libc++-dev", \
+ "libc++-static", \
  "libconfig-dev", \
  "libsodium-dev", \
  "libvpx-dev", \

--- a/testing/support/doubles/fake_clock.hh
+++ b/testing/support/doubles/fake_clock.hh
@@ -2,6 +2,7 @@
 #define C_TOXCORE_TESTING_SUPPORT_DOUBLES_FAKE_CLOCK_H
 
 #include <atomic>
+#include <cstdint>
 
 #include "../public/clock.hh"
 

--- a/testing/support/doubles/fake_network_stack.hh
+++ b/testing/support/doubles/fake_network_stack.hh
@@ -2,7 +2,9 @@
 #define C_TOXCORE_TESTING_SUPPORT_DOUBLES_FAKE_NETWORK_STACK_H
 
 #include <map>
+#include <memory>
 #include <mutex>
+#include <vector>
 
 #include "../public/network.hh"
 #include "fake_sockets.hh"

--- a/testing/support/doubles/fake_sockets.cc
+++ b/testing/support/doubles/fake_sockets.cc
@@ -3,7 +3,11 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstring>
+#include <deque>
+#include <functional>
 #include <iostream>
+#include <mutex>
+#include <vector>
 
 #include "network_universe.hh"
 

--- a/testing/support/public/simulation.hh
+++ b/testing/support/public/simulation.hh
@@ -1,6 +1,7 @@
 #ifndef C_TOXCORE_TESTING_SUPPORT_SIMULATION_H
 #define C_TOXCORE_TESTING_SUPPORT_SIMULATION_H
 
+#include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <memory>

--- a/testing/support/public/tox_network.hh
+++ b/testing/support/public/tox_network.hh
@@ -5,6 +5,8 @@
 #ifndef C_TOXCORE_TESTING_SUPPORT_TOX_NETWORK_H
 #define C_TOXCORE_TESTING_SUPPORT_TOX_NETWORK_H
 
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include "simulation.hh"

--- a/toxav/audio_bench.cc
+++ b/toxav/audio_bench.cc
@@ -5,6 +5,8 @@
 #include <benchmark/benchmark.h>
 
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <vector>
 
@@ -28,9 +30,9 @@ public:
         mono_time = mono_time_new(mem, mock_time_cb, &tm);
         ac = ac_new(mono_time, log, 123, nullptr, nullptr);
 
-        sampling_rate = static_cast<uint32_t>(state.range(0));
-        channels = static_cast<uint8_t>(state.range(1));
-        uint32_t bitrate = (channels == 1) ? 32000 : 64000;
+        sampling_rate = static_cast<std::uint32_t>(state.range(0));
+        channels = static_cast<std::uint8_t>(state.range(1));
+        std::uint32_t bitrate = (channels == 1) ? 32000 : 64000;
 
         ac_reconfigure_encoder(ac, bitrate, sampling_rate, channels);
 
@@ -66,19 +68,19 @@ public:
     MockTime tm;
     ACSession *ac = nullptr;
     RtpMock rtp_mock;
-    uint32_t sampling_rate = 0;
-    uint8_t channels = 0;
-    size_t sample_count = 0;
-    std::vector<int16_t> pcm;
+    std::uint32_t sampling_rate = 0;
+    std::uint8_t channels = 0;
+    std::size_t sample_count = 0;
+    std::vector<std::int16_t> pcm;
 };
 
 // Benchmark encoding a sequence of silent audio frames.
 BENCHMARK_DEFINE_F(AudioBench, EncodeSilentSequence)(benchmark::State &state)
 {
-    std::vector<int16_t> silent_pcm(sample_count * channels);
+    std::vector<std::int16_t> silent_pcm(sample_count * channels);
     fill_silent_frame(channels, sample_count, silent_pcm);
 
-    std::vector<uint8_t> encoded(2000);
+    std::vector<std::uint8_t> encoded(2000);
 
     for (auto _ : state) {
         int encoded_size
@@ -97,13 +99,13 @@ BENCHMARK_DEFINE_F(AudioBench, EncodeSequence)(benchmark::State &state)
 {
     int frame_index = 0;
     const int num_prefilled = 50;
-    std::vector<std::vector<int16_t>> pcms(
-        num_prefilled, std::vector<int16_t>(sample_count * channels));
+    std::vector<std::vector<std::int16_t>> pcms(
+        num_prefilled, std::vector<std::int16_t>(sample_count * channels));
     for (int i = 0; i < num_prefilled; ++i) {
         fill_audio_frame(sampling_rate, channels, i, sample_count, pcms[i]);
     }
 
-    std::vector<uint8_t> encoded(2000);
+    std::vector<std::uint8_t> encoded(2000);
 
     for (auto _ : state) {
         int idx = frame_index % num_prefilled;
@@ -125,16 +127,16 @@ BENCHMARK_REGISTER_F(AudioBench, EncodeSequence)
 BENCHMARK_DEFINE_F(AudioBench, DecodeSequence)(benchmark::State &state)
 {
     const int num_frames = 50;
-    std::vector<std::vector<uint8_t>> encoded_frames(num_frames);
+    std::vector<std::vector<std::uint8_t>> encoded_frames(num_frames);
 
     // Pre-encode
-    std::vector<uint8_t> encoded_tmp(2000);
+    std::vector<std::uint8_t> encoded_tmp(2000);
     for (int i = 0; i < num_frames; ++i) {
         fill_audio_frame(sampling_rate, channels, i, sample_count, pcm);
         int size = ac_encode(ac, pcm.data(), sample_count, encoded_tmp.data(), encoded_tmp.size());
 
         encoded_frames[i].resize(4 + size);
-        uint32_t net_sr = net_htonl(sampling_rate);
+        std::uint32_t net_sr = net_htonl(sampling_rate);
         std::memcpy(encoded_frames[i].data(), &net_sr, 4);
         std::memcpy(encoded_frames[i].data() + 4, encoded_tmp.data(), size);
     }
@@ -143,7 +145,7 @@ BENCHMARK_DEFINE_F(AudioBench, DecodeSequence)(benchmark::State &state)
     for (auto _ : state) {
         int idx = frame_index % num_frames;
         rtp_send_data(log, rtp_mock.recv_session, encoded_frames[idx].data(),
-            static_cast<uint32_t>(encoded_frames[idx].size()), false);
+            static_cast<std::uint32_t>(encoded_frames[idx].size()), false);
         ac_iterate(ac);
         frame_index++;
     }
@@ -161,26 +163,26 @@ BENCHMARK_DEFINE_F(AudioBench, FullSequence)(benchmark::State &state)
 {
     int frame_index = 0;
     const int num_prefilled = 50;
-    std::vector<std::vector<int16_t>> pcms(
-        num_prefilled, std::vector<int16_t>(sample_count * channels));
+    std::vector<std::vector<std::int16_t>> pcms(
+        num_prefilled, std::vector<std::int16_t>(sample_count * channels));
     for (int i = 0; i < num_prefilled; ++i) {
         fill_audio_frame(sampling_rate, channels, i, sample_count, pcms[i]);
     }
 
-    std::vector<uint8_t> encoded_tmp(2000);
+    std::vector<std::uint8_t> encoded_tmp(2000);
 
     for (auto _ : state) {
         int idx = frame_index % num_prefilled;
         int size
             = ac_encode(ac, pcms[idx].data(), sample_count, encoded_tmp.data(), encoded_tmp.size());
 
-        std::vector<uint8_t> payload(4 + size);
-        uint32_t net_sr = net_htonl(sampling_rate);
+        std::vector<std::uint8_t> payload(4 + size);
+        std::uint32_t net_sr = net_htonl(sampling_rate);
         std::memcpy(payload.data(), &net_sr, 4);
         std::memcpy(payload.data() + 4, encoded_tmp.data(), size);
 
         rtp_send_data(log, rtp_mock.recv_session, payload.data(),
-            static_cast<uint32_t>(payload.size()), false);
+            static_cast<std::uint32_t>(payload.size()), false);
         ac_iterate(ac);
 
         frame_index++;

--- a/toxav/av_test_support.cc
+++ b/toxav/av_test_support.cc
@@ -2,15 +2,17 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
+#include <cstdlib>
 #include <cstring>
 
 #include "../toxcore/os_memory.h"
 
 // Mock Time
-uint64_t mock_time_cb(void *ud) { return static_cast<MockTime *>(ud)->t; }
+std::uint64_t mock_time_cb(void *ud) { return static_cast<MockTime *>(ud)->t; }
 
 // RTP Mock
-int RtpMock::send_packet(void *user_data, const uint8_t *data, uint16_t length)
+int RtpMock::send_packet(void *user_data, const std::uint8_t *data, std::uint16_t length)
 {
     auto *self = static_cast<RtpMock *>(user_data);
     if (self->capture_packets) {
@@ -21,7 +23,7 @@ int RtpMock::send_packet(void *user_data, const uint8_t *data, uint16_t length)
                 self->captured_packets[0].assign(data, data + length);
             }
         } else {
-            self->captured_packets.push_back(std::vector<uint8_t>(data, data + length));
+            self->captured_packets.push_back(std::vector<std::uint8_t>(data, data + length));
         }
     }
     if (self->auto_forward && self->recv_session) {
@@ -47,28 +49,29 @@ int RtpMock::noop_cb(const Mono_Time * /*mono_time*/, void * /*cs*/, RTPMessage 
 }
 
 // Audio Helpers
-void fill_audio_frame(uint32_t sampling_rate, uint8_t channels, int frame_index,
-    size_t sample_count, std::vector<int16_t> &pcm)
+void fill_audio_frame(std::uint32_t sampling_rate, std::uint8_t channels, int frame_index,
+    std::size_t sample_count, std::vector<std::int16_t> &pcm)
 {
     const double pi = std::acos(-1.0);
     double amplitude = 10000.0;
 
-    for (size_t i = 0; i < sample_count; ++i) {
+    for (std::size_t i = 0; i < sample_count; ++i) {
         double t = static_cast<double>(frame_index * sample_count + i) / sampling_rate;
         // Linear frequency sweep from 50Hz to 440Hz over 1 second (50 frames)
         // f(t) = 50 + 390t
         // phi(t) = 2*pi * (50t + 195t^2)
         double phi = 2.0 * pi * (50.0 * t + 195.0 * t * t);
-        int16_t val = static_cast<int16_t>(std::sin(phi) * amplitude);
-        for (uint8_t c = 0; c < channels; ++c) {
+        std::int16_t val = static_cast<std::int16_t>(std::sin(phi) * amplitude);
+        for (std::uint8_t c = 0; c < channels; ++c) {
             pcm[i * channels + c] = val;
         }
     }
 }
 
-void fill_silent_frame(uint8_t channels, size_t sample_count, std::vector<int16_t> &pcm)
+void fill_silent_frame(
+    std::uint8_t channels, std::size_t sample_count, std::vector<std::int16_t> &pcm)
 {
-    for (size_t i = 0; i < sample_count * channels; ++i) {
+    for (std::size_t i = 0; i < sample_count * channels; ++i) {
         // Very low amplitude white noise (simulating silence with background hiss)
         pcm[i] = (std::rand() % 21) - 10;
     }
@@ -77,8 +80,8 @@ void fill_silent_frame(uint8_t channels, size_t sample_count, std::vector<int16_
 AudioTestData::AudioTestData() = default;
 AudioTestData::~AudioTestData() = default;
 
-void AudioTestData::receive_frame(uint32_t friend_number, const int16_t *pcm, size_t sample_count,
-    uint8_t channels, uint32_t sampling_rate, void *user_data)
+void AudioTestData::receive_frame(std::uint32_t friend_number, const std::int16_t *pcm,
+    std::size_t sample_count, std::uint8_t channels, std::uint32_t sampling_rate, void *user_data)
 {
     auto *self = static_cast<AudioTestData *>(user_data);
     self->friend_number = friend_number;
@@ -89,8 +92,8 @@ void AudioTestData::receive_frame(uint32_t friend_number, const int16_t *pcm, si
 }
 
 // Video Helpers
-void fill_video_frame(uint16_t width, uint16_t height, int frame_index, std::vector<uint8_t> &y,
-    std::vector<uint8_t> &u, std::vector<uint8_t> &v)
+void fill_video_frame(std::uint16_t width, std::uint16_t height, int frame_index,
+    std::vector<std::uint8_t> &y, std::vector<std::uint8_t> &u, std::vector<std::uint8_t> &v)
 {
     // Background (dark gray)
     std::fill(y.begin(), y.end(), 32);
@@ -110,10 +113,10 @@ void fill_video_frame(uint16_t width, uint16_t height, int frame_index, std::vec
     }
 }
 
-double calculate_video_mse(uint16_t width, uint16_t height, int32_t ystride,
-    const std::vector<uint8_t> &y_recv, const std::vector<uint8_t> &y_orig)
+double calculate_video_mse(std::uint16_t width, std::uint16_t height, std::int32_t ystride,
+    const std::vector<std::uint8_t> &y_recv, const std::vector<std::uint8_t> &y_orig)
 {
-    if (y_recv.empty() || y_orig.size() != static_cast<size_t>(width) * height) {
+    if (y_recv.empty() || y_orig.size() != static_cast<std::size_t>(width) * height) {
         return 1e10;
     }
 
@@ -124,16 +127,16 @@ double calculate_video_mse(uint16_t width, uint16_t height, int32_t ystride,
             mse += diff * diff;
         }
     }
-    return mse / (static_cast<size_t>(width) * height);
+    return mse / (static_cast<std::size_t>(width) * height);
 }
 
 // Video Test Data Helper
 VideoTestData::VideoTestData() = default;
 VideoTestData::~VideoTestData() = default;
 
-void VideoTestData::receive_frame(uint32_t friend_number, uint16_t width, uint16_t height,
-    const uint8_t *y, const uint8_t *u, const uint8_t *v, int32_t ystride, int32_t ustride,
-    int32_t vstride, void *user_data)
+void VideoTestData::receive_frame(std::uint32_t friend_number, std::uint16_t width,
+    std::uint16_t height, const std::uint8_t *y, const std::uint8_t *u, const std::uint8_t *v,
+    std::int32_t ystride, std::int32_t ustride, std::int32_t vstride, void *user_data)
 {
     auto *self = static_cast<VideoTestData *>(user_data);
     self->friend_number = friend_number;
@@ -143,12 +146,12 @@ void VideoTestData::receive_frame(uint32_t friend_number, uint16_t width, uint16
     self->ustride = ustride;
     self->vstride = vstride;
 
-    self->y.assign(y, y + static_cast<size_t>(std::abs(ystride)) * height);
-    self->u.assign(u, u + static_cast<size_t>(std::abs(ustride)) * (height / 2));
-    self->v.assign(v, v + static_cast<size_t>(std::abs(vstride)) * (height / 2));
+    self->y.assign(y, y + static_cast<std::size_t>(std::abs(ystride)) * height);
+    self->u.assign(u, u + static_cast<std::size_t>(std::abs(ustride)) * (height / 2));
+    self->v.assign(v, v + static_cast<std::size_t>(std::abs(vstride)) * (height / 2));
 }
 
-double VideoTestData::calculate_mse(const std::vector<uint8_t> &y_orig) const
+double VideoTestData::calculate_mse(const std::vector<std::uint8_t> &y_orig) const
 {
     return calculate_video_mse(width, height, ystride, y, y_orig);
 }

--- a/toxav/av_test_support.hh
+++ b/toxav/av_test_support.hh
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -14,65 +15,67 @@
 
 // Mock Time
 struct MockTime {
-    uint64_t t = 1000;
+    std::uint64_t t = 1000;
 };
-uint64_t mock_time_cb(void *ud);
+std::uint64_t mock_time_cb(void *ud);
 
 // RTP Mock
 struct RtpMock {
     RTPSession *recv_session = nullptr;
-    std::vector<std::vector<uint8_t>> captured_packets;
+    std::vector<std::vector<std::uint8_t>> captured_packets;
     bool auto_forward = true;
     bool capture_packets = true;
     bool store_last_packet_only = false;
 
-    static int send_packet(void *user_data, const uint8_t *data, uint16_t length);
+    static int send_packet(void *user_data, const std::uint8_t *data, std::uint16_t length);
     static int audio_cb(const Mono_Time *mono_time, void *cs, RTPMessage *msg);
     static int video_cb(const Mono_Time *mono_time, void *cs, RTPMessage *msg);
     static int noop_cb(const Mono_Time *mono_time, void *cs, RTPMessage *msg);
 };
 
 // Audio Helpers
-void fill_audio_frame(uint32_t sampling_rate, uint8_t channels, int frame_index,
-    size_t sample_count, std::vector<int16_t> &pcm);
-void fill_silent_frame(uint8_t channels, size_t sample_count, std::vector<int16_t> &pcm);
+void fill_audio_frame(std::uint32_t sampling_rate, std::uint8_t channels, int frame_index,
+    std::size_t sample_count, std::vector<std::int16_t> &pcm);
+void fill_silent_frame(
+    std::uint8_t channels, std::size_t sample_count, std::vector<std::int16_t> &pcm);
 
 struct AudioTestData {
-    uint32_t friend_number = 0;
-    std::vector<int16_t> last_pcm;
-    size_t sample_count = 0;
-    uint8_t channels = 0;
-    uint32_t sampling_rate = 0;
+    std::uint32_t friend_number = 0;
+    std::vector<std::int16_t> last_pcm;
+    std::size_t sample_count = 0;
+    std::uint8_t channels = 0;
+    std::uint32_t sampling_rate = 0;
 
     AudioTestData();
     ~AudioTestData();
 
-    static void receive_frame(uint32_t friend_number, const int16_t *pcm, size_t sample_count,
-        uint8_t channels, uint32_t sampling_rate, void *user_data);
+    static void receive_frame(std::uint32_t friend_number, const std::int16_t *pcm,
+        std::size_t sample_count, std::uint8_t channels, std::uint32_t sampling_rate,
+        void *user_data);
 };
 
 // Video Helpers
-void fill_video_frame(uint16_t width, uint16_t height, int frame_index, std::vector<uint8_t> &y,
-    std::vector<uint8_t> &u, std::vector<uint8_t> &v);
-double calculate_video_mse(uint16_t width, uint16_t height, int32_t ystride,
-    const std::vector<uint8_t> &y_recv, const std::vector<uint8_t> &y_orig);
+void fill_video_frame(std::uint16_t width, std::uint16_t height, int frame_index,
+    std::vector<std::uint8_t> &y, std::vector<std::uint8_t> &u, std::vector<std::uint8_t> &v);
+double calculate_video_mse(std::uint16_t width, std::uint16_t height, std::int32_t ystride,
+    const std::vector<std::uint8_t> &y_recv, const std::vector<std::uint8_t> &y_orig);
 
 // Video Test Data Helper
 struct VideoTestData {
-    uint32_t friend_number = 0;
-    uint16_t width = 0;
-    uint16_t height = 0;
-    std::vector<uint8_t> y, u, v;
-    int32_t ystride = 0, ustride = 0, vstride = 0;
+    std::uint32_t friend_number = 0;
+    std::uint16_t width = 0;
+    std::uint16_t height = 0;
+    std::vector<std::uint8_t> y, u, v;
+    std::int32_t ystride = 0, ustride = 0, vstride = 0;
 
     VideoTestData();
     ~VideoTestData();
 
-    static void receive_frame(uint32_t friend_number, uint16_t width, uint16_t height,
-        const uint8_t *y, const uint8_t *u, const uint8_t *v, int32_t ystride, int32_t ustride,
-        int32_t vstride, void *user_data);
+    static void receive_frame(std::uint32_t friend_number, std::uint16_t width,
+        std::uint16_t height, const std::uint8_t *y, const std::uint8_t *u, const std::uint8_t *v,
+        std::int32_t ystride, std::int32_t ustride, std::int32_t vstride, void *user_data);
 
-    double calculate_mse(const std::vector<uint8_t> &y_orig) const;
+    double calculate_mse(const std::vector<std::uint8_t> &y_orig) const;
 };
 
 // Common Test Fixture

--- a/toxav/bwcontroller_test.cc
+++ b/toxav/bwcontroller_test.cc
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "../toxcore/logger.h"
@@ -13,17 +15,17 @@
 namespace {
 
 struct BwcTimeMock {
-    uint64_t t;
+    std::uint64_t t;
 };
 
-uint64_t bwc_mock_time_cb(void *ud) { return static_cast<BwcTimeMock *>(ud)->t; }
+std::uint64_t bwc_mock_time_cb(void *ud) { return static_cast<BwcTimeMock *>(ud)->t; }
 
 struct MockBwcData {
-    std::vector<std::vector<uint8_t>> sent_packets;
+    std::vector<std::vector<std::uint8_t>> sent_packets;
     std::vector<float> reported_losses;
-    uint32_t friend_number = 0;
+    std::uint32_t friend_number = 0;
 
-    static int send_packet(void *user_data, const uint8_t *data, uint16_t length)
+    static int send_packet(void *user_data, const std::uint8_t *data, std::uint16_t length)
     {
         auto *sd = static_cast<MockBwcData *>(user_data);
         if (sd->fail_send) {
@@ -34,7 +36,7 @@ struct MockBwcData {
     }
 
     static void loss_report(
-        BWController * /*bwc*/, uint32_t friend_number, float loss, void *user_data)
+        BWController * /*bwc*/, std::uint32_t friend_number, float loss, void *user_data)
     {
         auto *sd = static_cast<MockBwcData *>(user_data);
         sd->friend_number = friend_number;
@@ -79,7 +81,7 @@ TEST_F(BwcTest, BasicNewKill)
 TEST_F(BwcTest, SendUpdate)
 {
     MockBwcData sd;
-    uint32_t friend_number = 123;
+    std::uint32_t friend_number = 123;
     BWController *bwc = bwc_new(log, friend_number, MockBwcData::loss_report, &sd,
         MockBwcData::send_packet, &sd, mono_time);
     ASSERT_NE(bwc, nullptr);
@@ -107,7 +109,7 @@ TEST_F(BwcTest, SendUpdate)
     EXPECT_EQ(sd.sent_packets[0][0], BWC_PACKET_ID);
 
     // Packet contains lost (4 bytes) and recv (4 bytes)
-    uint32_t lost, recv;
+    std::uint32_t lost, recv;
     net_unpack_u32(sd.sent_packets[0].data() + 1, &lost);
     net_unpack_u32(sd.sent_packets[0].data() + 5, &recv);
 
@@ -120,12 +122,12 @@ TEST_F(BwcTest, SendUpdate)
 TEST_F(BwcTest, HandlePacket)
 {
     MockBwcData sd;
-    uint32_t friend_number = 123;
+    std::uint32_t friend_number = 123;
     BWController *bwc = bwc_new(log, friend_number, MockBwcData::loss_report, &sd,
         MockBwcData::send_packet, &sd, mono_time);
     ASSERT_NE(bwc, nullptr);
 
-    uint8_t packet[9];
+    std::uint8_t packet[9];
     packet[0] = BWC_PACKET_ID;
     net_pack_u32(packet + 1, 100);  // lost
     net_pack_u32(packet + 5, 900);  // recv
@@ -155,7 +157,7 @@ TEST_F(BwcTest, InvalidPacketSize)
     MockBwcData sd;
     BWController *bwc = bwc_new(
         log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
-    uint8_t packet[10] = {0};
+    std::uint8_t packet[10] = {0};
 
     // Correct size is 9
     bwc_handle_packet(bwc, packet, 8);
@@ -193,7 +195,7 @@ TEST_F(BwcTest, NullCallback)
     BWController *bwc
         = bwc_new(log, 123, nullptr, nullptr, MockBwcData::send_packet, &sd, mono_time);
 
-    uint8_t packet[9];
+    std::uint8_t packet[9];
     packet[0] = BWC_PACKET_ID;
     net_pack_u32(packet + 1, 100);  // lost
     net_pack_u32(packet + 5, 900);  // recv
@@ -213,7 +215,7 @@ TEST_F(BwcTest, ZeroLoss)
         log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
 
     // 1. Peer sends update with zero loss
-    uint8_t packet[9];
+    std::uint8_t packet[9];
     packet[0] = BWC_PACKET_ID;
     net_pack_u32(packet + 1, 0);  // lost
     net_pack_u32(packet + 5, 1000);  // recv
@@ -255,7 +257,7 @@ TEST_F(BwcTest, Overflow)
     bwc_add_recv(bwc, 1);
 
     ASSERT_EQ(sd.sent_packets.size(), 1);
-    uint32_t lost, recv;
+    std::uint32_t lost, recv;
     net_unpack_u32(sd.sent_packets[0].data() + 1, &lost);
     net_unpack_u32(sd.sent_packets[0].data() + 5, &recv);
 
@@ -324,7 +326,7 @@ TEST_F(BwcTest, RecvPlusLostOverflowBug)
     MockBwcData sd;
     BWController *bwc = bwc_new(
         log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
-    uint8_t packet[9];
+    std::uint8_t packet[9];
     packet[0] = BWC_PACKET_ID;
     net_pack_u32(packet + 1, 1);
     net_pack_u32(packet + 5, 0xFFFFFFFF);
@@ -342,7 +344,7 @@ TEST_F(BwcTest, RateLimitBypassBug)
         log, 123, MockBwcData::loss_report, &sd, MockBwcData::send_packet, &sd, mono_time);
     tm.t = 0xFFFFFFF0;
     mono_time_update(mono_time);
-    uint8_t packet[9];
+    std::uint8_t packet[9];
     packet[0] = BWC_PACKET_ID;
     net_pack_u32(packet + 1, 1);
     net_pack_u32(packet + 5, 100);

--- a/toxav/msi_test.cc
+++ b/toxav/msi_test.cc
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "../toxcore/logger.h"
@@ -14,8 +16,8 @@
 namespace {
 
 struct MockMsi {
-    std::vector<std::vector<uint8_t>> sent_packets;
-    std::vector<uint32_t> sent_to_friends;
+    std::vector<std::vector<std::uint8_t>> sent_packets;
+    std::vector<std::uint32_t> sent_to_friends;
 
     struct CallbackStats {
         int invite = 0;
@@ -30,7 +32,7 @@ struct MockMsi {
     MSIError last_error = MSI_E_NONE;
 
     static int send_packet(
-        void *user_data, uint32_t friend_number, const uint8_t *data, size_t length)
+        void *user_data, std::uint32_t friend_number, const std::uint8_t *data, std::size_t length)
     {
         auto *self = static_cast<MockMsi *>(user_data);
         self->sent_packets.emplace_back(data, data + length);
@@ -122,8 +124,8 @@ TEST_F(MsiTest, BasicNewKill)
 TEST_F(MsiTest, Invite)
 {
     MSICall *call = nullptr;
-    uint32_t friend_number = 123;
-    uint8_t capabilities = MSI_CAP_S_AUDIO | MSI_CAP_R_AUDIO;
+    std::uint32_t friend_number = 123;
+    std::uint8_t capabilities = MSI_CAP_S_AUDIO | MSI_CAP_R_AUDIO;
 
     int rc = msi_invite(log, session, &call, friend_number, capabilities);
     ASSERT_EQ(rc, 0);
@@ -146,11 +148,11 @@ TEST_F(MsiTest, Invite)
 
 TEST_F(MsiTest, HandleIncomingInvite)
 {
-    uint32_t friend_number = 456;
-    uint8_t peer_caps = MSI_CAP_S_VIDEO | MSI_CAP_R_VIDEO;
+    std::uint32_t friend_number = 456;
+    std::uint8_t peer_caps = MSI_CAP_S_VIDEO | MSI_CAP_R_VIDEO;
 
     // Craft invite packet
-    uint8_t invite_pkt[] = {
+    std::uint8_t invite_pkt[] = {
         1, 1, 0,  // ID_REQUEST, len 1, REQU_INIT
         3, 1, peer_caps,  // ID_CAPABILITIES, len 1, caps
         0  // end
@@ -168,14 +170,14 @@ TEST_F(MsiTest, HandleIncomingInvite)
 TEST_F(MsiTest, Answer)
 {
     // 1. Receive invite first
-    uint32_t friend_number = 456;
-    uint8_t peer_caps = MSI_CAP_S_VIDEO | MSI_CAP_R_VIDEO;
-    uint8_t invite_pkt[] = {1, 1, 0, 3, 1, peer_caps, 0};
+    std::uint32_t friend_number = 456;
+    std::uint8_t peer_caps = MSI_CAP_S_VIDEO | MSI_CAP_R_VIDEO;
+    std::uint8_t invite_pkt[] = {1, 1, 0, 3, 1, peer_caps, 0};
     msi_handle_packet(session, log, friend_number, invite_pkt, sizeof(invite_pkt));
     MSICall *call = mock.last_call;
 
     // 2. Answer it
-    uint8_t my_caps = MSI_CAP_S_AUDIO | MSI_CAP_R_AUDIO;
+    std::uint8_t my_caps = MSI_CAP_S_AUDIO | MSI_CAP_R_AUDIO;
     int rc = msi_answer(log, call, my_caps);
     ASSERT_EQ(rc, 0);
     EXPECT_EQ(call->state, MSI_CALL_ACTIVE);
@@ -206,14 +208,14 @@ TEST_F(MsiTest, Hangup)
 TEST_F(MsiTest, ChangeCapabilities)
 {
     // Setup active call
-    uint32_t friend_number = 123;
-    uint8_t invite_pkt[] = {1, 1, 0, 3, 1, 0, 0};
+    std::uint32_t friend_number = 123;
+    std::uint8_t invite_pkt[] = {1, 1, 0, 3, 1, 0, 0};
     msi_handle_packet(session, log, friend_number, invite_pkt, sizeof(invite_pkt));
     MSICall *call = mock.last_call;
     msi_answer(log, call, 0);
     mock.sent_packets.clear();
 
-    uint8_t new_caps = MSI_CAP_S_VIDEO;
+    std::uint8_t new_caps = MSI_CAP_S_VIDEO;
     int rc = msi_change_capabilities(log, call, new_caps);
     ASSERT_EQ(rc, 0);
     EXPECT_EQ(call->self_capabilities, new_caps);
@@ -226,7 +228,7 @@ TEST_F(MsiTest, ChangeCapabilities)
 TEST_F(MsiTest, PeerTimeout)
 {
     MSICall *call = nullptr;
-    uint32_t friend_number = 123;
+    std::uint32_t friend_number = 123;
     msi_invite(log, session, &call, friend_number, 0);
 
     msi_call_timeout(session, log, friend_number);
@@ -236,12 +238,12 @@ TEST_F(MsiTest, PeerTimeout)
 
 TEST_F(MsiTest, RemoteHangup)
 {
-    uint32_t friend_number = 123;
+    std::uint32_t friend_number = 123;
     MSICall *call = nullptr;
     msi_invite(log, session, &call, friend_number, 0);
 
     // Craft pop packet
-    uint8_t pop_pkt[] = {1, 1, 2, 0};  // REQU_POP
+    std::uint8_t pop_pkt[] = {1, 1, 2, 0};  // REQU_POP
     msi_handle_packet(session, log, friend_number, pop_pkt, sizeof(pop_pkt));
 
     EXPECT_EQ(mock.stats.end, 1);
@@ -249,12 +251,12 @@ TEST_F(MsiTest, RemoteHangup)
 
 TEST_F(MsiTest, RemoteError)
 {
-    uint32_t friend_number = 123;
+    std::uint32_t friend_number = 123;
     MSICall *call = nullptr;
     msi_invite(log, session, &call, friend_number, 0);
 
     // Craft error packet (ID_ERROR = 2)
-    uint8_t error_pkt[] = {1, 1, 2, 2, 1, 1, 0};  // REQU_POP + MSI_E_INVALID_MESSAGE
+    std::uint8_t error_pkt[] = {1, 1, 2, 2, 1, 1, 0};  // REQU_POP + MSI_E_INVALID_MESSAGE
     msi_handle_packet(session, log, friend_number, error_pkt, sizeof(error_pkt));
 
     EXPECT_EQ(mock.stats.error, 1);
@@ -278,7 +280,7 @@ TEST_F(MsiTest, MultipleConcurrentCalls)
     msi_hangup(log, call1);
 
     // Call 2 should still be there
-    uint8_t pop_pkt[] = {1, 1, 2, 0};
+    std::uint8_t pop_pkt[] = {1, 1, 2, 0};
     msi_handle_packet(session, log, 2, pop_pkt, sizeof(pop_pkt));
     EXPECT_EQ(mock.stats.end, 1);
 }
@@ -288,8 +290,8 @@ TEST_F(MsiTest, RemoteAnswer)
     MSICall *call = nullptr;
     msi_invite(log, session, &call, 123, 0);
 
-    uint8_t peer_caps = MSI_CAP_S_AUDIO;
-    uint8_t push_pkt[] = {1, 1, 1, 3, 1, peer_caps, 0};  // REQU_PUSH + capabilities
+    std::uint8_t peer_caps = MSI_CAP_S_AUDIO;
+    std::uint8_t push_pkt[] = {1, 1, 1, 3, 1, peer_caps, 0};  // REQU_PUSH + capabilities
     msi_handle_packet(session, log, 123, push_pkt, sizeof(push_pkt));
 
     EXPECT_EQ(mock.stats.start, 1);
@@ -299,14 +301,14 @@ TEST_F(MsiTest, RemoteAnswer)
 
 TEST_F(MsiTest, RemoteCapabilitiesChange)
 {
-    uint32_t friend_number = 123;
-    uint8_t invite_pkt[] = {1, 1, 0, 3, 1, 0, 0};
+    std::uint32_t friend_number = 123;
+    std::uint8_t invite_pkt[] = {1, 1, 0, 3, 1, 0, 0};
     msi_handle_packet(session, log, friend_number, invite_pkt, sizeof(invite_pkt));
     MSICall *call = mock.last_call;
     msi_answer(log, call, 0);
 
-    uint8_t new_caps = MSI_CAP_S_VIDEO;
-    uint8_t push_pkt[] = {1, 1, 1, 3, 1, new_caps, 0};  // REQU_PUSH + new capabilities
+    std::uint8_t new_caps = MSI_CAP_S_VIDEO;
+    std::uint8_t push_pkt[] = {1, 1, 1, 3, 1, new_caps, 0};  // REQU_PUSH + new capabilities
     msi_handle_packet(session, log, friend_number, push_pkt, sizeof(push_pkt));
 
     EXPECT_EQ(mock.stats.capabilities, 1);
@@ -315,8 +317,8 @@ TEST_F(MsiTest, RemoteCapabilitiesChange)
 
 TEST_F(MsiTest, FriendRecall)
 {
-    uint32_t friend_number = 123;
-    uint8_t invite_pkt[] = {1, 1, 0, 3, 1, 0, 0};
+    std::uint32_t friend_number = 123;
+    std::uint8_t invite_pkt[] = {1, 1, 0, 3, 1, 0, 0};
     msi_handle_packet(session, log, friend_number, invite_pkt, sizeof(invite_pkt));
     MSICall *call = mock.last_call;
     msi_answer(log, call, 0);
@@ -348,30 +350,30 @@ TEST_F(MsiTest, GapInFriendNumbers)
 
 TEST_F(MsiTest, InvalidPackets)
 {
-    uint32_t friend_number = 123;
+    std::uint32_t friend_number = 123;
 
     // Empty packet
-    uint8_t empty = 0;
+    std::uint8_t empty = 0;
     msi_handle_packet(session, log, friend_number, &empty, 0);
 
     // Missing end byte
-    uint8_t no_end[] = {1, 1, 0};
+    std::uint8_t no_end[] = {1, 1, 0};
     msi_handle_packet(session, log, friend_number, no_end, sizeof(no_end));
 
     // Invalid ID
-    uint8_t invalid_id[] = {99, 1, 0, 0};
+    std::uint8_t invalid_id[] = {99, 1, 0, 0};
     msi_handle_packet(session, log, friend_number, invalid_id, sizeof(invalid_id));
 
     // Invalid size (too large)
-    uint8_t invalid_size[] = {1, 10, 0, 0};
+    std::uint8_t invalid_size[] = {1, 10, 0, 0};
     msi_handle_packet(session, log, friend_number, invalid_size, sizeof(invalid_size));
 
     // Invalid size (mismatch)
-    uint8_t size_mismatch[] = {1, 2, 0, 0};
+    std::uint8_t size_mismatch[] = {1, 2, 0, 0};
     msi_handle_packet(session, log, friend_number, size_mismatch, sizeof(size_mismatch));
 
     // Missing request field
-    uint8_t no_request[] = {3, 1, 0, 0};
+    std::uint8_t no_request[] = {3, 1, 0, 0};
     msi_handle_packet(session, log, friend_number, no_request, sizeof(no_request));
 }
 
@@ -387,7 +389,7 @@ TEST_F(MsiTest, CallbackFailure)
 
     MSISession *fail_session = msi_new(log, MockMsi::send_packet, &mock, &callbacks, &mock);
 
-    uint8_t invite_pkt[] = {1, 1, 0, 3, 1, 0, 0};
+    std::uint8_t invite_pkt[] = {1, 1, 0, 3, 1, 0, 0};
     msi_handle_packet(fail_session, log, 123, invite_pkt, sizeof(invite_pkt));
 
     // Should have sent an error back
@@ -417,14 +419,14 @@ TEST_F(MsiTest, InvalidStates)
 
 TEST_F(MsiTest, StrayPackets)
 {
-    uint32_t friend_number = 123;
+    std::uint32_t friend_number = 123;
 
     // PUSH for non-existent call
-    uint8_t push_pkt[] = {1, 1, 1, 3, 1, 0, 0};
+    std::uint8_t push_pkt[] = {1, 1, 1, 3, 1, 0, 0};
     msi_handle_packet(session, log, friend_number, push_pkt, sizeof(push_pkt));
 
     // POP for non-existent call
-    uint8_t pop_pkt[] = {1, 1, 2, 0};
+    std::uint8_t pop_pkt[] = {1, 1, 2, 0};
     msi_handle_packet(session, log, friend_number, pop_pkt, sizeof(pop_pkt));
 
     // Error sent back for stray PUSH

--- a/toxav/ring_buffer_test.cc
+++ b/toxav/ring_buffer_test.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <vector>
 
 namespace {
@@ -32,12 +33,12 @@ public:
         return res;
     }
 
-    uint16_t size() const { return rb_size(rb_); }
-    uint16_t data(T **dest) const
+    std::uint16_t size() const { return rb_size(rb_); }
+    std::uint16_t data(T **dest) const
     {
         std::vector<void *> vdest(size());
-        uint16_t res = rb_data(rb_, vdest.data());
-        for (uint16_t i = 0; i < size(); i++) {
+        std::uint16_t res = rb_data(rb_, vdest.data());
+        for (std::uint16_t i = 0; i < size(); i++) {
             dest[i] = static_cast<T *>(vdest.at(i));
         }
         return res;

--- a/toxav/rtp_bench.cc
+++ b/toxav/rtp_bench.cc
@@ -4,6 +4,8 @@
 
 #include <benchmark/benchmark.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <vector>
 
@@ -45,11 +47,11 @@ public:
 
 BENCHMARK_DEFINE_F(RtpBench, SendData)(benchmark::State &state)
 {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    std::vector<uint8_t> data(data_size, 0xAA);
+    std::size_t data_size = static_cast<std::size_t>(state.range(0));
+    std::vector<std::uint8_t> data(data_size, 0xAA);
 
     for (auto _ : state) {
-        rtp_send_data(log, session, data.data(), static_cast<uint32_t>(data.size()), false);
+        rtp_send_data(log, session, data.data(), static_cast<std::uint32_t>(data.size()), false);
         benchmark::DoNotOptimize(mock.captured_packets.back());
     }
 }
@@ -57,10 +59,10 @@ BENCHMARK_REGISTER_F(RtpBench, SendData)->Arg(100)->Arg(1000)->Arg(5000);
 
 BENCHMARK_DEFINE_F(RtpBench, ReceivePacket)(benchmark::State &state)
 {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    std::vector<uint8_t> data(data_size, 0xAA);
-    rtp_send_data(log, session, data.data(), static_cast<uint32_t>(data.size()), false);
-    std::vector<uint8_t> packet = mock.captured_packets.back();
+    std::size_t data_size = static_cast<std::size_t>(state.range(0));
+    std::vector<std::uint8_t> data(data_size, 0xAA);
+    rtp_send_data(log, session, data.data(), static_cast<std::uint32_t>(data.size()), false);
+    std::vector<std::uint8_t> packet = mock.captured_packets.back();
 
     for (auto _ : state) {
         rtp_receive_packet(session, packet.data(), packet.size());

--- a/toxav/rtp_fuzz_test.cc
+++ b/toxav/rtp_fuzz_test.cc
@@ -1,5 +1,7 @@
 #include "rtp.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
 #include <vector>
@@ -15,7 +17,8 @@ using tox::test::Fuzz_Data;
 
 struct MockSessionData { };
 
-static int mock_send_packet(void * /*user_data*/, const uint8_t * /*data*/, uint16_t /*length*/)
+static int mock_send_packet(
+    void * /*user_data*/, const std::uint8_t * /*data*/, std::uint16_t /*length*/)
 {
     return 0;
 }
@@ -34,7 +37,7 @@ void fuzz_rtp_receive(Fuzz_Data &input)
     };
     std::unique_ptr<Logger, LoggerDeleter> log(logger_new(mem));
 
-    auto time_cb = [](void *) -> uint64_t { return 0; };
+    auto time_cb = [](void *) -> std::uint64_t { return 0; };
     struct MonoTimeDeleter {
         const Memory *m;
         void operator()(Mono_Time *t) { mono_time_free(m, t); }
@@ -44,7 +47,7 @@ void fuzz_rtp_receive(Fuzz_Data &input)
 
     MockSessionData sd;
 
-    CONSUME1_OR_RETURN(uint8_t, payload_type_byte, input);
+    CONSUME1_OR_RETURN(std::uint8_t, payload_type_byte, input);
     int payload_type = (payload_type_byte % 2 == 0) ? RTP_TYPE_AUDIO : RTP_TYPE_VIDEO;
 
     struct RtpSessionDeleter {
@@ -57,7 +60,7 @@ void fuzz_rtp_receive(Fuzz_Data &input)
         RtpSessionDeleter{log.get()});
 
     while (!input.empty()) {
-        CONSUME1_OR_RETURN(uint16_t, len, input);
+        CONSUME1_OR_RETURN(std::uint16_t, len, input);
 
         if (input.size() < len) {
             len = input.size();
@@ -67,16 +70,16 @@ void fuzz_rtp_receive(Fuzz_Data &input)
             break;
         }
 
-        const uint8_t *pkt_data = input.consume(__func__, len);
+        const std::uint8_t *pkt_data = input.consume(__func__, len);
         rtp_receive_packet(session.get(), pkt_data, len);
     }
 }
 
 }  // namespace
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size);
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size)
 {
     Fuzz_Data input(data, size);
     fuzz_rtp_receive(input);

--- a/toxav/rtp_test.cc
+++ b/toxav/rtp_test.cc
@@ -3,6 +3,10 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
@@ -17,23 +21,23 @@ struct MockSessionData {
     MockSessionData();
     ~MockSessionData();
 
-    std::vector<std::vector<uint8_t>> sent_packets;
-    std::vector<std::vector<uint8_t>> received_frames;
-    std::vector<uint16_t> received_frame_lengths;
-    std::vector<uint32_t> received_32bit_lengths;
-    std::vector<uint32_t> received_full_lengths;
-    std::vector<uint16_t> received_sequnums;
-    std::vector<uint8_t> received_pts;
-    std::vector<uint64_t> received_flags;
+    std::vector<std::vector<std::uint8_t>> sent_packets;
+    std::vector<std::vector<std::uint8_t>> received_frames;
+    std::vector<std::uint16_t> received_frame_lengths;
+    std::vector<std::uint32_t> received_32bit_lengths;
+    std::vector<std::uint32_t> received_full_lengths;
+    std::vector<std::uint16_t> received_sequnums;
+    std::vector<std::uint8_t> received_pts;
+    std::vector<std::uint64_t> received_flags;
 
-    uint32_t total_bytes_received = 0;
-    uint32_t total_bytes_lost = 0;
+    std::uint32_t total_bytes_received = 0;
+    std::uint32_t total_bytes_lost = 0;
 };
 
 MockSessionData::MockSessionData() = default;
 MockSessionData::~MockSessionData() = default;
 
-static int mock_send_packet(void *user_data, const uint8_t *data, uint16_t length)
+static int mock_send_packet(void *user_data, const std::uint8_t *data, std::uint16_t length)
 {
     auto *sd = static_cast<MockSessionData *>(user_data);
     sd->sent_packets.emplace_back(data, data + length);
@@ -47,15 +51,15 @@ static int mock_m_cb(const Mono_Time * /*mono_time*/, void *cs, RTPMessage *msg)
     sd->received_pts.push_back(rtp_message_pt(msg));
     sd->received_flags.push_back(rtp_message_flags(msg));
 
-    const uint8_t *data = rtp_message_data(msg);
-    uint32_t len = rtp_message_len(msg);
-    uint32_t full_len = rtp_message_data_length_full(msg);
+    const std::uint8_t *data = rtp_message_data(msg);
+    std::uint32_t len = rtp_message_len(msg);
+    std::uint32_t full_len = rtp_message_data_length_full(msg);
 
     // If full_len is not set (old protocol), use len
-    uint32_t actual_len = (full_len > 0) ? full_len : len;
+    std::uint32_t actual_len = (full_len > 0) ? full_len : len;
 
     sd->received_frames.emplace_back(data, data + actual_len);
-    sd->received_frame_lengths.push_back(static_cast<uint16_t>(len));
+    sd->received_frame_lengths.push_back(static_cast<std::uint16_t>(len));
     sd->received_32bit_lengths.push_back(len);
     sd->received_full_lengths.push_back(full_len);
     sd->received_sequnums.push_back(rtp_message_sequnum(msg));
@@ -64,13 +68,13 @@ static int mock_m_cb(const Mono_Time * /*mono_time*/, void *cs, RTPMessage *msg)
     return 0;
 }
 
-static void mock_add_recv(void *user_data, uint32_t bytes)
+static void mock_add_recv(void *user_data, std::uint32_t bytes)
 {
     auto *sd = static_cast<MockSessionData *>(user_data);
     sd->total_bytes_received += bytes;
 }
 
-static void mock_add_lost(void *user_data, uint32_t bytes)
+static void mock_add_lost(void *user_data, std::uint32_t bytes)
 {
     auto *sd = static_cast<MockSessionData *>(user_data);
     sd->total_bytes_lost += bytes;
@@ -104,7 +108,7 @@ TEST_F(RtpPublicTest, BasicAudioSendReceive)
         mock_add_recv, mock_add_lost, &sd, &sd, mock_m_cb);
     ASSERT_NE(session, nullptr);
 
-    uint8_t data[] = "Hello RTP";
+    std::uint8_t data[] = "Hello RTP";
     rtp_send_data(log, session, data, sizeof(data), false);
 
     ASSERT_EQ(sd.sent_packets.size(), 1);
@@ -128,9 +132,9 @@ TEST_F(RtpPublicTest, LargeVideoFrameFragmentation)
         mock_add_recv, mock_add_lost, &sd, &sd, mock_m_cb);
 
     // Frame larger than MAX_CRYPTO_DATA_SIZE
-    const uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 500;
-    std::vector<uint8_t> data(frame_size);
-    for (uint32_t i = 0; i < frame_size; ++i)
+    const std::uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 500;
+    std::vector<std::uint8_t> data(frame_size);
+    for (std::uint32_t i = 0; i < frame_size; ++i)
         data[i] = i & 0xFF;
 
     rtp_send_data(log, session, data.data(), frame_size, true);
@@ -158,8 +162,8 @@ TEST_F(RtpPublicTest, OutOfOrderVideoPackets)
     RTPSession *session = rtp_new(log, RTP_TYPE_VIDEO, mono_time, mock_send_packet, &sd,
         mock_add_recv, mock_add_lost, &sd, &sd, mock_m_cb);
 
-    const uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 100;
-    std::vector<uint8_t> data(frame_size, 0x55);
+    const std::uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 100;
+    std::vector<std::uint8_t> data(frame_size, 0x55);
     rtp_send_data(log, session, data.data(), frame_size, false);
 
     ASSERT_EQ(sd.sent_packets.size(), 2);
@@ -183,15 +187,15 @@ TEST_F(RtpPublicTest, HandlingInvalidPackets)
         mock_add_recv, mock_add_lost, &sd, &sd, mock_m_cb);
 
     // Packet too short to even contain the Tox packet ID
-    uint8_t empty[1];
+    std::uint8_t empty[1];
     rtp_receive_packet(session, empty, 0);
 
     // Packet too short (less than RTP_HEADER_SIZE + 1)
-    uint8_t short_pkt[10] = {RTP_TYPE_AUDIO};
+    std::uint8_t short_pkt[10] = {RTP_TYPE_AUDIO};
     rtp_receive_packet(session, short_pkt, sizeof(short_pkt));
 
     // Wrong packet ID (Tox level)
-    uint8_t wrong_id[RTP_HEADER_SIZE + 10];
+    std::uint8_t wrong_id[RTP_HEADER_SIZE + 10];
     std::memset(wrong_id, 0, sizeof(wrong_id));
     wrong_id[0] = RTP_TYPE_VIDEO;  // Session expects AUDIO
     rtp_receive_packet(session, wrong_id, sizeof(wrong_id));
@@ -239,8 +243,8 @@ TEST_F(RtpPublicTest, LargeAudioFragmentationOldProtocol)
         mock_add_recv, mock_add_lost, &sd, &sd, mock_m_cb);
 
     // Audio doesn't use RTP_LARGE_FRAME, so it uses the old 16-bit offset/length fields
-    const uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 500;
-    std::vector<uint8_t> data(frame_size, 0x44);
+    const std::uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 500;
+    std::vector<std::uint8_t> data(frame_size, 0x44);
 
     rtp_send_data(log, session, data.data(), frame_size, false);
 
@@ -263,17 +267,17 @@ TEST_F(RtpPublicTest, WorkBufferEvictionAndKeyframePreservation)
         mock_add_recv, mock_add_lost, &sd, &sd, mock_m_cb);
 
     struct TimeMock {
-        uint64_t t;
+        std::uint64_t t;
     } tm = {1000};
 
-    auto time_cb = [](void *ud) -> uint64_t { return static_cast<TimeMock *>(ud)->t; };
+    auto time_cb = [](void *ud) -> std::uint64_t { return static_cast<TimeMock *>(ud)->t; };
     mono_time_set_current_time_callback(mono_time, time_cb, &tm);
     mono_time_update(mono_time);
 
     // USED_RTP_WORKBUFFER_COUNT is 3.
     // 1. Start a keyframe (frame 0) but don't finish it.
-    const uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 100;
-    std::vector<uint8_t> kf_data(frame_size, 0x11);
+    const std::uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 100;
+    std::vector<std::uint8_t> kf_data(frame_size, 0x11);
     rtp_send_data(log, session, kf_data.data(), frame_size, true);
     rtp_receive_packet(session, sd.sent_packets[0].data(), sd.sent_packets[0].size());
     sd.sent_packets.clear();
@@ -282,7 +286,7 @@ TEST_F(RtpPublicTest, WorkBufferEvictionAndKeyframePreservation)
     for (int i = 0; i < 2; ++i) {
         tm.t += 1;
         mono_time_update(mono_time);
-        std::vector<uint8_t> if_data(frame_size, 0x20 + i);
+        std::vector<std::uint8_t> if_data(frame_size, 0x20 + i);
         rtp_send_data(log, session, if_data.data(), frame_size, false);
         rtp_receive_packet(session, sd.sent_packets[0].data(), sd.sent_packets[0].size());
         sd.sent_packets.clear();
@@ -297,7 +301,7 @@ TEST_F(RtpPublicTest, WorkBufferEvictionAndKeyframePreservation)
     // The new IF should be DROPPED because there's no space and slot 0 is a protected KF.
     tm.t += 1;
     mono_time_update(mono_time);
-    std::vector<uint8_t> if3_data(frame_size, 0x33);
+    std::vector<std::uint8_t> if3_data(frame_size, 0x33);
     rtp_send_data(log, session, if3_data.data(), frame_size, false);
     rtp_receive_packet(session, sd.sent_packets[0].data(), sd.sent_packets[0].size());
     sd.sent_packets.clear();
@@ -311,7 +315,7 @@ TEST_F(RtpPublicTest, WorkBufferEvictionAndKeyframePreservation)
 
     // 5. Start another frame (frame 4).
     // Now the old KF should be evicted and processed (sent to callback), making room.
-    std::vector<uint8_t> if4_data(frame_size, 0x44);
+    std::vector<std::uint8_t> if4_data(frame_size, 0x44);
     rtp_send_data(log, session, if4_data.data(), frame_size, false);
     rtp_receive_packet(session, sd.sent_packets[0].data(), sd.sent_packets[0].size());
 
@@ -328,7 +332,7 @@ TEST_F(RtpPublicTest, BwcReporting)
     RTPSession *session = rtp_new(log, RTP_TYPE_VIDEO, mono_time, mock_send_packet, &sd,
         mock_add_recv, mock_add_lost, &sd, &sd, mock_m_cb);
 
-    uint8_t data[] = "test";
+    std::uint8_t data[] = "test";
     // DISMISS_FIRST_LOST_VIDEO_PACKET_COUNT is 10.
     // Packets 1-9 are dismissed. Packet 10 is reported.
     for (int i = 0; i < 10; ++i) {
@@ -351,8 +355,8 @@ TEST_F(RtpPublicTest, OldProtocolEdgeCases)
         nullptr, nullptr, &sd, mock_m_cb);
 
     // 1. Multipart message interrupted by a newer message.
-    const uint32_t large_size = 5000;
-    std::vector<uint8_t> data(large_size, 0xAA);
+    const std::uint32_t large_size = 5000;
+    std::vector<std::uint8_t> data(large_size, 0xAA);
     rtp_send_data(log, session, data.data(), large_size, false);
 
     ASSERT_GE(sd.sent_packets.size(), 2);
@@ -361,7 +365,7 @@ TEST_F(RtpPublicTest, OldProtocolEdgeCases)
     EXPECT_EQ(sd.received_frames.size(), 0);
 
     // Send a second message (newer)
-    std::vector<uint8_t> data2 = {0x1, 0x2, 0x3};
+    std::vector<std::uint8_t> data2 = {0x1, 0x2, 0x3};
     rtp_send_data(log, session, data2.data(), data2.size(), false);
     // The second message is the last one in sent_packets.
     rtp_receive_packet(session, sd.sent_packets.back().data(), sd.sent_packets.back().size());
@@ -370,7 +374,7 @@ TEST_F(RtpPublicTest, OldProtocolEdgeCases)
     ASSERT_EQ(sd.received_frames.size(), 2);
     EXPECT_LT(sd.received_frame_lengths[0], large_size);
     EXPECT_EQ(sd.received_pts[0], RTP_TYPE_AUDIO % 128);
-    EXPECT_EQ(sd.received_frame_lengths[1], static_cast<uint16_t>(data2.size()));
+    EXPECT_EQ(sd.received_frame_lengths[1], static_cast<std::uint16_t>(data2.size()));
 
     // 2. Discarding old message part
     sd.received_frames.clear();
@@ -379,7 +383,7 @@ TEST_F(RtpPublicTest, OldProtocolEdgeCases)
     sd.received_pts.clear();
 
     // Send a very new message.
-    std::vector<uint8_t> data3 = {0xDE, 0xAD};
+    std::vector<std::uint8_t> data3 = {0xDE, 0xAD};
     rtp_send_data(log, session, data3.data(), data3.size(), false);
     rtp_receive_packet(session, sd.sent_packets.back().data(), sd.sent_packets.back().size());
     EXPECT_EQ(sd.received_frames.size(), 1);
@@ -399,13 +403,13 @@ TEST_F(RtpPublicTest, MoreInvalidPackets)
         nullptr, nullptr, &sd, mock_m_cb);
 
     // Get a valid packet to start with
-    uint8_t data[] = "test";
+    std::uint8_t data[] = "test";
     rtp_send_data(log, session, data, sizeof(data), false);
-    std::vector<uint8_t> valid_pkt = sd.sent_packets[0];
+    std::vector<std::uint8_t> valid_pkt = sd.sent_packets[0];
     sd.sent_packets.clear();
 
     // 1. RTPHeader packet type and Tox protocol packet type do not agree
-    std::vector<uint8_t> bad_pkt_1 = valid_pkt;
+    std::vector<std::uint8_t> bad_pkt_1 = valid_pkt;
     bad_pkt_1[0] = RTP_TYPE_AUDIO;  // Tox ID says AUDIO, but header (byte 2) still says VIDEO
     rtp_receive_packet(session, bad_pkt_1.data(), bad_pkt_1.size());
     EXPECT_EQ(sd.received_frames.size(), 0);
@@ -421,7 +425,7 @@ TEST_F(RtpPublicTest, MoreInvalidPackets)
     // 3. Invalid video packet: offset >= length
     // From rtp.c, offset_full is at byte 20 and data_length_full at byte 24 of the RTP header.
     // The RTP header starts at index 1 of the packet.
-    std::vector<uint8_t> bad_pkt_3 = valid_pkt;
+    std::vector<std::uint8_t> bad_pkt_3 = valid_pkt;
     // Set offset (bytes 21-24) to be equal to length (bytes 25-28)
     // For a small packet, both are usually 0 and sizeof(data) respectively.
     // Let's just make offset very large.
@@ -437,10 +441,10 @@ TEST_F(RtpPublicTest, MoreInvalidPackets)
         nullptr, nullptr, nullptr, &sd, mock_m_cb);
 
     rtp_send_data(log, session_audio2, data, sizeof(data), false);
-    std::vector<uint8_t> audio_pkt = sd.sent_packets[0];
+    std::vector<std::uint8_t> audio_pkt = sd.sent_packets[0];
     sd.sent_packets.clear();
 
-    std::vector<uint8_t> bad_pkt_4 = audio_pkt;
+    std::vector<std::uint8_t> bad_pkt_4 = audio_pkt;
     // Set offset_lower (byte 1 + 76) > data_length_lower (byte 1 + 78)
     bad_pkt_4[1 + 76] = 0x01;  // offset = 256
     bad_pkt_4[1 + 77] = 0x00;
@@ -461,20 +465,20 @@ TEST_F(RtpPublicTest, VideoJitterBufferEdgeCases)
         nullptr, nullptr, &sd, mock_m_cb);
 
     // Use a large frame size to force fragmentation and keep slots occupied
-    const uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 100;
-    std::vector<uint8_t> data(frame_size, 0);
+    const std::uint32_t frame_size = MAX_CRYPTO_DATA_SIZE + 100;
+    std::vector<std::uint8_t> data(frame_size, 0);
 
     // Advancing time for subsequent frames
     struct TimeMock {
-        uint64_t t;
+        std::uint64_t t;
     } tm = {1000};
-    auto time_cb = [](void *ud) -> uint64_t { return static_cast<TimeMock *>(ud)->t; };
+    auto time_cb = [](void *ud) -> std::uint64_t { return static_cast<TimeMock *>(ud)->t; };
     mono_time_set_current_time_callback(mono_time, time_cb, &tm);
     mono_time_update(mono_time);
 
     // 1. Packet too old for work buffer
     rtp_send_data(log, session, data.data(), frame_size, false);  // Time 1000ms
-    std::vector<uint8_t> old_pkt = sd.sent_packets[0];
+    std::vector<std::uint8_t> old_pkt = sd.sent_packets[0];
     // Receive only first part to keep slot occupied
     rtp_receive_packet(session, sd.sent_packets[0].data(), sd.sent_packets[0].size());
     EXPECT_EQ(sd.received_frames.size(), 0);
@@ -501,7 +505,7 @@ TEST_F(RtpPublicTest, VideoJitterBufferEdgeCases)
         nullptr, &sd, mock_m_cb);
 
     // Fill slot 0 with an incomplete Keyframe
-    std::vector<uint8_t> kf_data(frame_size, 0x11);
+    std::vector<std::uint8_t> kf_data(frame_size, 0x11);
     tm.t = 3000;
     mono_time_update(mono_time);
     rtp_send_data(log, session, kf_data.data(), frame_size, true);
@@ -510,7 +514,7 @@ TEST_F(RtpPublicTest, VideoJitterBufferEdgeCases)
     sd.sent_packets.clear();
 
     // Now send a complete Interframe
-    std::vector<uint8_t> if_data(10, 0x22);
+    std::vector<std::uint8_t> if_data(10, 0x22);
     tm.t += 1;
     mono_time_update(mono_time);
     rtp_send_data(log, session, if_data.data(), if_data.size(), false);
@@ -531,9 +535,9 @@ TEST_F(RtpPublicTest, OldProtocolCorruption)
     // 1. Packet claiming a smaller length than its payload.
     // This triggers the condition that previously caused a DoS crash via
     // an assertion failure in new_message().
-    uint8_t data[10] = {0};
+    std::uint8_t data[10] = {0};
     rtp_send_data(log, session, data, sizeof(data), false);
-    std::vector<uint8_t> pkt = sd.sent_packets[0];
+    std::vector<std::uint8_t> pkt = sd.sent_packets[0];
     sd.sent_packets.clear();
 
     // Modify data_length_lower (byte 1 + 78) to be 2, while payload is 10.
@@ -545,8 +549,8 @@ TEST_F(RtpPublicTest, OldProtocolCorruption)
     EXPECT_EQ(sd.received_frames.size(), 0);
 
     // 2. Corruption check for an EXISTING multipart message.
-    const uint32_t multipart_size = 5000;
-    std::vector<uint8_t> multipart_data(multipart_size, 0xBB);
+    const std::uint32_t multipart_size = 5000;
+    std::vector<std::uint8_t> multipart_data(multipart_size, 0xBB);
     rtp_send_data(log, session, multipart_data.data(), multipart_size, false);
 
     // Receive the first part
@@ -554,7 +558,7 @@ TEST_F(RtpPublicTest, OldProtocolCorruption)
     EXPECT_EQ(sd.received_frames.size(), 0);
 
     // Now receive a corrupted second part that claims a weird offset
-    std::vector<uint8_t> corrupted_part = sd.sent_packets[1];
+    std::vector<std::uint8_t> corrupted_part = sd.sent_packets[1];
     // offset_lower is at byte 76. Set it beyond data_length_lower.
     corrupted_part[1 + 76] = 0xFF;
     corrupted_part[1 + 77] = 0xFF;
@@ -572,11 +576,11 @@ TEST_F(RtpPublicTest, HugeVideoFrameInternalLength)
     RTPSession *session = rtp_new(log, RTP_TYPE_VIDEO, mono_time, mock_send_packet, &sd, nullptr,
         nullptr, nullptr, &sd, mock_m_cb);
 
-    // Frame larger than 64KB (uint16_t max)
-    const uint32_t huge_frame_size = 65540;
-    std::vector<uint8_t> data(huge_frame_size);
-    for (uint32_t i = 0; i < huge_frame_size; ++i) {
-        data[i] = static_cast<uint8_t>(i & 0xFF);
+    // Frame larger than 64KB (std::uint16_t max)
+    const std::uint32_t huge_frame_size = 65540;
+    std::vector<std::uint8_t> data(huge_frame_size);
+    for (std::uint32_t i = 0; i < huge_frame_size; ++i) {
+        data[i] = static_cast<std::uint8_t>(i & 0xFF);
     }
 
     rtp_send_data(log, session, data.data(), huge_frame_size, false);
@@ -592,7 +596,7 @@ TEST_F(RtpPublicTest, HugeVideoFrameInternalLength)
     ASSERT_EQ(sd.received_frames.size(), 1);
     // This verifies that the internal 32-bit length is working correctly.
     // We cast huge_frame_size to 16-bit to show what it would have been if it truncated.
-    EXPECT_NE(static_cast<uint16_t>(sd.received_32bit_lengths[0]), huge_frame_size);
+    EXPECT_NE(static_cast<std::uint16_t>(sd.received_32bit_lengths[0]), huge_frame_size);
     EXPECT_EQ(sd.received_32bit_lengths[0], huge_frame_size);
     EXPECT_EQ(sd.received_full_lengths[0], huge_frame_size);
     EXPECT_EQ(sd.received_frames[0].size(), huge_frame_size);
@@ -609,10 +613,10 @@ TEST_F(RtpPublicTest, HeapBufferOverflowRaw)
 
     // Manually construct a malicious packet.
     // 1 byte ID + 80 bytes Header + 200 bytes Payload
-    const size_t header_size = 80;
-    const size_t payload_size = 200;
-    const size_t total_size = 1 + header_size + payload_size;
-    std::vector<uint8_t> pkt(total_size, 0);
+    const std::size_t header_size = 80;
+    const std::size_t payload_size = 200;
+    const std::size_t total_size = 1 + header_size + payload_size;
+    std::vector<std::uint8_t> pkt(total_size, 0);
 
     // 0: Packet ID
     pkt[0] = RTP_TYPE_VIDEO;
@@ -650,21 +654,21 @@ TEST_F(RtpPublicTest, HeapBufferOverflow)
         nullptr, nullptr, &sd, mock_m_cb);
 
     // Common parameters
-    uint16_t sequnum = 100;
-    uint32_t timestamp = 12345;
-    uint32_t ssrc = 0x11223344;
+    std::uint16_t sequnum = 100;
+    std::uint32_t timestamp = 12345;
+    std::uint32_t ssrc = 0x11223344;
 
     // --- Packet 1: Small allocation ---
     // data_length_full = 10
     // offset_full = 0
     // payload_len = 5
     {
-        uint8_t packet[100];
+        std::uint8_t packet[100];
         std::memset(packet, 0, sizeof(packet));
         packet[0] = RTP_TYPE_VIDEO;  // Tox Packet ID
 
         // RTP Header
-        uint8_t *h = &packet[1];
+        std::uint8_t *h = &packet[1];
         // Byte 0: VE=2 (0x80)
         h[0] = 0x80;
         // Byte 1: PT=0x41
@@ -720,11 +724,11 @@ TEST_F(RtpPublicTest, HeapBufferOverflow)
     // Memcpy to buf->data + 10. Buf was allocated with size 10. Writing 100
     // bytes to offset 10 -> Overflow.
     {
-        uint8_t packet[200];
+        std::uint8_t packet[200];
         std::memset(packet, 0, sizeof(packet));
         packet[0] = RTP_TYPE_VIDEO;
 
-        uint8_t *h = &packet[1];
+        std::uint8_t *h = &packet[1];
         h[0] = 0x80;
         h[1] = 0x41;
         h[2] = (sequnum >> 8) & 0xFF;
@@ -769,15 +773,15 @@ TEST_F(RtpPublicTest, AudioHeapBufferOverflow)
     RTPSession *session = rtp_new(log, RTP_TYPE_AUDIO, mono_time, mock_send_packet, &sd, nullptr,
         nullptr, nullptr, &sd, mock_m_cb);
 
-    uint16_t sequnum = 100;
-    uint32_t timestamp = 12345;
-    uint32_t ssrc = 0x11223344;
+    std::uint16_t sequnum = 100;
+    std::uint32_t timestamp = 12345;
+    std::uint32_t ssrc = 0x11223344;
 
-    uint8_t packet[200];
+    std::uint8_t packet[200];
     std::memset(packet, 0, sizeof(packet));
     packet[0] = RTP_TYPE_AUDIO;
 
-    uint8_t *h = &packet[1];
+    std::uint8_t *h = &packet[1];
     h[0] = 0x80;
     h[1] = 0x40;  // 64 (Audio)
     h[2] = (sequnum >> 8) & 0xFF;
@@ -816,21 +820,21 @@ TEST_F(RtpPublicTest, HeapBufferOverflowMultipartAudio)
     RTPSession *session = rtp_new(log, RTP_TYPE_AUDIO, mono_time, mock_send_packet, &sd, nullptr,
         nullptr, nullptr, &sd, mock_m_cb);
 
-    uint16_t sequnum = 200;
-    uint32_t timestamp = 67890;
-    uint32_t ssrc = 0x55667788;
-    uint16_t total_len = 100;
+    std::uint16_t sequnum = 200;
+    std::uint32_t timestamp = 67890;
+    std::uint32_t ssrc = 0x55667788;
+    std::uint16_t total_len = 100;
 
     // --- Packet 1: Allocate buffer ---
     // data_length_lower = 100
     // offset_lower = 0
     // payload_len = 10
     {
-        uint8_t packet[200];
+        std::uint8_t packet[200];
         std::memset(packet, 0, sizeof(packet));
         packet[0] = RTP_TYPE_AUDIO;
 
-        uint8_t *h = &packet[1];
+        std::uint8_t *h = &packet[1];
         h[0] = 0x80;
         h[1] = 0x40;  // Audio
         h[2] = (sequnum >> 8) & 0xFF;
@@ -865,11 +869,11 @@ TEST_F(RtpPublicTest, HeapBufferOverflowMultipartAudio)
     // Check 2: total (100) > offset (95). Safe.
     // Write: 95 + 10 = 105. Overflow.
     {
-        uint8_t packet[200];
+        std::uint8_t packet[200];
         std::memset(packet, 0, sizeof(packet));
         packet[0] = RTP_TYPE_AUDIO;
 
-        uint8_t *h = &packet[1];
+        std::uint8_t *h = &packet[1];
         h[0] = 0x80;
         h[1] = 0x40;
         h[2] = (sequnum >> 8) & 0xFF;
@@ -905,18 +909,18 @@ TEST_F(RtpPublicTest, HeapBufferOverflowLogRead)
     RTPSession *session = rtp_new(log, RTP_TYPE_VIDEO, mono_time, mock_send_packet, &sd, nullptr,
         nullptr, nullptr, &sd, mock_m_cb);
 
-    uint16_t sequnum = 123;
-    uint32_t timestamp = 99999;
-    uint32_t ssrc = 0x88776655;
+    std::uint16_t sequnum = 123;
+    std::uint32_t timestamp = 99999;
+    std::uint32_t ssrc = 0x88776655;
 
     // Packet with data_length_full = 1.
     // The logger tries to read data[0] and data[1].
     // data[1] will be out of bounds if only 1 byte is allocated.
-    uint8_t packet[100];
+    std::uint8_t packet[100];
     std::memset(packet, 0, sizeof(packet));
     packet[0] = RTP_TYPE_VIDEO;
 
-    uint8_t *h = &packet[1];
+    std::uint8_t *h = &packet[1];
     h[0] = 0x80;
     h[1] = 0x41;  // Video
     h[2] = (sequnum >> 8) & 0xFF;

--- a/toxav/video_test.cc
+++ b/toxav/video_test.cc
@@ -3,7 +3,11 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <vector>
 
 #include "../toxcore/logger.h"
@@ -38,21 +42,21 @@ TEST_F(VideoTest, EncodeDecodeLoop)
         nullptr, nullptr, nullptr, vc, RtpMock::video_cb);
     rtp_mock.recv_session = recv_rtp;
 
-    uint16_t width = 320;
-    uint16_t height = 240;
-    uint32_t bitrate = 500;
+    std::uint16_t width = 320;
+    std::uint16_t height = 240;
+    std::uint32_t bitrate = 500;
 
     ASSERT_EQ(vc_reconfigure_encoder(vc, bitrate, width, height, -1), 0);
 
-    std::vector<uint8_t> y(width * height, 128);
-    std::vector<uint8_t> u((width / 2) * (height / 2), 64);
-    std::vector<uint8_t> v((width / 2) * (height / 2), 192);
+    std::vector<std::uint8_t> y(width * height, 128);
+    std::vector<std::uint8_t> u((width / 2) * (height / 2), 64);
+    std::vector<std::uint8_t> v((width / 2) * (height / 2), 192);
 
     ASSERT_EQ(vc_encode(vc, width, height, y.data(), u.data(), v.data(), VC_EFLAG_FORCE_KF), 0);
     vc_increment_frame_counter(vc);
 
-    uint8_t *pkt_data;
-    uint32_t pkt_size;
+    std::uint8_t *pkt_data;
+    std::uint32_t pkt_size;
     bool is_keyframe;
 
     while (vc_get_cx_data(vc, &pkt_data, &pkt_size, &is_keyframe)) {
@@ -85,16 +89,16 @@ TEST_F(VideoTest, EncodeDecodeSequence)
         nullptr, nullptr, nullptr, vc, RtpMock::video_cb);
     rtp_mock.recv_session = recv_rtp;
 
-    uint16_t width = 320;
-    uint16_t height = 240;
-    uint32_t bitrate = 2000;
+    std::uint16_t width = 320;
+    std::uint16_t height = 240;
+    std::uint32_t bitrate = 2000;
 
     ASSERT_EQ(vc_reconfigure_encoder(vc, bitrate, width, height, -1), 0);
 
     for (int i = 0; i < 20; ++i) {
-        std::vector<uint8_t> y(width * height);
-        std::vector<uint8_t> u((width / 2) * (height / 2));
-        std::vector<uint8_t> v((width / 2) * (height / 2));
+        std::vector<std::uint8_t> y(width * height);
+        std::vector<std::uint8_t> u((width / 2) * (height / 2));
+        std::vector<std::uint8_t> v((width / 2) * (height / 2));
 
         // Background
         std::fill(y.begin(), y.end(), 16);
@@ -116,8 +120,8 @@ TEST_F(VideoTest, EncodeDecodeSequence)
             0);
         vc_increment_frame_counter(vc);
 
-        uint8_t *pkt_data;
-        uint32_t pkt_size;
+        std::uint8_t *pkt_data;
+        std::uint32_t pkt_size;
         bool is_keyframe;
 
         while (vc_get_cx_data(vc, &pkt_data, &pkt_size, &is_keyframe)) {
@@ -152,20 +156,20 @@ TEST_F(VideoTest, EncodeDecodeResolutionChange)
         nullptr, nullptr, nullptr, vc, RtpMock::video_cb);
     rtp_mock.recv_session = recv_rtp;
 
-    uint16_t widths[] = {320, 160, 480};
-    uint16_t heights[] = {240, 120, 360};
+    std::uint16_t widths[] = {320, 160, 480};
+    std::uint16_t heights[] = {240, 120, 360};
 
     for (int res = 0; res < 3; ++res) {
-        uint16_t width = widths[res];
-        uint16_t height = heights[res];
+        std::uint16_t width = widths[res];
+        std::uint16_t height = heights[res];
         ASSERT_EQ(vc_reconfigure_encoder(vc, 2000, width, height, -1), 0);
 
         for (int i = 0; i < 5; ++i) {
-            std::vector<uint8_t> y(width * height);
-            std::vector<uint8_t> u((width / 2) * (height / 2));
-            std::vector<uint8_t> v((width / 2) * (height / 2));
+            std::vector<std::uint8_t> y(width * height);
+            std::vector<std::uint8_t> u((width / 2) * (height / 2));
+            std::vector<std::uint8_t> v((width / 2) * (height / 2));
 
-            std::fill(y.begin(), y.end(), static_cast<uint8_t>((res * 50 + i * 10) % 256));
+            std::fill(y.begin(), y.end(), static_cast<std::uint8_t>((res * 50 + i * 10) % 256));
             std::fill(u.begin(), u.end(), 128);
             std::fill(v.begin(), v.end(), 128);
 
@@ -174,8 +178,8 @@ TEST_F(VideoTest, EncodeDecodeResolutionChange)
                 0);
             vc_increment_frame_counter(vc);
 
-            uint8_t *pkt_data;
-            uint32_t pkt_size;
+            std::uint8_t *pkt_data;
+            std::uint32_t pkt_size;
             bool is_keyframe;
 
             while (vc_get_cx_data(vc, &pkt_data, &pkt_size, &is_keyframe)) {
@@ -199,11 +203,11 @@ TEST_F(VideoTest, EncodeDecodeResolutionChange)
 
 TEST_F(VideoTest, EncodeDecodeBitrateImpact)
 {
-    uint32_t bitrates[] = {100, 500, 2000};
+    std::uint32_t bitrates[] = {100, 500, 2000};
     double mses[3];
 
-    uint16_t width = 320;
-    uint16_t height = 240;
+    std::uint16_t width = 320;
+    std::uint16_t height = 240;
 
     for (int b = 0; b < 3; ++b) {
         VideoTestData data;
@@ -222,12 +226,12 @@ TEST_F(VideoTest, EncodeDecodeBitrateImpact)
         double total_mse = 0;
         int frames = 10;
         for (int i = 0; i < frames; ++i) {
-            std::vector<uint8_t> y(width * height);
-            std::vector<uint8_t> u((width / 2) * (height / 2));
-            std::vector<uint8_t> v((width / 2) * (height / 2));
+            std::vector<std::uint8_t> y(width * height);
+            std::vector<std::uint8_t> u((width / 2) * (height / 2));
+            std::vector<std::uint8_t> v((width / 2) * (height / 2));
 
-            for (size_t j = 0; j < y.size(); ++j)
-                y[j] = static_cast<uint8_t>((j + i * 10) % 256);
+            for (std::size_t j = 0; j < y.size(); ++j)
+                y[j] = static_cast<std::uint8_t>((j + i * 10) % 256);
             std::fill(u.begin(), u.end(), 128);
             std::fill(v.begin(), v.end(), 128);
 
@@ -236,8 +240,8 @@ TEST_F(VideoTest, EncodeDecodeBitrateImpact)
                 0);
             vc_increment_frame_counter(vc);
 
-            uint8_t *pkt_data;
-            uint32_t pkt_size;
+            std::uint8_t *pkt_data;
+            std::uint32_t pkt_size;
             bool is_keyframe;
 
             while (vc_get_cx_data(vc, &pkt_data, &pkt_size, &is_keyframe)) {
@@ -260,7 +264,7 @@ TEST_F(VideoTest, EncodeDecodeBitrateImpact)
     EXPECT_GT(mses[0], mses[1]);
     EXPECT_GT(mses[1], mses[2]);
 
-    printf("MSE results: 100kbps: %f, 500kbps: %f, 2000kbps: %f\n", mses[0], mses[1], mses[2]);
+    std::printf("MSE results: 100kbps: %f, 500kbps: %f, 2000kbps: %f\n", mses[0], mses[1], mses[2]);
 }
 
 TEST_F(VideoTest, ReconfigureEncoder)
@@ -275,9 +279,9 @@ TEST_F(VideoTest, ReconfigureEncoder)
     // Change bitrate and resolution
     ASSERT_EQ(vc_reconfigure_encoder(vc, 1000, 640, 480, -1), 0);
 
-    std::vector<uint8_t> y(640 * 480, 128);
-    std::vector<uint8_t> u(320 * 240, 64);
-    std::vector<uint8_t> v(320 * 240, 192);
+    std::vector<std::uint8_t> y(640 * 480, 128);
+    std::vector<std::uint8_t> u(320 * 240, 64);
+    std::vector<std::uint8_t> v(320 * 240, 192);
 
     ASSERT_EQ(vc_encode(vc, 640, 480, y.data(), u.data(), v.data(), VC_EFLAG_NONE), 0);
 
@@ -310,9 +314,9 @@ TEST_F(VideoTest, QueueInvalidMessage)
         &rtp_mock, nullptr, nullptr, nullptr, vc, RtpMock::video_cb);
     rtp_mock.recv_session = video_recv_rtp;
 
-    std::vector<uint8_t> dummy_audio(100, 0);
+    std::vector<std::uint8_t> dummy_audio(100, 0);
     int rc = rtp_send_data(
-        log, audio_rtp, dummy_audio.data(), static_cast<uint32_t>(dummy_audio.size()), false);
+        log, audio_rtp, dummy_audio.data(), static_cast<std::uint32_t>(dummy_audio.size()), false);
     ASSERT_EQ(rc, 0);
 
     // Iterate should NOT trigger callback because payload type was wrong
@@ -357,9 +361,9 @@ TEST_F(VideoTest, LcfdAndSpecialPackets)
     // 1. Test lcfd update
     tm.t += 50;  // Advance time by 50ms
     mono_time_update(mono_time);
-    std::vector<uint8_t> dummy_frame(10, 0);
-    rtp_send_data(
-        log, video_recv_rtp, dummy_frame.data(), static_cast<uint32_t>(dummy_frame.size()), true);
+    std::vector<std::uint8_t> dummy_frame(10, 0);
+    rtp_send_data(log, video_recv_rtp, dummy_frame.data(),
+        static_cast<std::uint32_t>(dummy_frame.size()), true);
 
     // lcfd should be updated. Initial linfts was set at vc_new (tm.t=1000).
     // Now tm.t is 1050. t_lcfd = 1050 - 1000 = 50.
@@ -368,8 +372,8 @@ TEST_F(VideoTest, LcfdAndSpecialPackets)
     // 2. Test lcfd threshold (t_lcfd > 100 should be ignored)
     tm.t += 200;
     mono_time_update(mono_time);
-    rtp_send_data(
-        log, video_recv_rtp, dummy_frame.data(), static_cast<uint32_t>(dummy_frame.size()), true);
+    rtp_send_data(log, video_recv_rtp, dummy_frame.data(),
+        static_cast<std::uint32_t>(dummy_frame.size()), true);
     EXPECT_EQ(vc_get_lcfd(vc), 50u);  // Should still be 50
 
     // 3. Test dummy packet PT = (RTP_TYPE_VIDEO + 2) % 128
@@ -377,7 +381,7 @@ TEST_F(VideoTest, LcfdAndSpecialPackets)
         &rtp_mock, nullptr, nullptr, nullptr, vc, RtpMock::video_cb);
     rtp_mock.recv_session = dummy_rtp;
     rtp_send_data(
-        log, dummy_rtp, dummy_frame.data(), static_cast<uint32_t>(dummy_frame.size()), false);
+        log, dummy_rtp, dummy_frame.data(), static_cast<std::uint32_t>(dummy_frame.size()), false);
     // Should return 0 but do nothing (logged as "Got dummy!")
 
     // 4. Test GetQueueMutex
@@ -395,11 +399,11 @@ TEST_F(VideoTest, MultiReconfigureEncode)
     ASSERT_NE(vc, nullptr);
 
     for (int i = 0; i < 5; ++i) {
-        uint16_t w = static_cast<uint16_t>(160 + (i * 16));
-        uint16_t h = static_cast<uint16_t>(120 + (i * 16));
-        std::vector<uint8_t> y(static_cast<size_t>(w) * h, 128);
-        std::vector<uint8_t> u((static_cast<size_t>(w) / 2) * (h / 2), 64);
-        std::vector<uint8_t> v((static_cast<size_t>(w) / 2) * (h / 2), 192);
+        std::uint16_t w = static_cast<std::uint16_t>(160 + (i * 16));
+        std::uint16_t h = static_cast<std::uint16_t>(120 + (i * 16));
+        std::vector<std::uint8_t> y(static_cast<std::size_t>(w) * h, 128);
+        std::vector<std::uint8_t> u((static_cast<std::size_t>(w) / 2) * (h / 2), 64);
+        std::vector<std::uint8_t> v((static_cast<std::size_t>(w) / 2) * (h / 2), 192);
 
         ASSERT_EQ(vc_reconfigure_encoder(vc, 1000, w, h, -1), 0);
         ASSERT_EQ(vc_encode(vc, w, h, y.data(), u.data(), v.data(), VC_EFLAG_NONE), 0);
@@ -419,9 +423,9 @@ TEST_F(VideoTest, ReconfigureFailDoS)
     ASSERT_EQ(vc_reconfigure_encoder(vc, 1000, 0, 0, -1), -1);
 
     // Attempt to encode. This is expected to crash because vc->encoder is destroyed.
-    std::vector<uint8_t> y(320 * 240, 128);
-    std::vector<uint8_t> u(160 * 120, 64);
-    std::vector<uint8_t> v(160 * 120, 192);
+    std::vector<std::uint8_t> y(320 * 240, 128);
+    std::vector<std::uint8_t> u(160 * 120, 64);
+    std::vector<std::uint8_t> v(160 * 120, 192);
     // This call will crash in the current unfixed code.
     vc_encode(vc, 320, 240, y.data(), u.data(), v.data(), VC_EFLAG_NONE);
 
@@ -440,31 +444,31 @@ TEST_F(VideoTest, LyingLengthOOB)
     rtp_mock.recv_session = recv_rtp;
 
     // Craft a malicious RTP packet
-    uint16_t payload_len = 10;
-    uint8_t packet[RTP_HEADER_SIZE + 11];  // +1 for Tox ID
-    memset(packet, 0, sizeof(packet));
+    std::uint16_t payload_len = 10;
+    std::uint8_t packet[RTP_HEADER_SIZE + 11];  // +1 for Tox ID
+    std::memset(packet, 0, sizeof(packet));
 
     // Tox ID
-    packet[0] = static_cast<uint8_t>(RTP_TYPE_VIDEO);
+    packet[0] = static_cast<std::uint8_t>(RTP_TYPE_VIDEO);
 
-    auto pack_u16 = [](uint8_t *p, uint16_t v) {
-        p[0] = static_cast<uint8_t>(v >> 8);
-        p[1] = static_cast<uint8_t>(v & 0xff);
+    auto pack_u16 = [](std::uint8_t *p, std::uint16_t v) {
+        p[0] = static_cast<std::uint8_t>(v >> 8);
+        p[1] = static_cast<std::uint8_t>(v & 0xff);
     };
-    auto pack_u32 = [](uint8_t *p, uint32_t v) {
-        p[0] = static_cast<uint8_t>(v >> 24);
-        p[1] = static_cast<uint8_t>((v >> 16) & 0xff);
-        p[2] = static_cast<uint8_t>((v >> 8) & 0xff);
-        p[3] = static_cast<uint8_t>(v & 0xff);
+    auto pack_u32 = [](std::uint8_t *p, std::uint32_t v) {
+        p[0] = static_cast<std::uint8_t>(v >> 24);
+        p[1] = static_cast<std::uint8_t>((v >> 16) & 0xff);
+        p[2] = static_cast<std::uint8_t>((v >> 8) & 0xff);
+        p[3] = static_cast<std::uint8_t>(v & 0xff);
     };
-    auto pack_u64 = [&](uint8_t *p, uint64_t v) {
-        pack_u32(p, static_cast<uint32_t>(v >> 32));
-        pack_u32(p + 4, static_cast<uint32_t>(v & 0xffffffff));
+    auto pack_u64 = [&](std::uint8_t *p, std::uint64_t v) {
+        pack_u32(p, static_cast<std::uint32_t>(v >> 32));
+        pack_u32(p + 4, static_cast<std::uint32_t>(v & 0xffffffff));
     };
 
     // RTP Header starts at packet[1]
     packet[1] = 2 << 6;  // ve = 2
-    packet[2] = static_cast<uint8_t>(RTP_TYPE_VIDEO % 128);
+    packet[2] = static_cast<std::uint8_t>(RTP_TYPE_VIDEO % 128);
 
     pack_u16(packet + 3, 1);  // sequnum
     pack_u32(packet + 5, 1000);  // timestamp

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -10,6 +10,7 @@
 #define C_TOXCORE_TOXCORE_DHT_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "attributes.h"
 #include "crypto_core.h"

--- a/toxcore/DHT_fuzz_test.cc
+++ b/toxcore/DHT_fuzz_test.cc
@@ -18,12 +18,12 @@ void TestHandleRequest(Fuzz_Data &input)
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
 
-    CONSUME_OR_RETURN(const uint8_t *self_public_key, input, CRYPTO_PUBLIC_KEY_SIZE);
-    CONSUME_OR_RETURN(const uint8_t *self_secret_key, input, CRYPTO_SECRET_KEY_SIZE);
+    CONSUME_OR_RETURN(const std::uint8_t *self_public_key, input, CRYPTO_PUBLIC_KEY_SIZE);
+    CONSUME_OR_RETURN(const std::uint8_t *self_secret_key, input, CRYPTO_SECRET_KEY_SIZE);
 
-    uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t request[MAX_CRYPTO_REQUEST_SIZE];
-    uint8_t request_id;
+    std::uint8_t public_key[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t request[MAX_CRYPTO_REQUEST_SIZE];
+    std::uint8_t request_id;
     handle_request(&c_mem, self_public_key, self_secret_key, public_key, request, &request_id,
         input.data(), input.size());
 }
@@ -32,16 +32,16 @@ void TestUnpackNodes(Fuzz_Data &input)
 {
     CONSUME1_OR_RETURN(const bool, tcp_enabled, input);
 
-    const uint16_t node_count = 5;
+    const std::uint16_t node_count = 5;
     Node_format nodes[node_count];
-    uint16_t processed_data_len;
+    std::uint16_t processed_data_len;
     const int packed_count = unpack_nodes(
         nodes, node_count, &processed_data_len, input.data(), input.size(), tcp_enabled);
     if (packed_count > 0) {
         SimulatedEnvironment env;
         auto c_mem = env.fake_memory().c_memory();
         Logger *logger = logger_new(&c_mem);
-        std::vector<uint8_t> packed(packed_count * PACKED_NODE_SIZE_IP6);
+        std::vector<std::uint8_t> packed(packed_count * PACKED_NODE_SIZE_IP6);
         const int packed_size
             = pack_nodes(logger, packed.data(), packed.size(), nodes, packed_count);
         LOGGER_ASSERT(logger, packed_size == processed_data_len,
@@ -51,7 +51,7 @@ void TestUnpackNodes(Fuzz_Data &input)
         // Check that packed nodes can be unpacked again and result in the
         // original unpacked nodes.
         Node_format nodes2[node_count];
-        uint16_t processed_data_len2;
+        std::uint16_t processed_data_len2;
         const int packed_count2 = unpack_nodes(
             nodes2, node_count, &processed_data_len2, packed.data(), packed.size(), tcp_enabled);
         (void)packed_count2;
@@ -59,14 +59,14 @@ void TestUnpackNodes(Fuzz_Data &input)
         assert(processed_data_len2 == processed_data_len);
         assert(packed_count2 == packed_count);
 #endif
-        assert(memcmp(nodes, nodes2, sizeof(Node_format) * packed_count) == 0);
+        assert(std::memcmp(nodes, nodes2, sizeof(Node_format) * packed_count) == 0);
     }
 }
 
 }  // namespace
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size)
 {
     tox::test::fuzz_select_target<TestHandleRequest, TestUnpackNodes>(data, size);
     return 0;

--- a/toxcore/DHT_test.cc
+++ b/toxcore/DHT_test.cc
@@ -27,7 +27,7 @@ using ::testing::PrintToString;
 using ::testing::UnorderedElementsAre;
 using namespace tox::test;
 
-using SecretKey = std::array<uint8_t, CRYPTO_SECRET_KEY_SIZE>;
+using SecretKey = std::array<std::uint8_t, CRYPTO_SECRET_KEY_SIZE>;
 
 struct KeyPair {
     PublicKey pk;
@@ -100,7 +100,7 @@ TEST(IdClosest, DistinctKeysCannotHaveTheSameDistance)
     PublicKey const pk1 = {0x00};
     PublicKey pk2 = {0x00};
 
-    for (uint8_t i = 1; i < 0xff; ++i) {
+    for (std::uint8_t i = 1; i < 0xff; ++i) {
         pk2[0] = i;
         EXPECT_NE(id_closest(pk0.data(), pk1.data(), pk2.data()), 0);
     }
@@ -287,18 +287,18 @@ TEST(Request, CreateAndParse)
     // Peers.
     const KeyPair sender(&c_rng);
     const KeyPair receiver(&c_rng);
-    const uint8_t sent_pkt_id = CRYPTO_PACKET_FRIEND_REQ;
+    const std::uint8_t sent_pkt_id = CRYPTO_PACKET_FRIEND_REQ;
 
     // Encoded packet.
-    std::array<uint8_t, MAX_CRYPTO_REQUEST_SIZE> packet;
+    std::array<std::uint8_t, MAX_CRYPTO_REQUEST_SIZE> packet;
 
     // Received components.
     PublicKey pk;
-    std::array<uint8_t, MAX_CRYPTO_REQUEST_SIZE> incoming;
-    uint8_t recvd_pkt_id;
+    std::array<std::uint8_t, MAX_CRYPTO_REQUEST_SIZE> incoming;
+    std::uint8_t recvd_pkt_id;
 
     // Request data: maximum payload is 918 bytes, so create a payload 1 byte larger than max.
-    std::vector<uint8_t> outgoing(919);
+    std::vector<std::uint8_t> outgoing(919);
     random_bytes(&c_rng, outgoing.data(), outgoing.size());
 
     EXPECT_LT(create_request(&c_mem, &c_rng, sender.pk.data(), sender.sk.data(), packet.data(),
@@ -330,7 +330,7 @@ TEST(Request, CreateAndParse)
         ASSERT_GE(recvd_length, 0);
 
         EXPECT_EQ(
-            std::vector<uint8_t>(incoming.begin(), incoming.begin() + recvd_length), outgoing);
+            std::vector<std::uint8_t>(incoming.begin(), incoming.begin() + recvd_length), outgoing);
 
         outgoing.pop_back();
     }
@@ -356,7 +356,7 @@ TEST(AnnounceNodes, SetAndTest)
     // Hook up simulation clock to mono_time
     mono_time_set_current_time_callback(
         mono_time,
-        [](void *user_data) -> uint64_t {
+        [](void *user_data) -> std::uint64_t {
             auto *clock = static_cast<FakeClock *>(user_data);
             return clock->current_time_ms();
         },
@@ -367,8 +367,8 @@ TEST(AnnounceNodes, SetAndTest)
     Ptr<DHT> dht(new_dht(log, &c_mem, &c_rng, &net_struct, mono_time, net.get(), true, true));
     ASSERT_NE(dht, nullptr);
 
-    uint8_t pk_data[CRYPTO_PUBLIC_KEY_SIZE];
-    memcpy(pk_data, dht_get_self_public_key(dht.get()), sizeof(pk_data));
+    std::uint8_t pk_data[CRYPTO_PUBLIC_KEY_SIZE];
+    std::memcpy(pk_data, dht_get_self_public_key(dht.get()), sizeof(pk_data));
     PublicKey self_pk(to_array(pk_data));
 
     PublicKey pk1 = random_pk(&c_rng);

--- a/toxcore/DHT_test_util.cc
+++ b/toxcore/DHT_test_util.cc
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cstring>
 #include <iomanip>
+#include <ostream>
 
 #include "../testing/support/public/simulated_environment.hh"
 #include "DHT.h"
@@ -17,9 +18,9 @@ using tox::test::FakeClock;
 
 MockDHT::MockDHT(const Random *rng) { crypto_new_keypair(rng, self_public_key, self_secret_key); }
 
-const uint8_t *MockDHT::get_shared_key(const uint8_t *pk)
+const std::uint8_t *MockDHT::get_shared_key(const std::uint8_t *pk)
 {
-    std::array<uint8_t, CRYPTO_PUBLIC_KEY_SIZE> pk_arr;
+    std::array<std::uint8_t, CRYPTO_PUBLIC_KEY_SIZE> pk_arr;
     std::copy(pk, pk + CRYPTO_PUBLIC_KEY_SIZE, pk_arr.begin());
     auto it = shared_keys.find(pk_arr);
     if (it != shared_keys.end()) {
@@ -29,14 +30,14 @@ const uint8_t *MockDHT::get_shared_key(const uint8_t *pk)
     ++computation_count;
 
     // Compute new shared key
-    std::array<uint8_t, CRYPTO_SHARED_KEY_SIZE> sk;
+    std::array<std::uint8_t, CRYPTO_SHARED_KEY_SIZE> sk;
     encrypt_precompute(pk, self_secret_key, sk.data());
     shared_keys[pk_arr] = sk;
     return shared_keys[pk_arr].data();
 }
 
 const Net_Crypto_DHT_Funcs MockDHT::funcs = {
-    [](void *obj, const uint8_t *public_key) {
+    [](void *obj, const std::uint8_t *public_key) {
         return static_cast<MockDHT *>(obj)->get_shared_key(public_key);
     },
     [](const void *obj) { return static_cast<const MockDHT *>(obj)->self_public_key; },
@@ -45,12 +46,12 @@ const Net_Crypto_DHT_Funcs MockDHT::funcs = {
 
 // --- WrappedMockDHT Implementation ---
 
-WrappedMockDHT::WrappedMockDHT(tox::test::SimulatedEnvironment &env, uint16_t port)
+WrappedMockDHT::WrappedMockDHT(tox::test::SimulatedEnvironment &env, std::uint16_t port)
     : node_(env.create_node(0))
     , logger_(logger_new(&node_->c_memory), [](Logger *l) { logger_kill(l); })
     , mono_time_(mono_time_new(
                      &node_->c_memory,
-                     [](void *ud) -> uint64_t {
+                     [](void *ud) -> std::uint64_t {
                          return static_cast<tox::test::FakeClock *>(ud)->current_time_ms();
                      },
                      &env.fake_clock()),
@@ -91,14 +92,15 @@ const Net_Crypto_DHT_Funcs WrappedMockDHT::funcs = MockDHT::funcs;
 
 // --- WrappedDHT Implementation ---
 
-WrappedDHT::WrappedDHT(tox::test::SimulatedEnvironment &env, uint16_t port)
+WrappedDHT::WrappedDHT(tox::test::SimulatedEnvironment &env, std::uint16_t port)
     : node_(env.create_node(0))
     , logger_(logger_new(&node_->c_memory), [](Logger *l) { logger_kill(l); })
-    , mono_time_(
-          mono_time_new(
-              &node_->c_memory,
-              [](void *ud) -> uint64_t { return static_cast<FakeClock *>(ud)->current_time_ms(); },
-              &env.fake_clock()),
+    , mono_time_(mono_time_new(
+                     &node_->c_memory,
+                     [](void *ud) -> std::uint64_t {
+                         return static_cast<FakeClock *>(ud)->current_time_ms();
+                     },
+                     &env.fake_clock()),
           [mem = &node_->c_memory](Mono_Time *t) { mono_time_free(mem, t); })
     , networking_(nullptr, [](Networking_Core *n) { kill_networking(n); })
     , dht_(nullptr, [](DHT *d) { kill_dht(d); })
@@ -122,9 +124,15 @@ WrappedDHT::WrappedDHT(tox::test::SimulatedEnvironment &env, uint16_t port)
 
 WrappedDHT::~WrappedDHT() = default;
 
-const uint8_t *WrappedDHT::dht_public_key() const { return dht_get_self_public_key(dht_.get()); }
+const std::uint8_t *WrappedDHT::dht_public_key() const
+{
+    return dht_get_self_public_key(dht_.get());
+}
 
-const uint8_t *WrappedDHT::dht_secret_key() const { return dht_get_self_secret_key(dht_.get()); }
+const std::uint8_t *WrappedDHT::dht_secret_key() const
+{
+    return dht_get_self_secret_key(dht_.get());
+}
 
 IP_Port WrappedDHT::get_ip_port() const
 {
@@ -142,7 +150,7 @@ void WrappedDHT::poll()
 }
 
 const Net_Crypto_DHT_Funcs WrappedDHT::funcs = {
-    [](void *obj, const uint8_t *public_key) {
+    [](void *obj, const std::uint8_t *public_key) {
         return dht_get_shared_key_sent(static_cast<DHT *>(obj), public_key);
     },
     [](const void *obj) { return dht_get_self_public_key(static_cast<const DHT *>(obj)); },

--- a/toxcore/DHT_test_util.hh
+++ b/toxcore/DHT_test_util.hh
@@ -2,6 +2,7 @@
 #define C_TOXCORE_TOXCORE_DHT_TEST_UTIL_H
 
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <iosfwd>
 #include <map>
@@ -31,17 +32,17 @@ Node_format random_node_format(const Random *rng);
 
 // --- Mock DHT ---
 struct MockDHT {
-    uint8_t self_public_key[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t self_secret_key[CRYPTO_SECRET_KEY_SIZE];
+    std::uint8_t self_public_key[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t self_secret_key[CRYPTO_SECRET_KEY_SIZE];
     // Cache for shared keys: Public Key -> Shared Key
-    std::map<std::array<uint8_t, CRYPTO_PUBLIC_KEY_SIZE>,
-        std::array<uint8_t, CRYPTO_SHARED_KEY_SIZE>>
+    std::map<std::array<std::uint8_t, CRYPTO_PUBLIC_KEY_SIZE>,
+        std::array<std::uint8_t, CRYPTO_SHARED_KEY_SIZE>>
         shared_keys;
     int computation_count = 0;
 
     explicit MockDHT(const Random *rng);
 
-    const uint8_t *get_shared_key(const uint8_t *pk);
+    const std::uint8_t *get_shared_key(const std::uint8_t *pk);
 
     static const Net_Crypto_DHT_Funcs funcs;
 };
@@ -50,11 +51,11 @@ struct MockDHT {
 // Wraps a MockDHT instance and its dependencies (networking, etc.) within a SimulatedEnvironment
 class WrappedMockDHT {
 public:
-    WrappedMockDHT(tox::test::SimulatedEnvironment &env, uint16_t port);
+    WrappedMockDHT(tox::test::SimulatedEnvironment &env, std::uint16_t port);
 
     MockDHT *get_dht() { return &dht_; }
-    const uint8_t *dht_public_key() const { return dht_.self_public_key; }
-    const uint8_t *dht_secret_key() const { return dht_.self_secret_key; }
+    const std::uint8_t *dht_public_key() const { return dht_.self_public_key; }
+    const std::uint8_t *dht_secret_key() const { return dht_.self_secret_key; }
     int dht_computation_count() const { return dht_.computation_count; }
 
     // Returns a valid IP_Port for this node in the simulation (Localhost IPv6)
@@ -84,11 +85,11 @@ private:
 // Wraps a DHT instance and its dependencies within a SimulatedEnvironment
 class WrappedDHT {
 public:
-    WrappedDHT(tox::test::SimulatedEnvironment &env, uint16_t port);
+    WrappedDHT(tox::test::SimulatedEnvironment &env, std::uint16_t port);
 
     DHT *get_dht() { return dht_.get(); }
-    const uint8_t *dht_public_key() const;
-    const uint8_t *dht_secret_key() const;
+    const std::uint8_t *dht_public_key() const;
+    const std::uint8_t *dht_secret_key() const;
 
     // Returns a valid IP_Port for this node in the simulation (Localhost IPv6)
     IP_Port get_ip_port() const;

--- a/toxcore/LAN_discovery.h
+++ b/toxcore/LAN_discovery.h
@@ -9,6 +9,9 @@
 #ifndef C_TOXCORE_TOXCORE_LAN_DISCOVERY_H
 #define C_TOXCORE_TOXCORE_LAN_DISCOVERY_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "attributes.h"
 #include "mem.h"
 #include "network.h"

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -10,6 +10,9 @@
 #ifndef C_TOXCORE_TOXCORE_MESSENGER_H
 #define C_TOXCORE_TOXCORE_MESSENGER_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "DHT.h"
 #include "TCP_client.h"
 #include "TCP_server.h"

--- a/toxcore/TCP_client.h
+++ b/toxcore/TCP_client.h
@@ -9,6 +9,8 @@
 #ifndef C_TOXCORE_TOXCORE_TCP_CLIENT_H
 #define C_TOXCORE_TOXCORE_TCP_CLIENT_H
 
+#include <stdint.h>
+
 #include "attributes.h"
 #include "crypto_core.h"
 #include "forwarding.h"

--- a/toxcore/TCP_client_test.cc
+++ b/toxcore/TCP_client_test.cc
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdio>
+#include <cstring>
 #include <vector>
 
 #include "TCP_common.h"
@@ -28,7 +30,7 @@ protected:
         Mono_Time *mt = mono_time_new(mem, nullptr, nullptr);
         mono_time_set_current_time_callback(
             mt,
-            [](void *user_data) -> uint64_t {
+            [](void *user_data) -> std::uint64_t {
                 auto *clock = static_cast<FakeClock *>(user_data);
                 return clock->current_time_ms();
             },
@@ -36,7 +38,7 @@ protected:
         return mt;
     }
 
-    static void log_cb(void *context, Logger_Level level, const char *file, uint32_t line,
+    static void log_cb(void *context, Logger_Level level, const char *file, std::uint32_t line,
         const char *func, const char *message, void *userdata)
     {
         if (level > LOGGER_LEVEL_TRACE) {
@@ -68,13 +70,13 @@ TEST_F(TCPClientTest, ConnectsToRelay)
     ASSERT_EQ(0, net_listen(&server_node->c_network, server_sock, 5));
 
     // Server Keys
-    uint8_t server_pk[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t server_sk[CRYPTO_SECRET_KEY_SIZE];
+    std::uint8_t server_pk[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t server_sk[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(&server_node->c_random, server_pk, server_sk);
 
     // Client Keys
-    uint8_t client_pk[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t client_sk[CRYPTO_SECRET_KEY_SIZE];
+    std::uint8_t client_pk[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t client_sk[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(&client_node->c_random, client_pk, client_sk);
 
     Net_Profile *client_profile = netprof_new(client_log, &client_node->c_memory);
@@ -92,7 +94,7 @@ TEST_F(TCPClientTest, ConnectsToRelay)
     // 3. Simulation Loop
     bool connected = false;
     Socket accepted_sock = net_invalid_socket();
-    uint64_t start_time = env.clock().current_time_ms();
+    std::uint64_t start_time = env.clock().current_time_ms();
 
     while (env.clock().current_time_ms() - start_time < 5000) {
         env.advance_time(10);
@@ -109,7 +111,7 @@ TEST_F(TCPClientTest, ConnectsToRelay)
 
         // Server handles handshake
         if (sock_valid(accepted_sock)) {
-            uint8_t buf[TCP_CLIENT_HANDSHAKE_SIZE];
+            std::uint8_t buf[TCP_CLIENT_HANDSHAKE_SIZE];
             IP_Port remote = {{{0}}};
             int len = net_recv(
                 &server_node->c_network, server_log, accepted_sock, buf, sizeof(buf), &remote);
@@ -120,15 +122,16 @@ TEST_F(TCPClientTest, ConnectsToRelay)
 
             if (len == TCP_CLIENT_HANDSHAKE_SIZE) {
                 // Verify client PK
-                EXPECT_EQ(0, memcmp(buf, client_pk, CRYPTO_PUBLIC_KEY_SIZE));
+                EXPECT_EQ(0, std::memcmp(buf, client_pk, CRYPTO_PUBLIC_KEY_SIZE));
 
                 // Decrypt
-                uint8_t shared_key[CRYPTO_SHARED_KEY_SIZE];
+                std::uint8_t shared_key[CRYPTO_SHARED_KEY_SIZE];
                 encrypt_precompute(client_pk, server_sk, shared_key);
 
-                uint8_t plain[TCP_HANDSHAKE_PLAIN_SIZE];
-                const uint8_t *nonce_ptr = buf + CRYPTO_PUBLIC_KEY_SIZE;
-                const uint8_t *ciphertext_ptr = buf + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE;
+                std::uint8_t plain[TCP_HANDSHAKE_PLAIN_SIZE];
+                const std::uint8_t *nonce_ptr = buf + CRYPTO_PUBLIC_KEY_SIZE;
+                const std::uint8_t *ciphertext_ptr
+                    = buf + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE;
 
                 int res = decrypt_data_symmetric(&server_node->c_memory, shared_key, nonce_ptr,
                     ciphertext_ptr,
@@ -143,19 +146,19 @@ TEST_F(TCPClientTest, ConnectsToRelay)
                     // Generate Response
                     // [Nonce (24)] [Encrypted (PK(32)+Nonce(24)+MAC(16))]
 
-                    uint8_t resp_nonce[CRYPTO_NONCE_SIZE];
+                    std::uint8_t resp_nonce[CRYPTO_NONCE_SIZE];
                     random_nonce(&server_node->c_random, resp_nonce);
 
-                    uint8_t temp_pk[CRYPTO_PUBLIC_KEY_SIZE];
-                    uint8_t temp_sk[CRYPTO_SECRET_KEY_SIZE];
+                    std::uint8_t temp_pk[CRYPTO_PUBLIC_KEY_SIZE];
+                    std::uint8_t temp_sk[CRYPTO_SECRET_KEY_SIZE];
                     crypto_new_keypair(&server_node->c_random, temp_pk, temp_sk);
 
-                    uint8_t resp_plain[TCP_HANDSHAKE_PLAIN_SIZE];
-                    memcpy(resp_plain, temp_pk, CRYPTO_PUBLIC_KEY_SIZE);
+                    std::uint8_t resp_plain[TCP_HANDSHAKE_PLAIN_SIZE];
+                    std::memcpy(resp_plain, temp_pk, CRYPTO_PUBLIC_KEY_SIZE);
                     random_nonce(&server_node->c_random, resp_plain + CRYPTO_PUBLIC_KEY_SIZE);
 
-                    uint8_t response[TCP_SERVER_HANDSHAKE_SIZE];
-                    memcpy(response, resp_nonce, CRYPTO_NONCE_SIZE);
+                    std::uint8_t response[TCP_SERVER_HANDSHAKE_SIZE];
+                    std::memcpy(response, resp_nonce, CRYPTO_NONCE_SIZE);
 
                     encrypt_data_symmetric(&server_node->c_memory, shared_key,
                         resp_nonce,  // nonce
@@ -209,12 +212,12 @@ TEST_F(TCPClientTest, SendDataIntegerOverflow)
     ASSERT_TRUE(bind_to_port(&server_node->c_network, server_sock, net_family_ipv4(), 33446));
     ASSERT_EQ(0, net_listen(&server_node->c_network, server_sock, 5));
 
-    uint8_t server_pk[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t server_sk[CRYPTO_SECRET_KEY_SIZE];
+    std::uint8_t server_pk[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t server_sk[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(&server_node->c_random, server_pk, server_sk);
 
-    uint8_t client_pk[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t client_sk[CRYPTO_SECRET_KEY_SIZE];
+    std::uint8_t client_pk[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t client_sk[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(&client_node->c_random, client_pk, client_sk);
 
     Net_Profile *client_profile = netprof_new(client_log, &client_node->c_memory);
@@ -230,20 +233,20 @@ TEST_F(TCPClientTest, SendDataIntegerOverflow)
 
     bool connected = false;
     Socket accepted_sock = net_invalid_socket();
-    uint64_t start_time = env.clock().current_time_ms();
-    uint8_t shared_key[CRYPTO_SHARED_KEY_SIZE];
-    uint8_t sent_nonce[CRYPTO_NONCE_SIZE] = {0};
-    uint8_t recv_nonce[CRYPTO_NONCE_SIZE] = {0};
+    std::uint64_t start_time = env.clock().current_time_ms();
+    std::uint8_t shared_key[CRYPTO_SHARED_KEY_SIZE];
+    std::uint8_t sent_nonce[CRYPTO_NONCE_SIZE] = {0};
+    std::uint8_t recv_nonce[CRYPTO_NONCE_SIZE] = {0};
 
     // Helper to send encrypted packet from server to client
-    auto server_send_packet = [&](const uint8_t *data, uint16_t length) {
-        uint16_t packet_size = sizeof(uint16_t) + length + CRYPTO_MAC_SIZE;
-        std::vector<uint8_t> packet(packet_size);
-        uint16_t c_length = net_htons(length + CRYPTO_MAC_SIZE);
-        memcpy(packet.data(), &c_length, sizeof(uint16_t));
+    auto server_send_packet = [&](const std::uint8_t *data, std::uint16_t length) {
+        std::uint16_t packet_size = sizeof(std::uint16_t) + length + CRYPTO_MAC_SIZE;
+        std::vector<std::uint8_t> packet(packet_size);
+        std::uint16_t c_length = net_htons(length + CRYPTO_MAC_SIZE);
+        std::memcpy(packet.data(), &c_length, sizeof(std::uint16_t));
 
         encrypt_data_symmetric(&server_node->c_memory, shared_key, sent_nonce, data, length,
-            packet.data() + sizeof(uint16_t));
+            packet.data() + sizeof(std::uint16_t));
         increment_nonce(sent_nonce);
 
         IP_Port remote = {{{0}}};
@@ -263,39 +266,39 @@ TEST_F(TCPClientTest, SendDataIntegerOverflow)
         }
 
         if (sock_valid(accepted_sock) && !connected) {
-            uint8_t buf[TCP_CLIENT_HANDSHAKE_SIZE];
+            std::uint8_t buf[TCP_CLIENT_HANDSHAKE_SIZE];
             IP_Port remote = {{{0}}};
             int len = net_recv(
                 &server_node->c_network, server_log, accepted_sock, buf, sizeof(buf), &remote);
 
             if (len == TCP_CLIENT_HANDSHAKE_SIZE) {
                 encrypt_precompute(client_pk, server_sk, shared_key);
-                uint8_t plain[TCP_HANDSHAKE_PLAIN_SIZE];
+                std::uint8_t plain[TCP_HANDSHAKE_PLAIN_SIZE];
                 if (decrypt_data_symmetric(&server_node->c_memory, shared_key,
                         buf + CRYPTO_PUBLIC_KEY_SIZE,
                         buf + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE,
                         TCP_CLIENT_HANDSHAKE_SIZE - (CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE),
                         plain)
                     == TCP_HANDSHAKE_PLAIN_SIZE) {
-                    memcpy(recv_nonce, plain + CRYPTO_PUBLIC_KEY_SIZE, CRYPTO_NONCE_SIZE);
+                    std::memcpy(recv_nonce, plain + CRYPTO_PUBLIC_KEY_SIZE, CRYPTO_NONCE_SIZE);
 
-                    uint8_t resp_nonce[CRYPTO_NONCE_SIZE];
+                    std::uint8_t resp_nonce[CRYPTO_NONCE_SIZE];
                     random_nonce(&server_node->c_random, resp_nonce);
-                    memcpy(sent_nonce, resp_nonce, CRYPTO_NONCE_SIZE);
+                    std::memcpy(sent_nonce, resp_nonce, CRYPTO_NONCE_SIZE);
 
-                    uint8_t temp_pk[CRYPTO_PUBLIC_KEY_SIZE];
-                    uint8_t temp_sk[CRYPTO_SECRET_KEY_SIZE];
+                    std::uint8_t temp_pk[CRYPTO_PUBLIC_KEY_SIZE];
+                    std::uint8_t temp_sk[CRYPTO_SECRET_KEY_SIZE];
                     crypto_new_keypair(&server_node->c_random, temp_pk, temp_sk);
 
-                    uint8_t resp_plain[TCP_HANDSHAKE_PLAIN_SIZE];
-                    memcpy(resp_plain, temp_pk, CRYPTO_PUBLIC_KEY_SIZE);
+                    std::uint8_t resp_plain[TCP_HANDSHAKE_PLAIN_SIZE];
+                    std::memcpy(resp_plain, temp_pk, CRYPTO_PUBLIC_KEY_SIZE);
                     random_nonce(&server_node->c_random, resp_plain + CRYPTO_PUBLIC_KEY_SIZE);
 
                     // FIX: Save the nonce that client will use for receiving
-                    memcpy(sent_nonce, resp_plain + CRYPTO_PUBLIC_KEY_SIZE, CRYPTO_NONCE_SIZE);
+                    std::memcpy(sent_nonce, resp_plain + CRYPTO_PUBLIC_KEY_SIZE, CRYPTO_NONCE_SIZE);
 
-                    uint8_t response[TCP_SERVER_HANDSHAKE_SIZE];
-                    memcpy(response, resp_nonce, CRYPTO_NONCE_SIZE);
+                    std::uint8_t response[TCP_SERVER_HANDSHAKE_SIZE];
+                    std::memcpy(response, resp_nonce, CRYPTO_NONCE_SIZE);
                     encrypt_data_symmetric(&server_node->c_memory, shared_key, resp_nonce,
                         resp_plain, TCP_HANDSHAKE_PLAIN_SIZE, response + CRYPTO_NONCE_SIZE);
                     net_send(&server_node->c_network, server_log, accepted_sock, response,
@@ -315,14 +318,14 @@ TEST_F(TCPClientTest, SendDataIntegerOverflow)
     ASSERT_TRUE(connected);
 
     // Establish sub-connection 0
-    uint8_t con_id = 0;
-    uint8_t other_pk[CRYPTO_PUBLIC_KEY_SIZE] = {0};  // Dummy PK
+    std::uint8_t con_id = 0;
+    std::uint8_t other_pk[CRYPTO_PUBLIC_KEY_SIZE] = {0};  // Dummy PK
     // 1. Send Routing Response to set status=1
     {
-        uint8_t packet[1 + 1 + CRYPTO_PUBLIC_KEY_SIZE];
+        std::uint8_t packet[1 + 1 + CRYPTO_PUBLIC_KEY_SIZE];
         packet[0] = TCP_PACKET_ROUTING_RESPONSE;
         packet[1] = con_id + NUM_RESERVED_PORTS;
-        memcpy(packet + 2, other_pk, CRYPTO_PUBLIC_KEY_SIZE);
+        std::memcpy(packet + 2, other_pk, CRYPTO_PUBLIC_KEY_SIZE);
         server_send_packet(packet, sizeof(packet));
     }
 
@@ -334,7 +337,7 @@ TEST_F(TCPClientTest, SendDataIntegerOverflow)
 
     // 2. Send Connection Notification to set status=2
     {
-        uint8_t packet[1 + 1];
+        std::uint8_t packet[1 + 1];
         packet[0] = TCP_PACKET_CONNECTION_NOTIFICATION;
         packet[1] = con_id + NUM_RESERVED_PORTS;
         server_send_packet(packet, sizeof(packet));
@@ -347,7 +350,7 @@ TEST_F(TCPClientTest, SendDataIntegerOverflow)
     }
 
     // Now call send_data with 65535 bytes
-    std::vector<uint8_t> large_data(65535);
+    std::vector<std::uint8_t> large_data(65535);
     // This should trigger integer overflow: 1 + 65535 = 0. VLA(0). packet[0] write -> Crash/UB
     send_data(client_log, client_conn, con_id, large_data.data(), 65535);
 

--- a/toxcore/TCP_common.h
+++ b/toxcore/TCP_common.h
@@ -6,6 +6,9 @@
 #ifndef C_TOXCORE_TOXCORE_TCP_COMMON_H
 #define C_TOXCORE_TOXCORE_TCP_COMMON_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "attributes.h"
 #include "crypto_core.h"
 #include "logger.h"

--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -9,6 +9,9 @@
 #ifndef C_TOXCORE_TOXCORE_TCP_SERVER_H
 #define C_TOXCORE_TOXCORE_TCP_SERVER_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "attributes.h"
 #include "crypto_core.h"
 #include "forwarding.h"

--- a/toxcore/announce.h
+++ b/toxcore/announce.h
@@ -5,6 +5,7 @@
 #ifndef C_TOXCORE_TOXCORE_ANNOUNCE_H
 #define C_TOXCORE_TOXCORE_ANNOUNCE_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "DHT.h"

--- a/toxcore/bin_pack_test.cc
+++ b/toxcore/bin_pack_test.cc
@@ -13,11 +13,11 @@ namespace {
 
 TEST(BinPack, TooSmallBufferIsNotExceeded)
 {
-    const uint64_t orig = 1234567812345678LL;
-    std::array<uint8_t, sizeof(orig) - 1> buf;
+    const std::uint64_t orig = 1234567812345678LL;
+    std::array<std::uint8_t, sizeof(orig) - 1> buf;
     EXPECT_FALSE(bin_pack_obj(
         [](const void *obj, const Logger *logger, Bin_Pack *bp) {
-            return bin_pack_u64_b(bp, *static_cast<const uint64_t *>(obj));
+            return bin_pack_u64_b(bp, *static_cast<const std::uint64_t *>(obj));
         },
         &orig, nullptr, buf.data(), buf.size()));
 }
@@ -25,19 +25,19 @@ TEST(BinPack, TooSmallBufferIsNotExceeded)
 TEST(BinPack, PackedUint64CanBeUnpacked)
 {
     const Memory *mem = os_memory();
-    const uint64_t orig = 1234567812345678LL;
-    std::array<uint8_t, 8> buf;
+    const std::uint64_t orig = 1234567812345678LL;
+    std::array<std::uint8_t, 8> buf;
     EXPECT_TRUE(bin_pack_obj(
         [](const void *obj, const Logger *logger, Bin_Pack *bp) {
-            return bin_pack_u64_b(bp, *static_cast<const uint64_t *>(obj));
+            return bin_pack_u64_b(bp, *static_cast<const std::uint64_t *>(obj));
         },
         &orig, nullptr, buf.data(), buf.size()));
 
-    uint64_t unpacked = 0;
+    std::uint64_t unpacked = 0;
     EXPECT_TRUE(bin_unpack_obj(
         mem,
         [](void *obj, Bin_Unpack *bu) {
-            return bin_unpack_u64_b(bu, static_cast<uint64_t *>(obj));
+            return bin_unpack_u64_b(bu, static_cast<std::uint64_t *>(obj));
         },
         &unpacked, buf.data(), buf.size()));
     EXPECT_EQ(unpacked, 1234567812345678LL);
@@ -46,18 +46,20 @@ TEST(BinPack, PackedUint64CanBeUnpacked)
 TEST(BinPack, MsgPackedUint8CanBeUnpackedAsUint32)
 {
     const Memory *mem = os_memory();
-    const uint8_t orig = 123;
-    std::array<uint8_t, 2> buf;
+    const std::uint8_t orig = 123;
+    std::array<std::uint8_t, 2> buf;
     EXPECT_TRUE(bin_pack_obj(
         [](const void *obj, const Logger *logger, Bin_Pack *bp) {
-            return bin_pack_u08(bp, *static_cast<const uint8_t *>(obj));
+            return bin_pack_u08(bp, *static_cast<const std::uint8_t *>(obj));
         },
         &orig, nullptr, buf.data(), buf.size()));
 
-    uint32_t unpacked = 0;
+    std::uint32_t unpacked = 0;
     EXPECT_TRUE(bin_unpack_obj(
         mem,
-        [](void *obj, Bin_Unpack *bu) { return bin_unpack_u32(bu, static_cast<uint32_t *>(obj)); },
+        [](void *obj, Bin_Unpack *bu) {
+            return bin_unpack_u32(bu, static_cast<std::uint32_t *>(obj));
+        },
         &unpacked, buf.data(), buf.size()));
     EXPECT_EQ(unpacked, 123);
 }
@@ -65,18 +67,20 @@ TEST(BinPack, MsgPackedUint8CanBeUnpackedAsUint32)
 TEST(BinPack, MsgPackedUint32CanBeUnpackedAsUint8IfSmallEnough)
 {
     const Memory *mem = os_memory();
-    const uint32_t orig = 123;
-    std::array<uint8_t, 2> buf;
+    const std::uint32_t orig = 123;
+    std::array<std::uint8_t, 2> buf;
     EXPECT_TRUE(bin_pack_obj(
         [](const void *obj, const Logger *logger, Bin_Pack *bp) {
-            return bin_pack_u32(bp, *static_cast<const uint32_t *>(obj));
+            return bin_pack_u32(bp, *static_cast<const std::uint32_t *>(obj));
         },
         &orig, nullptr, buf.data(), buf.size()));
 
-    uint8_t unpacked = 0;
+    std::uint8_t unpacked = 0;
     EXPECT_TRUE(bin_unpack_obj(
         mem,
-        [](void *obj, Bin_Unpack *bu) { return bin_unpack_u08(bu, static_cast<uint8_t *>(obj)); },
+        [](void *obj, Bin_Unpack *bu) {
+            return bin_unpack_u08(bu, static_cast<std::uint8_t *>(obj));
+        },
         &unpacked, buf.data(), buf.size()));
 
     EXPECT_EQ(unpacked, 123);
@@ -85,18 +89,20 @@ TEST(BinPack, MsgPackedUint32CanBeUnpackedAsUint8IfSmallEnough)
 TEST(BinPack, LargeMsgPackedUint32CannotBeUnpackedAsUint8)
 {
     const Memory *mem = os_memory();
-    const uint32_t orig = 1234567;
-    std::array<uint8_t, 5> buf;
+    const std::uint32_t orig = 1234567;
+    std::array<std::uint8_t, 5> buf;
     EXPECT_TRUE(bin_pack_obj(
         [](const void *obj, const Logger *logger, Bin_Pack *bp) {
-            return bin_pack_u32(bp, *static_cast<const uint32_t *>(obj));
+            return bin_pack_u32(bp, *static_cast<const std::uint32_t *>(obj));
         },
         &orig, nullptr, buf.data(), buf.size()));
 
-    uint8_t unpacked = 0;
+    std::uint8_t unpacked = 0;
     EXPECT_FALSE(bin_unpack_obj(
         mem,
-        [](void *obj, Bin_Unpack *bu) { return bin_unpack_u08(bu, static_cast<uint8_t *>(obj)); },
+        [](void *obj, Bin_Unpack *bu) {
+            return bin_unpack_u08(bu, static_cast<std::uint8_t *>(obj));
+        },
         &unpacked, buf.data(), buf.size()));
 }
 
@@ -104,13 +110,13 @@ TEST(BinPack, BinCanHoldPackedInts)
 {
     const Memory *mem = os_memory();
     struct Stuff {
-        uint64_t u64;
-        uint16_t u16;
+        std::uint64_t u64;
+        std::uint16_t u16;
     };
     const Stuff orig = {1234567812345678LL, 54321};
-    static const uint32_t packed_size = sizeof(uint64_t) + sizeof(uint16_t);
+    static const std::uint32_t packed_size = sizeof(std::uint64_t) + sizeof(std::uint16_t);
 
-    std::array<uint8_t, 12> buf;
+    std::array<std::uint8_t, 12> buf;
     EXPECT_TRUE(bin_pack_obj(
         [](const void *obj, const Logger *logger, Bin_Pack *bp) {
             const Stuff *self = static_cast<const Stuff *>(obj);
@@ -125,7 +131,7 @@ TEST(BinPack, BinCanHoldPackedInts)
         mem,
         [](void *obj, Bin_Unpack *bu) {
             Stuff *stuff = static_cast<Stuff *>(obj);
-            uint32_t size;
+            std::uint32_t size;
             return bin_unpack_bin_size(bu, &size)  //
                 && size == 10  //
                 && bin_unpack_u64_b(bu, &stuff->u64)  //
@@ -139,35 +145,35 @@ TEST(BinPack, BinCanHoldPackedInts)
 TEST(BinPack, BinCanHoldArbitraryData)
 {
     const Memory *mem = os_memory();
-    std::array<uint8_t, 7> buf;
+    std::array<std::uint8_t, 7> buf;
     EXPECT_TRUE(bin_pack_obj(
         [](const void *obj, const Logger *logger, Bin_Pack *bp) {
             return bin_pack_bin_marker(bp, 5)  //
-                && bin_pack_bin_b(bp, reinterpret_cast<const uint8_t *>("hello"), 5);
+                && bin_pack_bin_b(bp, reinterpret_cast<const std::uint8_t *>("hello"), 5);
         },
         nullptr, nullptr, buf.data(), buf.size()));
 
-    std::array<uint8_t, 5> str;
+    std::array<std::uint8_t, 5> str;
     EXPECT_TRUE(bin_unpack_obj(
         mem,
         [](void *obj, Bin_Unpack *bu) {
-            uint8_t *data = static_cast<uint8_t *>(obj);
+            std::uint8_t *data = static_cast<std::uint8_t *>(obj);
             return bin_unpack_bin_fixed(bu, data, 5);
         },
         str.data(), buf.data(), buf.size()));
-    EXPECT_EQ(str, (std::array<uint8_t, 5>{'h', 'e', 'l', 'l', 'o'}));
+    EXPECT_EQ(str, (std::array<std::uint8_t, 5>{'h', 'e', 'l', 'l', 'o'}));
 }
 
 TEST(BinPack, OversizedArrayFailsUnpack)
 {
     const Memory *mem = os_memory();
-    std::array<uint8_t, 1> buf = {0x91};
+    std::array<std::uint8_t, 1> buf = {0x91};
 
-    uint32_t size;
+    std::uint32_t size;
     EXPECT_FALSE(bin_unpack_obj(
         mem,
         [](void *obj, Bin_Unpack *bu) {
-            uint32_t *size_ptr = static_cast<uint32_t *>(obj);
+            std::uint32_t *size_ptr = static_cast<std::uint32_t *>(obj);
             return bin_unpack_array(bu, size_ptr);
         },
         &size, buf.data(), buf.size()));

--- a/toxcore/crypto_core_test.cc
+++ b/toxcore/crypto_core_test.cc
@@ -7,17 +7,18 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <vector>
 
 #include "crypto_core_test_util.hh"
 
 namespace {
 
-using HmacKey = std::array<uint8_t, CRYPTO_HMAC_KEY_SIZE>;
-using Hmac = std::array<uint8_t, CRYPTO_HMAC_SIZE>;
-using SecretKey = std::array<uint8_t, CRYPTO_SECRET_KEY_SIZE>;
-using Signature = std::array<uint8_t, CRYPTO_SIGNATURE_SIZE>;
-using Nonce = std::array<uint8_t, CRYPTO_NONCE_SIZE>;
+using HmacKey = std::array<std::uint8_t, CRYPTO_HMAC_KEY_SIZE>;
+using Hmac = std::array<std::uint8_t, CRYPTO_HMAC_SIZE>;
+using SecretKey = std::array<std::uint8_t, CRYPTO_SECRET_KEY_SIZE>;
+using Signature = std::array<std::uint8_t, CRYPTO_SIGNATURE_SIZE>;
+using Nonce = std::array<std::uint8_t, CRYPTO_NONCE_SIZE>;
 
 using tox::test::SimulatedEnvironment;
 
@@ -26,8 +27,8 @@ TEST(PkEqual, TwoRandomIdsAreNotEqual)
     SimulatedEnvironment env;
     auto &rng = env.fake_random();
 
-    uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE];
 
     rng.bytes(pk1, sizeof(pk1));
     rng.bytes(pk2, sizeof(pk2));
@@ -40,8 +41,8 @@ TEST(PkEqual, IdCopyMakesKeysEqual)
     SimulatedEnvironment env;
     auto &rng = env.fake_random();
 
-    uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE] = {0};
+    std::uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t pk2[CRYPTO_PUBLIC_KEY_SIZE] = {0};
 
     rng.bytes(pk1, sizeof(pk1));
 
@@ -62,8 +63,8 @@ TEST(CryptoCore, EncryptLargeData)
     crypto_new_keypair(&c_rng, pk.data(), sk.data());
 
     // 100 MiB of data (all zeroes, doesn't matter what's inside).
-    std::vector<uint8_t> plain(100 * 1024 * 1024);
-    std::vector<uint8_t> encrypted(plain.size() + CRYPTO_MAC_SIZE);
+    std::vector<std::uint8_t> plain(100 * 1024 * 1024);
+    std::vector<std::uint8_t> encrypted(plain.size() + CRYPTO_MAC_SIZE);
 
     encrypt_data(
         &c_mem, pk.data(), sk.data(), nonce.data(), plain.data(), plain.size(), encrypted.data());
@@ -112,11 +113,11 @@ TEST(CryptoCore, Signatures)
 
     EXPECT_TRUE(create_extended_keypair(&pk, &sk, &c_rng));
 
-    std::vector<uint8_t> message{0};
+    std::vector<std::uint8_t> message{0};
     message.clear();
 
     // Try a few different sizes, including empty 0 length message.
-    for (uint8_t i = 0; i < 100; ++i) {
+    for (std::uint8_t i = 0; i < 100; ++i) {
         Signature signature;
         EXPECT_TRUE(crypto_signature_create(
             signature.data(), message.data(), message.size(), get_sig_sk(&sk)));
@@ -135,11 +136,11 @@ TEST(CryptoCore, Hmac)
     HmacKey sk;
     new_hmac_key(&c_rng, sk.data());
 
-    std::vector<uint8_t> message{0};
+    std::vector<std::uint8_t> message{0};
     message.clear();
 
     // Try a few different sizes, including empty 0 length message.
-    for (uint8_t i = 0; i < 100; ++i) {
+    for (std::uint8_t i = 0; i < 100; ++i) {
         Hmac auth;
         crypto_hmac(auth.data(), sk.data(), message.data(), message.size());
         EXPECT_TRUE(crypto_hmac_verify(auth.data(), sk.data(), message.data(), message.size()));

--- a/toxcore/crypto_core_test_util.cc
+++ b/toxcore/crypto_core_test_util.cc
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <iomanip>
+#include <ostream>
 
 #include "crypto_core.h"
 #include "test_util.hh"
@@ -16,8 +17,8 @@ PublicKey random_pk(const Random *rng)
 std::ostream &operator<<(std::ostream &out, PublicKey const &pk)
 {
     out << '"';
-    for (uint8_t byte : pk) {
-        out << std::setw(2) << std::setfill('0') << std::hex << uint32_t(byte);
+    for (std::uint8_t byte : pk) {
+        out << std::setw(2) << std::setfill('0') << std::hex << std::uint32_t(byte);
     }
     out << '"';
     return out;

--- a/toxcore/crypto_core_test_util.hh
+++ b/toxcore/crypto_core_test_util.hh
@@ -3,13 +3,14 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <iosfwd>
 
 #include "crypto_core.h"
 #include "test_util.hh"
 
-struct PublicKey : private std::array<uint8_t, CRYPTO_PUBLIC_KEY_SIZE> {
-    using Base = std::array<uint8_t, CRYPTO_PUBLIC_KEY_SIZE>;
+struct PublicKey : private std::array<std::uint8_t, CRYPTO_PUBLIC_KEY_SIZE> {
+    using Base = std::array<std::uint8_t, CRYPTO_PUBLIC_KEY_SIZE>;
 
     using Base::begin;
     using Base::data;
@@ -18,16 +19,16 @@ struct PublicKey : private std::array<uint8_t, CRYPTO_PUBLIC_KEY_SIZE> {
     using Base::operator[];
 
     PublicKey() = default;
-    explicit PublicKey(uint8_t const (&arr)[CRYPTO_PUBLIC_KEY_SIZE])
+    explicit PublicKey(std::uint8_t const (&arr)[CRYPTO_PUBLIC_KEY_SIZE])
         : PublicKey(to_array(arr))
     {
     }
-    explicit PublicKey(std::array<uint8_t, CRYPTO_PUBLIC_KEY_SIZE> const &arr)
+    explicit PublicKey(std::array<std::uint8_t, CRYPTO_PUBLIC_KEY_SIZE> const &arr)
     {
         std::copy(arr.begin(), arr.end(), begin());
     }
 
-    PublicKey(std::initializer_list<uint8_t> const &arr)
+    PublicKey(std::initializer_list<std::uint8_t> const &arr)
     {
         std::copy(arr.begin(), arr.end(), begin());
     }

--- a/toxcore/events/events_alloc.h
+++ b/toxcore/events/events_alloc.h
@@ -5,6 +5,9 @@
 #ifndef C_TOXCORE_TOXCORE_EVENTS_EVENTS_ALLOC_H
 #define C_TOXCORE_TOXCORE_EVENTS_EVENTS_ALLOC_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "../attributes.h"
 #include "../tox.h"
 #include "../tox_events.h"

--- a/toxcore/forwarding.h
+++ b/toxcore/forwarding.h
@@ -5,6 +5,9 @@
 #ifndef C_TOXCORE_TOXCORE_FORWARDING_H
 #define C_TOXCORE_TOXCORE_FORWARDING_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "DHT.h"
 #include "attributes.h"
 #include "crypto_core.h"

--- a/toxcore/forwarding_fuzz_test.cc
+++ b/toxcore/forwarding_fuzz_test.cc
@@ -15,37 +15,39 @@ using tox::test::configure_fuzz_memory_source;
 using tox::test::Fuzz_Data;
 using tox::test::SimulatedEnvironment;
 
-constexpr uint16_t SIZE_IP_PORT = SIZE_IP6 + sizeof(uint16_t);
+constexpr std::uint16_t SIZE_IP_PORT = SIZE_IP6 + sizeof(std::uint16_t);
 
 template <typename T>
 using Ptr = std::unique_ptr<T, void (*)(T *)>;
 
-std::optional<std::tuple<IP_Port, IP_Port, const uint8_t *, size_t>> prepare(Fuzz_Data &input)
+std::optional<std::tuple<IP_Port, IP_Port, const std::uint8_t *, std::size_t>> prepare(
+    Fuzz_Data &input)
 {
-    CONSUME_OR_RETURN_VAL(const uint8_t *ipp_packed, input, SIZE_IP_PORT, std::nullopt);
+    CONSUME_OR_RETURN_VAL(const std::uint8_t *ipp_packed, input, SIZE_IP_PORT, std::nullopt);
     IP_Port ipp{};
     unpack_ip_port(&ipp, ipp_packed, SIZE_IP6, true);
 
-    CONSUME_OR_RETURN_VAL(const uint8_t *forwarder_packed, input, SIZE_IP_PORT, std::nullopt);
+    CONSUME_OR_RETURN_VAL(const std::uint8_t *forwarder_packed, input, SIZE_IP_PORT, std::nullopt);
     IP_Port forwarder{};
     unpack_ip_port(&forwarder, forwarder_packed, SIZE_IP6, true);
 
     // 2 bytes: size of the request
-    CONSUME_OR_RETURN_VAL(const uint8_t *data_size_bytes, input, sizeof(uint16_t), std::nullopt);
-    uint16_t data_size;
-    std::memcpy(&data_size, data_size_bytes, sizeof(uint16_t));
+    CONSUME_OR_RETURN_VAL(
+        const std::uint8_t *data_size_bytes, input, sizeof(std::uint16_t), std::nullopt);
+    std::uint16_t data_size;
+    std::memcpy(&data_size, data_size_bytes, sizeof(std::uint16_t));
 
     // data bytes (max 64K)
-    CONSUME_OR_RETURN_VAL(const uint8_t *data, input, data_size, std::nullopt);
+    CONSUME_OR_RETURN_VAL(const std::uint8_t *data, input, data_size, std::nullopt);
 
     return {{ipp, forwarder, data, data_size}};
 }
 
 void TestSendForwardRequest(Fuzz_Data &input)
 {
-    CONSUME1_OR_RETURN(const uint16_t, chain_length, input);
-    const uint16_t chain_keys_size = chain_length * CRYPTO_PUBLIC_KEY_SIZE;
-    CONSUME_OR_RETURN(const uint8_t *chain_keys, input, chain_keys_size);
+    CONSUME1_OR_RETURN(const std::uint16_t, chain_length, input);
+    const std::uint16_t chain_keys_size = chain_length * CRYPTO_PUBLIC_KEY_SIZE;
+    CONSUME_OR_RETURN(const std::uint8_t *chain_keys, input, chain_keys_size);
 
     const auto prep = prepare(input);
     if (!prep.has_value()) {
@@ -75,8 +77,8 @@ void TestSendForwardRequest(Fuzz_Data &input)
 
 void TestForwardReply(Fuzz_Data &input)
 {
-    CONSUME1_OR_RETURN(const uint16_t, sendback_length, input);
-    CONSUME_OR_RETURN(const uint8_t *sendback, input, sendback_length);
+    CONSUME1_OR_RETURN(const std::uint16_t, sendback_length, input);
+    CONSUME_OR_RETURN(const std::uint8_t *sendback, input, sendback_length);
 
     const auto prep = prepare(input);
     if (!prep.has_value()) {
@@ -106,8 +108,8 @@ void TestForwardReply(Fuzz_Data &input)
 
 }  // namespace
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size)
 {
     tox::test::fuzz_select_target<TestSendForwardRequest, TestForwardReply>(data, size);
     return 0;

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -9,6 +9,7 @@
 #ifndef C_TOXCORE_TOXCORE_FRIEND_CONNECTION_H
 #define C_TOXCORE_TOXCORE_FRIEND_CONNECTION_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "DHT.h"

--- a/toxcore/friend_connection_test.cc
+++ b/toxcore/friend_connection_test.cc
@@ -30,7 +30,7 @@ using namespace tox::test;
 template <typename DHTWrapper>
 class FriendConnTestNode {
 public:
-    FriendConnTestNode(SimulatedEnvironment &env, uint16_t port)
+    FriendConnTestNode(SimulatedEnvironment &env, std::uint16_t port)
         : dht_wrapper_(env, port)
         , net_profile_(netprof_new(dht_wrapper_.logger(), &dht_wrapper_.node().c_memory),
               [mem = &dht_wrapper_.node().c_memory](Net_Profile *p) { netprof_kill(mem, p); })
@@ -40,8 +40,8 @@ public:
     {
         logger_callback_log(
             dht_wrapper_.logger(),
-            [](void *context, Logger_Level level, const char *file, uint32_t line, const char *func,
-                const char *message, void *userdata) {
+            [](void *context, Logger_Level level, const char *file, std::uint32_t line,
+                const char *func, const char *message, void *userdata) {
                 fprintf(stderr, "[%d] %s:%u: %s: %s\n", level, file, line, func, message);
             },
             nullptr, nullptr);
@@ -71,8 +71,11 @@ public:
     Onion_Client *get_onion_client() { return onion_client_.get(); }
     Net_Crypto *get_net_crypto() { return net_crypto_.get(); }
     DHT *get_dht() { return dht_wrapper_.get_dht(); }
-    const uint8_t *dht_public_key() const { return dht_wrapper_.dht_public_key(); }
-    const uint8_t *real_public_key() const { return nc_get_self_public_key(net_crypto_.get()); }
+    const std::uint8_t *dht_public_key() const { return dht_wrapper_.dht_public_key(); }
+    const std::uint8_t *real_public_key() const
+    {
+        return nc_get_self_public_key(net_crypto_.get());
+    }
     const Random *get_random() { return &dht_wrapper_.node().c_random; }
 
     IP_Port get_ip_port() const { return dht_wrapper_.get_ip_port(); }
@@ -114,8 +117,8 @@ TEST_F(FriendConnectionTest, CreationAndDestruction)
 TEST_F(FriendConnectionTest, AddKillConnection)
 {
     FriendConnNode alice(env, 33445);
-    uint8_t friend_pk[CRYPTO_PUBLIC_KEY_SIZE];
-    uint8_t friend_sk[CRYPTO_SECRET_KEY_SIZE];
+    std::uint8_t friend_pk[CRYPTO_PUBLIC_KEY_SIZE];
+    std::uint8_t friend_sk[CRYPTO_SECRET_KEY_SIZE];
     crypto_new_keypair(alice.get_random(), friend_pk, friend_sk);
 
     // Add Connection

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -10,6 +10,7 @@
 #define C_TOXCORE_TOXCORE_FRIEND_REQUESTS_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "attributes.h"
 #include "friend_connection.h"

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -9,6 +9,7 @@
 #ifndef C_TOXCORE_TOXCORE_GROUP_H
 #define C_TOXCORE_TOXCORE_GROUP_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/toxcore/group_announce_fuzz_test.cc
+++ b/toxcore/group_announce_fuzz_test.cc
@@ -16,12 +16,12 @@ using tox::test::SimulatedEnvironment;
 
 void TestUnpackAnnouncesList(Fuzz_Data &input)
 {
-    CONSUME1_OR_RETURN(const uint8_t, max_count, input);
+    CONSUME1_OR_RETURN(const std::uint8_t, max_count, input);
     // Always allocate at least something to avoid passing nullptr to functions below.
     std::vector<GC_Announce> announces(max_count + 1);
 
     // TODO(iphydf): How do we know the packed size?
-    CONSUME1_OR_RETURN(const uint16_t, packed_size, input);
+    CONSUME1_OR_RETURN(const std::uint16_t, packed_size, input);
 
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
@@ -29,8 +29,8 @@ void TestUnpackAnnouncesList(Fuzz_Data &input)
     if (gca_unpack_announces_list(logger, input.data(), input.size(), announces.data(), max_count)
         != -1) {
         // Always allocate at least something to avoid passing nullptr to functions below.
-        std::vector<uint8_t> packed(packed_size + 1);
-        size_t processed;
+        std::vector<std::uint8_t> packed(packed_size + 1);
+        std::size_t processed;
         gca_pack_announces_list(
             logger, packed.data(), packed_size, announces.data(), max_count, &processed);
     }
@@ -42,14 +42,14 @@ void TestUnpackPublicAnnounce(Fuzz_Data &input)
     GC_Public_Announce public_announce;
 
     // TODO(iphydf): How do we know the packed size?
-    CONSUME1_OR_RETURN(const uint16_t, packed_size, input);
+    CONSUME1_OR_RETURN(const std::uint16_t, packed_size, input);
 
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Logger *logger = logger_new(&c_mem);
     if (gca_unpack_public_announce(logger, input.data(), input.size(), &public_announce) != -1) {
         // Always allocate at least something to avoid passing nullptr to functions below.
-        std::vector<uint8_t> packed(packed_size + 1);
+        std::vector<std::uint8_t> packed(packed_size + 1);
         gca_pack_public_announce(logger, packed.data(), packed_size, &public_announce);
     }
     logger_kill(logger);
@@ -64,7 +64,7 @@ void TestDoGca(Fuzz_Data &input)
     std::unique_ptr<Mono_Time, std::function<void(Mono_Time *)>> mono_time(
         mono_time_new(
             &c_mem,
-            [](void *user_data) -> uint64_t {
+            [](void *user_data) -> std::uint64_t {
                 return static_cast<FakeClock *>(user_data)->current_time_ms();
             },
             &env.fake_clock()),
@@ -76,12 +76,12 @@ void TestDoGca(Fuzz_Data &input)
     assert(gca != nullptr);
 
     while (!input.empty()) {
-        CONSUME1_OR_RETURN(const uint8_t, choice, input);
+        CONSUME1_OR_RETURN(const std::uint8_t, choice, input);
         switch (choice) {
         case 0: {
             // Add an announce.
-            CONSUME1_OR_RETURN(const uint16_t, length, input);
-            CONSUME_OR_RETURN(const uint8_t *data, input, length);
+            CONSUME1_OR_RETURN(const std::uint16_t, length, input);
+            CONSUME_OR_RETURN(const std::uint8_t *data, input, length);
             GC_Public_Announce public_announce;
             if (gca_unpack_public_announce(logger.get(), data, length, &public_announce) != -1) {
                 gca_add_announce(&c_mem, mono_time.get(), gca.get(), &public_announce);
@@ -90,7 +90,7 @@ void TestDoGca(Fuzz_Data &input)
         }
         case 1: {
             // Advance the time by a number of tox_iteration_intervals.
-            CONSUME1_OR_RETURN(const uint8_t, iterations, input);
+            CONSUME1_OR_RETURN(const std::uint8_t, iterations, input);
             env.fake_clock().advance(iterations * 20);
             // Do an iteration.
             do_gca(mono_time.get(), gca.get());
@@ -98,18 +98,18 @@ void TestDoGca(Fuzz_Data &input)
         }
         case 2: {
             // Get announces.
-            CONSUME1_OR_RETURN(const uint8_t, max_nodes, input);
+            CONSUME1_OR_RETURN(const std::uint8_t, max_nodes, input);
             // Always allocate at least something to avoid passing nullptr to functions below.
             std::vector<GC_Announce> gc_announces(max_nodes + 1);
-            CONSUME_OR_RETURN(const uint8_t *chat_id, input, CHAT_ID_SIZE);
-            CONSUME_OR_RETURN(const uint8_t *except_public_key, input, ENC_PUBLIC_KEY_SIZE);
+            CONSUME_OR_RETURN(const std::uint8_t *chat_id, input, CHAT_ID_SIZE);
+            CONSUME_OR_RETURN(const std::uint8_t *except_public_key, input, ENC_PUBLIC_KEY_SIZE);
             gca_get_announces(
                 gca.get(), gc_announces.data(), max_nodes, chat_id, except_public_key);
             break;
         }
         case 3: {
             // Remove a chat.
-            CONSUME_OR_RETURN(const uint8_t *chat_id, input, CHAT_ID_SIZE);
+            CONSUME_OR_RETURN(const std::uint8_t *chat_id, input, CHAT_ID_SIZE);
             cleanup_gca(gca.get(), chat_id);
             break;
         }
@@ -119,8 +119,8 @@ void TestDoGca(Fuzz_Data &input)
 
 }  // namespace
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size)
 {
     tox::test::fuzz_select_target<TestUnpackAnnouncesList, TestUnpackPublicAnnounce, TestDoGca>(
         data, size);

--- a/toxcore/group_announce_test.cc
+++ b/toxcore/group_announce_test.cc
@@ -43,7 +43,7 @@ protected:
         mono_time_free(&c_mem_, mono_time_);
     }
 
-    void advance_clock(uint64_t increment)
+    void advance_clock(std::uint64_t increment)
     {
         env.fake_clock().advance(increment);
         mono_time_update(mono_time_);
@@ -105,7 +105,7 @@ TEST_F(Announces, AnnouncesGetAndCleanup)
     ASSERT_NE(gca_add_announce(&c_mem_, mono_time_, gca_, &ann2), nullptr);
     ASSERT_NE(gca_add_announce(&c_mem_, mono_time_, gca_, &ann2), nullptr);
 
-    uint8_t empty_pk[ENC_PUBLIC_KEY_SIZE] = {0};
+    std::uint8_t empty_pk[ENC_PUBLIC_KEY_SIZE] = {0};
 
     GC_Announce announces;
     ASSERT_EQ(gca_get_announces(gca_, &announces, 1, ann1.chat_public_key, empty_pk), 1);
@@ -168,7 +168,7 @@ TEST_F(AnnouncesPack, PublicAnnounceCanBePackedAndUnpacked)
     ann.chat_public_key[0] = 0x88;
     ann.base_announce = announces_[0];
 
-    std::vector<uint8_t> packed(GCA_PUBLIC_ANNOUNCE_MAX_SIZE);
+    std::vector<std::uint8_t> packed(GCA_PUBLIC_ANNOUNCE_MAX_SIZE);
     const int packed_size = gca_pack_public_announce(logger_, packed.data(), packed.size(), &ann);
 
     EXPECT_GT(packed_size, 0);
@@ -182,7 +182,7 @@ TEST_F(AnnouncesPack, UnpackEmptyPublicAnnounce)
 {
 #ifndef __clang__
     GC_Public_Announce ann{};
-    std::vector<uint8_t> packed(GCA_PUBLIC_ANNOUNCE_MAX_SIZE);
+    std::vector<std::uint8_t> packed(GCA_PUBLIC_ANNOUNCE_MAX_SIZE);
 
     EXPECT_EQ(gca_unpack_public_announce(logger_, nullptr, 0, &ann), -1);
     EXPECT_EQ(gca_unpack_public_announce(logger_, packed.data(), packed.size(), nullptr), -1);
@@ -193,7 +193,7 @@ TEST_F(AnnouncesPack, PackEmptyPublicAnnounce)
 {
 #ifndef __clang__
     GC_Public_Announce ann{};
-    std::vector<uint8_t> packed(GCA_PUBLIC_ANNOUNCE_MAX_SIZE);
+    std::vector<std::uint8_t> packed(GCA_PUBLIC_ANNOUNCE_MAX_SIZE);
     EXPECT_EQ(gca_pack_public_announce(logger_, packed.data(), packed.size(), nullptr), -1);
     EXPECT_EQ(gca_pack_public_announce(logger_, nullptr, 0, &ann), -1);
 #endif
@@ -202,13 +202,13 @@ TEST_F(AnnouncesPack, PackEmptyPublicAnnounce)
 TEST_F(AnnouncesPack, PublicAnnouncePackNull)
 {
     GC_Public_Announce ann{};
-    std::vector<uint8_t> packed(GCA_PUBLIC_ANNOUNCE_MAX_SIZE);
+    std::vector<std::uint8_t> packed(GCA_PUBLIC_ANNOUNCE_MAX_SIZE);
     EXPECT_EQ(gca_pack_public_announce(logger_, packed.data(), packed.size(), &ann), -1);
 
     ann.chat_public_key[0] = 0x88;
     ann.base_announce = announces_[0];
 
-    std::vector<uint8_t> packedTooSmall(GCA_PUBLIC_ANNOUNCE_MAX_SIZE - 1);
+    std::vector<std::uint8_t> packedTooSmall(GCA_PUBLIC_ANNOUNCE_MAX_SIZE - 1);
     EXPECT_EQ(
         gca_pack_public_announce(logger_, packedTooSmall.data(), packedTooSmall.size(), &ann), -1);
 
@@ -235,9 +235,9 @@ TEST_F(AnnouncesPack, AnnouncesValidationCheck)
 
 TEST_F(AnnouncesPack, UnpackIncompleteAnnouncesList)
 {
-    const uint8_t data[] = {0x00, 0x24, 0x3d, 0x00, 0x3d, 0xff, 0xff, 0x5b, 0x04, 0x20, 0x00, 0x01,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00};
+    const std::uint8_t data[] = {0x00, 0x24, 0x3d, 0x00, 0x3d, 0xff, 0xff, 0x5b, 0x04, 0x20, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00};
 
     GC_Announce announce;
     EXPECT_EQ(gca_unpack_announces_list(logger_, data, sizeof(data), &announce, 1), -1);
@@ -249,10 +249,10 @@ TEST_F(AnnouncesPack, UnpackIncompleteAnnouncesList)
 
 TEST_F(AnnouncesPack, PackedAnnouncesListCanBeUnpacked)
 {
-    const uint16_t size = gca_pack_announces_list_size(announces_.size());
-    std::vector<uint8_t> packed(size);
+    const std::uint16_t size = gca_pack_announces_list_size(announces_.size());
+    std::vector<std::uint8_t> packed(size);
 
-    size_t processed = 0;
+    std::size_t processed = 0;
 
     EXPECT_GT(gca_pack_announces_list(logger_, packed.data(), packed.size(), announces_.data(),
                   announces_.size(), &processed),
@@ -269,7 +269,7 @@ TEST_F(AnnouncesPack, PackedAnnouncesListCanBeUnpacked)
 TEST_F(AnnouncesPack, PackingEmptyAnnounceFails)
 {
     GC_Announce announce{};  // all zeroes
-    std::vector<uint8_t> packed(gca_pack_announces_list_size(1));
+    std::vector<std::uint8_t> packed(gca_pack_announces_list_size(1));
     EXPECT_EQ(
         gca_pack_announces_list(logger_, packed.data(), packed.size(), &announce, 1, nullptr), -1);
 #ifndef __clang__
@@ -282,7 +282,7 @@ TEST_F(AnnouncesPack, PackingEmptyAnnounceFails)
 TEST_F(AnnouncesPack, PackAnnounceNull)
 {
 #ifndef __clang__
-    std::vector<uint8_t> data(GCA_ANNOUNCE_MAX_SIZE);
+    std::vector<std::uint8_t> data(GCA_ANNOUNCE_MAX_SIZE);
     GC_Announce announce;
     ASSERT_EQ(gca_pack_announce(logger_, nullptr, 0, &announce), -1);
     ASSERT_EQ(gca_pack_announce(logger_, data.data(), data.size(), nullptr), -1);

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -10,6 +10,9 @@
 #ifndef C_TOXCORE_TOXCORE_GROUP_CONNECTION_H
 #define C_TOXCORE_TOXCORE_GROUP_CONNECTION_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "DHT.h"
 #include "TCP_connection.h"
 #include "attributes.h"

--- a/toxcore/group_moderation_fuzz_test.cc
+++ b/toxcore/group_moderation_fuzz_test.cc
@@ -10,7 +10,7 @@ using tox::test::SimulatedEnvironment;
 
 void TestModListUnpack(Fuzz_Data &input)
 {
-    CONSUME1_OR_RETURN(const uint16_t, num_mods, input);
+    CONSUME1_OR_RETURN(const std::uint16_t, num_mods, input);
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
@@ -22,21 +22,21 @@ void TestSanctionsListUnpack(Fuzz_Data &input)
 {
     Mod_Sanction sanctions[10];
     Mod_Sanction_Creds creds;
-    uint16_t processed_data_len;
+    std::uint16_t processed_data_len;
     sanctions_list_unpack(sanctions, &creds, 10, input.data(), input.size(), &processed_data_len);
 }
 
 void TestSanctionCredsUnpack(Fuzz_Data &input)
 {
-    CONSUME_OR_RETURN(const uint8_t *data, input, MOD_SANCTIONS_CREDS_SIZE);
+    CONSUME_OR_RETURN(const std::uint8_t *data, input, MOD_SANCTIONS_CREDS_SIZE);
     Mod_Sanction_Creds creds;
     sanctions_creds_unpack(&creds, data);
 }
 
 }  // namespace
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size)
 {
     tox::test::fuzz_select_target<TestModListUnpack, TestSanctionsListUnpack,
         TestSanctionCredsUnpack>(data, size);

--- a/toxcore/group_moderation_test.cc
+++ b/toxcore/group_moderation_test.cc
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <cstring>
 #include <vector>
 
 #include "DHT.h"
@@ -18,7 +20,7 @@
 namespace {
 
 using tox::test::SimulatedEnvironment;
-using ModerationHash = std::array<uint8_t, MOD_MODERATION_HASH_SIZE>;
+using ModerationHash = std::array<std::uint8_t, MOD_MODERATION_HASH_SIZE>;
 
 TEST(ModList, PackedSizeOfEmptyModListIsZero)
 {
@@ -27,7 +29,7 @@ TEST(ModList, PackedSizeOfEmptyModListIsZero)
     Moderation mods{&c_mem};
     EXPECT_EQ(mod_list_packed_size(&mods), 0);
 
-    uint8_t byte = 1;
+    std::uint8_t byte = 1;
     mod_list_pack(&mods, &byte);
     EXPECT_EQ(byte, 1);
 }
@@ -37,7 +39,7 @@ TEST(ModList, UnpackingZeroSizeArrayIsNoop)
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
-    const uint8_t byte = 1;
+    const std::uint8_t byte = 1;
     EXPECT_EQ(mod_list_unpack(&mods, &byte, 0, 0), 0);
 }
 
@@ -46,8 +48,8 @@ TEST(ModList, AddRemoveMultipleMods)
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
-    uint8_t sig_pk1[32] = {1};
-    uint8_t sig_pk2[32] = {2};
+    std::uint8_t sig_pk1[32] = {1};
+    std::uint8_t sig_pk2[32] = {2};
     EXPECT_TRUE(mod_list_add_entry(&mods, sig_pk1));
     EXPECT_TRUE(mod_list_add_entry(&mods, sig_pk2));
     EXPECT_TRUE(mod_list_remove_entry(&mods, sig_pk1));
@@ -56,13 +58,13 @@ TEST(ModList, AddRemoveMultipleMods)
 
 TEST(ModList, PackingAndUnpackingList)
 {
-    using ModListEntry = std::array<uint8_t, MOD_LIST_ENTRY_SIZE>;
+    using ModListEntry = std::array<std::uint8_t, MOD_LIST_ENTRY_SIZE>;
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     EXPECT_TRUE(mod_list_add_entry(&mods, ModListEntry{}.data()));
 
-    std::vector<uint8_t> packed(mod_list_packed_size(&mods));
+    std::vector<std::uint8_t> packed(mod_list_packed_size(&mods));
     mod_list_pack(&mods, packed.data());
 
     EXPECT_TRUE(mod_list_remove_entry(&mods, ModListEntry{}.data()));
@@ -74,13 +76,13 @@ TEST(ModList, PackingAndUnpackingList)
 
 TEST(ModList, UnpackingTooManyModsFails)
 {
-    using ModListEntry = std::array<uint8_t, MOD_LIST_ENTRY_SIZE>;
+    using ModListEntry = std::array<std::uint8_t, MOD_LIST_ENTRY_SIZE>;
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     EXPECT_TRUE(mod_list_add_entry(&mods, ModListEntry{}.data()));
 
-    std::vector<uint8_t> packed(mod_list_packed_size(&mods));
+    std::vector<std::uint8_t> packed(mod_list_packed_size(&mods));
     mod_list_pack(&mods, packed.data());
 
     Moderation mods2{&c_mem};
@@ -90,7 +92,7 @@ TEST(ModList, UnpackingTooManyModsFails)
 
 TEST(ModList, UnpackingFromEmptyBufferFails)
 {
-    std::vector<uint8_t> packed(1);
+    std::vector<std::uint8_t> packed(1);
 
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
@@ -127,7 +129,7 @@ TEST(ModList, RemoveEntryFromEmptyModListFails)
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
-    uint8_t sig_pk[32] = {0};
+    std::uint8_t sig_pk[32] = {0};
     EXPECT_FALSE(mod_list_remove_entry(&mods, sig_pk));
 }
 
@@ -136,7 +138,7 @@ TEST(ModList, ModListRemoveIndex)
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
-    uint8_t sig_pk[32] = {1};
+    std::uint8_t sig_pk[32] = {1};
     EXPECT_TRUE(mod_list_add_entry(&mods, sig_pk));
     EXPECT_TRUE(mod_list_remove_index(&mods, 0));
 }
@@ -154,7 +156,7 @@ TEST(ModList, EmptyModListCannotVerifyAnySigPk)
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
-    uint8_t sig_pk[32] = {1};
+    std::uint8_t sig_pk[32] = {1};
     EXPECT_FALSE(mod_list_verify_sig_pk(&mods, sig_pk));
 }
 
@@ -163,7 +165,7 @@ TEST(ModList, ModListAddVerifyRemoveSigPK)
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
-    uint8_t sig_pk[32] = {1};
+    std::uint8_t sig_pk[32] = {1};
     EXPECT_TRUE(mod_list_add_entry(&mods, sig_pk));
     EXPECT_TRUE(mod_list_verify_sig_pk(&mods, sig_pk));
     EXPECT_TRUE(mod_list_remove_entry(&mods, sig_pk));
@@ -175,8 +177,8 @@ TEST(ModList, ModListHashCheck)
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods1{&c_mem};
-    uint8_t sig_pk1[32] = {1};
-    std::array<uint8_t, MOD_MODERATION_HASH_SIZE> hash1;
+    std::uint8_t sig_pk1[32] = {1};
+    std::array<std::uint8_t, MOD_MODERATION_HASH_SIZE> hash1;
 
     EXPECT_TRUE(mod_list_add_entry(&mods1, sig_pk1));
     EXPECT_TRUE(mod_list_make_hash(&mods1, hash1.data()));
@@ -186,11 +188,11 @@ TEST(ModList, ModListHashCheck)
 TEST(SanctionsList, PackingIntoUndersizedBufferFails)
 {
     Mod_Sanction sanctions[1] = {};
-    std::array<uint8_t, 1> packed;
+    std::array<std::uint8_t, 1> packed;
     EXPECT_EQ(sanctions_list_pack(packed.data(), packed.size(), sanctions, 1, nullptr), -1);
 
-    uint16_t length = sanctions_list_packed_size(1) - 1;
-    std::vector<uint8_t> packed2(length);
+    std::uint16_t length = sanctions_list_packed_size(1) - 1;
+    std::vector<std::uint8_t> packed2(length);
     EXPECT_EQ(sanctions_list_pack(packed2.data(), packed2.size(), sanctions, 1, nullptr), -1);
 }
 
@@ -199,7 +201,7 @@ TEST(SanctionsList, PackUnpackSanctionsCreds)
     SimulatedEnvironment env;
     auto c_mem = env.fake_memory().c_memory();
     Moderation mod{&c_mem};
-    std::array<uint8_t, MOD_SANCTIONS_CREDS_SIZE> packed;
+    std::array<std::uint8_t, MOD_SANCTIONS_CREDS_SIZE> packed;
     EXPECT_EQ(sanctions_creds_pack(&mod.sanctions_creds, packed.data()), MOD_SANCTIONS_CREDS_SIZE);
     EXPECT_EQ(
         sanctions_creds_unpack(&mod.sanctions_creds, packed.data()), MOD_SANCTIONS_CREDS_SIZE);
@@ -217,8 +219,8 @@ protected:
     Moderation mod;
 
     Mod_Sanction sanctions[2] = {};
-    const uint8_t sanctioned_pk1[32] = {1};
-    const uint8_t sanctioned_pk2[32] = {2};
+    const std::uint8_t sanctioned_pk1[32] = {1};
+    const std::uint8_t sanctioned_pk2[32] = {2};
 
     SanctionsListMod()
         : c_mem_(env.fake_memory().c_memory())
@@ -234,8 +236,8 @@ protected:
 
         mod.log = log;
 
-        memcpy(mod.self_public_sig_key, get_sig_pk(&pk), SIG_PUBLIC_KEY_SIZE);
-        memcpy(mod.self_secret_sig_key, get_sig_sk(&sk), SIG_SECRET_KEY_SIZE);
+        std::memcpy(mod.self_public_sig_key, get_sig_pk(&pk), SIG_PUBLIC_KEY_SIZE);
+        std::memcpy(mod.self_secret_sig_key, get_sig_sk(&sk), SIG_SECRET_KEY_SIZE);
 
         ASSERT_TRUE(mod_list_add_entry(&mod, get_sig_pk(&pk)));
 
@@ -267,13 +269,13 @@ protected:
 // TODO(JFreegman): Split this up into smaller subtests
 TEST_F(SanctionsListMod, PackUnpackSanction)
 {
-    std::vector<uint8_t> packed(sanctions_list_packed_size(2));
+    std::vector<std::uint8_t> packed(sanctions_list_packed_size(2));
 
     EXPECT_EQ(
         sanctions_list_pack(packed.data(), packed.size(), sanctions, 2, nullptr), packed.size());
 
     Mod_Sanction unpacked_sanctions[2] = {};
-    uint16_t processed_data_len = 0;
+    std::uint16_t processed_data_len = 0;
 
     EXPECT_EQ(sanctions_list_unpack(unpacked_sanctions, &mod.sanctions_creds, 2, packed.data(),
                   packed.size(), &processed_data_len),

--- a/toxcore/group_onion_announce.h
+++ b/toxcore/group_onion_announce.h
@@ -6,6 +6,8 @@
 #ifndef C_TOXCORE_TOXCORE_GROUP_ONION_ANNOUNCE_H
 #define C_TOXCORE_TOXCORE_GROUP_ONION_ANNOUNCE_H
 
+#include <stdint.h>
+
 #include "attributes.h"
 #include "crypto_core.h"
 #include "group_announce.h"

--- a/toxcore/group_pack.h
+++ b/toxcore/group_pack.h
@@ -11,6 +11,7 @@
 #define C_TOXCORE_TOXCORE_GROUP_PACK_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "attributes.h"
 #include "bin_pack.h"

--- a/toxcore/list_test.cc
+++ b/toxcore/list_test.cc
@@ -2,6 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <cstring>
+
 #include "mem.h"
 #include "os_memory.h"
 
@@ -11,7 +14,7 @@ TEST(List, CreateAndDestroyWithNonZeroSize)
 {
     const Memory *mem = os_memory();
     BS_List list;
-    bs_list_init(&list, mem, sizeof(int), 10, memcmp);
+    bs_list_init(&list, mem, sizeof(int), 10, std::memcmp);
     bs_list_free(&list);
 }
 
@@ -19,7 +22,7 @@ TEST(List, CreateAndDestroyWithZeroSize)
 {
     const Memory *mem = os_memory();
     BS_List list;
-    bs_list_init(&list, mem, sizeof(int), 0, memcmp);
+    bs_list_init(&list, mem, sizeof(int), 0, std::memcmp);
     bs_list_free(&list);
 }
 
@@ -27,8 +30,8 @@ TEST(List, DeleteFromEmptyList)
 {
     const Memory *mem = os_memory();
     BS_List list;
-    bs_list_init(&list, mem, sizeof(int), 0, memcmp);
-    const uint8_t data[sizeof(int)] = {0};
+    bs_list_init(&list, mem, sizeof(int), 0, std::memcmp);
+    const std::uint8_t data[sizeof(int)] = {0};
     bs_list_remove(&list, data, 0);
     bs_list_free(&list);
 }

--- a/toxcore/mem_test.cc
+++ b/toxcore/mem_test.cc
@@ -9,7 +9,7 @@ namespace {
 TEST(Mem, AllocLarge)
 {
     // Mebi prefix: https://en.wikipedia.org/wiki/Binary_prefix.
-    constexpr uint32_t MI = 1024 * 1024;
+    constexpr std::uint32_t MI = 1024 * 1024;
 
     const Memory *mem = os_memory();
 
@@ -22,7 +22,7 @@ TEST(Mem, AllocLarge)
 TEST(Mem, AllocOverflow)
 {
     // Gibi prefix.
-    constexpr uint32_t GI = 1024 * 1024 * 1024;
+    constexpr std::uint32_t GI = 1024 * 1024 * 1024;
 
     const Memory *mem = os_memory();
 

--- a/toxcore/mono_time_test.cc
+++ b/toxcore/mono_time_test.cc
@@ -21,13 +21,13 @@ TEST(MonoTime, TimeIncreasesWhenAdvanced)
     setup_fake_clock(mono_time, env.fake_clock());
 
     mono_time_update(mono_time);
-    uint64_t const start = mono_time_get(mono_time);
+    std::uint64_t const start = mono_time_get(mono_time);
 
     // Advance 10 seconds to ensure we definitely cross second boundaries and see an increase
     env.fake_clock().advance(10000);
     mono_time_update(mono_time);
 
-    uint64_t const end = mono_time_get(mono_time);
+    std::uint64_t const end = mono_time_get(mono_time);
     EXPECT_GT(end, start);
     EXPECT_EQ(end, start + 10);
 
@@ -43,7 +43,7 @@ TEST(MonoTime, IsTimeout)
     setup_fake_clock(mono_time, env.fake_clock());
 
     mono_time_update(mono_time);  // Ensure start is consistent with fake clock
-    uint64_t const start = mono_time_get(mono_time);
+    std::uint64_t const start = mono_time_get(mono_time);
     EXPECT_FALSE(mono_time_is_timeout(mono_time, start, 1));
 
     env.fake_clock().advance(2000);  // 2 seconds
@@ -63,7 +63,7 @@ TEST(MonoTime, IsTimeoutWithIntermediateUpdates)
     setup_fake_clock(mono_time, env.fake_clock());
 
     mono_time_update(mono_time);
-    uint64_t const start = mono_time_get(mono_time);
+    std::uint64_t const start = mono_time_get(mono_time);
     EXPECT_FALSE(mono_time_is_timeout(mono_time, start, 5));
 
     env.fake_clock().advance(100);
@@ -86,14 +86,15 @@ TEST(MonoTime, CustomTime)
     Mono_Time *mono_time = mono_time_new(&c_mem, nullptr, nullptr);
     ASSERT_NE(mono_time, nullptr);
 
-    uint64_t test_time = 123456;
+    std::uint64_t test_time = 123456;
     mono_time_set_current_time_callback(
-        mono_time, [](void *user_data) { return *static_cast<uint64_t *>(user_data); }, &test_time);
+        mono_time, [](void *user_data) { return *static_cast<std::uint64_t *>(user_data); },
+        &test_time);
     mono_time_update(mono_time);
 
     EXPECT_EQ(current_time_monotonic(mono_time), test_time);
 
-    uint64_t const start = mono_time_get(mono_time);
+    std::uint64_t const start = mono_time_get(mono_time);
 
     test_time += 7000;
     mono_time_update(mono_time);

--- a/toxcore/mono_time_test_util.cc
+++ b/toxcore/mono_time_test_util.cc
@@ -6,7 +6,7 @@ void setup_fake_clock(Mono_Time *mono_time, FakeClock &clock)
 {
     mono_time_set_current_time_callback(
         mono_time,
-        [](void *user_data) -> uint64_t {
+        [](void *user_data) -> std::uint64_t {
             return static_cast<FakeClock *>(user_data)->current_time_ms();
         },
         &clock);

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -9,6 +9,9 @@
 #ifndef C_TOXCORE_TOXCORE_NET_CRYPTO_H
 #define C_TOXCORE_TOXCORE_NET_CRYPTO_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "DHT.h" // Node_format
 #include "TCP_client.h"
 #include "TCP_connection.h"

--- a/toxcore/net_crypto_fuzz_test.cc
+++ b/toxcore/net_crypto_fuzz_test.cc
@@ -24,20 +24,20 @@ using tox::test::SimulatedEnvironment;
 template <typename T>
 using Ptr = std::unique_ptr<T, void (*)(T *)>;
 
-std::optional<std::tuple<IP_Port, uint8_t>> prepare(Fuzz_Data &input)
+std::optional<std::tuple<IP_Port, std::uint8_t>> prepare(Fuzz_Data &input)
 {
     IP_Port ipp;
     ip_init(&ipp.ip, true);
     ipp.port = net_htons(33445);
 
-    CONSUME_OR_RETURN_VAL(const uint8_t *iterations_packed, input, 1, std::nullopt);
-    uint8_t iterations = *iterations_packed;
+    CONSUME_OR_RETURN_VAL(const std::uint8_t *iterations_packed, input, 1, std::nullopt);
+    std::uint8_t iterations = *iterations_packed;
 
     return {{ipp, iterations}};
 }
 
 static constexpr Net_Crypto_DHT_Funcs dht_funcs = {
-    [](void *dht, const uint8_t *public_key) {
+    [](void *dht, const std::uint8_t *public_key) {
         return dht_get_shared_key_sent(static_cast<DHT *>(dht), public_key);
     },
     [](const void *dht) { return dht_get_self_public_key(static_cast<const DHT *>(dht)); },
@@ -105,7 +105,7 @@ void TestNetCrypto(Fuzz_Data &input)
         return;
     }
 
-    for (uint8_t i = 0; i < iterations; ++i) {
+    for (std::uint8_t i = 0; i < iterations; ++i) {
         networking_poll(net.get(), nullptr);
         do_dht(dht.get());
         do_net_crypto(net_crypto.get(), nullptr);
@@ -118,8 +118,8 @@ void TestNetCrypto(Fuzz_Data &input)
 
 }  // namespace
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size)
 {
     tox::test::fuzz_select_target<TestNetCrypto>(data, size);
     return 0;

--- a/toxcore/network_test.cc
+++ b/toxcore/network_test.cc
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+
 #include "network_test_util.hh"
 
 namespace {
@@ -106,7 +108,7 @@ TEST(IpportCmp, BehavesLikeMemcmp)
         << "b=" << b;
     EXPECT_EQ(  //
         ipport_cmp_handler(&a, &b, sizeof(IP_Port)),  //
-        cmp_val(memcmp(&a, &b, sizeof(IP_Port))))
+        cmp_val(std::memcmp(&a, &b, sizeof(IP_Port))))
         << "a=" << a << "\n"
         << "b=" << b;
 
@@ -119,7 +121,7 @@ TEST(IpportCmp, BehavesLikeMemcmp)
         << "b=" << b;
     EXPECT_EQ(  //
         ipport_cmp_handler(&a, &b, sizeof(IP_Port)),  //
-        cmp_val(memcmp(&a, &b, sizeof(IP_Port))))
+        cmp_val(std::memcmp(&a, &b, sizeof(IP_Port))))
         << "a=" << a << "\n"
         << "b=" << b;
 }

--- a/toxcore/network_test_util.cc
+++ b/toxcore/network_test_util.cc
@@ -1,6 +1,7 @@
 #include "network_test_util.hh"
 
 #include <iomanip>
+#include <ostream>
 
 #include "crypto_core.h"
 #include "mem.h"

--- a/toxcore/network_test_util.hh
+++ b/toxcore/network_test_util.hh
@@ -1,6 +1,7 @@
 #ifndef C_TOXCORE_TOXCORE_NETWORK_TEST_UTIL_H
 #define C_TOXCORE_TOXCORE_NETWORK_TEST_UTIL_H
 
+#include <cstdint>
 #include <iosfwd>
 
 #include "crypto_core.h"
@@ -14,11 +15,11 @@ struct Deleter<Networking_Core> : Function_Deleter<Networking_Core, kill_network
 IP_Port random_ip_port(const Random *rng);
 
 class increasing_ip_port {
-    uint8_t start_;
+    std::uint8_t start_;
     const Random *rng_;
 
 public:
-    explicit increasing_ip_port(uint8_t start, const Random *rng)
+    explicit increasing_ip_port(std::uint8_t start, const Random *rng)
         : start_(start)
         , rng_(rng)
     {

--- a/toxcore/onion.h
+++ b/toxcore/onion.h
@@ -9,6 +9,8 @@
 #ifndef C_TOXCORE_TOXCORE_ONION_H
 #define C_TOXCORE_TOXCORE_ONION_H
 
+#include <stdint.h>
+
 #include "DHT.h"
 #include "attributes.h"
 #include "crypto_core.h"

--- a/toxcore/onion_announce.h
+++ b/toxcore/onion_announce.h
@@ -9,6 +9,8 @@
 #ifndef C_TOXCORE_TOXCORE_ONION_ANNOUNCE_H
 #define C_TOXCORE_TOXCORE_ONION_ANNOUNCE_H
 
+#include <stdint.h>
+
 #include "DHT.h"
 #include "attributes.h"
 #include "crypto_core.h"

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -11,6 +11,7 @@
 #define C_TOXCORE_TOXCORE_ONION_CLIENT_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "DHT.h"
 #include "attributes.h"

--- a/toxcore/onion_client_fuzz_test.cc
+++ b/toxcore/onion_client_fuzz_test.cc
@@ -32,12 +32,12 @@ T consume_range(Fuzz_Data &input, T min, T max)
 // Minimal DHT wrapper for fuzzing
 class FuzzDHT {
 public:
-    FuzzDHT(SimulatedEnvironment &env, uint16_t port)
+    FuzzDHT(SimulatedEnvironment &env, std::uint16_t port)
         : node_(env.create_node(port))
         , logger_(logger_new(&node_->c_memory), [](Logger *l) { logger_kill(l); })
         , mono_time_(mono_time_new(
                          &node_->c_memory,
-                         [](void *ud) -> uint64_t {
+                         [](void *ud) -> std::uint64_t {
                              return static_cast<tox::test::FakeClock *>(ud)->current_time_ms();
                          },
                          &env.fake_clock()),
@@ -75,7 +75,7 @@ private:
 };
 
 const Net_Crypto_DHT_Funcs FuzzDHT::funcs = {
-    [](void *obj, const uint8_t *public_key) {
+    [](void *obj, const std::uint8_t *public_key) {
         return dht_get_shared_key_sent(static_cast<DHT *>(obj), public_key);
     },
     [](const void *obj) { return dht_get_self_public_key(static_cast<const DHT *>(obj)); },
@@ -104,7 +104,7 @@ public:
         // Register a handler for onion data to verify reception
         oniondata_registerhandler(
             onion_client_.get(), 0,
-            [](void *, const uint8_t *, const uint8_t *, uint16_t, void *) {
+            [](void *, const std::uint8_t *, const std::uint8_t *, std::uint16_t, void *) {
                 // Callback hit
                 return 0;
             },
@@ -124,7 +124,7 @@ public:
 private:
     void Action(Fuzz_Data &input)
     {
-        uint8_t op = input.consume_integral<uint8_t>();
+        std::uint8_t op = input.consume_integral<std::uint8_t>();
         switch (op % 12) {
         case 0:
             AddFriend(input);
@@ -167,15 +167,15 @@ private:
 
     void AddFriend(Fuzz_Data &input)
     {
-        uint8_t pk[CRYPTO_PUBLIC_KEY_SIZE];
-        uint8_t sk[CRYPTO_SECRET_KEY_SIZE];
+        std::uint8_t pk[CRYPTO_PUBLIC_KEY_SIZE];
+        std::uint8_t sk[CRYPTO_SECRET_KEY_SIZE];
         crypto_new_keypair(&dht_.node().c_random, pk, sk);
 
         int friend_num = onion_addfriend(onion_client_.get(), pk);
         if (friend_num != -1) {
             friends_.push_back(friend_num);
-            friend_keys_[friend_num] = {std::vector<uint8_t>(pk, pk + CRYPTO_PUBLIC_KEY_SIZE),
-                std::vector<uint8_t>(sk, sk + CRYPTO_SECRET_KEY_SIZE)};
+            friend_keys_[friend_num] = {std::vector<std::uint8_t>(pk, pk + CRYPTO_PUBLIC_KEY_SIZE),
+                std::vector<std::uint8_t>(sk, sk + CRYPTO_SECRET_KEY_SIZE)};
         }
     }
 
@@ -183,7 +183,7 @@ private:
     {
         if (friends_.empty())
             return;
-        size_t idx = consume_range<size_t>(input, 0, friends_.size() - 1);
+        std::size_t idx = consume_range<std::size_t>(input, 0, friends_.size() - 1);
         int friend_num = friends_[idx];
         onion_delfriend(onion_client_.get(), friend_num);
         friends_.erase(friends_.begin() + idx);
@@ -194,7 +194,7 @@ private:
     {
         if (friends_.empty())
             return;
-        int friend_num = friends_[consume_range<size_t>(input, 0, friends_.size() - 1)];
+        int friend_num = friends_[consume_range<std::size_t>(input, 0, friends_.size() - 1)];
         bool online = input.consume_integral<bool>();
         onion_set_friend_online(onion_client_.get(), friend_num, online);
     }
@@ -203,8 +203,8 @@ private:
     {
         if (friends_.empty())
             return;
-        int friend_num = friends_[consume_range<size_t>(input, 0, friends_.size() - 1)];
-        CONSUME_OR_RETURN(const uint8_t *pk, input, CRYPTO_PUBLIC_KEY_SIZE);
+        int friend_num = friends_[consume_range<std::size_t>(input, 0, friends_.size() - 1)];
+        CONSUME_OR_RETURN(const std::uint8_t *pk, input, CRYPTO_PUBLIC_KEY_SIZE);
         onion_set_friend_dht_pubkey(onion_client_.get(), friend_num, pk);
     }
 
@@ -212,8 +212,8 @@ private:
     {
         IP_Port ip_port;
         ip_init(&ip_port.ip, 1);
-        ip_port.port = input.consume_integral<uint16_t>();
-        CONSUME_OR_RETURN(const uint8_t *pk, input, CRYPTO_PUBLIC_KEY_SIZE);
+        ip_port.port = input.consume_integral<std::uint16_t>();
+        CONSUME_OR_RETURN(const std::uint8_t *pk, input, CRYPTO_PUBLIC_KEY_SIZE);
         onion_add_bs_path_node(onion_client_.get(), &ip_port, pk);
     }
 
@@ -222,30 +222,30 @@ private:
         if (input.remaining_bytes() < 1)
             return;
 
-        std::vector<uint8_t> packet;
-        uint8_t type = input.consume_integral<uint8_t>();
+        std::vector<std::uint8_t> packet;
+        std::uint8_t type = input.consume_integral<std::uint8_t>();
 
         if (type < 50) {
-            size_t size = consume_range<size_t>(input, 10, 500);
+            std::size_t size = consume_range<std::size_t>(input, 10, 500);
             if (input.remaining_bytes() >= size) {
-                const uint8_t *ptr = input.consume("ReceivePacket", size);
+                const std::uint8_t *ptr = input.consume("ReceivePacket", size);
                 if (ptr)
                     packet.assign(ptr, ptr + size);
             }
         } else if (type >= 50 && type < 150) {
             // Generate valid NET_PACKET_ANNOUNCE_RESPONSE
-            uint8_t secret_key[CRYPTO_SYMMETRIC_KEY_SIZE];
+            std::uint8_t secret_key[CRYPTO_SYMMETRIC_KEY_SIZE];
             onion_testonly_get_secret_symmetric_key(onion_client_.get(), secret_key);
 
-            uint8_t nonce[CRYPTO_NONCE_SIZE];
+            std::uint8_t nonce[CRYPTO_NONCE_SIZE];
             random_bytes(&dht_.node().c_random, nonce, sizeof(nonce));
 
-            size_t data_len = consume_range<size_t>(input, 1, 100);
-            std::vector<uint8_t> plaintext = input.consume_bytes(data_len);
+            std::size_t data_len = consume_range<std::size_t>(input, 1, 100);
+            std::vector<std::uint8_t> plaintext = input.consume_bytes(data_len);
             if (plaintext.empty())
                 plaintext = {1, 2, 3};  // fallback
 
-            std::vector<uint8_t> ciphertext(plaintext.size() + CRYPTO_MAC_SIZE);
+            std::vector<std::uint8_t> ciphertext(plaintext.size() + CRYPTO_MAC_SIZE);
             int len = encrypt_data_symmetric(&dht_.node().c_memory, secret_key, nonce,
                 plaintext.data(), plaintext.size(), ciphertext.data());
 
@@ -257,25 +257,25 @@ private:
 
         } else if (type >= 150 && !friends_.empty()) {
             // Valid onion data response injection
-            int friend_num = friends_[consume_range<size_t>(input, 0, friends_.size() - 1)];
+            int friend_num = friends_[consume_range<std::size_t>(input, 0, friends_.size() - 1)];
             const auto &keys = friend_keys_[friend_num];
 
-            uint8_t sender_temp_pk[CRYPTO_PUBLIC_KEY_SIZE];
-            uint8_t sender_temp_sk[CRYPTO_SECRET_KEY_SIZE];
+            std::uint8_t sender_temp_pk[CRYPTO_PUBLIC_KEY_SIZE];
+            std::uint8_t sender_temp_sk[CRYPTO_SECRET_KEY_SIZE];
             crypto_new_keypair(&dht_.node().c_random, sender_temp_pk, sender_temp_sk);
 
-            uint8_t nonce[CRYPTO_NONCE_SIZE];
+            std::uint8_t nonce[CRYPTO_NONCE_SIZE];
             random_bytes(&dht_.node().c_random, nonce, sizeof(nonce));
 
             // Inner packet - Let fuzzer choose type
-            uint8_t inner_type = input.consume_integral<uint8_t>();
-            std::vector<uint8_t> inner_data = {inner_type};
+            std::uint8_t inner_type = input.consume_integral<std::uint8_t>();
+            std::vector<std::uint8_t> inner_data = {inner_type};
 
-            size_t data_len = consume_range<size_t>(input, 1, 100);
-            std::vector<uint8_t> rand_data = input.consume_bytes(data_len);
+            std::size_t data_len = consume_range<std::size_t>(input, 1, 100);
+            std::vector<std::uint8_t> rand_data = input.consume_bytes(data_len);
             inner_data.insert(inner_data.end(), rand_data.begin(), rand_data.end());
 
-            std::vector<uint8_t> inner_ciphertext(inner_data.size() + CRYPTO_MAC_SIZE);
+            std::vector<std::uint8_t> inner_ciphertext(inner_data.size() + CRYPTO_MAC_SIZE);
             int len = encrypt_data(&dht_.node().c_memory, dht_get_self_public_key(dht_.get_dht()),
                 keys.second.data(), nonce, inner_data.data(), inner_data.size(),
                 inner_ciphertext.data());
@@ -283,15 +283,16 @@ private:
                 return;
 
             // Outer packet content: Sender Real PK + Inner Ciphertext
-            std::vector<uint8_t> outer_plaintext(CRYPTO_PUBLIC_KEY_SIZE + inner_ciphertext.size());
-            memcpy(outer_plaintext.data(), keys.first.data(), CRYPTO_PUBLIC_KEY_SIZE);
-            memcpy(outer_plaintext.data() + CRYPTO_PUBLIC_KEY_SIZE, inner_ciphertext.data(),
+            std::vector<std::uint8_t> outer_plaintext(
+                CRYPTO_PUBLIC_KEY_SIZE + inner_ciphertext.size());
+            std::memcpy(outer_plaintext.data(), keys.first.data(), CRYPTO_PUBLIC_KEY_SIZE);
+            std::memcpy(outer_plaintext.data() + CRYPTO_PUBLIC_KEY_SIZE, inner_ciphertext.data(),
                 inner_ciphertext.size());
 
-            uint8_t receiver_temp_pk[CRYPTO_PUBLIC_KEY_SIZE];
+            std::uint8_t receiver_temp_pk[CRYPTO_PUBLIC_KEY_SIZE];
             onion_testonly_get_temp_public_key(onion_client_.get(), receiver_temp_pk);
 
-            std::vector<uint8_t> outer_ciphertext(outer_plaintext.size() + CRYPTO_MAC_SIZE);
+            std::vector<std::uint8_t> outer_ciphertext(outer_plaintext.size() + CRYPTO_MAC_SIZE);
             len = encrypt_data(&dht_.node().c_memory, receiver_temp_pk, sender_temp_sk, nonce,
                 outer_plaintext.data(), outer_plaintext.size(), outer_ciphertext.data());
             if (len == -1)
@@ -318,7 +319,7 @@ private:
 
     void AdvanceTime(Fuzz_Data &input)
     {
-        uint32_t ms = input.consume_integral_in_range<uint32_t>(1, 10000);
+        std::uint32_t ms = input.consume_integral_in_range<std::uint32_t>(1, 10000);
         env_.fake_clock().advance(ms);
     }
 
@@ -326,11 +327,11 @@ private:
     {
         if (friends_.empty())
             return;
-        int friend_num = friends_[consume_range<size_t>(input, 0, friends_.size() - 1)];
+        int friend_num = friends_[consume_range<std::size_t>(input, 0, friends_.size() - 1)];
 
-        uint16_t length = consume_range<uint16_t>(input, 1, 1024);
+        std::uint16_t length = consume_range<std::uint16_t>(input, 1, 1024);
         if (input.remaining_bytes() >= length) {
-            const uint8_t *ptr = input.consume("SendData", length);
+            const std::uint8_t *ptr = input.consume("SendData", length);
             if (ptr)
                 send_onion_data(onion_client_.get(), friend_num, ptr, length);
         }
@@ -340,7 +341,7 @@ private:
     {
         if (friends_.empty())
             return;
-        int friend_num = friends_[consume_range<size_t>(input, 0, friends_.size() - 1)];
+        int friend_num = friends_[consume_range<std::size_t>(input, 0, friends_.size() - 1)];
         IP_Port ip_port;
         onion_getfriendip(onion_client_.get(), friend_num, &ip_port);
     }
@@ -357,11 +358,13 @@ private:
     {
         if (friends_.empty())
             return;
-        int friend_num = friends_[input.consume_integral_in_range<size_t>(0, friends_.size() - 1)];
+        int friend_num
+            = friends_[input.consume_integral_in_range<std::size_t>(0, friends_.size() - 1)];
         // Just setting a dummy callback
         recv_tcp_relay_handler(
             onion_client_.get(), friend_num,
-            [](void *, uint32_t, const IP_Port *, const uint8_t *) { return 0; }, this, 0);
+            [](void *, std::uint32_t, const IP_Port *, const std::uint8_t *) { return 0; }, this,
+            0);
     }
 
     SimulatedEnvironment &env_;
@@ -370,13 +373,13 @@ private:
     std::unique_ptr<Net_Crypto, void (*)(Net_Crypto *)> net_crypto_;
     std::unique_ptr<Onion_Client, void (*)(Onion_Client *)> onion_client_;
     std::vector<int> friends_;
-    std::map<int, std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> friend_keys_;
+    std::map<int, std::pair<std::vector<std::uint8_t>, std::vector<std::uint8_t>>> friend_keys_;
 };
 
 }  // namespace
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size)
 {
     if (size == 0)
         return 0;

--- a/toxcore/ping_array_test.cc
+++ b/toxcore/ping_array_test.cc
@@ -77,13 +77,13 @@ TEST(PingArray, StoredDataCanBeRetrieved)
     Mono_Time_Ptr const mono_time(mono_time_new(&c_mem, nullptr, nullptr), c_mem);
     ASSERT_NE(mono_time, nullptr);
 
-    uint64_t const ping_id = ping_array_add(
-        arr.get(), mono_time.get(), &c_rng, std::vector<uint8_t>{1, 2, 3, 4}.data(), 4);
+    std::uint64_t const ping_id = ping_array_add(
+        arr.get(), mono_time.get(), &c_rng, std::vector<std::uint8_t>{1, 2, 3, 4}.data(), 4);
     EXPECT_NE(ping_id, 0);
 
-    std::vector<uint8_t> data(4);
+    std::vector<std::uint8_t> data(4);
     EXPECT_EQ(ping_array_check(arr.get(), mono_time.get(), data.data(), data.size(), ping_id), 4);
-    EXPECT_EQ(data, std::vector<uint8_t>({1, 2, 3, 4}));
+    EXPECT_EQ(data, std::vector<std::uint8_t>({1, 2, 3, 4}));
 }
 
 TEST(PingArray, RetrievingDataWithTooSmallOutputBufferHasNoEffect)
@@ -96,17 +96,17 @@ TEST(PingArray, RetrievingDataWithTooSmallOutputBufferHasNoEffect)
     Mono_Time_Ptr const mono_time(mono_time_new(&c_mem, nullptr, nullptr), c_mem);
     ASSERT_NE(mono_time, nullptr);
 
-    uint64_t const ping_id = ping_array_add(
-        arr.get(), mono_time.get(), &c_rng, (std::vector<uint8_t>{1, 2, 3, 4}).data(), 4);
+    std::uint64_t const ping_id = ping_array_add(
+        arr.get(), mono_time.get(), &c_rng, (std::vector<std::uint8_t>{1, 2, 3, 4}).data(), 4);
     EXPECT_NE(ping_id, 0);
 
-    std::vector<uint8_t> data(4);
+    std::vector<std::uint8_t> data(4);
     EXPECT_EQ(ping_array_check(arr.get(), mono_time.get(), data.data(), 3, ping_id), -1);
     // It doesn't write anything to the data array.
-    EXPECT_EQ(data, std::vector<uint8_t>({0, 0, 0, 0}));
+    EXPECT_EQ(data, std::vector<std::uint8_t>({0, 0, 0, 0}));
     // Afterwards, we can still read it.
     EXPECT_EQ(ping_array_check(arr.get(), mono_time.get(), data.data(), 4, ping_id), 4);
-    EXPECT_EQ(data, std::vector<uint8_t>({1, 2, 3, 4}));
+    EXPECT_EQ(data, std::vector<std::uint8_t>({1, 2, 3, 4}));
 }
 
 TEST(PingArray, ZeroLengthDataCanBeAdded)
@@ -119,8 +119,8 @@ TEST(PingArray, ZeroLengthDataCanBeAdded)
     Mono_Time_Ptr const mono_time(mono_time_new(&c_mem, nullptr, nullptr), c_mem);
     ASSERT_NE(mono_time, nullptr);
 
-    uint8_t c = 0;
-    uint64_t const ping_id = ping_array_add(arr.get(), mono_time.get(), &c_rng, &c, sizeof(c));
+    std::uint8_t c = 0;
+    std::uint64_t const ping_id = ping_array_add(arr.get(), mono_time.get(), &c_rng, &c, sizeof(c));
     EXPECT_NE(ping_id, 0);
 
     EXPECT_EQ(ping_array_check(arr.get(), mono_time.get(), &c, sizeof(c), ping_id), 1);
@@ -135,7 +135,7 @@ TEST(PingArray, PingId0IsInvalid)
     Mono_Time_Ptr const mono_time(mono_time_new(&c_mem, nullptr, nullptr), c_mem);
     ASSERT_NE(mono_time, nullptr);
 
-    uint8_t c = 0;
+    std::uint8_t c = 0;
     EXPECT_EQ(ping_array_check(arr.get(), mono_time.get(), &c, sizeof(c), 0), -1);
 }
 
@@ -150,8 +150,8 @@ TEST(PingArray, DataCanOnlyBeRetrievedOnce)
     Mono_Time_Ptr const mono_time(mono_time_new(&c_mem, nullptr, nullptr), c_mem);
     ASSERT_NE(mono_time, nullptr);
 
-    uint8_t c = 0;
-    uint64_t const ping_id = ping_array_add(arr.get(), mono_time.get(), &c_rng, &c, sizeof(c));
+    std::uint8_t c = 0;
+    std::uint64_t const ping_id = ping_array_add(arr.get(), mono_time.get(), &c_rng, &c, sizeof(c));
     EXPECT_NE(ping_id, 0);
 
     EXPECT_EQ(ping_array_check(arr.get(), mono_time.get(), &c, sizeof(c), ping_id), 1);
@@ -168,11 +168,11 @@ TEST(PingArray, PingIdMustMatchOnCheck)
     Mono_Time_Ptr const mono_time(mono_time_new(&c_mem, nullptr, nullptr), c_mem);
     ASSERT_NE(mono_time, nullptr);
 
-    uint8_t c = 0;
-    uint64_t const ping_id = ping_array_add(arr.get(), mono_time.get(), &c_rng, &c, sizeof(c));
+    std::uint8_t c = 0;
+    std::uint64_t const ping_id = ping_array_add(arr.get(), mono_time.get(), &c_rng, &c, sizeof(c));
     EXPECT_NE(ping_id, 0);
 
-    uint64_t const bad_ping_id = ping_id == 1 ? 2 : 1;
+    std::uint64_t const bad_ping_id = ping_id == 1 ? 2 : 1;
 
     // bad_ping_id will also be pointing at the same element, but won't match the
     // actual ping_id.

--- a/toxcore/sort_bench.cc
+++ b/toxcore/sort_bench.cc
@@ -19,12 +19,12 @@ std::pair<std::vector<Some_Type>, std::minstd_rand> random_vec(benchmark::State 
 {
     std::minstd_rand rng;
     // INT_MAX-1 so later we have room to add 1 larger element if needed.
-    std::uniform_int_distribution<uint32_t> dist{
-        std::numeric_limits<uint32_t>::min(), std::numeric_limits<uint32_t>::max() - 1};
+    std::uniform_int_distribution<std::uint32_t> dist{
+        std::numeric_limits<std::uint32_t>::min(), std::numeric_limits<std::uint32_t>::max() - 1};
 
     std::vector<Some_Type> vec(state.range(0));
     std::generate(std::begin(vec), std::end(vec), [&]() {
-        std::array<uint32_t, 8> compare_value;
+        std::array<std::uint32_t, 8> compare_value;
         std::generate(
             std::begin(compare_value), std::end(compare_value), [&]() { return dist(rng); });
         return Some_Type{nullptr, compare_value, "hello there"};

--- a/toxcore/sort_test.cc
+++ b/toxcore/sort_test.cc
@@ -24,7 +24,7 @@ TEST(MergeSort, BehavesLikeStdSort)
     constexpr auto int_funcs = sort_funcs<int>();
 
     // Test with int arrays.
-    for (uint32_t i = 1; i < 500; ++i) {
+    for (std::uint32_t i = 1; i < 500; ++i) {
         std::vector<int> vec(i);
         std::generate(std::begin(vec), std::end(vec), [&]() { return dist(rng); });
 
@@ -55,7 +55,7 @@ TEST(MergeSort, WorksWithNonTrivialTypes)
     constexpr auto string_funcs = sort_funcs<std::string>();
 
     // Test with std::string arrays.
-    for (uint32_t i = 1; i < 500; ++i) {
+    for (std::uint32_t i = 1; i < 500; ++i) {
         std::vector<std::string> vec(i);
         std::generate(std::begin(vec), std::end(vec), [&]() { return std::to_string(dist(rng)); });
 

--- a/toxcore/sort_test_util.hh
+++ b/toxcore/sort_test_util.hh
@@ -6,6 +6,7 @@
 #define C_TOXCORE_TOXCORE_SORT_TEST_UTIL_H
 
 #include <array>
+#include <cstdint>
 
 #include "sort.h"
 
@@ -21,28 +22,28 @@ constexpr Sort_Funcs sort_funcs()
 
             return *a < *b;
         },
-        [](const void *arr, uint32_t index) -> const void * {
+        [](const void *arr, std::uint32_t index) -> const void * {
             const T *vec = static_cast<const T *>(arr);
             return &vec[index];
         },
-        [](void *arr, uint32_t index, const void *val) {
+        [](void *arr, std::uint32_t index, const void *val) {
             T *vec = static_cast<T *>(arr);
             const T *value = static_cast<const T *>(val);
             vec[index] = *value;
         },
-        [](void *arr, uint32_t index, uint32_t size) -> void * {
+        [](void *arr, std::uint32_t index, std::uint32_t size) -> void * {
             T *vec = static_cast<T *>(arr);
             return &vec[index];
         },
-        [](const void *object, uint32_t size) -> void * { return new T[size]; },
-        [](const void *object, void *arr, uint32_t size) { delete[] static_cast<T *>(arr); },
+        [](const void *object, std::uint32_t size) -> void * { return new T[size]; },
+        [](const void *object, void *arr, std::uint32_t size) { delete[] static_cast<T *>(arr); },
     };
 }
 
 // A realistic test case where we have a struct with some stuff and an expensive value we compare.
 struct Some_Type {
     const Tox_Memory *mem;
-    std::array<uint32_t, 8> compare_value;
+    std::array<std::uint32_t, 8> compare_value;
     const char *name;
 
     static const Sort_Funcs funcs;

--- a/toxcore/state.h
+++ b/toxcore/state.h
@@ -17,6 +17,8 @@
 #ifndef C_TOXCORE_TOXCORE_STATE_H
 #define C_TOXCORE_TOXCORE_STATE_H
 
+#include <stdint.h>
+
 #include "attributes.h"
 #include "logger.h"
 

--- a/toxcore/test_util_test.cc
+++ b/toxcore/test_util_test.cc
@@ -19,8 +19,8 @@ TEST(CryptoCoreTestUtil, RandomBytesDoesNotTouchZeroSizeArray)
     SimulatedEnvironment env;
     auto c_rng = env.fake_random().c_random();
 
-    std::array<uint8_t, 32> bytes{};
-    for (uint32_t i = 0; i < 100; ++i) {
+    std::array<std::uint8_t, 32> bytes{};
+    for (std::uint32_t i = 0; i < 100; ++i) {
         random_bytes(&c_rng, bytes.data(), 0);
         ASSERT_THAT(bytes, Each(Eq(0x00)));
     }
@@ -31,13 +31,13 @@ TEST(CryptoCoreTestUtil, RandomBytesFillsEntireArray)
     SimulatedEnvironment env;
     auto c_rng = env.fake_random().c_random();
 
-    std::array<uint8_t, 32> bytes{};
+    std::array<std::uint8_t, 32> bytes{};
 
-    for (uint32_t size = 1; size < bytes.size(); ++size) {
+    for (std::uint32_t size = 1; size < bytes.size(); ++size) {
         bool const success = [&]() {
             // Try a few times. There ought to be a non-zero byte in our randomness at
             // some point.
-            for (uint32_t i = 0; i < 100; ++i) {
+            for (std::uint32_t i = 0; i < 100; ++i) {
                 random_bytes(&c_rng, bytes.data(), bytes.size());
                 if (bytes[size - 1] != 0x00) {
                     return true;
@@ -54,15 +54,16 @@ TEST(CryptoCoreTestUtil, RandomBytesDoesNotBufferOverrun)
     SimulatedEnvironment env;
     auto c_rng = env.fake_random().c_random();
 
-    std::array<uint8_t, 32> bytes{};
+    std::array<std::uint8_t, 32> bytes{};
 
     // Try a few times. It should never overrun.
-    for (uint32_t i = 0; i < 100; ++i) {
-        for (uint32_t diff = 1; diff < sizeof(uint64_t); ++diff) {
+    for (std::uint32_t i = 0; i < 100; ++i) {
+        for (std::uint32_t diff = 1; diff < sizeof(std::uint64_t); ++diff) {
             bytes = {};
             random_bytes(&c_rng, bytes.data(), bytes.size() - diff);
             // All bytes not in the range we want to write should be 0.
-            ASSERT_THAT(std::vector<uint8_t>(bytes.begin() + (bytes.size() - diff), bytes.end()),
+            ASSERT_THAT(
+                std::vector<std::uint8_t>(bytes.begin() + (bytes.size() - diff), bytes.end()),
                 Each(Eq(0x00)));
         }
     }

--- a/toxcore/timed_auth.h
+++ b/toxcore/timed_auth.h
@@ -4,6 +4,9 @@
 #ifndef C_TOXCORE_TOXCORE_TIMED_AUTH_H
 #define C_TOXCORE_TOXCORE_TIMED_AUTH_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "attributes.h"
 #include "crypto_core.h"
 #include "mono_time.h"

--- a/toxcore/tox_event.h
+++ b/toxcore/tox_event.h
@@ -5,6 +5,8 @@
 #ifndef C_TOXCORE_TOXCORE_TOX_EVENT_H
 #define C_TOXCORE_TOXCORE_TOX_EVENT_H
 
+#include <stdbool.h>
+
 #include "attributes.h"
 #include "bin_pack.h"
 #include "bin_unpack.h"

--- a/toxcore/tox_events.h
+++ b/toxcore/tox_events.h
@@ -12,6 +12,9 @@
 #ifndef C_TOXCORE_TOXCORE_TOX_EVENTS_H
 #define C_TOXCORE_TOXCORE_TOX_EVENTS_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "tox.h"
 
 #ifdef __cplusplus

--- a/toxcore/tox_events_fuzz_test.cc
+++ b/toxcore/tox_events_fuzz_test.cc
@@ -19,20 +19,20 @@ using tox::test::SimulatedEnvironment;
 void TestUnpack(Fuzz_Data data)
 {
     // 2 bytes: size of the events data
-    CONSUME_OR_RETURN(const uint8_t *events_size_bytes, data, sizeof(uint16_t));
-    uint16_t events_size;
-    std::memcpy(&events_size, events_size_bytes, sizeof(uint16_t));
+    CONSUME_OR_RETURN(const std::uint8_t *events_size_bytes, data, sizeof(std::uint16_t));
+    std::uint16_t events_size;
+    std::memcpy(&events_size, events_size_bytes, sizeof(std::uint16_t));
 
     // events_size bytes: events data (max 64K)
-    CONSUME_OR_RETURN(const uint8_t *events_data, data, events_size);
+    CONSUME_OR_RETURN(const std::uint8_t *events_data, data, events_size);
 
     if (data.empty()) {
-        // If there's no more input, no malloc failure paths can possibly be
+        // If there's no more input, no std::malloc failure paths can possibly be
         // tested, so we ignore this input.
         return;
     }
 
-    // rest of the fuzz data is input for malloc
+    // rest of the fuzz data is input for std::malloc
     SimulatedEnvironment env;
     auto node = env.create_node(33445);
     configure_fuzz_memory_source(env.fake_memory(), data);
@@ -83,7 +83,7 @@ void TestUnpack(Fuzz_Data data)
 
     Tox_Events *events = tox_events_load(&node->system, events_data, events_size);
     if (events) {
-        std::vector<uint8_t> packed(tox_events_bytes_size(events));
+        std::vector<std::uint8_t> packed(tox_events_bytes_size(events));
         tox_events_get_bytes(events, packed.data());
 
         tox_dispatch_invoke(dispatch, events, nullptr);
@@ -94,8 +94,8 @@ void TestUnpack(Fuzz_Data data)
 
 }  // namespace
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size)
 {
     TestUnpack(Fuzz_Data(data, size));
     return 0;

--- a/toxcore/tox_events_test.cc
+++ b/toxcore/tox_events_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cstdint>
 #include <vector>
 
 #include "crypto_core.h"
@@ -20,7 +21,7 @@ TEST(ToxEvents, UnpackRandomDataDoesntCrash)
     SimulatedEnvironment env;
     auto node = env.create_node(33445);
     ASSERT_NE(node->system.rng, nullptr);
-    std::array<uint8_t, 128> data;
+    std::array<std::uint8_t, 128> data;
     random_bytes(node->system.rng, data.data(), data.size());
     tox_events_free(tox_events_load(&node->system, data.data(), data.size()));
 }
@@ -29,7 +30,7 @@ TEST(ToxEvents, UnpackEmptyDataFails)
 {
     SimulatedEnvironment env;
     auto node = env.create_node(33445);
-    std::array<uint8_t, 1> data;
+    std::array<std::uint8_t, 1> data;
     Tox_Events *events = tox_events_load(&node->system, data.end(), 0);
     EXPECT_EQ(events, nullptr);
 }
@@ -38,7 +39,7 @@ TEST(ToxEvents, UnpackEmptyArrayCreatesEmptyEvents)
 {
     SimulatedEnvironment env;
     auto node = env.create_node(33445);
-    std::array<uint8_t, 1> data{0x90};  // empty msgpack array
+    std::array<std::uint8_t, 1> data{0x90};  // empty msgpack array
     Tox_Events *events = tox_events_load(&node->system, data.data(), data.size());
     ASSERT_NE(events, nullptr);
     EXPECT_EQ(tox_events_get_size(events), 0);
@@ -47,10 +48,10 @@ TEST(ToxEvents, UnpackEmptyArrayCreatesEmptyEvents)
 
 TEST(ToxEvents, NullEventsPacksToEmptyArray)
 {
-    std::array<uint8_t, 1> bytes;
+    std::array<std::uint8_t, 1> bytes;
     ASSERT_EQ(tox_events_bytes_size(nullptr), bytes.size());
     tox_events_get_bytes(nullptr, bytes.data());
-    EXPECT_EQ(bytes, (std::array<uint8_t, 1>{0x90}));
+    EXPECT_EQ(bytes, (std::array<std::uint8_t, 1>{0x90}));
 }
 
 TEST(ToxEvents, PackedEventsCanBeUnpacked)
@@ -58,13 +59,13 @@ TEST(ToxEvents, PackedEventsCanBeUnpacked)
     SimulatedEnvironment env;
     auto node = env.create_node(33445);
     // [[0, 1]] == Tox_Self_Connection_Status { .connection_status = TOX_CONNECTION_TCP }
-    std::array<uint8_t, 6> packed{0x91, 0x92, 0xcc, 0x00, 0xcc, 0x01};
+    std::array<std::uint8_t, 6> packed{0x91, 0x92, 0xcc, 0x00, 0xcc, 0x01};
     Tox_Events *events = tox_events_load(&node->system, packed.data(), packed.size());
     ASSERT_NE(events, nullptr);
-    std::array<uint8_t, 4> bytes;
+    std::array<std::uint8_t, 4> bytes;
     ASSERT_EQ(tox_events_bytes_size(events), bytes.size());
     tox_events_get_bytes(events, bytes.data());
-    EXPECT_EQ(bytes, (std::array<uint8_t, 4>{0x91, 0x92, 0x00, 0x01}));
+    EXPECT_EQ(bytes, (std::array<std::uint8_t, 4>{0x91, 0x92, 0x00, 0x01}));
     tox_events_free(events);
 }
 
@@ -72,7 +73,7 @@ TEST(ToxEvents, DealsWithHugeMsgpackArrays)
 {
     SimulatedEnvironment env;
     auto node = env.create_node(33445);
-    std::vector<uint8_t> data{0xdd, 0xff, 0xff, 0xff, 0xff};
+    std::vector<std::uint8_t> data{0xdd, 0xff, 0xff, 0xff, 0xff};
     EXPECT_EQ(tox_events_load(&node->system, data.data(), data.size()), nullptr);
 }
 

--- a/toxcore/tox_pack.h
+++ b/toxcore/tox_pack.h
@@ -5,6 +5,8 @@
 #ifndef C_TOXCORE_TOXCORE_TOX_PACK_H
 #define C_TOXCORE_TOXCORE_TOX_PACK_H
 
+#include <stdbool.h>
+
 #include "attributes.h"
 #include "bin_pack.h"
 #include "tox.h"

--- a/toxcore/tox_random_impl.h
+++ b/toxcore/tox_random_impl.h
@@ -5,6 +5,8 @@
 #ifndef C_TOXCORE_TOXCORE_TOX_RANDOM_IMPL_H
 #define C_TOXCORE_TOXCORE_TOX_RANDOM_IMPL_H
 
+#include <stdint.h>
+
 #include "tox_memory.h"
 #include "tox_random.h"
 

--- a/toxcore/tox_test.cc
+++ b/toxcore/tox_test.cc
@@ -19,13 +19,13 @@ namespace {
 using tox::test::SimulatedEnvironment;
 
 static void set_random_name_and_status_message(
-    Tox *tox, const Random *rng, uint8_t *name, uint8_t *status_message)
+    Tox *tox, const Random *rng, std::uint8_t *name, std::uint8_t *status_message)
 {
-    for (uint16_t i = 0; i < tox_max_name_length(); ++i) {
+    for (std::uint16_t i = 0; i < tox_max_name_length(); ++i) {
         name[i] = random_u08(rng);
     }
 
-    for (uint16_t i = 0; i < tox_max_status_message_length(); ++i) {
+    for (std::uint16_t i = 0; i < tox_max_status_message_length(); ++i) {
         status_message[i] = random_u08(rng);
     }
 }
@@ -75,7 +75,7 @@ TEST(Tox, BootstrapErrorCodes)
     ASSERT_NE(tox, nullptr);
 
     Tox_Err_Bootstrap err;
-    std::array<uint8_t, TOX_PUBLIC_KEY_SIZE> pk;
+    std::array<std::uint8_t, TOX_PUBLIC_KEY_SIZE> pk;
     tox_bootstrap(tox, "127.0.0.1", 0, pk.data(), &err);
     EXPECT_EQ(err, TOX_ERR_BOOTSTRAP_BAD_PORT);
 
@@ -92,7 +92,7 @@ TEST(Tox, OneTest)
     ASSERT_NE(options, nullptr);
 
     tox_options_set_log_callback(options,
-        [](Tox *tox, Tox_Log_Level level, const char *file, uint32_t line, const char *func,
+        [](Tox *tox, Tox_Log_Level level, const char *file, std::uint32_t line, const char *func,
             const char *message, void *user_data) {
             fprintf(stderr, "[%c] %s:%u(%s): %s\n", tox_log_level_to_string(level)[0], file, line,
                 func, message);
@@ -102,11 +102,11 @@ TEST(Tox, OneTest)
     tox_options_set_start_port(options, 33545);
     tox_options_set_end_port(options, 33545 + 2000);
 
-    std::vector<uint8_t> name(tox_max_name_length());
-    std::vector<uint8_t> status_message(tox_max_status_message_length());
+    std::vector<std::uint8_t> name(tox_max_name_length());
+    std::vector<std::uint8_t> status_message(tox_max_status_message_length());
 
-    std::vector<uint8_t> name2(tox_max_name_length());
-    std::vector<uint8_t> status_message2(tox_max_status_message_length());
+    std::vector<std::uint8_t> name2(tox_max_name_length());
+    std::vector<std::uint8_t> status_message2(tox_max_status_message_length());
 
     auto node1 = env.create_node(33545);
     Tox_Options_Testing testing_opts1 = {};
@@ -126,16 +126,16 @@ TEST(Tox, OneTest)
     ASSERT_NE(tox2, nullptr);
     set_random_name_and_status_message(tox2, rng, name2.data(), status_message2.data());
 
-    std::array<uint8_t, TOX_ADDRESS_SIZE> address;
+    std::array<std::uint8_t, TOX_ADDRESS_SIZE> address;
     tox_self_get_address(tox1, address.data());
     Tox_Err_Friend_Add error;
-    uint32_t ret
-        = tox_friend_add(tox1, address.data(), reinterpret_cast<const uint8_t *>("m"), 1, &error);
+    std::uint32_t ret = tox_friend_add(
+        tox1, address.data(), reinterpret_cast<const std::uint8_t *>("m"), 1, &error);
     EXPECT_EQ(error, TOX_ERR_FRIEND_ADD_OWN_KEY) << "Adding own address worked.";
     EXPECT_EQ(ret, UINT32_MAX);
 
     tox_self_get_address(tox2, address.data());
-    std::vector<uint8_t> message(tox_max_friend_request_length() + 1);
+    std::vector<std::uint8_t> message(tox_max_friend_request_length() + 1);
     ret = tox_friend_add(tox1, address.data(), nullptr, 0, &error);
     EXPECT_EQ(error, TOX_ERR_FRIEND_ADD_NULL) << "Sending request with no message worked.";
     EXPECT_EQ(ret, UINT32_MAX);
@@ -147,7 +147,8 @@ TEST(Tox, OneTest)
     EXPECT_EQ(ret, UINT32_MAX);
 
     address[0]++;
-    ret = tox_friend_add(tox1, address.data(), reinterpret_cast<const uint8_t *>("m"), 1, &error);
+    ret = tox_friend_add(
+        tox1, address.data(), reinterpret_cast<const std::uint8_t *>("m"), 1, &error);
     EXPECT_EQ(error, TOX_ERR_FRIEND_ADD_BAD_CHECKSUM) << "Adding address with bad checksum worked.";
     EXPECT_EQ(ret, UINT32_MAX);
 
@@ -170,7 +171,7 @@ TEST(Tox, OneTest)
         << "Can't set status message of length " << tox_max_status_message_length();
 
     tox_self_get_address(tox1, address.data());
-    std::vector<uint8_t> data(tox_get_savedata_size(tox1));
+    std::vector<std::uint8_t> data(tox_get_savedata_size(tox1));
     tox_get_savedata(tox1, data.data());
 
     tox_kill(tox2);
@@ -185,22 +186,22 @@ TEST(Tox, OneTest)
     EXPECT_EQ(tox_self_get_status_message_size(tox2), status_message.size())
         << "Wrong status message size";
 
-    std::vector<uint8_t> name_loaded(tox_max_name_length());
+    std::vector<std::uint8_t> name_loaded(tox_max_name_length());
     tox_self_get_name(tox2, name_loaded.data());
     EXPECT_EQ(name, name_loaded) << "Wrong name.";
 
-    std::vector<uint8_t> status_message_loaded(tox_max_status_message_length());
+    std::vector<std::uint8_t> status_message_loaded(tox_max_status_message_length());
     tox_self_get_status_message(tox2, status_message_loaded.data());
     EXPECT_EQ(status_message, status_message_loaded) << "Wrong status message.";
 
-    std::array<uint8_t, TOX_ADDRESS_SIZE> address2;
+    std::array<std::uint8_t, TOX_ADDRESS_SIZE> address2;
     tox_self_get_address(tox2, address2.data());
     EXPECT_EQ(address2, address) << "Wrong address.";
-    std::vector<uint8_t> new_name(tox_max_name_length());
+    std::vector<std::uint8_t> new_name(tox_max_name_length());
     tox_self_get_name(tox2, new_name.data());
     EXPECT_EQ(name, new_name) << "Wrong name";
 
-    std::array<uint8_t, TOX_SECRET_KEY_SIZE> sk;
+    std::array<std::uint8_t, TOX_SECRET_KEY_SIZE> sk;
     tox_self_get_secret_key(tox2, sk.data());
     tox_kill(tox2);
 
@@ -210,12 +211,12 @@ TEST(Tox, OneTest)
     tox2 = tox_new_testing(options, &err_n, &testing_opts2, nullptr);
     ASSERT_EQ(err_n, TOX_ERR_NEW_OK) << "Load failed";
     tox_self_set_nospam(tox2, tox_self_get_nospam(tox1));
-    std::array<uint8_t, TOX_ADDRESS_SIZE> address3;
+    std::array<std::uint8_t, TOX_ADDRESS_SIZE> address3;
     tox_self_get_address(tox2, address3.data());
     EXPECT_EQ(address3, address) << "Wrong public key.";
-    std::array<uint8_t, TOX_PUBLIC_KEY_SIZE> pk;
+    std::array<std::uint8_t, TOX_PUBLIC_KEY_SIZE> pk;
     tox_self_get_public_key(tox2, pk.data());
-    std::array<uint8_t, TOX_PUBLIC_KEY_SIZE> pk_from_addr;
+    std::array<std::uint8_t, TOX_PUBLIC_KEY_SIZE> pk_from_addr;
     std::copy(address.begin(), address.begin() + TOX_PUBLIC_KEY_SIZE, pk_from_addr.begin());
     EXPECT_EQ(pk, pk_from_addr) << "Wrong public key.";
 

--- a/toxcore/tox_unpack.h
+++ b/toxcore/tox_unpack.h
@@ -5,6 +5,8 @@
 #ifndef C_TOXCORE_TOXCORE_TOX_UNPACK_H
 #define C_TOXCORE_TOXCORE_TOX_UNPACK_H
 
+#include <stdbool.h>
+
 #include "attributes.h"
 #include "bin_unpack.h"
 #include "tox.h"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2973)
<!-- Reviewable:end -->
