### PR TITLE
fix(DHT): Correct node skipping logic timed out nodes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,5 +98,10 @@ tox.spec
 .cache/
 compile_commands.json
 
+# gtags
+/GPATH
+/GRTAGS
+/GTAGS
+
 /infer
 .idea/

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2015,7 +2015,7 @@ static uint32_t foreach_ip_port(const DHT *_Nonnull dht, const DHT_Friend *_Nonn
 
             /* If ip is not zero and node is good. */
             if (!ip_isset(&assoc->ret_ip_port.ip)
-                    && !mono_time_is_timeout(dht->mono_time, assoc->ret_timestamp, BAD_NODE_TIMEOUT)) {
+                    || mono_time_is_timeout(dht->mono_time, assoc->ret_timestamp, BAD_NODE_TIMEOUT)) {
                 continue;
             }
 


### PR DESCRIPTION
The previous logic would only skip nodes if they were both missing an IP and NOT timed out. This caused Tox to attempt routing packets through stale or informed but unreachable nodes.

This change ensures we skip any node that either lacks an IP or has timed out, improving DHT routing reliability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3003)
<!-- Reviewable:end -->
