### PR TITLE
refactor: Allow nullable data in group chat handlers.

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -1967,7 +1967,7 @@ static bool sync_response_send_state(GC_Chat *_Nonnull chat, GC_Connection *_Non
  * Return -3 if we fail to send a response packet.
  * Return -4 if `peer_number` does not designate a valid peer.
  */
-static int handle_gc_sync_request(GC_Chat *_Nonnull chat, uint32_t peer_number, const uint8_t *_Nonnull data, uint16_t length)
+static int handle_gc_sync_request(GC_Chat *_Nonnull chat, uint32_t peer_number, const uint8_t *_Nullable data, uint16_t length)
 {
     GC_Connection *gconn = get_gc_connection(chat, peer_number);
 
@@ -2067,7 +2067,7 @@ static bool send_gc_tcp_relays(const GC_Chat *_Nonnull chat, GC_Connection *_Non
  * Return -1 if packet has invalid size.
  * Return -2 if packet contains invalid data.
  */
-static int handle_gc_tcp_relays(GC_Chat *_Nonnull chat, GC_Connection *_Nonnull gconn, const uint8_t *_Nonnull data, uint16_t length)
+static int handle_gc_tcp_relays(GC_Chat *_Nonnull chat, GC_Connection *_Nonnull gconn, const uint8_t *_Nullable data, uint16_t length)
 {
     if (length == 0) {
         return -1;
@@ -2203,7 +2203,7 @@ static bool send_gc_invite_response_reject(const GC_Chat *_Nonnull chat, GC_Conn
  * Return -3 if we fail to send an invite response.
  * Return -4 if peer_number does not designate a valid peer.
  */
-static int handle_gc_invite_request(GC_Chat *_Nonnull chat, uint32_t peer_number, const uint8_t *_Nonnull data, uint16_t length)
+static int handle_gc_invite_request(GC_Chat *_Nonnull chat, uint32_t peer_number, const uint8_t *_Nullable data, uint16_t length)
 {
     if (chat->shared_state.version == 0) {  // we aren't synced yet; ignore request
         return 0;
@@ -2682,7 +2682,7 @@ static bool send_gc_peer_exchange(const GC_Chat *chat, GC_Connection *gconn)
  * Return -8 if memory allocation fails.
  */
 static int handle_gc_peer_info_response(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, uint32_t peer_number,
-                                        const uint8_t *_Nonnull data, uint16_t length, void *_Nullable userdata)
+                                        const uint8_t *_Nullable data, uint16_t length, void *_Nullable userdata)
 {
     if (length < PACKED_GC_PEER_SIZE) {
         return -1;
@@ -2918,7 +2918,7 @@ static int handle_gc_shared_state_error(GC_Chat *_Nonnull chat, GC_Connection *_
  * Return 0 if packet is successfully handled.
  * Return -1 if packet is invalid and this is not successfully handled.
  */
-static int handle_gc_shared_state(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, GC_Connection *_Nonnull gconn, const uint8_t *_Nonnull data,
+static int handle_gc_shared_state(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, GC_Connection *_Nonnull gconn, const uint8_t *_Nullable data,
                                   uint16_t length, void *_Nullable userdata)
 {
     if (length < GC_SHARED_STATE_ENC_PACKET_SIZE) {
@@ -3015,7 +3015,7 @@ static int validate_unpack_mod_list(GC_Chat *_Nonnull chat, const uint8_t *_Nonn
  * Return -1 if packet has invalid size.
  * Return -2 if packet contained invalid data or validation failed.
  */
-static int handle_gc_mod_list(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, const uint8_t *_Nonnull data, uint16_t length, void *_Nullable userdata)
+static int handle_gc_mod_list(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, const uint8_t *_Nullable data, uint16_t length, void *_Nullable userdata)
 {
     if (length < sizeof(uint16_t)) {
         return -1;
@@ -3094,7 +3094,7 @@ static int handle_gc_sanctions_list_error(GC_Chat *_Nonnull chat)
  * Return -1 if we failed to gracefully handle a sanctions list error.
  * Return -2 if packet has invalid size.
  */
-static int handle_gc_sanctions_list(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, const uint8_t *_Nonnull data, uint16_t length,
+static int handle_gc_sanctions_list(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, const uint8_t *_Nullable data, uint16_t length,
                                     void *_Nullable userdata)
 {
     if (length < sizeof(uint16_t)) {
@@ -3869,7 +3869,7 @@ static bool handle_gc_topic_validate(const GC_Chat *_Nonnull chat, const GC_Peer
  * Return 0 if packet is correctly handled.
  * Return -1 if packet has invalid size.
  */
-static int handle_gc_topic(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, const GC_Peer *_Nonnull peer, const uint8_t *_Nonnull data,
+static int handle_gc_topic(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, const GC_Peer *_Nonnull peer, const uint8_t *_Nullable data,
                            uint16_t length, void *_Nullable userdata)
 {
     if (length < SIGNATURE_SIZE + GC_MIN_PACKED_TOPIC_INFO_SIZE) {
@@ -3931,7 +3931,7 @@ static int handle_gc_topic(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat,
  * Return -2 if we fail to create a new session keypair.
  * Return -3 if response packet fails to send.
  */
-static int handle_gc_key_exchange(const GC_Chat *_Nonnull chat, GC_Connection *_Nonnull gconn, const uint8_t *_Nonnull data, uint16_t length)
+static int handle_gc_key_exchange(const GC_Chat *_Nonnull chat, GC_Connection *_Nonnull gconn, const uint8_t *_Nullable data, uint16_t length)
 {
     if (length < 1 + ENC_PUBLIC_KEY_SIZE) {
         return -1;
@@ -4995,7 +4995,7 @@ int gc_send_custom_private_packet(const GC_Chat *chat, bool lossless, GC_Peer_Id
  * @retval -1 if packet has invalid size.
  */
 static int handle_gc_custom_private_packet(const GC_Session *_Nonnull c, const GC_Chat *_Nonnull chat, const GC_Peer *_Nonnull peer,
-        const uint8_t *_Nonnull data, uint16_t length, bool lossless, void *_Nullable userdata)
+        const uint8_t *_Nullable data, uint16_t length, bool lossless, void *_Nullable userdata)
 {
     if (!custom_gc_packet_length_is_valid(length, lossless)) {
         return -1;
@@ -5038,7 +5038,7 @@ int gc_send_custom_packet(const GC_Chat *chat, bool lossless, const uint8_t *dat
  * Return 0 if packet is handled correctly.
  * Return -1 if packet has invalid size.
  */
-static int handle_gc_custom_packet(const GC_Session *_Nonnull c, const GC_Chat *_Nonnull chat, const GC_Peer *_Nonnull peer, const uint8_t *_Nonnull data,
+static int handle_gc_custom_packet(const GC_Session *_Nonnull c, const GC_Chat *_Nonnull chat, const GC_Peer *_Nonnull peer, const uint8_t *_Nullable data,
                                    uint16_t length, bool lossless, void *_Nullable userdata)
 {
     if (!custom_gc_packet_length_is_valid(length, lossless)) {
@@ -5301,7 +5301,7 @@ int gc_set_ignore(const GC_Chat *chat, GC_Peer_Id peer_id, bool ignore)
  * Returns 0 if packet is handled correctly.
  * Returns -1 on failure.
  */
-static int handle_gc_broadcast(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, uint32_t peer_number, const uint8_t *_Nonnull data,
+static int handle_gc_broadcast(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, uint32_t peer_number, const uint8_t *_Nullable data,
                                uint16_t length, void *_Nullable userdata)
 {
     if (length < GC_BROADCAST_ENC_HEADER_SIZE) {

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -680,7 +680,7 @@ bool gc_send_message_ack(const GC_Chat *_Nonnull chat, GC_Connection *_Nonnull g
  *
  * @retval true if packet is successfully handled.
  */
-bool handle_gc_lossless_helper(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, uint32_t peer_number, const uint8_t *_Nonnull data,
+bool handle_gc_lossless_helper(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat, uint32_t peer_number, const uint8_t *_Nullable data,
                                uint16_t length, uint8_t packet_type, void *_Nullable userdata);
 /** @brief Handles an invite accept packet.
  *

--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -512,14 +512,7 @@ static bool process_recv_array_entry(const GC_Session *_Nonnull c, GC_Chat *_Non
     uint8_t sender_pk[ENC_PUBLIC_KEY_SIZE];
     memcpy(sender_pk, get_enc_key(&gconn->addr.public_key), ENC_PUBLIC_KEY_SIZE);
 
-    const uint8_t *data = array_entry->data;
-    // TODO(iphydf): This is ugly. We should probably change all the handlers to accept nullable.
-    const uint8_t empty_data[1] = { 0 };
-    if (data == nullptr) {
-        data = empty_data;
-    }
-
-    const bool ret = handle_gc_lossless_helper(c, chat, peer_number, data, array_entry->data_length,
+    const bool ret = handle_gc_lossless_helper(c, chat, peer_number, array_entry->data, array_entry->data_length,
                      array_entry->packet_type, userdata);
 
     /* peer number can change from peer add operations in packet handlers */


### PR DESCRIPTION
Removed the workaround in process_recv_array_entry where we replaced nullptr data with empty_data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2982)
<!-- Reviewable:end -->
