### PR TITLE
cleanup: Use `std::size_t` in C++ to fix compilation errors.

### DIFF
--- a/other/event_tooling/generate_event_c.cpp
+++ b/other/event_tooling/generate_event_c.cpp
@@ -5,6 +5,7 @@
 // requires c++17
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -410,7 +411,7 @@ void generate_event_impl(const std::string& event_name, const std::vector<EventT
 
     // gen destruct
     f << "static void tox_event_" << event_name_l << "_destruct(Tox_Event_" << event_name << " *_Nonnull " << event_name_l << ", const Memory *_Nonnull mem)\n{\n";
-    size_t data_count = 0;
+    std::size_t data_count = 0;
     for (const auto& t : event_types) {
         std::visit(
             overloaded{

--- a/testing/bench/tox_friends_scaling_bench.cc
+++ b/testing/bench/tox_friends_scaling_bench.cc
@@ -4,6 +4,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include <cstddef>
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -267,8 +268,8 @@ struct GroupScalingContext {
                 static_cast<GroupContext *>(user_data)->peer_count++;
             });
         tox_callback_group_peer_exit(main_tox.get(),
-            [](Tox *, uint32_t, uint32_t, Tox_Group_Exit_Type, const uint8_t *, size_t,
-                const uint8_t *, size_t,
+            [](Tox *, uint32_t, uint32_t, Tox_Group_Exit_Type, const uint8_t *, std::size_t,
+                const uint8_t *, std::size_t,
                 void *user_data) { static_cast<GroupContext *>(user_data)->peer_count--; });
 
         Tox_Err_Group_New err_new;
@@ -299,11 +300,11 @@ struct GroupScalingContext {
                     tox_iterate(main_tox.get(), &main_ctx);
 
                     // Poll events
-                    for (size_t i = 0; i < friends.size(); ++i) {
+                    for (std::size_t i = 0; i < friends.size(); ++i) {
                         auto batches = friends[i].runner->poll_events();
                         for (const auto &batch : batches) {
-                            size_t size = tox_events_get_size(batch.get());
-                            for (size_t k = 0; k < size; ++k) {
+                            std::size_t size = tox_events_get_size(batch.get());
+                            for (std::size_t k = 0; k < size; ++k) {
                                 const Tox_Event *e = tox_events_get(batch.get(), k);
                                 if (tox_event_get_type(e) == TOX_EVENT_GROUP_INVITE) {
                                     auto *ev = tox_event_get_group_invite(e);
@@ -311,7 +312,8 @@ struct GroupScalingContext {
                                         = tox_event_group_invite_get_friend_number(ev);
                                     const uint8_t *data
                                         = tox_event_group_invite_get_invite_data(ev);
-                                    size_t len = tox_event_group_invite_get_invite_data_length(ev);
+                                    std::size_t len
+                                        = tox_event_group_invite_get_invite_data_length(ev);
                                     std::vector<uint8_t> invite_data(data, data + len);
                                     friends[i].runner->execute([=](Tox *tox) {
                                         tox_group_invite_accept(tox, friend_number,

--- a/testing/bench/tox_messenger_bench.cc
+++ b/testing/bench/tox_messenger_bench.cc
@@ -4,6 +4,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include <cstddef>
 #include <iostream>
 
 #include "../../testing/support/public/simulation.hh"
@@ -15,7 +16,7 @@ namespace {
 using tox::test::Simulation;
 
 struct Context {
-    size_t count = 0;
+    std::size_t count = 0;
 };
 
 void BM_ToxMessengerThroughput(benchmark::State &state)
@@ -90,11 +91,11 @@ void BM_ToxMessengerThroughput(benchmark::State &state)
     }
 
     const uint8_t msg[] = "benchmark message";
-    const size_t msg_len = sizeof(msg);
+    const std::size_t msg_len = sizeof(msg);
 
     Context ctx;
     tox_callback_friend_message(tox2.get(),
-        [](Tox *, uint32_t, Tox_Message_Type, const uint8_t *, size_t, void *user_data) {
+        [](Tox *, uint32_t, Tox_Message_Type, const uint8_t *, std::size_t, void *user_data) {
             static_cast<Context *>(user_data)->count++;
         });
 
@@ -186,16 +187,16 @@ void BM_ToxMessengerBidirectional(benchmark::State &state)
     }
 
     const uint8_t msg[] = "benchmark message";
-    const size_t msg_len = sizeof(msg);
+    const std::size_t msg_len = sizeof(msg);
 
     Context ctx1, ctx2;
     tox_callback_friend_message(tox1.get(),
-        [](Tox *, uint32_t, Tox_Message_Type, const uint8_t *, size_t, void *user_data) {
+        [](Tox *, uint32_t, Tox_Message_Type, const uint8_t *, std::size_t, void *user_data) {
             static_cast<Context *>(user_data)->count++;
         });
 
     tox_callback_friend_message(tox2.get(),
-        [](Tox *, uint32_t, Tox_Message_Type, const uint8_t *, size_t, void *user_data) {
+        [](Tox *, uint32_t, Tox_Message_Type, const uint8_t *, std::size_t, void *user_data) {
             static_cast<Context *>(user_data)->count++;
         });
 

--- a/testing/fuzzing/bootstrap_fuzz_test.cc
+++ b/testing/fuzzing/bootstrap_fuzz_test.cc
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cstddef>
 #include <cstdio>
 #include <functional>
 #include <memory>
@@ -196,7 +197,7 @@ void TestBootstrap(Fuzz_Data &input)
     assert(dispatch != nullptr);
     setup_callbacks(dispatch);
 
-    size_t input_size = input.size();
+    std::size_t input_size = input.size();
     while (!input.empty()) {
         Tox_Err_Events_Iterate error_iterate;
         Tox_Events *events = tox_events_iterate(tox, true, &error_iterate);
@@ -221,8 +222,8 @@ void TestBootstrap(Fuzz_Data &input)
 
 }
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size)
 {
     Fuzz_Data input{data, size};
     TestBootstrap(input);

--- a/testing/fuzzing/e2e_fuzz_test.cc
+++ b/testing/fuzzing/e2e_fuzz_test.cc
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 #include <cassert>
+#include <cstddef>
 #include <cstdio>
 #include <functional>
 #include <vector>
@@ -244,8 +245,8 @@ const std::vector<uint8_t> startup_data = [] {
 
 }
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size)
 {
     std::vector<uint8_t> full_data(startup_data.size() + size);
     std::copy(startup_data.begin(), startup_data.end(), full_data.begin());

--- a/testing/fuzzing/protodump.cc
+++ b/testing/fuzzing/protodump.cc
@@ -22,6 +22,7 @@
  */
 #include <array>
 #include <cassert>
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
@@ -49,10 +50,13 @@ public:
 
     void push(bool val) { data.push_back(val); }
     void push(uint8_t val) { data.push_back(val); }
-    void push(const uint8_t *bytes, size_t size) { data.insert(data.end(), bytes, bytes + size); }
+    void push(const uint8_t *bytes, std::size_t size)
+    {
+        data.insert(data.end(), bytes, bytes + size);
+    }
 
     // Format: 2 bytes length (big-endian), then data.
-    void push_packet(const uint8_t *bytes, size_t size)
+    void push_packet(const uint8_t *bytes, std::size_t size)
     {
         assert(size <= 65535);
         push(static_cast<uint8_t>(size >> 8));
@@ -197,16 +201,16 @@ void RecordBootstrap(const char *init, const char *bootstrap)
 
     // Set deterministic seeds.
     std::minstd_rand rng1(4);
-    env1.fake_random().set_entropy_source([&](uint8_t *out, size_t count) {
+    env1.fake_random().set_entropy_source([&](uint8_t *out, std::size_t count) {
         std::uniform_int_distribution<uint16_t> dist(0, 255);
-        for (size_t i = 0; i < count; ++i)
+        for (std::size_t i = 0; i < count; ++i)
             out[i] = static_cast<uint8_t>(dist(rng1));
     });
 
     std::minstd_rand rng2(5);
-    env2.fake_random().set_entropy_source([&](uint8_t *out, size_t count) {
+    env2.fake_random().set_entropy_source([&](uint8_t *out, std::size_t count) {
         std::uniform_int_distribution<uint16_t> dist(0, 255);
-        for (size_t i = 0; i < count; ++i)
+        for (std::size_t i = 0; i < count; ++i)
             out[i] = static_cast<uint8_t>(dist(rng2));
     });
 
@@ -216,7 +220,7 @@ void RecordBootstrap(const char *init, const char *bootstrap)
     env1.fake_memory().set_observer([&](bool success) { recorder1.push(success); });
 
     env1.fake_random().set_observer(
-        [&](const uint8_t *data, size_t count) { recorder1.push(data, count); });
+        [&](const uint8_t *data, std::size_t count) { recorder1.push(data, count); });
 
     auto node1 = env1.create_node(33445);
     auto node2 = env2.create_node(33446);

--- a/testing/fuzzing/toxsave_fuzz_test.cc
+++ b/testing/fuzzing/toxsave_fuzz_test.cc
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -21,7 +22,7 @@ void TestSaveDataLoading(Fuzz_Data &input)
     assert(tox_options != nullptr);
     assert(error_options == TOX_ERR_OPTIONS_NEW_OK);
 
-    const size_t savedata_size = input.size();
+    const std::size_t savedata_size = input.size();
     CONSUME_OR_RETURN(const uint8_t *savedata, input, savedata_size);
 
     tox_options_set_experimental_groups_persistence(tox_options, true);
@@ -52,8 +53,8 @@ void TestSaveDataLoading(Fuzz_Data &input)
 
 }
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size)
 {
     Fuzz_Data input{data, size};
     TestSaveDataLoading(input);

--- a/testing/support/bootstrap_scaling_test.cc
+++ b/testing/support/bootstrap_scaling_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -51,7 +52,7 @@ namespace {
         std::cerr << "[Test] Bootstrapping to Node 0 at " << bootstrap_ip << ":" << bootstrap_port
                   << std::endl;
 
-        size_t total_packets = 0;
+        std::size_t total_packets = 0;
         sim.net().add_observer([&](const Packet &) { total_packets++; });
 
         // Everyone else bootstraps to Node 0
@@ -69,7 +70,7 @@ namespace {
         sim.run_until(
             [&]() {
                 all_connected = true;
-                size_t connected_count = 0;
+                std::size_t connected_count = 0;
                 for (int i = 0; i < num_nodes; ++i) {
                     tox_iterate(toxes[i].get(), nullptr);
                     if (tox_self_get_connection_status(toxes[i].get()) != TOX_CONNECTION_NONE) {

--- a/testing/support/doubles/fake_memory.hh
+++ b/testing/support/doubles/fake_memory.hh
@@ -2,6 +2,7 @@
 #define C_TOXCORE_TESTING_SUPPORT_DOUBLES_FAKE_MEMORY_H
 
 #include <atomic>
+#include <cstddef>
 #include <functional>
 
 #include "../public/memory.hh"
@@ -13,14 +14,14 @@ namespace tox::test {
 
 class FakeMemory : public MemorySystem {
 public:
-    using FailureInjector = std::function<bool(size_t size)>;  // Return true to fail
+    using FailureInjector = std::function<bool(std::size_t size)>;  // Return true to fail
     using Observer = std::function<void(bool success)>;
 
     FakeMemory();
     ~FakeMemory() override;
 
-    void *_Nullable malloc(size_t size) override;
-    void *_Nullable realloc(void *_Nullable ptr, size_t size) override;
+    void *_Nullable malloc(std::size_t size) override;
+    void *_Nullable realloc(void *_Nullable ptr, std::size_t size) override;
     void free(void *_Nullable ptr) override;
 
     // Configure failure injection
@@ -34,22 +35,22 @@ public:
      */
     struct Memory c_memory() override;
 
-    size_t current_allocation() const;
-    size_t max_allocation() const;
+    std::size_t current_allocation() const;
+    std::size_t max_allocation() const;
 
 private:
-    void on_allocation(size_t size);
-    void on_deallocation(size_t size);
+    void on_allocation(std::size_t size);
+    void on_deallocation(std::size_t size);
 
     struct Header {
-        size_t size;
-        size_t magic;
+        std::size_t size;
+        std::size_t magic;
     };
-    static constexpr size_t kMagic = 0xDEADC0DE;
-    static constexpr size_t kFreeMagic = 0xBAADF00D;
+    static constexpr std::size_t kMagic = 0xDEADC0DE;
+    static constexpr std::size_t kFreeMagic = 0xBAADF00D;
 
-    std::atomic<size_t> current_allocation_{0};
-    std::atomic<size_t> max_allocation_{0};
+    std::atomic<std::size_t> current_allocation_{0};
+    std::atomic<std::size_t> max_allocation_{0};
 
     FailureInjector failure_injector_;
     Observer observer_;

--- a/testing/support/doubles/fake_network_stack.cc
+++ b/testing/support/doubles/fake_network_stack.cc
@@ -1,6 +1,7 @@
 #include "fake_network_stack.hh"
 
 #include <cerrno>
+#include <cstddef>
 #include <cstring>
 #include <iostream>
 
@@ -26,17 +27,19 @@ static const Network_Funcs kNetworkVtable = {
         },
     .recvbuf = [](void *_Nonnull obj,
                    Socket sock) { return static_cast<FakeNetworkStack *>(obj)->recvbuf(sock); },
-    .recv = [](void *_Nonnull obj, Socket sock, uint8_t *_Nonnull buf,
-                size_t len) { return static_cast<FakeNetworkStack *>(obj)->recv(sock, buf, len); },
+    .recv
+    = [](void *_Nonnull obj, Socket sock, uint8_t *_Nonnull buf,
+          std::size_t len) { return static_cast<FakeNetworkStack *>(obj)->recv(sock, buf, len); },
     .recvfrom =
-        [](void *_Nonnull obj, Socket sock, uint8_t *_Nonnull buf, size_t len,
+        [](void *_Nonnull obj, Socket sock, uint8_t *_Nonnull buf, std::size_t len,
             IP_Port *_Nonnull addr) {
             return static_cast<FakeNetworkStack *>(obj)->recvfrom(sock, buf, len, addr);
         },
-    .send = [](void *_Nonnull obj, Socket sock, const uint8_t *_Nonnull buf,
-                size_t len) { return static_cast<FakeNetworkStack *>(obj)->send(sock, buf, len); },
+    .send
+    = [](void *_Nonnull obj, Socket sock, const uint8_t *_Nonnull buf,
+          std::size_t len) { return static_cast<FakeNetworkStack *>(obj)->send(sock, buf, len); },
     .sendto =
-        [](void *_Nonnull obj, Socket sock, const uint8_t *_Nonnull buf, size_t len,
+        [](void *_Nonnull obj, Socket sock, const uint8_t *_Nonnull buf, std::size_t len,
             const IP_Port *_Nonnull addr) {
             return static_cast<FakeNetworkStack *>(obj)->sendto(sock, buf, len, addr);
         },
@@ -49,13 +52,13 @@ static const Network_Funcs kNetworkVtable = {
         },
     .getsockopt =
         [](void *_Nonnull obj, Socket sock, int level, int optname, void *_Nonnull optval,
-            size_t *_Nonnull optlen) {
+            std::size_t *_Nonnull optlen) {
             return static_cast<FakeNetworkStack *>(obj)->getsockopt(
                 sock, level, optname, optval, optlen);
         },
     .setsockopt =
         [](void *_Nonnull obj, Socket sock, int level, int optname, const void *_Nonnull optval,
-            size_t optlen) {
+            std::size_t optlen) {
             return static_cast<FakeNetworkStack *>(obj)->setsockopt(
                 sock, level, optname, optval, optlen);
         },
@@ -213,7 +216,7 @@ Socket FakeNetworkStack::accept(Socket sock)
     return net_socket_from_native(fd);
 }
 
-int FakeNetworkStack::send(Socket sock, const uint8_t *buf, size_t len)
+int FakeNetworkStack::send(Socket sock, const uint8_t *buf, std::size_t len)
 {
     if (auto *s = get_sock(sock))
         return s->send(buf, len);
@@ -221,7 +224,7 @@ int FakeNetworkStack::send(Socket sock, const uint8_t *buf, size_t len)
     return -1;
 }
 
-int FakeNetworkStack::recv(Socket sock, uint8_t *buf, size_t len)
+int FakeNetworkStack::recv(Socket sock, uint8_t *buf, std::size_t len)
 {
     if (auto *s = get_sock(sock))
         return s->recv(buf, len);
@@ -237,7 +240,7 @@ int FakeNetworkStack::recvbuf(Socket sock)
     return -1;
 }
 
-int FakeNetworkStack::sendto(Socket sock, const uint8_t *buf, size_t len, const IP_Port *addr)
+int FakeNetworkStack::sendto(Socket sock, const uint8_t *buf, std::size_t len, const IP_Port *addr)
 {
     if (auto *s = get_sock(sock))
         return s->sendto(buf, len, addr);
@@ -245,7 +248,7 @@ int FakeNetworkStack::sendto(Socket sock, const uint8_t *buf, size_t len, const 
     return -1;
 }
 
-int FakeNetworkStack::recvfrom(Socket sock, uint8_t *buf, size_t len, IP_Port *addr)
+int FakeNetworkStack::recvfrom(Socket sock, uint8_t *buf, std::size_t len, IP_Port *addr)
 {
     if (auto *s = get_sock(sock))
         return s->recvfrom(buf, len, addr);
@@ -261,7 +264,8 @@ int FakeNetworkStack::socket_nonblock(Socket sock, bool nonblock)
     return -1;
 }
 
-int FakeNetworkStack::getsockopt(Socket sock, int level, int optname, void *optval, size_t *optlen)
+int FakeNetworkStack::getsockopt(
+    Socket sock, int level, int optname, void *optval, std::size_t *optlen)
 {
     if (auto *s = get_sock(sock))
         return s->getsockopt(level, optname, optval, optlen);
@@ -270,7 +274,7 @@ int FakeNetworkStack::getsockopt(Socket sock, int level, int optname, void *optv
 }
 
 int FakeNetworkStack::setsockopt(
-    Socket sock, int level, int optname, const void *optval, size_t optlen)
+    Socket sock, int level, int optname, const void *optval, std::size_t optlen)
 {
     if (auto *s = get_sock(sock))
         return s->setsockopt(level, optname, optval, optlen);

--- a/testing/support/doubles/fake_network_stack.hh
+++ b/testing/support/doubles/fake_network_stack.hh
@@ -1,6 +1,7 @@
 #ifndef C_TOXCORE_TESTING_SUPPORT_DOUBLES_FAKE_NETWORK_STACK_H
 #define C_TOXCORE_TESTING_SUPPORT_DOUBLES_FAKE_NETWORK_STACK_H
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -22,22 +23,23 @@ public:
     Socket socket(int domain, int type, int protocol) override;
     int bind(Socket sock, const IP_Port *_Nonnull addr) override;
     int close(Socket sock) override;
-    int sendto(Socket sock, const uint8_t *_Nonnull buf, size_t len,
+    int sendto(Socket sock, const uint8_t *_Nonnull buf, std::size_t len,
         const IP_Port *_Nonnull addr) override;
-    int recvfrom(Socket sock, uint8_t *_Nonnull buf, size_t len, IP_Port *_Nonnull addr) override;
+    int recvfrom(
+        Socket sock, uint8_t *_Nonnull buf, std::size_t len, IP_Port *_Nonnull addr) override;
 
     int listen(Socket sock, int backlog) override;
     Socket accept(Socket sock) override;
     int connect(Socket sock, const IP_Port *_Nonnull addr) override;
-    int send(Socket sock, const uint8_t *_Nonnull buf, size_t len) override;
-    int recv(Socket sock, uint8_t *_Nonnull buf, size_t len) override;
+    int send(Socket sock, const uint8_t *_Nonnull buf, std::size_t len) override;
+    int recv(Socket sock, uint8_t *_Nonnull buf, std::size_t len) override;
     int recvbuf(Socket sock) override;
 
     int socket_nonblock(Socket sock, bool nonblock) override;
     int getsockopt(Socket sock, int level, int optname, void *_Nonnull optval,
-        size_t *_Nonnull optlen) override;
-    int setsockopt(
-        Socket sock, int level, int optname, const void *_Nonnull optval, size_t optlen) override;
+        std::size_t *_Nonnull optlen) override;
+    int setsockopt(Socket sock, int level, int optname, const void *_Nonnull optval,
+        std::size_t optlen) override;
 
     /**
      * @brief Returns C-compatible Network struct.

--- a/testing/support/doubles/fake_network_udp_test.cc
+++ b/testing/support/doubles/fake_network_udp_test.cc
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "fake_network_stack.hh"
 #include "network_universe.hh"
 
@@ -48,7 +50,7 @@ namespace {
         ASSERT_EQ(stack2.bind(sock2, &addr2), 0);
 
         const char *msg = "Hello UDP";
-        size_t msg_len = strlen(msg) + 1;
+        std::size_t msg_len = strlen(msg) + 1;
 
         // Send from 1 to 2
         ASSERT_EQ(stack1.sendto(sock1, reinterpret_cast<const uint8_t *>(msg), msg_len, &addr2),

--- a/testing/support/doubles/fake_random.hh
+++ b/testing/support/doubles/fake_random.hh
@@ -1,6 +1,7 @@
 #ifndef C_TOXCORE_TESTING_SUPPORT_DOUBLES_FAKE_RANDOM_H
 #define C_TOXCORE_TESTING_SUPPORT_DOUBLES_FAKE_RANDOM_H
 
+#include <cstddef>
 #include <functional>
 #include <random>
 
@@ -13,13 +14,13 @@ namespace tox::test {
 
 class FakeRandom : public RandomSystem {
 public:
-    using EntropySource = std::function<void(uint8_t *_Nonnull out, size_t count)>;
-    using Observer = std::function<void(const uint8_t *_Nonnull data, size_t count)>;
+    using EntropySource = std::function<void(uint8_t *_Nonnull out, std::size_t count)>;
+    using Observer = std::function<void(const uint8_t *_Nonnull data, std::size_t count)>;
 
     explicit FakeRandom(uint64_t seed);
 
     uint32_t uniform(uint32_t upper_bound) override;
-    void bytes(uint8_t *_Nonnull out, size_t count) override;
+    void bytes(uint8_t *_Nonnull out, std::size_t count) override;
 
     /**
      * @brief Set a custom entropy source.

--- a/testing/support/doubles/fake_sockets.hh
+++ b/testing/support/doubles/fake_sockets.hh
@@ -2,6 +2,7 @@
 #define C_TOXCORE_TESTING_SUPPORT_DOUBLES_FAKE_SOCKETS_H
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <functional>
@@ -39,18 +40,20 @@ public:
     virtual int listen(int backlog) = 0;
     virtual std::unique_ptr<FakeSocket> accept(IP_Port *_Nullable addr) = 0;
 
-    virtual int send(const uint8_t *_Nonnull buf, size_t len) = 0;
-    virtual int recv(uint8_t *_Nonnull buf, size_t len) = 0;
+    virtual int send(const uint8_t *_Nonnull buf, std::size_t len) = 0;
+    virtual int recv(uint8_t *_Nonnull buf, std::size_t len) = 0;
 
-    virtual size_t recv_buffer_size() { return 0; }
+    virtual std::size_t recv_buffer_size() { return 0; }
     virtual bool is_readable() { return recv_buffer_size() > 0; }
     virtual bool is_writable() { return true; }
 
-    virtual int sendto(const uint8_t *_Nonnull buf, size_t len, const IP_Port *_Nonnull addr) = 0;
-    virtual int recvfrom(uint8_t *_Nonnull buf, size_t len, IP_Port *_Nonnull addr) = 0;
+    virtual int sendto(const uint8_t *_Nonnull buf, std::size_t len, const IP_Port *_Nonnull addr)
+        = 0;
+    virtual int recvfrom(uint8_t *_Nonnull buf, std::size_t len, IP_Port *_Nonnull addr) = 0;
 
-    virtual int getsockopt(int level, int optname, void *_Nonnull optval, size_t *_Nonnull optlen);
-    virtual int setsockopt(int level, int optname, const void *_Nonnull optval, size_t optlen);
+    virtual int getsockopt(
+        int level, int optname, void *_Nonnull optval, std::size_t *_Nonnull optlen);
+    virtual int setsockopt(int level, int optname, const void *_Nonnull optval, std::size_t optlen);
     virtual int socket_nonblock(bool nonblock);
 
     virtual int close();
@@ -85,12 +88,12 @@ public:
     std::unique_ptr<FakeSocket> accept(IP_Port *_Nullable addr) override;
     int close() override;
 
-    int send(const uint8_t *_Nonnull buf, size_t len) override;
-    int recv(uint8_t *_Nonnull buf, size_t len) override;
-    size_t recv_buffer_size() override;
+    int send(const uint8_t *_Nonnull buf, std::size_t len) override;
+    int recv(uint8_t *_Nonnull buf, std::size_t len) override;
+    std::size_t recv_buffer_size() override;
 
-    int sendto(const uint8_t *_Nonnull buf, size_t len, const IP_Port *_Nonnull addr) override;
-    int recvfrom(uint8_t *_Nonnull buf, size_t len, IP_Port *_Nonnull addr) override;
+    int sendto(const uint8_t *_Nonnull buf, std::size_t len, const IP_Port *_Nonnull addr) override;
+    int recvfrom(uint8_t *_Nonnull buf, std::size_t len, IP_Port *_Nonnull addr) override;
 
     // Called by Universe to deliver a packet
     void push_packet(std::vector<uint8_t> data, IP_Port from);
@@ -134,16 +137,17 @@ public:
     std::unique_ptr<FakeSocket> accept(IP_Port *_Nullable addr) override;
     int close() override;
 
-    int send(const uint8_t *_Nonnull buf, size_t len) override;
-    int recv(uint8_t *_Nonnull buf, size_t len) override;
-    size_t recv_buffer_size() override;
+    int send(const uint8_t *_Nonnull buf, std::size_t len) override;
+    int recv(uint8_t *_Nonnull buf, std::size_t len) override;
+    std::size_t recv_buffer_size() override;
     bool is_readable() override;
     bool is_writable() override;
 
-    int sendto(const uint8_t *_Nonnull buf, size_t len, const IP_Port *_Nonnull addr) override;
-    int recvfrom(uint8_t *_Nonnull buf, size_t len, IP_Port *_Nonnull addr) override;
+    int sendto(const uint8_t *_Nonnull buf, std::size_t len, const IP_Port *_Nonnull addr) override;
+    int recvfrom(uint8_t *_Nonnull buf, std::size_t len, IP_Port *_Nonnull addr) override;
 
-    int getsockopt(int level, int optname, void *_Nonnull optval, size_t *_Nonnull optlen) override;
+    int getsockopt(
+        int level, int optname, void *_Nonnull optval, std::size_t *_Nonnull optlen) override;
 
     // Internal events
     bool handle_packet(const Packet &p);

--- a/testing/support/doubles/network_universe_test.cc
+++ b/testing/support/doubles/network_universe_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "fake_sockets.hh"
 
 namespace tox::test {
@@ -83,11 +85,11 @@ namespace {
 
         int len1 = sock1.recvfrom(buf, sizeof(buf), &from);
         ASSERT_GT(len1, 0);
-        EXPECT_EQ(std::string(reinterpret_cast<char *>(buf), static_cast<size_t>(len1)), msg1);
+        EXPECT_EQ(std::string(reinterpret_cast<char *>(buf), static_cast<std::size_t>(len1)), msg1);
 
         int len2 = sock2.recvfrom(buf, sizeof(buf), &from);
         ASSERT_GT(len2, 0);
-        EXPECT_EQ(std::string(reinterpret_cast<char *>(buf), static_cast<size_t>(len2)), msg2);
+        EXPECT_EQ(std::string(reinterpret_cast<char *>(buf), static_cast<std::size_t>(len2)), msg2);
     }
 
     TEST_F(NetworkUniverseTest, FindFreePortIsIpSpecific)
@@ -196,7 +198,7 @@ namespace {
             IP_Port from;
             int len = nodes[num_nodes - 1 - i].sock->recvfrom(buf, sizeof(buf), &from);
             ASSERT_GT(len, 0);
-            EXPECT_EQ(std::string(reinterpret_cast<char *>(buf), static_cast<size_t>(len)),
+            EXPECT_EQ(std::string(reinterpret_cast<char *>(buf), static_cast<std::size_t>(len)),
                 "Stress test");
             EXPECT_TRUE(ip_equal(&from.ip, &nodes[i].addr.ip));
         }
@@ -232,8 +234,8 @@ namespace {
 
         // If this fails, it means NetworkUniverse is not robust against padding garbage
         ASSERT_GT(len, 0);
-        EXPECT_EQ(
-            std::string(reinterpret_cast<char *>(buf), static_cast<size_t>(len)), "Padding test");
+        EXPECT_EQ(std::string(reinterpret_cast<char *>(buf), static_cast<std::size_t>(len)),
+            "Padding test");
     }
 
     TEST_F(NetworkUniverseTest, TcpRoutingSpecificity)

--- a/testing/support/public/fuzz_data.hh
+++ b/testing/support/public/fuzz_data.hh
@@ -2,6 +2,7 @@
 #define C_TOXCORE_TESTING_SUPPORT_PUBLIC_FUZZ_DATA_H
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>

--- a/testing/support/public/memory.hh
+++ b/testing/support/public/memory.hh
@@ -18,8 +18,8 @@ class MemorySystem {
 public:
     virtual ~MemorySystem();
 
-    virtual void *_Nullable malloc(size_t size) = 0;
-    virtual void *_Nullable realloc(void *_Nullable ptr, size_t size) = 0;
+    virtual void *_Nullable malloc(std::size_t size) = 0;
+    virtual void *_Nullable realloc(void *_Nullable ptr, std::size_t size) = 0;
     virtual void free(void *_Nullable ptr) = 0;
 
     /**

--- a/testing/support/public/network.hh
+++ b/testing/support/public/network.hh
@@ -1,6 +1,7 @@
 #ifndef C_TOXCORE_TESTING_SUPPORT_NETWORK_H
 #define C_TOXCORE_TESTING_SUPPORT_NETWORK_H
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -21,26 +22,27 @@ public:
     virtual int bind(Socket sock, const IP_Port *_Nonnull addr) = 0;
     virtual int close(Socket sock) = 0;
     virtual int sendto(
-        Socket sock, const uint8_t *_Nonnull buf, size_t len, const IP_Port *_Nonnull addr)
+        Socket sock, const uint8_t *_Nonnull buf, std::size_t len, const IP_Port *_Nonnull addr)
         = 0;
-    virtual int recvfrom(Socket sock, uint8_t *_Nonnull buf, size_t len, IP_Port *_Nonnull addr)
+    virtual int recvfrom(
+        Socket sock, uint8_t *_Nonnull buf, std::size_t len, IP_Port *_Nonnull addr)
         = 0;
 
     // TCP Support
     virtual int listen(Socket sock, int backlog) = 0;
     virtual Socket accept(Socket sock) = 0;
     virtual int connect(Socket sock, const IP_Port *_Nonnull addr) = 0;
-    virtual int send(Socket sock, const uint8_t *_Nonnull buf, size_t len) = 0;
-    virtual int recv(Socket sock, uint8_t *_Nonnull buf, size_t len) = 0;
+    virtual int send(Socket sock, const uint8_t *_Nonnull buf, std::size_t len) = 0;
+    virtual int recv(Socket sock, uint8_t *_Nonnull buf, std::size_t len) = 0;
     virtual int recvbuf(Socket sock) = 0;
 
     // Auxiliary
     virtual int socket_nonblock(Socket sock, bool nonblock) = 0;
     virtual int getsockopt(
-        Socket sock, int level, int optname, void *_Nonnull optval, size_t *_Nonnull optlen)
+        Socket sock, int level, int optname, void *_Nonnull optval, std::size_t *_Nonnull optlen)
         = 0;
     virtual int setsockopt(
-        Socket sock, int level, int optname, const void *_Nonnull optval, size_t optlen)
+        Socket sock, int level, int optname, const void *_Nonnull optval, std::size_t optlen)
         = 0;
 
     /**

--- a/testing/support/public/random.hh
+++ b/testing/support/public/random.hh
@@ -1,6 +1,7 @@
 #ifndef C_TOXCORE_TESTING_SUPPORT_RANDOM_H
 #define C_TOXCORE_TESTING_SUPPORT_RANDOM_H
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -19,7 +20,7 @@ public:
     virtual ~RandomSystem();
 
     virtual uint32_t uniform(uint32_t upper_bound) = 0;
-    virtual void bytes(uint8_t *_Nonnull out, size_t count) = 0;
+    virtual void bytes(uint8_t *_Nonnull out, std::size_t count) = 0;
 
     /**
      * @brief Returns C-compatible Random struct.

--- a/testing/support/src/fake_random.cc
+++ b/testing/support/src/fake_random.cc
@@ -1,6 +1,7 @@
 #include "../doubles/fake_random.hh"
 
 #include <algorithm>
+#include <cstddef>
 
 #include "../../../toxcore/rng.h"
 
@@ -44,7 +45,7 @@ uint32_t FakeRandom::uniform(uint32_t upper_bound)
     return dist(rng_);
 }
 
-void FakeRandom::bytes(uint8_t *_Nonnull out, size_t count)
+void FakeRandom::bytes(uint8_t *_Nonnull out, std::size_t count)
 {
     if (entropy_source_) {
         entropy_source_(out, count);

--- a/testing/support/src/tox_network.cc
+++ b/testing/support/src/tox_network.cc
@@ -4,6 +4,7 @@
 
 #include "../public/tox_network.hh"
 
+#include <cstddef>
 #include <cstring>
 #include <future>
 #include <iostream>
@@ -100,7 +101,7 @@ std::vector<ConnectedFriend> setup_connected_friends(Simulation &sim, Tox *_Nonn
             // Check connection status
             int connected_count = 0;
 
-            for (size_t i = 0; i < friends.size(); ++i) {
+            for (std::size_t i = 0; i < friends.size(); ++i) {
                 // Check if main sees friend
                 bool main_sees_friend
                     = tox_friend_get_connection_status(main_tox, friends[i].friend_number, nullptr)
@@ -109,8 +110,8 @@ std::vector<ConnectedFriend> setup_connected_friends(Simulation &sim, Tox *_Nonn
                 // Check if friend sees main by polling events from the runner
                 auto batches = friends[i].runner->poll_events();
                 for (const auto &batch : batches) {
-                    size_t size = tox_events_get_size(batch.get());
-                    for (size_t k = 0; k < size; ++k) {
+                    std::size_t size = tox_events_get_size(batch.get());
+                    for (std::size_t k = 0; k < size; ++k) {
                         const Tox_Event *e = tox_events_get(batch.get(), k);
                         if (tox_event_get_type(e) == TOX_EVENT_FRIEND_CONNECTION_STATUS) {
                             auto *ev = tox_event_get_friend_connection_status(e);
@@ -238,14 +239,14 @@ uint32_t setup_connected_group(
     // Main tox sends invites; friends accept via events polled from their runners.
 
     bool success = false;
-    size_t invites_sent = 0;
+    std::size_t invites_sent = 0;
 
     sim.run_until(
         [&]() {
             tox_iterate(main_tox, &main_state);
 
             // Throttle invites
-            size_t accepted_count = 0;
+            std::size_t accepted_count = 0;
             for (const auto &fs : friend_states) {
                 if (fs.group_number != UINT32_MAX)
                     accepted_count++;
@@ -262,11 +263,11 @@ uint32_t setup_connected_group(
             }
 
             // Process friend events
-            for (size_t i = 0; i < friends.size(); ++i) {
+            for (std::size_t i = 0; i < friends.size(); ++i) {
                 auto batches = friends[i].runner->poll_events();
                 for (const auto &batch : batches) {
-                    size_t size = tox_events_get_size(batch.get());
-                    for (size_t k = 0; k < size; ++k) {
+                    std::size_t size = tox_events_get_size(batch.get());
+                    for (std::size_t k = 0; k < size; ++k) {
                         const Tox_Event *e = tox_events_get(batch.get(), k);
                         Tox_Event_Type type = tox_event_get_type(e);
 
@@ -274,7 +275,7 @@ uint32_t setup_connected_group(
                             auto *ev = tox_event_get_group_invite(e);
                             uint32_t friend_number = tox_event_group_invite_get_friend_number(ev);
                             const uint8_t *data = tox_event_group_invite_get_invite_data(ev);
-                            size_t len = tox_event_group_invite_get_invite_data_length(ev);
+                            std::size_t len = tox_event_group_invite_get_invite_data_length(ev);
 
                             // Accept invite on runner thread.
                             // We must copy data because the event structure will be freed.

--- a/testing/support/tox_network_test.cc
+++ b/testing/support/tox_network_test.cc
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <cstddef>
 #include <iomanip>
 #include <sstream>
 
@@ -42,7 +43,7 @@ namespace {
         } ctx;
 
         tox_callback_friend_message(main_tox.get(),
-            [](Tox *_Nonnull, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull, size_t,
+            [](Tox *_Nonnull, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull, std::size_t,
                 void *_Nullable user_data) { static_cast<Context *>(user_data)->count++; });
 
         for (const auto &f : friends) {
@@ -78,7 +79,7 @@ namespace {
         } ctx;
 
         tox_callback_friend_message(main_tox.get(),
-            [](Tox *_Nonnull, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull, size_t,
+            [](Tox *_Nonnull, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull, std::size_t,
                 void *_Nullable user_data) { static_cast<Context *>(user_data)->count++; });
 
         for (const auto &f : friends) {
@@ -118,7 +119,7 @@ namespace {
         // Verify communication
         std::atomic<bool> received{false};
         tox_callback_friend_message(tox2.get(),
-            [](Tox *_Nonnull, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull, size_t,
+            [](Tox *_Nonnull, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull, std::size_t,
                 void *_Nullable user_data) {
                 *static_cast<std::atomic<bool> *>(user_data) = true;
             });
@@ -156,8 +157,8 @@ namespace {
         } ctx;
 
         tox_callback_group_message(main_tox.get(),
-            [](Tox *_Nonnull, uint32_t, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull, size_t,
-                uint32_t,
+            [](Tox *_Nonnull, uint32_t, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull,
+                std::size_t, uint32_t,
                 void *_Nullable user_data) { static_cast<Context *>(user_data)->count++; });
 
         for (const auto &f : friends) {
@@ -200,8 +201,8 @@ namespace {
         } ctx;
 
         tox_callback_group_message(main_tox.get(),
-            [](Tox *_Nonnull, uint32_t, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull, size_t,
-                uint32_t,
+            [](Tox *_Nonnull, uint32_t, uint32_t, Tox_Message_Type, const uint8_t *_Nonnull,
+                std::size_t, uint32_t,
                 void *_Nullable user_data) { static_cast<Context *>(user_data)->count++; });
 
         for (const auto &f : friends) {
@@ -349,7 +350,7 @@ namespace {
         } ctx;
 
         tox_callback_friend_message(toxF.get(),
-            [](Tox *, uint32_t, Tox_Message_Type, const uint8_t *, size_t, void *user_data) {
+            [](Tox *, uint32_t, Tox_Message_Type, const uint8_t *, std::size_t, void *user_data) {
                 static_cast<Context *>(user_data)->received = true;
             });
 

--- a/toxav/av_test_support.cc
+++ b/toxav/av_test_support.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>

--- a/toxcore/DHT_fuzz_test.cc
+++ b/toxcore/DHT_fuzz_test.cc
@@ -1,6 +1,7 @@
 #include "DHT.h"
 
 #include <cassert>
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <vector>

--- a/toxcore/TCP_common_test.cc
+++ b/toxcore/TCP_common_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "logger.h"
 #include "os_memory.h"
 #include "os_random.h"
@@ -21,7 +23,7 @@ TEST(TCP_common, PriorityQueueOrderingAndIntegrity)
         nullptr,
         // Mock net_send to simulate a full buffer (returns 0)
         // This forces packets into the priority queue.
-        [](void *obj, Socket sock, const uint8_t *buf, size_t len) {
+        [](void *obj, Socket sock, const uint8_t *buf, std::size_t len) {
             (void)obj;
             (void)sock;
             (void)buf;

--- a/toxcore/ev_bench.cc
+++ b/toxcore/ev_bench.cc
@@ -4,6 +4,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include <cstddef>
 #include <cstdlib>
 #include <vector>
 
@@ -32,7 +33,7 @@ public:
 
     void TearDown(const ::benchmark::State &state) override
     {
-        for (size_t i = 0; i < sockets_r.size(); ++i) {
+        for (std::size_t i = 0; i < sockets_r.size(); ++i) {
             close_pair(sockets_r[i], sockets_w[i]);
         }
         sockets_r.clear();

--- a/toxcore/ev_test.cc
+++ b/toxcore/ev_test.cc
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <vector>
 
 #include "ev_test_util.hh"
@@ -282,7 +283,7 @@ TEST_F(EvTest, ReallocPointers)
 
     // Cleanup
     close_pair(rs, ws);
-    for (size_t i = 0; i < extra_sockets_r.size(); ++i) {
+    for (std::size_t i = 0; i < extra_sockets_r.size(); ++i) {
         close_pair(extra_sockets_r[i], extra_sockets_w[i]);
     }
 }

--- a/toxcore/ev_test_util.cc
+++ b/toxcore/ev_test_util.cc
@@ -4,6 +4,8 @@
 
 #include "ev_test_util.hh"
 
+#include <cstddef>
+
 #include "net.h"
 
 #ifdef _WIN32
@@ -76,7 +78,7 @@ void close_pair(Socket s1, Socket s2)
     closesocket(net_socket_to_native(s2));
 }
 
-int write_socket(Socket s, const void *buf, size_t count)
+int write_socket(Socket s, const void *buf, std::size_t count)
 {
     return send(net_socket_to_native(s), (const char *)buf, (int)count, 0);
 }
@@ -99,7 +101,7 @@ void close_pair(Socket s1, Socket s2)
     close(net_socket_to_native(s2));
 }
 
-int write_socket(Socket s, const void *buf, size_t count)
+int write_socket(Socket s, const void *buf, std::size_t count)
 {
     return write(net_socket_to_native(s), buf, count);
 }

--- a/toxcore/ev_test_util.hh
+++ b/toxcore/ev_test_util.hh
@@ -5,7 +5,7 @@
 #ifndef C_TOXCORE_TOXCORE_EV_TEST_UTIL_HH
 #define C_TOXCORE_TOXCORE_EV_TEST_UTIL_HH
 
-#include <stddef.h>
+#include <cstddef>
 
 #include "net.h"
 
@@ -30,6 +30,6 @@ void close_socket(Socket s);
 /**
  * @brief Writes data to a socket.
  */
-int write_socket(Socket s, const void *buf, size_t count);
+int write_socket(Socket s, const void *buf, std::size_t count);
 
 #endif /* C_TOXCORE_TOXCORE_EV_TEST_UTIL_HH */

--- a/toxcore/forwarding_fuzz_test.cc
+++ b/toxcore/forwarding_fuzz_test.cc
@@ -1,6 +1,7 @@
 #include "forwarding.h"
 
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <memory>
 #include <optional>

--- a/toxcore/group_announce_fuzz_test.cc
+++ b/toxcore/group_announce_fuzz_test.cc
@@ -1,6 +1,7 @@
 #include "group_announce.h"
 
 #include <cassert>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <vector>

--- a/toxcore/group_announce_test.cc
+++ b/toxcore/group_announce_test.cc
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "DHT.h"
 #include "attributes.h"
 #include "crypto_core.h"

--- a/toxcore/group_moderation_fuzz_test.cc
+++ b/toxcore/group_moderation_fuzz_test.cc
@@ -1,5 +1,7 @@
 #include "group_moderation.h"
 
+#include <cstddef>
+
 #include "../testing/support/public/fuzz_data.hh"
 #include "../testing/support/public/simulated_environment.hh"
 

--- a/toxcore/net_crypto_fuzz_test.cc
+++ b/toxcore/net_crypto_fuzz_test.cc
@@ -1,6 +1,7 @@
 #include "net_crypto.h"
 
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <functional>
 #include <memory>

--- a/toxcore/onion_client_fuzz_test.cc
+++ b/toxcore/onion_client_fuzz_test.cc
@@ -1,6 +1,7 @@
 #include "onion_client.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
 #include <map>
 #include <memory>

--- a/toxcore/onion_client_test.cc
+++ b/toxcore/onion_client_test.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstring>
 #include <functional>
 #include <iostream>

--- a/toxcore/sort_bench.cc
+++ b/toxcore/sort_bench.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <random>
 

--- a/toxcore/test_util.hh
+++ b/toxcore/test_util.hh
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <memory>

--- a/toxcore/tox_events_fuzz_test.cc
+++ b/toxcore/tox_events_fuzz_test.cc
@@ -1,6 +1,7 @@
 #include "tox_events.h"
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <vector>


### PR DESCRIPTION
On some stdlibs, `size_t` doesn't exist in the global namespace.

Fixes #3020.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3021)
<!-- Reviewable:end -->
