### PR TITLE
refactor(clock): Add `Clock` vtable and refactor `Mono_Time`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,8 @@ set(toxcore_SOURCES
   toxcore/bin_unpack.h
   toxcore/ccompat.c
   toxcore/ccompat.h
+  toxcore/clock.c
+  toxcore/clock.h
   toxcore/crypto_core.c
   toxcore/crypto_core.h
   toxcore/crypto_core_pack.c
@@ -322,6 +324,8 @@ set(toxcore_SOURCES
   toxcore/Messenger.h
   toxcore/mem.c
   toxcore/mem.h
+  toxcore/mono_clock.c
+  toxcore/mono_clock.h
   toxcore/mono_time.c
   toxcore/mono_time.h
   toxcore/net.c
@@ -340,6 +344,8 @@ set(toxcore_SOURCES
   toxcore/onion_client.c
   toxcore/onion_client.h
   toxcore/onion.h
+  toxcore/os_clock.c
+  toxcore/os_clock.h
   toxcore/os_event.c
   toxcore/os_event.h
   toxcore/os_memory.c

--- a/toxcore/BUILD.bazel
+++ b/toxcore/BUILD.bazel
@@ -103,6 +103,45 @@ cc_library(
 )
 
 cc_library(
+    name = "clock",
+    srcs = ["clock.c"],
+    hdrs = ["clock.h"],
+    visibility = ["//c-toxcore:__subpackages__"],
+    deps = [
+        ":attributes",
+        ":ccompat",
+    ],
+)
+
+cc_library(
+    name = "os_clock",
+    srcs = ["os_clock.c"],
+    hdrs = ["os_clock.h"],
+    visibility = ["//c-toxcore:__subpackages__"],
+    deps = [
+        ":attributes",
+        ":ccompat",
+        ":clock",
+    ],
+)
+
+cc_library(
+    name = "mono_clock",
+    srcs = ["mono_clock.c"],
+    hdrs = ["mono_clock.h"],
+    visibility = ["//c-toxcore:__subpackages__"],
+    deps = [
+        ":attributes",
+        ":ccompat",
+        ":clock",
+        ":mem",
+        ":os_clock",
+        ":util",
+        "@pthread",
+    ],
+)
+
+cc_library(
     name = "ev",
     srcs = ["ev.c"],
     hdrs = ["ev.h"],
@@ -432,6 +471,8 @@ cc_library(
         ":attributes",
         ":ccompat",
         ":mem",
+        ":mono_clock",
+        ":os_clock",
         ":util",
         "@pthread",
     ],
@@ -1503,12 +1544,14 @@ cc_library(
         ":group_moderation",
         ":logger",
         ":mem",
+        ":mono_clock",
         ":mono_time",
         ":net",
         ":net_crypto",
         ":net_profile",
         ":network",
         ":onion_client",
+        ":os_clock",
         ":os_event",
         ":os_memory",
         ":os_network",

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -60,6 +60,8 @@ libtoxcore_la_SOURCES = ../third_party/cmp/cmp.c \
                         ../toxcore/bin_unpack.h \
                         ../toxcore/ccompat.c \
                         ../toxcore/ccompat.h \
+                        ../toxcore/clock.c \
+                        ../toxcore/clock.h \
                         ../toxcore/crypto_core_pack.c \
                         ../toxcore/crypto_core_pack.h \
                         ../toxcore/crypto_core.c \
@@ -99,6 +101,8 @@ libtoxcore_la_SOURCES = ../third_party/cmp/cmp.c \
                         ../toxcore/mem.h \
                         ../toxcore/Messenger.c \
                         ../toxcore/Messenger.h \
+                        ../toxcore/mono_clock.c \
+                        ../toxcore/mono_clock.h \
                         ../toxcore/mono_time.c \
                         ../toxcore/mono_time.h \
                         ../toxcore/net_crypto.c \
@@ -117,6 +121,8 @@ libtoxcore_la_SOURCES = ../third_party/cmp/cmp.c \
                         ../toxcore/onion_client.h \
                         ../toxcore/onion.c \
                         ../toxcore/onion.h \
+                        ../toxcore/os_clock.c \
+                        ../toxcore/os_clock.h \
                         ../toxcore/os_event.c \
                         ../toxcore/os_event.h \
                         ../toxcore/os_memory.c \

--- a/toxcore/clock.c
+++ b/toxcore/clock.c
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022-2026 The TokTok team.
+ */
+
+#include "clock.h"
+
+#include "ccompat.h"
+
+uint64_t clock_monotonic_ms(const Clock *clock)
+{
+    return clock->funcs->monotonic_ms(clock->user_data);
+}
+
+uint64_t clock_monotonic_s(const Clock *clock)
+{
+    return clock_monotonic_ms(clock) / UINT64_C(1000);
+}
+
+uint64_t clock_real_ms(const Clock *clock)
+{
+    return clock->funcs->real_ms(clock->user_data);
+}
+
+uint64_t clock_real_s(const Clock *clock)
+{
+    return clock_real_ms(clock) / UINT64_C(1000);
+}
+
+bool clock_is_timeout(const Clock *clock, uint64_t timestamp, uint64_t timeout)
+{
+    return timestamp + timeout <= clock_monotonic_s(clock);
+}
+
+void clock_update(Clock *clock)
+{
+    if (clock->funcs->update != nullptr) {
+        clock->funcs->update(clock->user_data);
+    }
+}

--- a/toxcore/clock.h
+++ b/toxcore/clock.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022-2026 The TokTok team.
+ */
+
+#ifndef C_TOXCORE_TOXCORE_CLOCK_H
+#define C_TOXCORE_TOXCORE_CLOCK_H
+
+#include <stdint.h>
+
+#include "attributes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Return monotonic time in milliseconds. */
+typedef uint64_t clock_monotonic_ms_cb(void *_Nullable self);
+
+/** @brief Return real system time (Unix epoch) in milliseconds. */
+typedef uint64_t clock_real_ms_cb(void *_Nullable self);
+
+/** @brief Update the cached time (if applicable). */
+typedef void clock_update_cb(void *_Nullable self);
+
+/** @brief Virtual function table for Clock. */
+typedef struct Clock_Funcs {
+    clock_monotonic_ms_cb *_Nonnull monotonic_ms;
+    clock_real_ms_cb *_Nonnull real_ms;
+    clock_update_cb *_Nullable update;
+} Clock_Funcs;
+
+/** @brief Clock object. */
+typedef struct Clock {
+    const Clock_Funcs *_Nonnull funcs;
+    void *_Nullable user_data;
+} Clock;
+
+/** @brief Return current monotonic time in milliseconds (ms). */
+uint64_t clock_monotonic_ms(const Clock *_Nonnull clock);
+
+/** @brief Return current monotonic time in seconds (s). */
+uint64_t clock_monotonic_s(const Clock *_Nonnull clock);
+
+/** @brief Return current real system time (Unix epoch) in milliseconds (ms). */
+uint64_t clock_real_ms(const Clock *_Nonnull clock);
+
+/** @brief Return current real system time (Unix epoch) in seconds (s). */
+uint64_t clock_real_s(const Clock *_Nonnull clock);
+
+/** @brief Return true iff timestamp is at least timeout seconds in the past. */
+bool clock_is_timeout(const Clock *_Nonnull clock, uint64_t timestamp, uint64_t timeout);
+
+/** @brief Update the clock; subsequent calls to clock_monotonic_ms or
+ *  clock_real_ms will use the time at the call to clock_update (if the clock
+ *  supports caching).
+ */
+void clock_update(Clock *_Nonnull clock);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* C_TOXCORE_TOXCORE_CLOCK_H */

--- a/toxcore/mono_clock.c
+++ b/toxcore/mono_clock.c
@@ -1,0 +1,153 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022-2026 The TokTok team.
+ */
+
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif /* _XOPEN_SOURCE */
+
+#include "mono_clock.h"
+
+#include "ccompat.h"
+
+#ifndef ESP_PLATFORM
+#include <pthread.h>
+#endif /* ESP_PLATFORM */
+
+#include "attributes.h"
+#include "ccompat.h"
+#include "os_clock.h"
+#include "util.h"
+
+struct Mono_Clock {
+    Clock clock;
+
+    const Clock *_Nonnull source_clock;
+
+    uint64_t cur_monotonic_ms;
+    uint64_t cur_real_ms;
+    uint64_t base_time_ms;
+
+#ifndef ESP_PLATFORM
+    pthread_rwlock_t *_Nonnull lock;
+#endif /* ESP_PLATFORM */
+};
+
+static uint64_t mono_clock_monotonic_ms(void *_Nullable self)
+{
+    Mono_Clock *mc = (Mono_Clock *)self;
+#ifndef ESP_PLATFORM
+    pthread_rwlock_rdlock(mc->lock);
+#endif /* ESP_PLATFORM */
+    const uint64_t res = mc->cur_monotonic_ms;
+#ifndef ESP_PLATFORM
+    pthread_rwlock_unlock(mc->lock);
+#endif /* ESP_PLATFORM */
+    return res;
+}
+
+static uint64_t mono_clock_real_ms(void *_Nullable self)
+{
+    Mono_Clock *mc = (Mono_Clock *)self;
+#ifndef ESP_PLATFORM
+    pthread_rwlock_rdlock(mc->lock);
+#endif /* ESP_PLATFORM */
+    const uint64_t res = mc->cur_real_ms;
+#ifndef ESP_PLATFORM
+    pthread_rwlock_unlock(mc->lock);
+#endif /* ESP_PLATFORM */
+    return res;
+}
+
+static void mono_clock_update(void *_Nullable self)
+{
+    Mono_Clock *mc = (Mono_Clock *)self;
+    const uint64_t mono = clock_monotonic_ms(mc->source_clock);
+
+#ifndef ESP_PLATFORM
+    pthread_rwlock_wrlock(mc->lock);
+#endif /* ESP_PLATFORM */
+    mc->cur_monotonic_ms = mc->base_time_ms + mono;
+    mc->cur_real_ms = clock_real_ms(mc->source_clock);
+#ifndef ESP_PLATFORM
+    pthread_rwlock_unlock(mc->lock);
+#endif /* ESP_PLATFORM */
+}
+
+static const Clock_Funcs mono_clock_funcs = {
+    mono_clock_monotonic_ms,
+    mono_clock_real_ms,
+    mono_clock_update,
+};
+
+Mono_Clock *mono_clock_new(const Memory *mem, const Clock *source_clock)
+{
+    Mono_Clock *mc = (Mono_Clock *)mem_alloc(mem, sizeof(Mono_Clock));
+
+    if (mc == nullptr) {
+        return nullptr;
+    }
+
+    if (source_clock == nullptr) {
+        source_clock = os_clock();
+    }
+
+    mc->clock.funcs = &mono_clock_funcs;
+    mc->clock.user_data = mc;
+    mc->source_clock = source_clock;
+
+#ifndef ESP_PLATFORM
+    pthread_rwlock_t *lock = (pthread_rwlock_t *)mem_alloc(mem, sizeof(pthread_rwlock_t));
+
+    if (lock == nullptr) {
+        mem_delete(mem, mc);
+        return nullptr;
+    }
+
+    if (pthread_rwlock_init(lock, nullptr) != 0) {
+        mem_delete(mem, lock);
+        mem_delete(mem, mc);
+        return nullptr;
+    }
+
+    mc->lock = lock;
+#endif /* ESP_PLATFORM */
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    // Maximum reproducibility. Never return time = 0.
+    mc->base_time_ms = UINT64_C(1000000000);
+#else
+    // Match legacy behavior: initialize base_time_ms so that the first
+    // mono_clock_monotonic_ms returns approximately current real time.
+    const uint64_t real = clock_real_ms(mc->source_clock);
+    const uint64_t mono = clock_monotonic_ms(mc->source_clock);
+    mc->base_time_ms = max_u64(UINT64_C(1000), real) - mono;
+#endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
+
+    mono_clock_update(mc);
+
+    return mc;
+}
+
+void mono_clock_free(const Memory *mem, Mono_Clock *mc)
+{
+    if (mc == nullptr) {
+        return;
+    }
+
+#ifndef ESP_PLATFORM
+    pthread_rwlock_destroy(mc->lock);
+    mem_delete(mem, mc->lock);
+#endif /* ESP_PLATFORM */
+    mem_delete(mem, mc);
+}
+
+const Clock *mono_clock_get_clock(const Mono_Clock *mc)
+{
+    return &mc->clock;
+}
+
+Clock *mono_clock_get_clock_mutable(Mono_Clock *mc)
+{
+    return &mc->clock;
+}

--- a/toxcore/mono_clock.h
+++ b/toxcore/mono_clock.h
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022-2026 The TokTok team.
+ */
+
+#ifndef C_TOXCORE_TOXCORE_MONO_CLOCK_H
+#define C_TOXCORE_TOXCORE_MONO_CLOCK_H
+
+#include "clock.h"
+#include "mem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct Mono_Clock Mono_Clock;
+
+/** @brief Create a new cached monotonic clock.
+ *
+ * If @p source_clock is NULL, the system clock (@ref os_clock) is used.
+ */
+Mono_Clock *_Nullable mono_clock_new(const Memory *_Nonnull mem, const Clock *_Nullable source_clock);
+
+/** @brief Free a Mono_Clock instance. */
+void mono_clock_free(const Memory *_Nonnull mem, Mono_Clock *_Nullable clock);
+
+/** @brief Return the Clock interface for this Mono_Clock. */
+const Clock *_Nonnull mono_clock_get_clock(const Mono_Clock *_Nonnull clock);
+
+/** @brief Return the Clock interface for this Mono_Clock (non-const). */
+Clock *_Nonnull mono_clock_get_clock_mutable(Mono_Clock *_Nonnull clock);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* C_TOXCORE_TOXCORE_MONO_CLOCK_H */

--- a/toxcore/mono_time.c
+++ b/toxcore/mono_time.c
@@ -12,6 +12,8 @@
 
 #include "mono_time.h"
 
+#include <time.h>
+
 #ifdef OS_WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -26,34 +28,22 @@
 #include <sys/time.h>
 #endif /* OS_WIN32 */
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-#include <assert.h>
-#endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
-#include <pthread.h>
-#include <time.h>
-
-#include "attributes.h"
 #include "ccompat.h"
 #include "mem.h"
+#include "mono_clock.h"
+#include "os_clock.h"
 #include "util.h"
 
-/** don't call into system billions of times for no reason */
 struct Mono_Time {
-    uint64_t cur_time;
-    uint64_t base_time;
-
-#ifndef ESP_PLATFORM
-    /** protect @ref cur_time from concurrent access */
-    pthread_rwlock_t *_Nonnull time_update_lock;
-#endif /* ESP_PLATFORM */
-
-    mono_time_current_time_cb *_Nonnull current_time_callback;
-    void *_Nullable user_data;
+    Mono_Clock *mc;
+    Clock custom_source;
+    mono_time_current_time_cb *cb;
+    void *cb_user_data;
 };
 
-static uint64_t timespec_to_u64(struct timespec clock_mono)
+static uint64_t timespec_to_u64(struct timespec ts)
 {
-    return UINT64_C(1000) * clock_mono.tv_sec + (clock_mono.tv_nsec / UINT64_C(1000000));
+    return UINT64_C(1000) * ts.tv_sec + (ts.tv_nsec / UINT64_C(1000000));
 }
 
 #ifdef OS_WIN32
@@ -61,19 +51,24 @@ static uint64_t current_time_monotonic_default(void *_Nonnull user_data)
 {
     LARGE_INTEGER freq;
     LARGE_INTEGER count;
+
     if (!QueryPerformanceFrequency(&freq)) {
         return 0;
     }
+
     if (!QueryPerformanceCounter(&count)) {
         return 0;
     }
+
     struct timespec sp = {0};
     sp.tv_sec = count.QuadPart / freq.QuadPart;
+
     if (freq.QuadPart < 1000000000) {
         sp.tv_nsec = (count.QuadPart % freq.QuadPart) * 1000000000 / freq.QuadPart;
     } else {
         sp.tv_nsec = (long)((count.QuadPart % freq.QuadPart) * (1000000000.0 / freq.QuadPart));
     }
+
     return timespec_to_u64(sp);
 }
 #else
@@ -95,11 +90,6 @@ static uint64_t current_time_monotonic_default(void *_Nonnull user_data)
 #else // !__APPLE__
 static uint64_t current_time_monotonic_default(void *_Nonnull user_data)
 {
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    // This assert should always fail. If it does, the fuzzing harness didn't
-    // override the mono time callback.
-    assert(user_data == nullptr);
-#endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
     struct timespec clock_mono;
     clock_gettime(CLOCK_MONOTONIC, &clock_mono);
     return timespec_to_u64(clock_mono);
@@ -107,115 +97,94 @@ static uint64_t current_time_monotonic_default(void *_Nonnull user_data)
 #endif /* !__APPLE__ */
 #endif /* !OS_WIN32 */
 
+static uint64_t legacy_monotonic_ms(void *self)
+{
+    Mono_Time *mt = (Mono_Time *)self;
+    return mt->cb(mt->cb_user_data);
+}
+
+static uint64_t legacy_real_ms(void *self)
+{
+    return clock_real_ms(os_clock());
+}
+
+static const Clock_Funcs legacy_funcs = {
+    legacy_monotonic_ms,
+    legacy_real_ms,
+    nullptr
+};
+
+Mono_Clock *mono_time_get_mono_clock(Mono_Time *mt)
+{
+    return mt->mc;
+}
+
 Mono_Time *mono_time_new(const Memory *mem, mono_time_current_time_cb *current_time_callback, void *user_data)
 {
-    Mono_Time *mono_time = (Mono_Time *)mem_alloc(mem, sizeof(Mono_Time));
+    Mono_Time *mt = (Mono_Time *)mem_alloc(mem, sizeof(Mono_Time));
 
-    if (mono_time == nullptr) {
+    if (mt == nullptr) {
         return nullptr;
     }
 
-#ifndef ESP_PLATFORM
-    pthread_rwlock_t *const rwlock = (pthread_rwlock_t *)mem_alloc(mem, sizeof(pthread_rwlock_t));
+    mt->custom_source.funcs = &legacy_funcs;
+    mt->custom_source.user_data = mt;
 
-    if (rwlock == nullptr) {
-        mem_delete(mem, mono_time);
+    mono_time_set_current_time_callback(mt, current_time_callback, user_data);
+
+    mt->mc = mono_clock_new(mem, &mt->custom_source);
+
+    if (mt->mc == nullptr) {
+        mem_delete(mem, mt);
         return nullptr;
     }
 
-    if (pthread_rwlock_init(rwlock, nullptr) != 0) {
-        mem_delete(mem, rwlock);
-        mem_delete(mem, mono_time);
-        return nullptr;
-    }
-
-    mono_time->time_update_lock = rwlock;
-#endif /* ESP_PLATFORM */
-
-    mono_time_set_current_time_callback(mono_time, current_time_callback, user_data);
-
-    mono_time->cur_time = 0;
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    // Maximum reproducibility. Never return time = 0.
-    mono_time->base_time = 1000000000;
-#else
-    // Never return time = 0 in case time() returns 0 (e.g. on microcontrollers
-    // without battery-powered RTC or ones where NTP didn't initialise it yet).
-    mono_time->base_time = max_u64(1, (uint64_t)time(nullptr)) * UINT64_C(1000) - current_time_monotonic(mono_time);
-#endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
-
-    mono_time_update(mono_time);
-
-    return mono_time;
+    return mt;
 }
 
-void mono_time_free(const Memory *mem, Mono_Time *mono_time)
+void mono_time_free(const Memory *mem, Mono_Time *mt)
 {
-    if (mono_time == nullptr) {
+    if (mt == nullptr) {
         return;
     }
-#ifndef ESP_PLATFORM
-    pthread_rwlock_destroy(mono_time->time_update_lock);
-    mem_delete(mem, mono_time->time_update_lock);
-#endif /* ESP_PLATFORM */
-    mem_delete(mem, mono_time);
+
+    mono_clock_free(mem, mt->mc);
+    mem_delete(mem, mt);
 }
 
-void mono_time_update(Mono_Time *mono_time)
+void mono_time_update(Mono_Time *mt)
 {
-    const uint64_t cur_time =
-        mono_time->base_time + mono_time->current_time_callback(mono_time->user_data);
-
-#ifndef ESP_PLATFORM
-    pthread_rwlock_wrlock(mono_time->time_update_lock);
-#endif /* ESP_PLATFORM */
-    mono_time->cur_time = cur_time;
-#ifndef ESP_PLATFORM
-    pthread_rwlock_unlock(mono_time->time_update_lock);
-#endif /* ESP_PLATFORM */
+    clock_update(mono_clock_get_clock_mutable(mt->mc));
 }
 
-uint64_t mono_time_get_ms(const Mono_Time *mono_time)
+uint64_t mono_time_get_ms(const Mono_Time *mt)
 {
-#if !defined(ESP_PLATFORM) && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
-    // Fuzzing is only single thread for now, no locking needed */
-    pthread_rwlock_rdlock(mono_time->time_update_lock);
-#endif /* !ESP_PLATFORM */
-    const uint64_t cur_time = mono_time->cur_time;
-#if !defined(ESP_PLATFORM) && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
-    pthread_rwlock_unlock(mono_time->time_update_lock);
-#endif /* !ESP_PLATFORM */
-    return cur_time;
+    return clock_monotonic_ms(mono_clock_get_clock(mt->mc));
 }
 
-uint64_t mono_time_get(const Mono_Time *mono_time)
+uint64_t mono_time_get(const Mono_Time *mt)
 {
-    return mono_time_get_ms(mono_time) / UINT64_C(1000);
+    return mono_time_get_ms(mt) / UINT64_C(1000);
 }
 
-bool mono_time_is_timeout(const Mono_Time *mono_time, uint64_t timestamp, uint64_t timeout)
+bool mono_time_is_timeout(const Mono_Time *mt, uint64_t timestamp, uint64_t timeout)
 {
-    return timestamp + timeout <= mono_time_get(mono_time);
+    return timestamp + timeout <= mono_time_get(mt);
 }
 
-void mono_time_set_current_time_callback(Mono_Time *mono_time,
+void mono_time_set_current_time_callback(Mono_Time *mt,
         mono_time_current_time_cb *current_time_callback, void *user_data)
 {
     if (current_time_callback == nullptr) {
-        mono_time->current_time_callback = current_time_monotonic_default;
-        mono_time->user_data = mono_time;
+        mt->cb = current_time_monotonic_default;
+        mt->cb_user_data = mt;
     } else {
-        mono_time->current_time_callback = current_time_callback;
-        mono_time->user_data = user_data;
+        mt->cb = current_time_callback;
+        mt->cb_user_data = user_data;
     }
 }
 
-/** @brief Return current monotonic time in milliseconds (ms).
- *
- * The starting point is unspecified and in particular is likely not comparable
- * to the return value of `mono_time_get_ms()`.
- */
-uint64_t current_time_monotonic(const Mono_Time *mono_time)
+uint64_t current_time_monotonic(const Mono_Time *mt)
 {
-    return mono_time->current_time_callback(mono_time->user_data);
+    return mt->cb(mt->cb_user_data);
 }

--- a/toxcore/mono_time.h
+++ b/toxcore/mono_time.h
@@ -48,6 +48,9 @@ typedef struct Mono_Time Mono_Time;
 
 typedef uint64_t mono_time_current_time_cb(void *_Nullable user_data);
 
+typedef struct Mono_Clock Mono_Clock;
+Mono_Clock *_Nonnull mono_time_get_mono_clock(Mono_Time *_Nonnull mt);
+
 Mono_Time *_Nullable mono_time_new(const Memory *_Nonnull mem, mono_time_current_time_cb *_Nullable current_time_callback, void *_Nullable user_data);
 void mono_time_free(const Memory *_Nonnull mem, Mono_Time *_Nullable mono_time);
 /**

--- a/toxcore/os_clock.c
+++ b/toxcore/os_clock.c
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022-2026 The TokTok team.
+ */
+
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif /* _XOPEN_SOURCE */
+
+#if !defined(OS_WIN32) && (defined(_WIN32) || defined(__WIN32__) || defined(WIN32))
+#define OS_WIN32
+#endif /* WIN32 */
+
+#include "os_clock.h"
+
+#ifdef OS_WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif /* OS_WIN32 */
+
+#ifdef __APPLE__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif /* __APPLE__ */
+
+#ifndef OS_WIN32
+#include <sys/time.h>
+#endif /* OS_WIN32 */
+
+#include <time.h>
+
+#include "ccompat.h"
+#include "attributes.h"
+#include "ccompat.h"
+
+static uint64_t timespec_to_u64(struct timespec ts)
+{
+    return UINT64_C(1000) * ts.tv_sec + (ts.tv_nsec / UINT64_C(1000000));
+}
+
+#ifdef OS_WIN32
+static uint64_t os_monotonic_ms(void *_Nullable self)
+{
+    LARGE_INTEGER freq;
+    LARGE_INTEGER count;
+
+    if (!QueryPerformanceFrequency(&freq)) {
+        return 0;
+    }
+
+    if (!QueryPerformanceCounter(&count)) {
+        return 0;
+    }
+
+    struct timespec sp = {0};
+    sp.tv_sec = count.QuadPart / freq.QuadPart;
+
+    if (freq.QuadPart < 1000000000) {
+        sp.tv_nsec = (count.QuadPart % freq.QuadPart) * 1000000000 / freq.QuadPart;
+    } else {
+        sp.tv_nsec = (long)((count.QuadPart % freq.QuadPart) * (1000000000.0 / freq.QuadPart));
+    }
+
+    return timespec_to_u64(sp);
+}
+
+static uint64_t os_real_ms(void *_Nullable self)
+{
+    FILETIME ft;
+    GetSystemTimeAsFileTime(&ft);
+    const uint64_t t = ((uint64_t)ft.dwHighDateTime << 32) | ft.dwLowDateTime;
+    /* Convert from 100-nanosecond intervals since Jan 1, 1601 to milliseconds since Jan 1, 1970. */
+    return (t - UINT64_C(116444736000000000)) / 10000;
+}
+#else
+#ifdef __APPLE__
+static uint64_t os_monotonic_ms(void *_Nullable self)
+{
+    struct timespec clock_mono;
+    clock_serv_t muhclock;
+    mach_timespec_t machtime;
+
+    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &muhclock);
+    clock_get_time(muhclock, &machtime);
+    mach_port_deallocate(mach_task_self(), muhclock);
+
+    clock_mono.tv_sec = machtime.tv_sec;
+    clock_mono.tv_nsec = machtime.tv_nsec;
+    return timespec_to_u64(clock_mono);
+}
+#else /* !__APPLE__ */
+static uint64_t os_monotonic_ms(void *_Nullable self)
+{
+    struct timespec clock_mono;
+    clock_gettime(CLOCK_MONOTONIC, &clock_mono);
+    return timespec_to_u64(clock_mono);
+}
+#endif /* !__APPLE__ */
+
+static uint64_t os_real_ms(void *_Nullable self)
+{
+#ifdef __APPLE__
+    struct timespec clock_real;
+    clock_serv_t muhclock;
+    mach_timespec_t machtime;
+
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &muhclock);
+    clock_get_time(muhclock, &machtime);
+    mach_port_deallocate(mach_task_self(), muhclock);
+
+    clock_real.tv_sec = machtime.tv_sec;
+    clock_real.tv_nsec = machtime.tv_nsec;
+    return timespec_to_u64(clock_real);
+#else /* !__APPLE__ */
+    struct timespec clock_real;
+    clock_gettime(CLOCK_REALTIME, &clock_real);
+    return timespec_to_u64(clock_real);
+#endif /* !__APPLE__ */
+}
+#endif /* !OS_WIN32 */
+
+static const Clock_Funcs os_clock_funcs = {
+    os_monotonic_ms,
+    os_real_ms,
+    nullptr,
+};
+
+const Clock os_clock_obj = {&os_clock_funcs, nullptr};
+
+const Clock *os_clock(void)
+{
+    return &os_clock_obj;
+}

--- a/toxcore/os_clock.h
+++ b/toxcore/os_clock.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2022-2026 The TokTok team.
+ */
+
+#ifndef C_TOXCORE_TOXCORE_OS_CLOCK_H
+#define C_TOXCORE_TOXCORE_OS_CLOCK_H
+
+#include "clock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const Clock os_clock_obj;
+
+/** @brief System clock.
+ *
+ * Uses the system's high-resolution monotonic and real-time clocks.
+ */
+const Clock *_Nonnull os_clock(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* C_TOXCORE_TOXCORE_OS_CLOCK_H */

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -820,6 +820,7 @@ static Tox *tox_new_system(const struct Tox_Options *_Nullable options, Tox_Err_
         return nullptr;
     }
     tox->mono_time = temp_mono_time;
+    tox->mono_clock = mono_time_get_mono_clock(tox->mono_time);
 
     if (tox_options_get_experimental_thread_safety(opts)) {
         pthread_mutex_t *mutex = (pthread_mutex_t *)mem_alloc(mem, sizeof(pthread_mutex_t));
@@ -1013,6 +1014,7 @@ void tox_kill(Tox *tox)
     kill_messenger(tox->m);
     logger_kill(tox->log);
     mono_time_free(tox->sys.mem, tox->mono_time);
+    tox->mono_clock = nullptr;
     tox_unlock(tox);
 
     if (tox->mutex != nullptr) {

--- a/toxcore/tox_private.c
+++ b/toxcore/tox_private.c
@@ -23,6 +23,7 @@
 #include "net_crypto.h"
 #include "net_profile.h"
 #include "network.h"
+#include "os_clock.h"
 #include "os_memory.h"
 #include "os_network.h"
 #include "os_random.h"
@@ -41,6 +42,7 @@ Tox_System tox_default_system(void)
     const Tox_System sys = {
         nullptr,  // mono_time_callback
         nullptr,  // mono_time_user_data
+        os_clock(),
         os_random(),
         os_network(),
         os_memory(),

--- a/toxcore/tox_private.h
+++ b/toxcore/tox_private.h
@@ -23,10 +23,13 @@ typedef uint64_t tox_mono_time_cb(void *_Nullable user_data);
 typedef struct Random Random;
 typedef struct Network Network;
 typedef struct Memory Memory;
+typedef struct Clock Clock;
+typedef struct Mono_Clock Mono_Clock;
 
 typedef struct Tox_System {
     tox_mono_time_cb *_Nullable mono_time_callback;
     void *_Nullable mono_time_user_data;
+    const Clock *_Nullable clock;
     const Random *_Nullable rng;
     const Network *_Nullable ns;
     const Memory *_Nullable mem;

--- a/toxcore/tox_struct.h
+++ b/toxcore/tox_struct.h
@@ -21,6 +21,7 @@ struct Tox {
     struct Logger *_Nonnull log;
     struct Messenger *_Nonnull m;
     Mono_Time *_Nonnull mono_time;
+    Mono_Clock *_Nonnull mono_clock;
     Tox_System sys;
     pthread_mutex_t *_Nullable mutex;
 


### PR DESCRIPTION
- Add `Clock` interface and `os_clock` system implementation.
- Add `Mono_Clock` for thread-safe time caching.
- Refactor `Mono_Time` to wrap the new `Mono_Clock`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3005)
<!-- Reviewable:end -->
