### PR TITLE
refactor: Internalize DHT structs and add debug helpers.

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -55,6 +55,19 @@
 #define MAX_KEYS_PER_SLOT 4
 #define KEYS_TIMEOUT 600
 
+typedef struct NAT {
+    /* true if currently hole punching */
+    bool        hole_punching;
+    uint32_t    punching_index;
+    uint32_t    tries;
+    uint32_t    punching_index2;
+
+    uint64_t    punching_timestamp;
+    uint64_t    recv_nat_ping_timestamp;
+    uint64_t    nat_ping_id;
+    uint64_t    nat_ping_timestamp;
+} NAT;
+
 typedef struct DHT_Friend_Callback {
     dht_ip_cb *_Nullable ip_callback;
     void *_Nullable data;

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -159,19 +159,6 @@ typedef struct Client_data {
 
 /*----------------------------------------------------------------------------------*/
 
-typedef struct NAT {
-    /* true if currently hole punching */
-    bool        hole_punching;
-    uint32_t    punching_index;
-    uint32_t    tries;
-    uint32_t    punching_index2;
-
-    uint64_t    punching_timestamp;
-    uint64_t    recv_nat_ping_timestamp;
-    uint64_t    nat_ping_id;
-    uint64_t    nat_ping_timestamp;
-} NAT;
-
 typedef struct Node_format {
     uint8_t     public_key[CRYPTO_PUBLIC_KEY_SIZE];
     IP_Port     ip_port;

--- a/toxcore/TCP_common.c
+++ b/toxcore/TCP_common.c
@@ -316,3 +316,69 @@ int read_packet_tcp_secure_connection(
 
     return len;
 }
+
+const char *tcp_packet_type_to_string(Tcp_Packet type)
+{
+    switch (type) {
+        case TCP_PACKET_ROUTING_REQUEST:
+            return "TCP_PACKET_ROUTING_REQUEST";
+
+        case TCP_PACKET_ROUTING_RESPONSE:
+            return "TCP_PACKET_ROUTING_RESPONSE";
+
+        case TCP_PACKET_CONNECTION_NOTIFICATION:
+            return "TCP_PACKET_CONNECTION_NOTIFICATION";
+
+        case TCP_PACKET_DISCONNECT_NOTIFICATION:
+            return "TCP_PACKET_DISCONNECT_NOTIFICATION";
+
+        case TCP_PACKET_PING:
+            return "TCP_PACKET_PING";
+
+        case TCP_PACKET_PONG:
+            return "TCP_PACKET_PONG";
+
+        case TCP_PACKET_OOB_SEND:
+            return "TCP_PACKET_OOB_SEND";
+
+        case TCP_PACKET_OOB_RECV:
+            return "TCP_PACKET_OOB_RECV";
+
+        case TCP_PACKET_ONION_REQUEST:
+            return "TCP_PACKET_ONION_REQUEST";
+
+        case TCP_PACKET_ONION_RESPONSE:
+            return "TCP_PACKET_ONION_RESPONSE";
+
+        case TCP_PACKET_FORWARD_REQUEST:
+            return "TCP_PACKET_FORWARD_REQUEST";
+
+        case TCP_PACKET_FORWARDING:
+            return "TCP_PACKET_FORWARDING";
+    }
+
+    return "<invalid Tcp_Packet>";
+}
+
+bool tcp_packet_from_int(uint32_t value, Tcp_Packet *_Nonnull out_enum)
+{
+    switch (value) {
+        case TCP_PACKET_ROUTING_REQUEST:
+        case TCP_PACKET_ROUTING_RESPONSE:
+        case TCP_PACKET_CONNECTION_NOTIFICATION:
+        case TCP_PACKET_DISCONNECT_NOTIFICATION:
+        case TCP_PACKET_PING:
+        case TCP_PACKET_PONG:
+        case TCP_PACKET_OOB_SEND:
+        case TCP_PACKET_OOB_RECV:
+        case TCP_PACKET_ONION_REQUEST:
+        case TCP_PACKET_ONION_RESPONSE:
+        case TCP_PACKET_FORWARD_REQUEST:
+        case TCP_PACKET_FORWARDING: {
+            *out_enum = (Tcp_Packet)value;
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/toxcore/TCP_common.h
+++ b/toxcore/TCP_common.h
@@ -45,6 +45,9 @@ typedef enum Tcp_Packet {
     TCP_PACKET_FORWARDING               = 11,
 } Tcp_Packet;
 
+const char *_Nonnull tcp_packet_type_to_string(Tcp_Packet type);
+bool tcp_packet_from_int(uint32_t value, Tcp_Packet *_Nonnull out_enum);
+
 #define TCP_HANDSHAKE_PLAIN_SIZE (CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE)
 #define TCP_SERVER_HANDSHAKE_SIZE (CRYPTO_NONCE_SIZE + TCP_HANDSHAKE_PLAIN_SIZE + CRYPTO_MAC_SIZE)
 #define TCP_CLIENT_HANDSHAKE_SIZE (CRYPTO_PUBLIC_KEY_SIZE + TCP_SERVER_HANDSHAKE_SIZE)

--- a/toxcore/net.c
+++ b/toxcore/net.c
@@ -260,3 +260,44 @@ bool net_family_is_tox_tcp_ipv6(Family family)
 {
     return family.value == family_tox_tcp_ipv6.value;
 }
+
+const char *net_family_to_string(Family family)
+{
+    if (net_family_is_unspec(family)) {
+        return "TOX_AF_UNSPEC";
+    }
+
+    if (net_family_is_ipv4(family)) {
+        return "TOX_AF_INET";
+    }
+
+    if (net_family_is_ipv6(family)) {
+        return "TOX_AF_INET6";
+    }
+
+    if (net_family_is_tcp_server(family)) {
+        return "TCP_SERVER_FAMILY";
+    }
+
+    if (net_family_is_tcp_client(family)) {
+        return "TCP_CLIENT_FAMILY";
+    }
+
+    if (net_family_is_tcp_ipv4(family)) {
+        return "TCP_INET";
+    }
+
+    if (net_family_is_tcp_ipv6(family)) {
+        return "TCP_INET6";
+    }
+
+    if (net_family_is_tox_tcp_ipv4(family)) {
+        return "TOX_TCP_INET";
+    }
+
+    if (net_family_is_tox_tcp_ipv6(family)) {
+        return "TOX_TCP_INET6";
+    }
+
+    return "<invalid Family>";
+}

--- a/toxcore/net.h
+++ b/toxcore/net.h
@@ -161,6 +161,8 @@ Family net_family_tcp_ipv6(void);
 Family net_family_tox_tcp_ipv4(void);
 Family net_family_tox_tcp_ipv6(void);
 
+const char *_Nonnull net_family_to_string(Family family);
+
 uint32_t net_htonl(uint32_t hostlong);
 uint16_t net_htons(uint16_t hostshort);
 uint32_t net_ntohl(uint32_t hostlong);


### PR DESCRIPTION
- Move `struct NAT` from `toxcore/DHT.h` to `toxcore/DHT.c` to improve encapsulation.
- Add `tcp_packet_type_to_string` and `tcp_packet_from_int` to `toxcore/TCP_common` for better debug logs.
- Add `net_family_to_string` to `toxcore/net` for the same reason.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2986)
<!-- Reviewable:end -->
