### PR TITLE
refactor: Harden event system and improve type safety.

### DIFF
--- a/other/event_tooling/generate_event_c.cpp
+++ b/other/event_tooling/generate_event_c.cpp
@@ -4,13 +4,14 @@
 // this file can be used to generate event.c files
 // requires c++17
 
+#include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
-#include <string>
-#include <algorithm>
-#include <vector>
-#include <variant>
 #include <map>
+#include <string>
+#include <variant>
+#include <vector>
 
 std::string str_tolower(std::string s) {
     std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c){ return std::tolower(c); });
@@ -168,6 +169,7 @@ std::string zero_initializer_for_type(const std::string& type) {
 
 void generate_event_impl(const std::string& event_name, const std::vector<EventType>& event_types) {
     const std::string event_name_l = str_tolower(event_name);
+    const std::string event_name_u = str_toupper(event_name);
     std::string file_name = output_folder + "/" + event_name_l + ".c";
 
     std::ofstream f(file_name);
@@ -218,11 +220,20 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h")";
+
     if (need_tox_unpack_h) {
         f << R"(
-#include "../tox_pack.h"
+#include "../tox_pack.h")";
+    }
+
+    f << R"(
+#include "../tox_struct.h")";
+
+    if (need_tox_unpack_h) {
+        f << R"(
 #include "../tox_unpack.h")";
     }
+
     f << R"(
 
 /*****************************************************
@@ -242,7 +253,7 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
                     f << "    " << t.type << " " << t.name << ";\n";
                 },
                 [&](const EventTypeByteRange& t) {
-                    f << "    " << "uint8_t" << " *" << t.name_data << ";\n";
+                    f << "    " << t.type_c_arg << " *_Nullable " << t.name_data << ";\n";
                     f << "    " << "uint32_t" << " " << t.name_length << ";\n";
                 },
                 [&](const EventTypeByteArray& t) {
@@ -279,7 +290,7 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
                     f << " " << t.type << " " << t.name << ")\n";
                 },
                 [&](const EventTypeByteRange& t) {
-                    f << "\n        const Memory *_Nonnull mem, const uint8_t *_Nullable " << t.name_data << ", uint32_t " << t.name_length << ")\n";
+                    f << "\n        const Memory *_Nonnull mem, const " << t.type_c_arg << " *_Nullable " << t.name_data << ", uint32_t " << t.name_length << ")\n";
                 },
                 [&](const EventTypeByteArray& t) {
                     f << " const uint8_t " << t.name << "[" << t.length_constant << "])\n";
@@ -294,28 +305,41 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
                     f << "    " << event_name_l << "->" << t.name << " = " << t.name << ";\n";
                 },
                 [&](const EventTypeByteRange& t) {
-                    f << "    if (" << event_name_l << "->" << t.name_data << " != nullptr) {\n";
-                    f << "        mem_delete(mem, " << event_name_l << "->" << t.name_data << ");\n";
-                    f << "        " << event_name_l << "->" << t.name_data << " = nullptr;\n";
-                    f << "        " << event_name_l << "->" << t.name_length << " = 0;\n";
-                    f << "    }\n\n";
-                    f << "    if (" << t.name_data << " == nullptr) {\n";
-                    f << "        assert(" << t.name_length << " == 0);\n";
-                    f << "        return true;\n    }\n\n";
+                    f << "    if (" << event_name_l << "->" << t.name_data << " != nullptr) {\n"
+                         "        mem_delete(mem, " << event_name_l << "->" << t.name_data << ");\n"
+                         "        " << event_name_l << "->" << t.name_data << " = nullptr;\n"
+                         "        " << event_name_l << "->" << t.name_length << " = 0;\n"
+                         "    }\n\n"
+                         "    if (" << t.name_data << " == nullptr) {\n"
+                         "        assert(" << t.name_length << " == 0);\n"
+                         "        return true;\n"
+                         "    }\n\n";
+
                     if (t.null_terminated) {
-                        f << "    uint8_t *" << t.name_data << "_copy = (uint8_t *)mem_balloc(mem, " << t.name_length << " + 1);\n\n";
+                        f << "    if (" << t.name_length << " == UINT32_MAX) {\n"
+                             "        return false;\n"
+                             "    }\n\n";
                     } else {
-                        f << "    uint8_t *" << t.name_data << "_copy = (uint8_t *)mem_balloc(mem, " << t.name_length << ");\n\n";
+                        f << "    if (" << t.name_length << " == 0) {\n"
+                             "        " << event_name_l << "->" << t.name_data << " = nullptr;\n"
+                             "        " << event_name_l << "->" << t.name_length << " = 0;\n"
+                             "        return true;\n"
+                             "    }\n\n";
                     }
-                    f << "    if (" << t.name_data << "_copy == nullptr) {\n";
-                    f << "        return false;\n    }\n\n";
-                    f << "    memcpy(" << t.name_data << "_copy, " << t.name_data << ", " << t.name_length << ");\n";
+
+                    f << "    " << t.type_c_arg << " *" << t.name_data << "_copy = (" << t.type_c_arg << " *)mem_balloc(mem, " << t.name_length << (t.null_terminated ? " + 1" : "") << ");\n\n"
+                         "    if (" << t.name_data << "_copy == nullptr) {\n"
+                         "        return false;\n"
+                         "    }\n\n"
+                         "    memcpy(" << t.name_data << "_copy, " << t.name_data << ", " << t.name_length << ");\n";
+
                     if (t.null_terminated) {
                         f << "    " << t.name_data << "_copy[" << t.name_length << "] = 0;\n";
                     }
-                    f << "    " << event_name_l << "->" << t.name_data << " = " << t.name_data << "_copy;\n";
-                    f << "    " << event_name_l << "->" << t.name_length << " = " << t.name_length << ";\n";
-                    f << "    return true;\n";
+
+                    f << "    " << event_name_l << "->" << t.name_data << " = " << t.name_data << "_copy;\n"
+                         "    " << event_name_l << "->" << t.name_length << " = " << t.name_length << ";\n"
+                         "    return true;\n";
                 },
                 [&](const EventTypeByteArray& t) {
                     f << "    memcpy(" << event_name_l << "->" << t.name << ", " << t.name << ", " << t.length_constant << ");\n";
@@ -342,7 +366,7 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
                     f << "(const Tox_Event_" << event_name << " *" << event_name_l << ")\n";
                     f << "{\n    assert(" << event_name_l << " != nullptr);\n";
                     f << "    return " << event_name_l << "->" << t.name_length << ";\n}\n";
-                    f << "const uint8_t *tox_event_" << event_name_l << "_get_" << t.name_data;
+                    f << "const " << t.type_c_arg << " *tox_event_" << event_name_l << "_get_" << t.name_data;
                     f << "(const Tox_Event_" << event_name << " *" << event_name_l << ")\n";
                     f << "{\n    assert(" << event_name_l << " != nullptr);\n";
                     f << "    return " << event_name_l << "->" << t.name_data << ";\n}\n\n";
@@ -435,7 +459,11 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
                     }
                 },
                 [&](const EventTypeByteRange& t) {
-                    f << "bin_pack_bin(bp, event->" << t.name_data << ", event->" << t.name_length << ")";
+                    if (t.type_c_arg == "char") {
+                        f << "bin_pack_str(bp, event->" << t.name_data << ", event->" << t.name_length << ")";
+                    } else {
+                        f << "bin_pack_bin(bp, event->" << t.name_data << ", event->" << t.name_length << ")";
+                    }
                 },
                 [&](const EventTypeByteArray& t) {
                     f << "bin_pack_bin(bp, event->" << t.name << ", " << t.length_constant << ")";
@@ -471,7 +499,11 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
                     }
                 },
                 [&](const EventTypeByteRange& t) {
-                    f << "bin_unpack_bin(bu, &event->" << t.name_data << ", &event->" << t.name_length << ")";
+                    if (t.type_c_arg == "char") {
+                        f << "bin_unpack_str(bu, &event->" << t.name_data << ", &event->" << t.name_length << ")";
+                    } else {
+                        f << "bin_unpack_bin(bu, &event->" << t.name_data << ", &event->" << t.name_length << ")";
+                    }
                 },
                 [&](const EventTypeByteArray& t) {
                     f << "bin_unpack_bin_fixed(bu, event->" << t.name << ", " << t.length_constant << ")";
@@ -493,7 +525,7 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
 )";
 
     f << "const Tox_Event_" << event_name << " *tox_event_get_" << event_name_l << "(const Tox_Event *event)\n{\n";
-    f << "    return event->type == TOX_EVENT_" << str_toupper(event_name) << " ? event->data." << event_name_l << " : nullptr;\n}\n\n";
+    f << "    return event->type == TOX_EVENT_" << event_name_u << " ? event->data." << event_name_l << " : nullptr;\n}\n\n";
 
     // new
     f << "Tox_Event_" << event_name << " *tox_event_" << event_name_l << "_new(const Memory *mem)\n{\n";
@@ -506,7 +538,7 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
     // free
     f << "void tox_event_" << event_name_l << "_free(Tox_Event_" << event_name << " *" << event_name_l << ", const Memory *mem)\n{\n";
     f << "    if (" << event_name_l << " != nullptr) {\n";
-    f << "        tox_event_" << event_name_l << "_destruct((Tox_Event_" << event_name << " * _Nonnull)" << event_name_l << ", mem);\n    }\n";
+    f << "        tox_event_" << event_name_l << "_destruct(" << event_name_l << ", mem);\n    }\n";
     f << "    mem_delete(mem, " << event_name_l << ");\n}\n\n";
 
     // add
@@ -515,7 +547,7 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
     f << "    if (" << event_name_l << " == nullptr) {\n";
     f << "        return nullptr;\n    }\n\n";
     f << "    Tox_Event event;\n";
-    f << "    event.type = TOX_EVENT_" << str_toupper(event_name) << ";\n";
+    f << "    event.type = TOX_EVENT_" << event_name_u << ";\n";
     f << "    event.data." << event_name_l << " = " << event_name_l << ";\n\n";
     f << "    if (!tox_events_add(events, &event)) {\n";
     f << "        tox_event_" << event_name_l << "_free(" << event_name_l << ", mem);\n";
@@ -581,11 +613,10 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
                     f << "    tox_event_" << event_name_l << "_set_" << t.name << "(" << event_name_l << ", " << t.name << ");\n";
                 },
                 [&](const EventTypeByteRange& t) {
-                    f << "    tox_event_" << event_name_l << "_set_" << t.name_data << "(" << event_name_l << ", state->mem, ";
-                    if (t.type_c_arg != "uint8_t") {
-                        f << "(const uint8_t *)";
-                    }
-                    f << t.name_data << ", " << t.name_length_cb << ");\n";
+                    f << "    if (!tox_event_" << event_name_l << "_set_" << t.name_data << "(" << event_name_l << ", state->mem, ";
+                    f << t.name_data << ", " << t.name_length_cb << ")) {\n";
+                    f << "        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;\n";
+                    f << "    }\n";
                 },
                 [&](const EventTypeByteArray& t) {
                     f << "    tox_event_" << event_name_l << "_set_" << t.name << "(" << event_name_l << ", " << t.name << ");\n";

--- a/toxcore/events/conference_connected.c
+++ b/toxcore/events/conference_connected.c
@@ -14,6 +14,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -86,7 +87,7 @@ Tox_Event_Conference_Connected *tox_event_conference_connected_new(const Memory 
 void tox_event_conference_connected_free(Tox_Event_Conference_Connected *conference_connected, const Memory *mem)
 {
     if (conference_connected != nullptr) {
-        tox_event_conference_connected_destruct((Tox_Event_Conference_Connected * _Nonnull)conference_connected, mem);
+        tox_event_conference_connected_destruct(conference_connected, mem);
     }
     mem_delete(mem, conference_connected);
 }

--- a/toxcore/events/conference_message.c
+++ b/toxcore/events/conference_message.c
@@ -16,6 +16,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -28,7 +29,7 @@ struct Tox_Event_Conference_Message {
     uint32_t conference_number;
     uint32_t peer_number;
     Tox_Message_Type type;
-    uint8_t *message;
+    uint8_t *_Nullable message;
     uint32_t message_length;
 };
 
@@ -77,6 +78,12 @@ static bool tox_event_conference_message_set_message(Tox_Event_Conference_Messag
 
     if (message == nullptr) {
         assert(message_length == 0);
+        return true;
+    }
+
+    if (message_length == 0) {
+        conference_message->message = nullptr;
+        conference_message->message_length = 0;
         return true;
     }
 
@@ -163,7 +170,7 @@ Tox_Event_Conference_Message *tox_event_conference_message_new(const Memory *mem
 void tox_event_conference_message_free(Tox_Event_Conference_Message *conference_message, const Memory *mem)
 {
     if (conference_message != nullptr) {
-        tox_event_conference_message_destruct((Tox_Event_Conference_Message * _Nonnull)conference_message, mem);
+        tox_event_conference_message_destruct(conference_message, mem);
     }
     mem_delete(mem, conference_message);
 }
@@ -237,5 +244,7 @@ void tox_events_handle_conference_message(
     tox_event_conference_message_set_conference_number(conference_message, conference_number);
     tox_event_conference_message_set_peer_number(conference_message, peer_number);
     tox_event_conference_message_set_type(conference_message, type);
-    tox_event_conference_message_set_message(conference_message, state->mem, message, length);
+    if (!tox_event_conference_message_set_message(conference_message, state->mem, message, length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/conference_peer_list_changed.c
+++ b/toxcore/events/conference_peer_list_changed.c
@@ -14,6 +14,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -86,7 +87,7 @@ Tox_Event_Conference_Peer_List_Changed *tox_event_conference_peer_list_changed_n
 void tox_event_conference_peer_list_changed_free(Tox_Event_Conference_Peer_List_Changed *conference_peer_list_changed, const Memory *mem)
 {
     if (conference_peer_list_changed != nullptr) {
-        tox_event_conference_peer_list_changed_destruct((Tox_Event_Conference_Peer_List_Changed * _Nonnull)conference_peer_list_changed, mem);
+        tox_event_conference_peer_list_changed_destruct(conference_peer_list_changed, mem);
     }
     mem_delete(mem, conference_peer_list_changed);
 }

--- a/toxcore/events/conference_title.c
+++ b/toxcore/events/conference_title.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -25,7 +26,7 @@
 struct Tox_Event_Conference_Title {
     uint32_t conference_number;
     uint32_t peer_number;
-    uint8_t *title;
+    uint8_t *_Nullable title;
     uint32_t title_length;
 };
 
@@ -63,6 +64,12 @@ static bool tox_event_conference_title_set_title(Tox_Event_Conference_Title *_No
 
     if (title == nullptr) {
         assert(title_length == 0);
+        return true;
+    }
+
+    if (title_length == 0) {
+        conference_title->title = nullptr;
+        conference_title->title_length = 0;
         return true;
     }
 
@@ -147,7 +154,7 @@ Tox_Event_Conference_Title *tox_event_conference_title_new(const Memory *mem)
 void tox_event_conference_title_free(Tox_Event_Conference_Title *conference_title, const Memory *mem)
 {
     if (conference_title != nullptr) {
-        tox_event_conference_title_destruct((Tox_Event_Conference_Title * _Nonnull)conference_title, mem);
+        tox_event_conference_title_destruct(conference_title, mem);
     }
     mem_delete(mem, conference_title);
 }
@@ -220,5 +227,7 @@ void tox_events_handle_conference_title(
 
     tox_event_conference_title_set_conference_number(conference_title, conference_number);
     tox_event_conference_title_set_peer_number(conference_title, peer_number);
-    tox_event_conference_title_set_title(conference_title, state->mem, title, length);
+    if (!tox_event_conference_title_set_title(conference_title, state->mem, title, length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/dht_nodes_response.c
+++ b/toxcore/events/dht_nodes_response.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -24,7 +25,7 @@
 
 struct Tox_Event_Dht_Nodes_Response {
     uint8_t public_key[TOX_PUBLIC_KEY_SIZE];
-    uint8_t *ip;
+    char *_Nullable ip;
     uint32_t ip_length;
     uint16_t port;
 };
@@ -42,7 +43,7 @@ const uint8_t *tox_event_dht_nodes_response_get_public_key(const Tox_Event_Dht_N
 }
 
 static bool tox_event_dht_nodes_response_set_ip(Tox_Event_Dht_Nodes_Response *_Nonnull dht_nodes_response,
-        const Memory *_Nonnull mem, const uint8_t *_Nullable ip, uint32_t ip_length)
+        const Memory *_Nonnull mem, const char *_Nullable ip, uint32_t ip_length)
 {
     assert(dht_nodes_response != nullptr);
     if (dht_nodes_response->ip != nullptr) {
@@ -56,7 +57,11 @@ static bool tox_event_dht_nodes_response_set_ip(Tox_Event_Dht_Nodes_Response *_N
         return true;
     }
 
-    uint8_t *ip_copy = (uint8_t *)mem_balloc(mem, ip_length + 1);
+    if (ip_length == UINT32_MAX) {
+        return false;
+    }
+
+    char *ip_copy = (char *)mem_balloc(mem, ip_length + 1);
 
     if (ip_copy == nullptr) {
         return false;
@@ -73,7 +78,7 @@ uint32_t tox_event_dht_nodes_response_get_ip_length(const Tox_Event_Dht_Nodes_Re
     assert(dht_nodes_response != nullptr);
     return dht_nodes_response->ip_length;
 }
-const uint8_t *tox_event_dht_nodes_response_get_ip(const Tox_Event_Dht_Nodes_Response *dht_nodes_response)
+const char *tox_event_dht_nodes_response_get_ip(const Tox_Event_Dht_Nodes_Response *dht_nodes_response)
 {
     assert(dht_nodes_response != nullptr);
     return dht_nodes_response->ip;
@@ -108,7 +113,7 @@ bool tox_event_dht_nodes_response_pack(
 {
     return bin_pack_array(bp, 3)
            && bin_pack_bin(bp, event->public_key, TOX_PUBLIC_KEY_SIZE)
-           && bin_pack_bin(bp, event->ip, event->ip_length)
+           && bin_pack_str(bp, event->ip, event->ip_length)
            && bin_pack_u16(bp, event->port);
 }
 
@@ -120,7 +125,7 @@ static bool tox_event_dht_nodes_response_unpack_into(Tox_Event_Dht_Nodes_Respons
     }
 
     return bin_unpack_bin_fixed(bu, event->public_key, TOX_PUBLIC_KEY_SIZE)
-           && bin_unpack_bin(bu, &event->ip, &event->ip_length)
+           && bin_unpack_str(bu, &event->ip, &event->ip_length)
            && bin_unpack_u16(bu, &event->port);
 }
 
@@ -151,7 +156,7 @@ Tox_Event_Dht_Nodes_Response *tox_event_dht_nodes_response_new(const Memory *mem
 void tox_event_dht_nodes_response_free(Tox_Event_Dht_Nodes_Response *dht_nodes_response, const Memory *mem)
 {
     if (dht_nodes_response != nullptr) {
-        tox_event_dht_nodes_response_destruct((Tox_Event_Dht_Nodes_Response * _Nonnull)dht_nodes_response, mem);
+        tox_event_dht_nodes_response_destruct(dht_nodes_response, mem);
     }
     mem_delete(mem, dht_nodes_response);
 }
@@ -223,6 +228,8 @@ void tox_events_handle_dht_nodes_response(
     }
 
     tox_event_dht_nodes_response_set_public_key(dht_nodes_response, public_key);
-    tox_event_dht_nodes_response_set_ip(dht_nodes_response, state->mem, (const uint8_t *)ip, ip_length);
+    if (!tox_event_dht_nodes_response_set_ip(dht_nodes_response, state->mem, ip, ip_length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
     tox_event_dht_nodes_response_set_port(dht_nodes_response, port);
 }

--- a/toxcore/events/events_alloc.c
+++ b/toxcore/events/events_alloc.c
@@ -61,7 +61,13 @@ bool tox_events_add(Tox_Events *events, const Tox_Event *event)
     }
 
     if (events->events_size == events->events_capacity) {
-        const uint32_t new_events_capacity = events->events_capacity * 2 + 1;
+        const uint64_t new_events_capacity_64 = (uint64_t)events->events_capacity * 2 + 1;
+
+        if (new_events_capacity_64 > UINT32_MAX) {
+            return false;
+        }
+
+        const uint32_t new_events_capacity = (uint32_t)new_events_capacity_64;
         Tox_Event *new_events = (Tox_Event *)mem_vrealloc(
                                     events->mem, events->events, new_events_capacity, sizeof(Tox_Event));
 

--- a/toxcore/events/file_chunk_request.c
+++ b/toxcore/events/file_chunk_request.c
@@ -14,6 +14,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -133,7 +134,7 @@ Tox_Event_File_Chunk_Request *tox_event_file_chunk_request_new(const Memory *mem
 void tox_event_file_chunk_request_free(Tox_Event_File_Chunk_Request *file_chunk_request, const Memory *mem)
 {
     if (file_chunk_request != nullptr) {
-        tox_event_file_chunk_request_destruct((Tox_Event_File_Chunk_Request * _Nonnull)file_chunk_request, mem);
+        tox_event_file_chunk_request_destruct(file_chunk_request, mem);
     }
     mem_delete(mem, file_chunk_request);
 }

--- a/toxcore/events/file_recv.c
+++ b/toxcore/events/file_recv.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -27,7 +28,7 @@ struct Tox_Event_File_Recv {
     uint32_t file_number;
     uint32_t kind;
     uint64_t file_size;
-    uint8_t *filename;
+    uint8_t *_Nullable filename;
     uint32_t filename_length;
 };
 
@@ -87,6 +88,12 @@ static bool tox_event_file_recv_set_filename(Tox_Event_File_Recv *_Nonnull file_
 
     if (filename == nullptr) {
         assert(filename_length == 0);
+        return true;
+    }
+
+    if (filename_length == 0) {
+        file_recv->filename = nullptr;
+        file_recv->filename_length = 0;
         return true;
     }
 
@@ -175,7 +182,7 @@ Tox_Event_File_Recv *tox_event_file_recv_new(const Memory *mem)
 void tox_event_file_recv_free(Tox_Event_File_Recv *file_recv, const Memory *mem)
 {
     if (file_recv != nullptr) {
-        tox_event_file_recv_destruct((Tox_Event_File_Recv * _Nonnull)file_recv, mem);
+        tox_event_file_recv_destruct(file_recv, mem);
     }
     mem_delete(mem, file_recv);
 }
@@ -250,5 +257,7 @@ void tox_events_handle_file_recv(
     tox_event_file_recv_set_file_number(file_recv, file_number);
     tox_event_file_recv_set_kind(file_recv, kind);
     tox_event_file_recv_set_file_size(file_recv, file_size);
-    tox_event_file_recv_set_filename(file_recv, state->mem, filename, filename_length);
+    if (!tox_event_file_recv_set_filename(file_recv, state->mem, filename, filename_length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/file_recv_chunk.c
+++ b/toxcore/events/file_recv_chunk.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -26,7 +27,7 @@ struct Tox_Event_File_Recv_Chunk {
     uint32_t friend_number;
     uint32_t file_number;
     uint64_t position;
-    uint8_t *data;
+    uint8_t *_Nullable data;
     uint32_t data_length;
 };
 
@@ -75,6 +76,12 @@ static bool tox_event_file_recv_chunk_set_data(Tox_Event_File_Recv_Chunk *_Nonnu
 
     if (data == nullptr) {
         assert(data_length == 0);
+        return true;
+    }
+
+    if (data_length == 0) {
+        file_recv_chunk->data = nullptr;
+        file_recv_chunk->data_length = 0;
         return true;
     }
 
@@ -161,7 +168,7 @@ Tox_Event_File_Recv_Chunk *tox_event_file_recv_chunk_new(const Memory *mem)
 void tox_event_file_recv_chunk_free(Tox_Event_File_Recv_Chunk *file_recv_chunk, const Memory *mem)
 {
     if (file_recv_chunk != nullptr) {
-        tox_event_file_recv_chunk_destruct((Tox_Event_File_Recv_Chunk * _Nonnull)file_recv_chunk, mem);
+        tox_event_file_recv_chunk_destruct(file_recv_chunk, mem);
     }
     mem_delete(mem, file_recv_chunk);
 }
@@ -235,5 +242,7 @@ void tox_events_handle_file_recv_chunk(
     tox_event_file_recv_chunk_set_friend_number(file_recv_chunk, friend_number);
     tox_event_file_recv_chunk_set_file_number(file_recv_chunk, file_number);
     tox_event_file_recv_chunk_set_position(file_recv_chunk, position);
-    tox_event_file_recv_chunk_set_data(file_recv_chunk, state->mem, data, length);
+    if (!tox_event_file_recv_chunk_set_data(file_recv_chunk, state->mem, data, length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/file_recv_control.c
+++ b/toxcore/events/file_recv_control.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -121,7 +122,7 @@ Tox_Event_File_Recv_Control *tox_event_file_recv_control_new(const Memory *mem)
 void tox_event_file_recv_control_free(Tox_Event_File_Recv_Control *file_recv_control, const Memory *mem)
 {
     if (file_recv_control != nullptr) {
-        tox_event_file_recv_control_destruct((Tox_Event_File_Recv_Control * _Nonnull)file_recv_control, mem);
+        tox_event_file_recv_control_destruct(file_recv_control, mem);
     }
     mem_delete(mem, file_recv_control);
 }

--- a/toxcore/events/friend_connection_status.c
+++ b/toxcore/events/friend_connection_status.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -107,7 +108,7 @@ Tox_Event_Friend_Connection_Status *tox_event_friend_connection_status_new(const
 void tox_event_friend_connection_status_free(Tox_Event_Friend_Connection_Status *friend_connection_status, const Memory *mem)
 {
     if (friend_connection_status != nullptr) {
-        tox_event_friend_connection_status_destruct((Tox_Event_Friend_Connection_Status * _Nonnull)friend_connection_status, mem);
+        tox_event_friend_connection_status_destruct(friend_connection_status, mem);
     }
     mem_delete(mem, friend_connection_status);
 }

--- a/toxcore/events/friend_lossless_packet.c
+++ b/toxcore/events/friend_lossless_packet.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -24,7 +25,7 @@
 
 struct Tox_Event_Friend_Lossless_Packet {
     uint32_t friend_number;
-    uint8_t *data;
+    uint8_t *_Nullable data;
     uint32_t data_length;
 };
 
@@ -51,6 +52,12 @@ static bool tox_event_friend_lossless_packet_set_data(Tox_Event_Friend_Lossless_
 
     if (data == nullptr) {
         assert(data_length == 0);
+        return true;
+    }
+
+    if (data_length == 0) {
+        friend_lossless_packet->data = nullptr;
+        friend_lossless_packet->data_length = 0;
         return true;
     }
 
@@ -133,7 +140,7 @@ Tox_Event_Friend_Lossless_Packet *tox_event_friend_lossless_packet_new(const Mem
 void tox_event_friend_lossless_packet_free(Tox_Event_Friend_Lossless_Packet *friend_lossless_packet, const Memory *mem)
 {
     if (friend_lossless_packet != nullptr) {
-        tox_event_friend_lossless_packet_destruct((Tox_Event_Friend_Lossless_Packet * _Nonnull)friend_lossless_packet, mem);
+        tox_event_friend_lossless_packet_destruct(friend_lossless_packet, mem);
     }
     mem_delete(mem, friend_lossless_packet);
 }
@@ -205,5 +212,7 @@ void tox_events_handle_friend_lossless_packet(
     }
 
     tox_event_friend_lossless_packet_set_friend_number(friend_lossless_packet, friend_number);
-    tox_event_friend_lossless_packet_set_data(friend_lossless_packet, state->mem, data, length);
+    if (!tox_event_friend_lossless_packet_set_data(friend_lossless_packet, state->mem, data, length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/friend_lossy_packet.c
+++ b/toxcore/events/friend_lossy_packet.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -24,7 +25,7 @@
 
 struct Tox_Event_Friend_Lossy_Packet {
     uint32_t friend_number;
-    uint8_t *data;
+    uint8_t *_Nullable data;
     uint32_t data_length;
 };
 
@@ -51,6 +52,12 @@ static bool tox_event_friend_lossy_packet_set_data(Tox_Event_Friend_Lossy_Packet
 
     if (data == nullptr) {
         assert(data_length == 0);
+        return true;
+    }
+
+    if (data_length == 0) {
+        friend_lossy_packet->data = nullptr;
+        friend_lossy_packet->data_length = 0;
         return true;
     }
 
@@ -133,7 +140,7 @@ Tox_Event_Friend_Lossy_Packet *tox_event_friend_lossy_packet_new(const Memory *m
 void tox_event_friend_lossy_packet_free(Tox_Event_Friend_Lossy_Packet *friend_lossy_packet, const Memory *mem)
 {
     if (friend_lossy_packet != nullptr) {
-        tox_event_friend_lossy_packet_destruct((Tox_Event_Friend_Lossy_Packet * _Nonnull)friend_lossy_packet, mem);
+        tox_event_friend_lossy_packet_destruct(friend_lossy_packet, mem);
     }
     mem_delete(mem, friend_lossy_packet);
 }
@@ -205,5 +212,7 @@ void tox_events_handle_friend_lossy_packet(
     }
 
     tox_event_friend_lossy_packet_set_friend_number(friend_lossy_packet, friend_number);
-    tox_event_friend_lossy_packet_set_data(friend_lossy_packet, state->mem, data, length);
+    if (!tox_event_friend_lossy_packet_set_data(friend_lossy_packet, state->mem, data, length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/friend_name.c
+++ b/toxcore/events/friend_name.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -24,7 +25,7 @@
 
 struct Tox_Event_Friend_Name {
     uint32_t friend_number;
-    uint8_t *name;
+    uint8_t *_Nullable name;
     uint32_t name_length;
 };
 
@@ -51,6 +52,12 @@ static bool tox_event_friend_name_set_name(Tox_Event_Friend_Name *_Nonnull frien
 
     if (name == nullptr) {
         assert(name_length == 0);
+        return true;
+    }
+
+    if (name_length == 0) {
+        friend_name->name = nullptr;
+        friend_name->name_length = 0;
         return true;
     }
 
@@ -133,7 +140,7 @@ Tox_Event_Friend_Name *tox_event_friend_name_new(const Memory *mem)
 void tox_event_friend_name_free(Tox_Event_Friend_Name *friend_name, const Memory *mem)
 {
     if (friend_name != nullptr) {
-        tox_event_friend_name_destruct((Tox_Event_Friend_Name * _Nonnull)friend_name, mem);
+        tox_event_friend_name_destruct(friend_name, mem);
     }
     mem_delete(mem, friend_name);
 }
@@ -205,5 +212,7 @@ void tox_events_handle_friend_name(
     }
 
     tox_event_friend_name_set_friend_number(friend_name, friend_number);
-    tox_event_friend_name_set_name(friend_name, state->mem, name, length);
+    if (!tox_event_friend_name_set_name(friend_name, state->mem, name, length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/friend_read_receipt.c
+++ b/toxcore/events/friend_read_receipt.c
@@ -14,6 +14,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -105,7 +106,7 @@ Tox_Event_Friend_Read_Receipt *tox_event_friend_read_receipt_new(const Memory *m
 void tox_event_friend_read_receipt_free(Tox_Event_Friend_Read_Receipt *friend_read_receipt, const Memory *mem)
 {
     if (friend_read_receipt != nullptr) {
-        tox_event_friend_read_receipt_destruct((Tox_Event_Friend_Read_Receipt * _Nonnull)friend_read_receipt, mem);
+        tox_event_friend_read_receipt_destruct(friend_read_receipt, mem);
     }
     mem_delete(mem, friend_read_receipt);
 }

--- a/toxcore/events/friend_status.c
+++ b/toxcore/events/friend_status.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -107,7 +108,7 @@ Tox_Event_Friend_Status *tox_event_friend_status_new(const Memory *mem)
 void tox_event_friend_status_free(Tox_Event_Friend_Status *friend_status, const Memory *mem)
 {
     if (friend_status != nullptr) {
-        tox_event_friend_status_destruct((Tox_Event_Friend_Status * _Nonnull)friend_status, mem);
+        tox_event_friend_status_destruct(friend_status, mem);
     }
     mem_delete(mem, friend_status);
 }

--- a/toxcore/events/friend_status_message.c
+++ b/toxcore/events/friend_status_message.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -24,7 +25,7 @@
 
 struct Tox_Event_Friend_Status_Message {
     uint32_t friend_number;
-    uint8_t *message;
+    uint8_t *_Nullable message;
     uint32_t message_length;
 };
 
@@ -51,6 +52,12 @@ static bool tox_event_friend_status_message_set_message(Tox_Event_Friend_Status_
 
     if (message == nullptr) {
         assert(message_length == 0);
+        return true;
+    }
+
+    if (message_length == 0) {
+        friend_status_message->message = nullptr;
+        friend_status_message->message_length = 0;
         return true;
     }
 
@@ -133,7 +140,7 @@ Tox_Event_Friend_Status_Message *tox_event_friend_status_message_new(const Memor
 void tox_event_friend_status_message_free(Tox_Event_Friend_Status_Message *friend_status_message, const Memory *mem)
 {
     if (friend_status_message != nullptr) {
-        tox_event_friend_status_message_destruct((Tox_Event_Friend_Status_Message * _Nonnull)friend_status_message, mem);
+        tox_event_friend_status_message_destruct(friend_status_message, mem);
     }
     mem_delete(mem, friend_status_message);
 }
@@ -205,5 +212,7 @@ void tox_events_handle_friend_status_message(
     }
 
     tox_event_friend_status_message_set_friend_number(friend_status_message, friend_number);
-    tox_event_friend_status_message_set_message(friend_status_message, state->mem, message, length);
+    if (!tox_event_friend_status_message_set_message(friend_status_message, state->mem, message, length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/friend_typing.c
+++ b/toxcore/events/friend_typing.c
@@ -14,6 +14,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -105,7 +106,7 @@ Tox_Event_Friend_Typing *tox_event_friend_typing_new(const Memory *mem)
 void tox_event_friend_typing_free(Tox_Event_Friend_Typing *friend_typing, const Memory *mem)
 {
     if (friend_typing != nullptr) {
-        tox_event_friend_typing_destruct((Tox_Event_Friend_Typing * _Nonnull)friend_typing, mem);
+        tox_event_friend_typing_destruct(friend_typing, mem);
     }
     mem_delete(mem, friend_typing);
 }

--- a/toxcore/events/group_custom_private_packet.c
+++ b/toxcore/events/group_custom_private_packet.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -25,7 +26,7 @@
 struct Tox_Event_Group_Custom_Private_Packet {
     uint32_t group_number;
     uint32_t peer_id;
-    uint8_t *data;
+    uint8_t *_Nullable data;
     uint32_t data_length;
 };
 
@@ -63,6 +64,12 @@ static bool tox_event_group_custom_private_packet_set_data(Tox_Event_Group_Custo
 
     if (data == nullptr) {
         assert(data_length == 0);
+        return true;
+    }
+
+    if (data_length == 0) {
+        group_custom_private_packet->data = nullptr;
+        group_custom_private_packet->data_length = 0;
         return true;
     }
 
@@ -147,7 +154,7 @@ Tox_Event_Group_Custom_Private_Packet *tox_event_group_custom_private_packet_new
 void tox_event_group_custom_private_packet_free(Tox_Event_Group_Custom_Private_Packet *group_custom_private_packet, const Memory *mem)
 {
     if (group_custom_private_packet != nullptr) {
-        tox_event_group_custom_private_packet_destruct((Tox_Event_Group_Custom_Private_Packet * _Nonnull)group_custom_private_packet, mem);
+        tox_event_group_custom_private_packet_destruct(group_custom_private_packet, mem);
     }
     mem_delete(mem, group_custom_private_packet);
 }
@@ -220,5 +227,7 @@ void tox_events_handle_group_custom_private_packet(
 
     tox_event_group_custom_private_packet_set_group_number(group_custom_private_packet, group_number);
     tox_event_group_custom_private_packet_set_peer_id(group_custom_private_packet, peer_id);
-    tox_event_group_custom_private_packet_set_data(group_custom_private_packet, state->mem, data, data_length);
+    if (!tox_event_group_custom_private_packet_set_data(group_custom_private_packet, state->mem, data, data_length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/group_join_fail.c
+++ b/toxcore/events/group_join_fail.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -107,7 +108,7 @@ Tox_Event_Group_Join_Fail *tox_event_group_join_fail_new(const Memory *mem)
 void tox_event_group_join_fail_free(Tox_Event_Group_Join_Fail *group_join_fail, const Memory *mem)
 {
     if (group_join_fail != nullptr) {
-        tox_event_group_join_fail_destruct((Tox_Event_Group_Join_Fail * _Nonnull)group_join_fail, mem);
+        tox_event_group_join_fail_destruct(group_join_fail, mem);
     }
     mem_delete(mem, group_join_fail);
 }

--- a/toxcore/events/group_message.c
+++ b/toxcore/events/group_message.c
@@ -16,6 +16,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -28,7 +29,7 @@ struct Tox_Event_Group_Message {
     uint32_t group_number;
     uint32_t peer_id;
     Tox_Message_Type message_type;
-    uint8_t *message;
+    uint8_t *_Nullable message;
     uint32_t message_length;
     uint32_t message_id;
 };
@@ -78,6 +79,12 @@ static bool tox_event_group_message_set_message(Tox_Event_Group_Message *_Nonnul
 
     if (message == nullptr) {
         assert(message_length == 0);
+        return true;
+    }
+
+    if (message_length == 0) {
+        group_message->message = nullptr;
+        group_message->message_length = 0;
         return true;
     }
 
@@ -177,7 +184,7 @@ Tox_Event_Group_Message *tox_event_group_message_new(const Memory *mem)
 void tox_event_group_message_free(Tox_Event_Group_Message *group_message, const Memory *mem)
 {
     if (group_message != nullptr) {
-        tox_event_group_message_destruct((Tox_Event_Group_Message * _Nonnull)group_message, mem);
+        tox_event_group_message_destruct(group_message, mem);
     }
     mem_delete(mem, group_message);
 }
@@ -251,6 +258,8 @@ void tox_events_handle_group_message(
     tox_event_group_message_set_group_number(group_message, group_number);
     tox_event_group_message_set_peer_id(group_message, peer_id);
     tox_event_group_message_set_message_type(group_message, message_type);
-    tox_event_group_message_set_message(group_message, state->mem, message, message_length);
+    if (!tox_event_group_message_set_message(group_message, state->mem, message, message_length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
     tox_event_group_message_set_message_id(group_message, message_id);
 }

--- a/toxcore/events/group_moderation.c
+++ b/toxcore/events/group_moderation.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -135,7 +136,7 @@ Tox_Event_Group_Moderation *tox_event_group_moderation_new(const Memory *mem)
 void tox_event_group_moderation_free(Tox_Event_Group_Moderation *group_moderation, const Memory *mem)
 {
     if (group_moderation != nullptr) {
-        tox_event_group_moderation_destruct((Tox_Event_Group_Moderation * _Nonnull)group_moderation, mem);
+        tox_event_group_moderation_destruct(group_moderation, mem);
     }
     mem_delete(mem, group_moderation);
 }

--- a/toxcore/events/group_password.c
+++ b/toxcore/events/group_password.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -24,7 +25,7 @@
 
 struct Tox_Event_Group_Password {
     uint32_t group_number;
-    uint8_t *password;
+    uint8_t *_Nullable password;
     uint32_t password_length;
 };
 
@@ -51,6 +52,12 @@ static bool tox_event_group_password_set_password(Tox_Event_Group_Password *_Non
 
     if (password == nullptr) {
         assert(password_length == 0);
+        return true;
+    }
+
+    if (password_length == 0) {
+        group_password->password = nullptr;
+        group_password->password_length = 0;
         return true;
     }
 
@@ -133,7 +140,7 @@ Tox_Event_Group_Password *tox_event_group_password_new(const Memory *mem)
 void tox_event_group_password_free(Tox_Event_Group_Password *group_password, const Memory *mem)
 {
     if (group_password != nullptr) {
-        tox_event_group_password_destruct((Tox_Event_Group_Password * _Nonnull)group_password, mem);
+        tox_event_group_password_destruct(group_password, mem);
     }
     mem_delete(mem, group_password);
 }
@@ -205,5 +212,7 @@ void tox_events_handle_group_password(
     }
 
     tox_event_group_password_set_group_number(group_password, group_number);
-    tox_event_group_password_set_password(group_password, state->mem, password, password_length);
+    if (!tox_event_group_password_set_password(group_password, state->mem, password, password_length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/group_peer_exit.c
+++ b/toxcore/events/group_peer_exit.c
@@ -16,6 +16,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -28,9 +29,9 @@ struct Tox_Event_Group_Peer_Exit {
     uint32_t group_number;
     uint32_t peer_id;
     Tox_Group_Exit_Type exit_type;
-    uint8_t *name;
+    uint8_t *_Nullable name;
     uint32_t name_length;
-    uint8_t *part_message;
+    uint8_t *_Nullable part_message;
     uint32_t part_message_length;
 };
 
@@ -82,6 +83,12 @@ static bool tox_event_group_peer_exit_set_name(Tox_Event_Group_Peer_Exit *_Nonnu
         return true;
     }
 
+    if (name_length == 0) {
+        group_peer_exit->name = nullptr;
+        group_peer_exit->name_length = 0;
+        return true;
+    }
+
     uint8_t *name_copy = (uint8_t *)mem_balloc(mem, name_length);
 
     if (name_copy == nullptr) {
@@ -116,6 +123,12 @@ static bool tox_event_group_peer_exit_set_part_message(Tox_Event_Group_Peer_Exit
 
     if (part_message == nullptr) {
         assert(part_message_length == 0);
+        return true;
+    }
+
+    if (part_message_length == 0) {
+        group_peer_exit->part_message = nullptr;
+        group_peer_exit->part_message_length = 0;
         return true;
     }
 
@@ -205,7 +218,7 @@ Tox_Event_Group_Peer_Exit *tox_event_group_peer_exit_new(const Memory *mem)
 void tox_event_group_peer_exit_free(Tox_Event_Group_Peer_Exit *group_peer_exit, const Memory *mem)
 {
     if (group_peer_exit != nullptr) {
-        tox_event_group_peer_exit_destruct((Tox_Event_Group_Peer_Exit * _Nonnull)group_peer_exit, mem);
+        tox_event_group_peer_exit_destruct(group_peer_exit, mem);
     }
     mem_delete(mem, group_peer_exit);
 }
@@ -279,6 +292,10 @@ void tox_events_handle_group_peer_exit(
     tox_event_group_peer_exit_set_group_number(group_peer_exit, group_number);
     tox_event_group_peer_exit_set_peer_id(group_peer_exit, peer_id);
     tox_event_group_peer_exit_set_exit_type(group_peer_exit, exit_type);
-    tox_event_group_peer_exit_set_name(group_peer_exit, state->mem, name, name_length);
-    tox_event_group_peer_exit_set_part_message(group_peer_exit, state->mem, part_message, part_message_length);
+    if (!tox_event_group_peer_exit_set_name(group_peer_exit, state->mem, name, name_length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
+    if (!tox_event_group_peer_exit_set_part_message(group_peer_exit, state->mem, part_message, part_message_length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/group_peer_join.c
+++ b/toxcore/events/group_peer_join.c
@@ -14,6 +14,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -105,7 +106,7 @@ Tox_Event_Group_Peer_Join *tox_event_group_peer_join_new(const Memory *mem)
 void tox_event_group_peer_join_free(Tox_Event_Group_Peer_Join *group_peer_join, const Memory *mem)
 {
     if (group_peer_join != nullptr) {
-        tox_event_group_peer_join_destruct((Tox_Event_Group_Peer_Join * _Nonnull)group_peer_join, mem);
+        tox_event_group_peer_join_destruct(group_peer_join, mem);
     }
     mem_delete(mem, group_peer_join);
 }

--- a/toxcore/events/group_peer_limit.c
+++ b/toxcore/events/group_peer_limit.c
@@ -14,6 +14,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -105,7 +106,7 @@ Tox_Event_Group_Peer_Limit *tox_event_group_peer_limit_new(const Memory *mem)
 void tox_event_group_peer_limit_free(Tox_Event_Group_Peer_Limit *group_peer_limit, const Memory *mem)
 {
     if (group_peer_limit != nullptr) {
-        tox_event_group_peer_limit_destruct((Tox_Event_Group_Peer_Limit * _Nonnull)group_peer_limit, mem);
+        tox_event_group_peer_limit_destruct(group_peer_limit, mem);
     }
     mem_delete(mem, group_peer_limit);
 }

--- a/toxcore/events/group_peer_name.c
+++ b/toxcore/events/group_peer_name.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -25,7 +26,7 @@
 struct Tox_Event_Group_Peer_Name {
     uint32_t group_number;
     uint32_t peer_id;
-    uint8_t *name;
+    uint8_t *_Nullable name;
     uint32_t name_length;
 };
 
@@ -63,6 +64,12 @@ static bool tox_event_group_peer_name_set_name(Tox_Event_Group_Peer_Name *_Nonnu
 
     if (name == nullptr) {
         assert(name_length == 0);
+        return true;
+    }
+
+    if (name_length == 0) {
+        group_peer_name->name = nullptr;
+        group_peer_name->name_length = 0;
         return true;
     }
 
@@ -147,7 +154,7 @@ Tox_Event_Group_Peer_Name *tox_event_group_peer_name_new(const Memory *mem)
 void tox_event_group_peer_name_free(Tox_Event_Group_Peer_Name *group_peer_name, const Memory *mem)
 {
     if (group_peer_name != nullptr) {
-        tox_event_group_peer_name_destruct((Tox_Event_Group_Peer_Name * _Nonnull)group_peer_name, mem);
+        tox_event_group_peer_name_destruct(group_peer_name, mem);
     }
     mem_delete(mem, group_peer_name);
 }
@@ -220,5 +227,7 @@ void tox_events_handle_group_peer_name(
 
     tox_event_group_peer_name_set_group_number(group_peer_name, group_number);
     tox_event_group_peer_name_set_peer_id(group_peer_name, peer_id);
-    tox_event_group_peer_name_set_name(group_peer_name, state->mem, name, name_length);
+    if (!tox_event_group_peer_name_set_name(group_peer_name, state->mem, name, name_length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/group_peer_status.c
+++ b/toxcore/events/group_peer_status.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -121,7 +122,7 @@ Tox_Event_Group_Peer_Status *tox_event_group_peer_status_new(const Memory *mem)
 void tox_event_group_peer_status_free(Tox_Event_Group_Peer_Status *group_peer_status, const Memory *mem)
 {
     if (group_peer_status != nullptr) {
-        tox_event_group_peer_status_destruct((Tox_Event_Group_Peer_Status * _Nonnull)group_peer_status, mem);
+        tox_event_group_peer_status_destruct(group_peer_status, mem);
     }
     mem_delete(mem, group_peer_status);
 }

--- a/toxcore/events/group_privacy_state.c
+++ b/toxcore/events/group_privacy_state.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -107,7 +108,7 @@ Tox_Event_Group_Privacy_State *tox_event_group_privacy_state_new(const Memory *m
 void tox_event_group_privacy_state_free(Tox_Event_Group_Privacy_State *group_privacy_state, const Memory *mem)
 {
     if (group_privacy_state != nullptr) {
-        tox_event_group_privacy_state_destruct((Tox_Event_Group_Privacy_State * _Nonnull)group_privacy_state, mem);
+        tox_event_group_privacy_state_destruct(group_privacy_state, mem);
     }
     mem_delete(mem, group_privacy_state);
 }

--- a/toxcore/events/group_self_join.c
+++ b/toxcore/events/group_self_join.c
@@ -14,6 +14,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -86,7 +87,7 @@ Tox_Event_Group_Self_Join *tox_event_group_self_join_new(const Memory *mem)
 void tox_event_group_self_join_free(Tox_Event_Group_Self_Join *group_self_join, const Memory *mem)
 {
     if (group_self_join != nullptr) {
-        tox_event_group_self_join_destruct((Tox_Event_Group_Self_Join * _Nonnull)group_self_join, mem);
+        tox_event_group_self_join_destruct(group_self_join, mem);
     }
     mem_delete(mem, group_self_join);
 }

--- a/toxcore/events/group_topic.c
+++ b/toxcore/events/group_topic.c
@@ -15,6 +15,7 @@
 #include "../tox.h"
 #include "../tox_event.h"
 #include "../tox_events.h"
+#include "../tox_struct.h"
 
 /*****************************************************
  *
@@ -25,7 +26,7 @@
 struct Tox_Event_Group_Topic {
     uint32_t group_number;
     uint32_t peer_id;
-    uint8_t *topic;
+    uint8_t *_Nullable topic;
     uint32_t topic_length;
 };
 
@@ -63,6 +64,12 @@ static bool tox_event_group_topic_set_topic(Tox_Event_Group_Topic *_Nonnull grou
 
     if (topic == nullptr) {
         assert(topic_length == 0);
+        return true;
+    }
+
+    if (topic_length == 0) {
+        group_topic->topic = nullptr;
+        group_topic->topic_length = 0;
         return true;
     }
 
@@ -147,7 +154,7 @@ Tox_Event_Group_Topic *tox_event_group_topic_new(const Memory *mem)
 void tox_event_group_topic_free(Tox_Event_Group_Topic *group_topic, const Memory *mem)
 {
     if (group_topic != nullptr) {
-        tox_event_group_topic_destruct((Tox_Event_Group_Topic * _Nonnull)group_topic, mem);
+        tox_event_group_topic_destruct(group_topic, mem);
     }
     mem_delete(mem, group_topic);
 }
@@ -220,5 +227,7 @@ void tox_events_handle_group_topic(
 
     tox_event_group_topic_set_group_number(group_topic, group_number);
     tox_event_group_topic_set_peer_id(group_topic, peer_id);
-    tox_event_group_topic_set_topic(group_topic, state->mem, topic, topic_length);
+    if (!tox_event_group_topic_set_topic(group_topic, state->mem, topic, topic_length)) {
+        state->error = TOX_ERR_EVENTS_ITERATE_MALLOC;
+    }
 }

--- a/toxcore/events/group_topic_lock.c
+++ b/toxcore/events/group_topic_lock.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -107,7 +108,7 @@ Tox_Event_Group_Topic_Lock *tox_event_group_topic_lock_new(const Memory *mem)
 void tox_event_group_topic_lock_free(Tox_Event_Group_Topic_Lock *group_topic_lock, const Memory *mem)
 {
     if (group_topic_lock != nullptr) {
-        tox_event_group_topic_lock_destruct((Tox_Event_Group_Topic_Lock * _Nonnull)group_topic_lock, mem);
+        tox_event_group_topic_lock_destruct(group_topic_lock, mem);
     }
     mem_delete(mem, group_topic_lock);
 }

--- a/toxcore/events/group_voice_state.c
+++ b/toxcore/events/group_voice_state.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -107,7 +108,7 @@ Tox_Event_Group_Voice_State *tox_event_group_voice_state_new(const Memory *mem)
 void tox_event_group_voice_state_free(Tox_Event_Group_Voice_State *group_voice_state, const Memory *mem)
 {
     if (group_voice_state != nullptr) {
-        tox_event_group_voice_state_destruct((Tox_Event_Group_Voice_State * _Nonnull)group_voice_state, mem);
+        tox_event_group_voice_state_destruct(group_voice_state, mem);
     }
     mem_delete(mem, group_voice_state);
 }

--- a/toxcore/events/self_connection_status.c
+++ b/toxcore/events/self_connection_status.c
@@ -15,6 +15,7 @@
 #include "../tox_event.h"
 #include "../tox_events.h"
 #include "../tox_pack.h"
+#include "../tox_struct.h"
 #include "../tox_unpack.h"
 
 /*****************************************************
@@ -88,7 +89,7 @@ Tox_Event_Self_Connection_Status *tox_event_self_connection_status_new(const Mem
 void tox_event_self_connection_status_free(Tox_Event_Self_Connection_Status *self_connection_status, const Memory *mem)
 {
     if (self_connection_status != nullptr) {
-        tox_event_self_connection_status_destruct((Tox_Event_Self_Connection_Status * _Nonnull)self_connection_status, mem);
+        tox_event_self_connection_status_destruct(self_connection_status, mem);
     }
     mem_delete(mem, self_connection_status);
 }

--- a/toxcore/tox_events.h
+++ b/toxcore/tox_events.h
@@ -27,7 +27,7 @@ uint32_t tox_event_conference_connected_get_conference_number(
     const Tox_Event_Conference_Connected *_Nonnull conference_connected);
 
 typedef struct Tox_Event_Conference_Invite Tox_Event_Conference_Invite;
-const uint8_t *_Nonnull tox_event_conference_invite_get_cookie(
+const uint8_t *_Nullable tox_event_conference_invite_get_cookie(
     const Tox_Event_Conference_Invite *_Nonnull conference_invite);
 uint32_t tox_event_conference_invite_get_cookie_length(
     const Tox_Event_Conference_Invite *_Nonnull conference_invite);
@@ -37,7 +37,7 @@ uint32_t tox_event_conference_invite_get_friend_number(
     const Tox_Event_Conference_Invite *_Nonnull conference_invite);
 
 typedef struct Tox_Event_Conference_Message Tox_Event_Conference_Message;
-const uint8_t *_Nonnull tox_event_conference_message_get_message(
+const uint8_t *_Nullable tox_event_conference_message_get_message(
     const Tox_Event_Conference_Message *_Nonnull conference_message);
 uint32_t tox_event_conference_message_get_message_length(
     const Tox_Event_Conference_Message *_Nonnull conference_message);
@@ -53,7 +53,7 @@ uint32_t tox_event_conference_peer_list_changed_get_conference_number(
     const Tox_Event_Conference_Peer_List_Changed *_Nonnull conference_peer_list_changed);
 
 typedef struct Tox_Event_Conference_Peer_Name Tox_Event_Conference_Peer_Name;
-const uint8_t *_Nonnull tox_event_conference_peer_name_get_name(
+const uint8_t *_Nullable tox_event_conference_peer_name_get_name(
     const Tox_Event_Conference_Peer_Name *_Nonnull conference_peer_name);
 uint32_t tox_event_conference_peer_name_get_name_length(
     const Tox_Event_Conference_Peer_Name *_Nonnull conference_peer_name);
@@ -63,7 +63,7 @@ uint32_t tox_event_conference_peer_name_get_peer_number(
     const Tox_Event_Conference_Peer_Name *_Nonnull conference_peer_name);
 
 typedef struct Tox_Event_Conference_Title Tox_Event_Conference_Title;
-const uint8_t *_Nonnull tox_event_conference_title_get_title(
+const uint8_t *_Nullable tox_event_conference_title_get_title(
     const Tox_Event_Conference_Title *_Nonnull conference_title);
 uint32_t tox_event_conference_title_get_title_length(
     const Tox_Event_Conference_Title *_Nonnull conference_title);
@@ -83,7 +83,7 @@ uint64_t tox_event_file_chunk_request_get_position(
     const Tox_Event_File_Chunk_Request *_Nonnull file_chunk_request);
 
 typedef struct Tox_Event_File_Recv Tox_Event_File_Recv;
-const uint8_t *_Nonnull tox_event_file_recv_get_filename(
+const uint8_t *_Nullable tox_event_file_recv_get_filename(
     const Tox_Event_File_Recv *_Nonnull file_recv);
 uint32_t tox_event_file_recv_get_filename_length(
     const Tox_Event_File_Recv *_Nonnull file_recv);
@@ -123,7 +123,7 @@ uint32_t tox_event_friend_connection_status_get_friend_number(
     const Tox_Event_Friend_Connection_Status *_Nonnull friend_connection_status);
 
 typedef struct Tox_Event_Friend_Lossless_Packet Tox_Event_Friend_Lossless_Packet;
-const uint8_t *_Nonnull tox_event_friend_lossless_packet_get_data(
+const uint8_t *_Nullable tox_event_friend_lossless_packet_get_data(
     const Tox_Event_Friend_Lossless_Packet *_Nonnull friend_lossless_packet);
 uint32_t tox_event_friend_lossless_packet_get_data_length(
     const Tox_Event_Friend_Lossless_Packet *_Nonnull friend_lossless_packet);
@@ -131,7 +131,7 @@ uint32_t tox_event_friend_lossless_packet_get_friend_number(
     const Tox_Event_Friend_Lossless_Packet *_Nonnull friend_lossless_packet);
 
 typedef struct Tox_Event_Friend_Lossy_Packet Tox_Event_Friend_Lossy_Packet;
-const uint8_t *_Nonnull tox_event_friend_lossy_packet_get_data(
+const uint8_t *_Nullable tox_event_friend_lossy_packet_get_data(
     const Tox_Event_Friend_Lossy_Packet *_Nonnull friend_lossy_packet);
 uint32_t tox_event_friend_lossy_packet_get_data_length(
     const Tox_Event_Friend_Lossy_Packet *_Nonnull friend_lossy_packet);
@@ -145,11 +145,11 @@ Tox_Message_Type tox_event_friend_message_get_type(
     const Tox_Event_Friend_Message *_Nonnull friend_message);
 uint32_t tox_event_friend_message_get_message_length(
     const Tox_Event_Friend_Message *_Nonnull friend_message);
-const uint8_t *_Nonnull tox_event_friend_message_get_message(
+const uint8_t *_Nullable tox_event_friend_message_get_message(
     const Tox_Event_Friend_Message *_Nonnull friend_message);
 
 typedef struct Tox_Event_Friend_Name Tox_Event_Friend_Name;
-const uint8_t *_Nonnull tox_event_friend_name_get_name(
+const uint8_t *_Nullable tox_event_friend_name_get_name(
     const Tox_Event_Friend_Name *_Nonnull friend_name);
 uint32_t tox_event_friend_name_get_name_length(
     const Tox_Event_Friend_Name *_Nonnull friend_name);
@@ -163,7 +163,7 @@ uint32_t tox_event_friend_read_receipt_get_message_id(
     const Tox_Event_Friend_Read_Receipt *_Nonnull friend_read_receipt);
 
 typedef struct Tox_Event_Friend_Request Tox_Event_Friend_Request;
-const uint8_t *_Nonnull tox_event_friend_request_get_message(
+const uint8_t *_Nullable tox_event_friend_request_get_message(
     const Tox_Event_Friend_Request *_Nonnull friend_request);
 const uint8_t *_Nonnull tox_event_friend_request_get_public_key(
     const Tox_Event_Friend_Request *_Nonnull friend_request);
@@ -177,7 +177,7 @@ uint32_t tox_event_friend_status_get_friend_number(
     const Tox_Event_Friend_Status *_Nonnull friend_status);
 
 typedef struct Tox_Event_Friend_Status_Message Tox_Event_Friend_Status_Message;
-const uint8_t *_Nonnull tox_event_friend_status_message_get_message(
+const uint8_t *_Nullable tox_event_friend_status_message_get_message(
     const Tox_Event_Friend_Status_Message *_Nonnull friend_status_message);
 uint32_t tox_event_friend_status_message_get_message_length(
     const Tox_Event_Friend_Status_Message *_Nonnull friend_status_message);
@@ -199,7 +199,7 @@ uint32_t tox_event_group_peer_name_get_group_number(
     const Tox_Event_Group_Peer_Name *_Nonnull group_peer_name);
 uint32_t tox_event_group_peer_name_get_peer_id(
     const Tox_Event_Group_Peer_Name *_Nonnull group_peer_name);
-const uint8_t *_Nonnull tox_event_group_peer_name_get_name(
+const uint8_t *_Nullable tox_event_group_peer_name_get_name(
     const Tox_Event_Group_Peer_Name *_Nonnull group_peer_name);
 uint32_t tox_event_group_peer_name_get_name_length(
     const Tox_Event_Group_Peer_Name *_Nonnull group_peer_name);
@@ -217,7 +217,7 @@ uint32_t tox_event_group_topic_get_group_number(
     const Tox_Event_Group_Topic *_Nonnull group_topic);
 uint32_t tox_event_group_topic_get_peer_id(
     const Tox_Event_Group_Topic *_Nonnull group_topic);
-const uint8_t *_Nonnull tox_event_group_topic_get_topic(
+const uint8_t *_Nullable tox_event_group_topic_get_topic(
     const Tox_Event_Group_Topic *_Nonnull group_topic);
 uint32_t tox_event_group_topic_get_topic_length(
     const Tox_Event_Group_Topic *_Nonnull group_topic);
@@ -261,7 +261,7 @@ uint32_t tox_event_group_message_get_peer_id(
     const Tox_Event_Group_Message *_Nonnull group_message);
 Tox_Message_Type tox_event_group_message_get_message_type(
     const Tox_Event_Group_Message *_Nonnull group_message);
-const uint8_t *_Nonnull tox_event_group_message_get_message(
+const uint8_t *_Nullable tox_event_group_message_get_message(
     const Tox_Event_Group_Message *_Nonnull group_message);
 uint32_t tox_event_group_message_get_message_length(
     const Tox_Event_Group_Message *_Nonnull group_message);
@@ -275,7 +275,7 @@ uint32_t tox_event_group_private_message_get_peer_id(
     const Tox_Event_Group_Private_Message *_Nonnull group_private_message);
 Tox_Message_Type tox_event_group_private_message_get_message_type(
     const Tox_Event_Group_Private_Message *_Nonnull group_private_message);
-const uint8_t *_Nonnull tox_event_group_private_message_get_message(
+const uint8_t *_Nullable tox_event_group_private_message_get_message(
     const Tox_Event_Group_Private_Message *_Nonnull group_private_message);
 uint32_t tox_event_group_private_message_get_message_length(
     const Tox_Event_Group_Private_Message *_Nonnull group_private_message);
@@ -287,7 +287,7 @@ uint32_t tox_event_group_custom_packet_get_group_number(
     const Tox_Event_Group_Custom_Packet *_Nonnull group_custom_packet);
 uint32_t tox_event_group_custom_packet_get_peer_id(
     const Tox_Event_Group_Custom_Packet *_Nonnull group_custom_packet);
-const uint8_t *_Nonnull tox_event_group_custom_packet_get_data(
+const uint8_t *_Nullable tox_event_group_custom_packet_get_data(
     const Tox_Event_Group_Custom_Packet *_Nonnull group_custom_packet);
 uint32_t tox_event_group_custom_packet_get_data_length(
     const Tox_Event_Group_Custom_Packet *_Nonnull group_custom_packet);
@@ -297,7 +297,7 @@ uint32_t tox_event_group_custom_private_packet_get_group_number(
     const Tox_Event_Group_Custom_Private_Packet *_Nonnull group_custom_private_packet);
 uint32_t tox_event_group_custom_private_packet_get_peer_id(
     const Tox_Event_Group_Custom_Private_Packet *_Nonnull group_custom_private_packet);
-const uint8_t *_Nonnull tox_event_group_custom_private_packet_get_data(
+const uint8_t *_Nullable tox_event_group_custom_private_packet_get_data(
     const Tox_Event_Group_Custom_Private_Packet *_Nonnull group_custom_private_packet);
 uint32_t tox_event_group_custom_private_packet_get_data_length(
     const Tox_Event_Group_Custom_Private_Packet *_Nonnull group_custom_private_packet);
@@ -305,11 +305,11 @@ uint32_t tox_event_group_custom_private_packet_get_data_length(
 typedef struct Tox_Event_Group_Invite Tox_Event_Group_Invite;
 uint32_t tox_event_group_invite_get_friend_number(
     const Tox_Event_Group_Invite *_Nonnull group_invite);
-const uint8_t *_Nonnull tox_event_group_invite_get_invite_data(
+const uint8_t *_Nullable tox_event_group_invite_get_invite_data(
     const Tox_Event_Group_Invite *_Nonnull group_invite);
 uint32_t tox_event_group_invite_get_invite_data_length(
     const Tox_Event_Group_Invite *_Nonnull group_invite);
-const uint8_t *_Nonnull tox_event_group_invite_get_group_name(
+const uint8_t *_Nullable tox_event_group_invite_get_group_name(
     const Tox_Event_Group_Invite *_Nonnull group_invite);
 uint32_t tox_event_group_invite_get_group_name_length(
     const Tox_Event_Group_Invite *_Nonnull group_invite);
@@ -327,7 +327,7 @@ uint32_t tox_event_group_peer_exit_get_peer_id(
     const Tox_Event_Group_Peer_Exit *_Nonnull group_peer_exit);
 Tox_Group_Exit_Type tox_event_group_peer_exit_get_exit_type(
     const Tox_Event_Group_Peer_Exit *_Nonnull group_peer_exit);
-const uint8_t *_Nonnull tox_event_group_peer_exit_get_name(
+const uint8_t *_Nullable tox_event_group_peer_exit_get_name(
     const Tox_Event_Group_Peer_Exit *_Nonnull group_peer_exit);
 uint32_t tox_event_group_peer_exit_get_name_length(
     const Tox_Event_Group_Peer_Exit *_Nonnull group_peer_exit);
@@ -359,7 +359,7 @@ Tox_Group_Mod_Event tox_event_group_moderation_get_mod_type(
 typedef struct Tox_Event_Dht_Nodes_Response Tox_Event_Dht_Nodes_Response;
 const uint8_t *_Nonnull tox_event_dht_nodes_response_get_public_key(
     const Tox_Event_Dht_Nodes_Response *_Nonnull dht_nodes_response);
-const uint8_t *_Nonnull tox_event_dht_nodes_response_get_ip(
+const char *_Nullable tox_event_dht_nodes_response_get_ip(
     const Tox_Event_Dht_Nodes_Response *_Nonnull dht_nodes_response);
 uint32_t tox_event_dht_nodes_response_get_ip_length(
     const Tox_Event_Dht_Nodes_Response *_Nonnull dht_nodes_response);


### PR DESCRIPTION
- Use MessagePack strings for IP addresses and other text fields.
- Mark dynamic event fields as nullable in getters.
- Add overflow checks for event list capacity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/2997)
<!-- Reviewable:end -->
