### PR TITLE
chore: Improve Windows Docker support.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Build and store to local Docker daemon
         uses: docker/build-push-action@v5
         with:
-          context: other/docker/windows
+          file: other/docker/windows/windows.Dockerfile
           load: true
           tags: toxchat/windows:win${{ matrix.bits }}
           cache-from: type=registry,ref=toxchat/windows:win${{ matrix.bits }}
@@ -150,7 +150,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: docker/build-push-action@v5
         with:
-          context: other/docker/windows
+          file: other/docker/windows/windows.Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: toxchat/windows:win${{ matrix.bits }}
           build-args: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -286,7 +286,7 @@ requirements are that you have Docker version of >= 1.9.0 and you are running
 64-bit system.
 
 The cross-compilation is fully automated by a parameterized
-[Dockerfile](/other/docker/windows/Dockerfile).
+[Dockerfile](/other/docker/windows/windows.Dockerfile).
 
 Install Docker
 
@@ -313,10 +313,10 @@ available to customize the building of the container image.
 Example of building a container image with options
 
 ```sh
-cd other/docker/windows
 docker build \
   --build-arg SUPPORT_TEST=true \
   -t toxcore \
+  -f other/docker/windows/windows.Dockerfile \
   .
 ```
 

--- a/other/docker/windows/build_dependencies.sh
+++ b/other/docker/windows/build_dependencies.sh
@@ -114,6 +114,21 @@ build() {
   make install
   cd ..
 
+  echo
+  echo "=== Building GTest $VERSION_GTEST $ARCH ==="
+  curl "${CURL_OPTIONS[@]}" "https://github.com/google/googletest/archive/refs/tags/v$VERSION_GTEST.tar.gz" -o "googletest-$VERSION_GTEST.tar.gz"
+  check_sha256 "65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c" "googletest-$VERSION_GTEST.tar.gz"
+  tar -xf "googletest-$VERSION_GTEST.tar.gz"
+  cd "googletest-$VERSION_GTEST"
+  cmake \
+    -DCMAKE_TOOLCHAIN_FILE=../windows_toolchain.cmake \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX_DIR" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF \
+    -S . -B build
+  cmake --build build --target install --parallel "$(nproc)"
+  cd ..
+
   rm -rf /tmp/*
 }
 

--- a/other/docker/windows/dockerignore
+++ b/other/docker/windows/dockerignore
@@ -1,0 +1,1 @@
+!other/docker/windows/*.sh

--- a/other/docker/windows/run
+++ b/other/docker/windows/run
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+DOCKERFLAGS=(--build-arg SUPPORT_TEST=true)
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")/../sources" && pwd)/run.sh"
+
+# Create a temporary directory for the source to workaround potential bind mount issues
+# (e.g. FUSE/SSHFS filesystems or Docker daemon visibility issues).
+TEMP_SRC=$(mktemp -d -t toxcore-src-XXXXXX)
+cleanup() {
+  rm -rf "$TEMP_SRC"
+}
+trap cleanup EXIT
+
+echo "Copying source to temporary directory $TEMP_SRC..."
+# Exclude .git and build artifacts to speed up copy
+rsync -a --exclude .git --exclude _build . "$TEMP_SRC/"
+
+docker run \
+  -e ENABLE_TEST=true \
+  -e EXTRA_CMAKE_FLAGS=-DUNITTEST=ON \
+  -v "$TEMP_SRC:/toxcore" \
+  -v /tmp/c-toxcore-build:/prefix \
+  -t \
+  --rm \
+  toxchat/c-toxcore:windows

--- a/other/docker/windows/windows.Dockerfile
+++ b/other/docker/windows/windows.Dockerfile
@@ -7,6 +7,7 @@ FROM debian:trixie-slim
 ARG VERSION_OPUS=1.4 \
     VERSION_SODIUM=1.0.19 \
     VERSION_VPX=1.14.0 \
+    VERSION_GTEST=1.17.0 \
     ENABLE_HASH_VERIFICATION=true \
  \
     SUPPORT_TEST=false \
@@ -21,14 +22,14 @@ ENV SUPPORT_TEST=${SUPPORT_TEST} \
     CROSS_COMPILE=${CROSS_COMPILE}
 
 WORKDIR /work
-COPY check_sha256.sh .
-COPY get_packages.sh .
+COPY other/docker/windows/check_sha256.sh .
+COPY other/docker/windows/get_packages.sh .
 RUN ./get_packages.sh
 
-COPY build_dependencies.sh .
+COPY other/docker/windows/build_dependencies.sh .
 RUN ./build_dependencies.sh
 
-COPY build_toxcore.sh .
+COPY other/docker/windows/build_toxcore.sh .
 
 ENV ENABLE_TEST=false \
     ALLOW_TEST_FAILURE=false \

--- a/other/docker/windows/windows.Dockerfile.dockerignore
+++ b/other/docker/windows/windows.Dockerfile.dockerignore
@@ -1,0 +1,24 @@
+# ===== common =====
+# Ignore everything ...
+**/*
+# ... except sources
+!**/*.[ch]
+!**/*.cc
+!**/*.hh
+!CHANGELOG.md
+!LICENSE
+!README.md
+!auto_tests/data/*
+!other/bootstrap_daemon/bash-completion/**
+!other/bootstrap_daemon/tox-bootstrapd.*
+!other/proxy/*.mod
+!other/proxy/*.sum
+!other/proxy/*.go
+# ... and CMake build files (used by most builds).
+!**/CMakeLists.txt
+!.github/scripts/flags*.sh
+!cmake/*.cmake
+!other/pkgconfig/*
+!other/rpm/*
+!so.version
+!other/docker/windows/*.sh

--- a/other/windows_build_script_toxcore.sh
+++ b/other/windows_build_script_toxcore.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# When editing, make sure to update /other/docker/windows/Dockerfile and
+# When editing, make sure to update /other/docker/windows/windows.Dockerfile and
 # INSTALL.md to match.
 
 export VERSION_OPUS="1.4"


### PR DESCRIPTION
- Add `run` helper script and `.dockerignore` files.
- Update `build_dependencies.sh` to include GTest so we can run unit tests on Windows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2980)
<!-- Reviewable:end -->
