### PR TITLE
test: Improve simulation determinism and reliability.

### DIFF
--- a/testing/bench/tox_friends_scaling_bench.cc
+++ b/testing/bench/tox_friends_scaling_bench.cc
@@ -42,7 +42,7 @@ public:
         sim.reset();
 
         int num_friends = state.range(0);
-        sim = std::make_unique<Simulation>();
+        sim = std::make_unique<Simulation>(12345);
         main_node = sim->create_node();
         main_tox = main_node->create_tox();
 
@@ -86,7 +86,7 @@ public:
         sim.reset();
 
         int num_friends = state.range(0);
-        sim = std::make_unique<Simulation>();
+        sim = std::make_unique<Simulation>(12345);
         sim->net().set_latency(1);  // Low latency to encourage traffic
         sim->net().set_verbose(kVerbose);
 
@@ -212,7 +212,7 @@ struct ConnectedContext {
         main_node.reset();
         sim.reset();
 
-        sim = std::make_unique<Simulation>();
+        sim = std::make_unique<Simulation>(12345);
         sim->net().set_latency(5);
         main_node = sim->create_node();
         main_tox = main_node->create_tox();
@@ -250,7 +250,7 @@ struct GroupScalingContext {
         main_node.reset();
         sim.reset();
 
-        sim = std::make_unique<Simulation>();
+        sim = std::make_unique<Simulation>(12345);
         sim->net().set_latency(5);
         main_node = sim->create_node();
 
@@ -429,7 +429,7 @@ static void BM_MassDiscovery(benchmark::State &state)
     const int num_friends = state.range(0);
 
     for (auto _ : state) {
-        Simulation sim;
+        Simulation sim{12345};
         // Set a realistic latency to ensure packets are in flight and DHT/Onion logic
         // has to run multiple iterations.
         sim.net().set_latency(10);

--- a/testing/bench/tox_messenger_bench.cc
+++ b/testing/bench/tox_messenger_bench.cc
@@ -21,7 +21,7 @@ struct Context {
 
 void BM_ToxMessengerThroughput(benchmark::State &state)
 {
-    Simulation sim;
+    Simulation sim{12345};
     sim.net().set_latency(5);
     auto node1 = sim.create_node();
     auto node2 = sim.create_node();
@@ -117,7 +117,7 @@ BENCHMARK(BM_ToxMessengerThroughput);
 
 void BM_ToxMessengerBidirectional(benchmark::State &state)
 {
-    Simulation sim;
+    Simulation sim{12345};
     sim.net().set_latency(5);
     auto node1 = sim.create_node();
     auto node2 = sim.create_node();

--- a/testing/fuzzing/bootstrap_fuzz_test.cc
+++ b/testing/fuzzing/bootstrap_fuzz_test.cc
@@ -110,14 +110,14 @@ void setup_callbacks(Tox_Dispatch *dispatch)
 
 void TestBootstrap(Fuzz_Data &input)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     env.fake_clock().advance(1000000000);  // Match legacy behavior
     auto node = env.create_node(33445);
     configure_fuzz_memory_source(env.fake_memory(), input);
     configure_fuzz_packet_source(*node->endpoint, input);
 
     // Create a second null system for tox_events_equal check
-    SimulatedEnvironment null_env;
+    SimulatedEnvironment null_env{12346};
     auto null_node = null_env.create_node(0);  // Port 0 (unbound/irrelevant)
 
     Ptr<Tox_Options> opts(tox_options_new(nullptr), tox_options_free);

--- a/testing/fuzzing/e2e_fuzz_test.cc
+++ b/testing/fuzzing/e2e_fuzz_test.cc
@@ -144,7 +144,7 @@ void setup_callbacks(Tox_Dispatch *dispatch)
 
 void TestEndToEnd(Fuzz_Data &input)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     env.fake_clock().advance(1000000000);  // Match legacy behavior
     auto node = env.create_node(33445);
     configure_fuzz_memory_source(env.fake_memory(), input);
@@ -152,7 +152,7 @@ void TestEndToEnd(Fuzz_Data &input)
     configure_fuzz_random_source(env.fake_random(), input);
 
     // Null system replacement for event comparison
-    SimulatedEnvironment null_env;
+    SimulatedEnvironment null_env{12346};
     auto null_node = null_env.create_node(0);
 
     Ptr<Tox_Options> opts(tox_options_new(nullptr), tox_options_free);

--- a/testing/fuzzing/protodump.cc
+++ b/testing/fuzzing/protodump.cc
@@ -196,8 +196,8 @@ void dump(std::vector<uint8_t> recording, const char *filename)
 
 void RecordBootstrap(const char *init, const char *bootstrap)
 {
-    SimulatedEnvironment env1;
-    SimulatedEnvironment env2;
+    SimulatedEnvironment env1{12345};
+    SimulatedEnvironment env2{12346};
 
     // Set deterministic seeds.
     std::minstd_rand rng1(4);

--- a/testing/fuzzing/toxsave_fuzz_test.cc
+++ b/testing/fuzzing/toxsave_fuzz_test.cc
@@ -32,7 +32,7 @@ void TestSaveDataLoading(Fuzz_Data &input)
     tox_options_set_savedata_type(tox_options, TOX_SAVEDATA_TYPE_TOX_SAVE);
 
     Tox_Options_Testing tox_options_testing;
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto node = env.create_node(33445);
     tox_options_testing.operating_system = &node->system;
 

--- a/testing/support/BUILD.bazel
+++ b/testing/support/BUILD.bazel
@@ -60,6 +60,7 @@ cc_library(
 
 cc_test(
     name = "fake_sockets_test",
+    size = "small",
     srcs = ["doubles/fake_sockets_test.cc"],
     deps = [
         ":support",
@@ -71,6 +72,7 @@ cc_test(
 
 cc_test(
     name = "fake_network_udp_test",
+    size = "small",
     srcs = ["doubles/fake_network_udp_test.cc"],
     deps = [
         ":support",
@@ -93,6 +95,7 @@ cc_test(
 
 cc_test(
     name = "fake_network_stack_test",
+    size = "small",
     srcs = ["doubles/fake_network_stack_test.cc"],
     deps = [
         ":support",
@@ -104,6 +107,7 @@ cc_test(
 
 cc_test(
     name = "network_universe_test",
+    size = "small",
     srcs = ["doubles/network_universe_test.cc"],
     deps = [
         ":support",
@@ -115,6 +119,7 @@ cc_test(
 
 cc_test(
     name = "bootstrap_scaling_test",
+    size = "small",
     srcs = ["bootstrap_scaling_test.cc"],
     deps = [
         ":support",
@@ -137,7 +142,6 @@ cc_test(
 
 cc_test(
     name = "tox_network_test",
-    timeout = "long",
     srcs = ["tox_network_test.cc"],
     deps = [
         ":support",

--- a/testing/support/bootstrap_scaling_test.cc
+++ b/testing/support/bootstrap_scaling_test.cc
@@ -17,7 +17,7 @@ namespace {
 
     class BootstrapScalingTest : public ::testing::Test {
     protected:
-        Simulation sim;
+        Simulation sim{12345};
     };
 
     TEST_F(BootstrapScalingTest, TwentyNodes)

--- a/testing/support/doubles/fake_sockets.hh
+++ b/testing/support/doubles/fake_sockets.hh
@@ -79,6 +79,8 @@ protected:
  */
 class FakeUdpSocket : public FakeSocket {
 public:
+    static constexpr std::size_t kMaxQueueSize = 1024;
+
     explicit FakeUdpSocket(NetworkUniverse &universe);
     ~FakeUdpSocket() override;
 
@@ -127,6 +129,9 @@ private:
 class FakeTcpSocket : public FakeSocket {
 public:
     enum State { CLOSED, LISTEN, SYN_SENT, SYN_RECEIVED, ESTABLISHED, CLOSE_WAIT };
+
+    static constexpr std::size_t kMaxBufferSize = 1024 * 1024;
+    static constexpr std::size_t kMaxBacklog = 128;
 
     explicit FakeTcpSocket(NetworkUniverse &universe);
     ~FakeTcpSocket() override;

--- a/testing/support/doubles/fake_sockets_test.cc
+++ b/testing/support/doubles/fake_sockets_test.cc
@@ -193,6 +193,111 @@ namespace {
         EXPECT_EQ(server.recv_buffer_size(), 0);
     }
 
+    TEST_F(FakeUdpSocketTest, QueueLimit)
+    {
+        IP_Port server_addr;
+        ip_init(&server_addr.ip, false);
+        server_addr.ip.ip.v4.uint32 = net_htonl(0x7F000001);
+        server_addr.port = net_htons(9002);
+
+        ASSERT_EQ(server.bind(&server_addr), 0);
+
+        // Fill the queue
+        for (std::size_t i = 0; i < FakeUdpSocket::kMaxQueueSize; ++i) {
+            uint8_t data = static_cast<uint8_t>(i % 256);
+            ASSERT_EQ(client.sendto(&data, 1, &server_addr), 1);
+        }
+
+        universe.process_events(0);
+
+        // This packet should be dropped
+        uint8_t dropped_data = 0xFF;
+        ASSERT_EQ(client.sendto(&dropped_data, 1, &server_addr), 1);
+        universe.process_events(0);
+
+        // Verify we can read MaxQueueSize packets
+        for (std::size_t i = 0; i < FakeUdpSocket::kMaxQueueSize; ++i) {
+            uint8_t recv_buf[1];
+            IP_Port from;
+            ASSERT_EQ(server.recvfrom(recv_buf, 1, &from), 1);
+        }
+
+        // The queue should now be empty
+        uint8_t dummy[1];
+        IP_Port from;
+        EXPECT_EQ(server.recvfrom(dummy, 1, &from), -1);
+        EXPECT_EQ(errno, EWOULDBLOCK);
+    }
+
+    TEST_F(FakeTcpSocketTest, BacklogLimit)
+    {
+        IP_Port server_addr;
+        ip_init(&server_addr.ip, false);
+        server_addr.ip.ip.v4.uint32 = net_htonl(0x7F000001);
+        server_addr.port = net_htons(8082);
+
+        ASSERT_EQ(server.bind(&server_addr), 0);
+        // Small backlog for testing
+        ASSERT_EQ(server.listen(2), 0);
+
+        // Client 1
+        FakeTcpSocket client1{universe};
+        client1.connect(&server_addr);
+        // Client 2
+        FakeTcpSocket client2{universe};
+        client2.connect(&server_addr);
+        // Client 3 (Should be dropped)
+        FakeTcpSocket client3{universe};
+        client3.connect(&server_addr);
+
+        universe.process_events(0);  // Deliver SYNs
+        universe.process_events(0);  // Deliver SYN-ACKs
+        universe.process_events(0);  // Deliver ACKs
+
+        // Accept first two
+        ASSERT_NE(server.accept(nullptr), nullptr);
+        ASSERT_NE(server.accept(nullptr), nullptr);
+
+        // Third should not be there
+        EXPECT_EQ(server.accept(nullptr), nullptr);
+        EXPECT_EQ(errno, EWOULDBLOCK);
+    }
+
+    TEST_F(FakeTcpSocketTest, BufferLimit)
+    {
+        IP_Port server_addr;
+        ip_init(&server_addr.ip, false);
+        server_addr.ip.ip.v4.uint32 = net_htonl(0x7F000001);
+        server_addr.port = net_htons(8083);
+
+        server.bind(&server_addr);
+        server.listen(5);
+        client.connect(&server_addr);
+
+        // Handshake
+        universe.process_events(0);  // SYN
+        universe.process_events(0);  // SYN-ACK
+        universe.process_events(0);  // ACK
+
+        auto accepted = server.accept(nullptr);
+        ASSERT_NE(accepted, nullptr);
+
+        // Fill buffer to just below limit
+        std::vector<uint8_t> large_data(FakeTcpSocket::kMaxBufferSize - 10, 'A');
+        ASSERT_EQ(client.send(large_data.data(), large_data.size()), large_data.size());
+        universe.process_events(0);
+
+        EXPECT_EQ(accepted->recv_buffer_size(), FakeTcpSocket::kMaxBufferSize - 10);
+
+        // Send 20 more bytes, total would exceed limit
+        uint8_t extra_data[20];
+        ASSERT_EQ(client.send(extra_data, 20), 20);
+        universe.process_events(0);
+
+        // Size should remain the same
+        EXPECT_EQ(accepted->recv_buffer_size(), FakeTcpSocket::kMaxBufferSize - 10);
+    }
+
 }  // namespace
 }  // namespace tox::test
 

--- a/testing/support/public/simulated_environment.hh
+++ b/testing/support/public/simulated_environment.hh
@@ -43,7 +43,7 @@ struct ScopedToxSystem {
 
 class SimulatedEnvironment : public Environment {
 public:
-    SimulatedEnvironment();
+    explicit SimulatedEnvironment(uint64_t seed);
     ~SimulatedEnvironment() override;
 
     NetworkSystem &network() override;

--- a/testing/support/public/simulation.hh
+++ b/testing/support/public/simulation.hh
@@ -89,7 +89,7 @@ class Simulation {
 public:
     static constexpr uint32_t kDefaultTickIntervalMs = 50;
 
-    Simulation();
+    explicit Simulation(uint64_t seed);
     ~Simulation();
 
     // Time Control
@@ -157,6 +157,8 @@ public:
     NetworkUniverse &net() { return *net_; }
     const NetworkUniverse &net() const { return *net_; }
 
+    uint64_t seed() const { return seed_; }
+
     // Node Factory
     std::unique_ptr<SimulatedNode> create_node();
 
@@ -164,7 +166,8 @@ private:
     std::unique_ptr<FakeClock> clock_;
     std::unique_ptr<NetworkUniverse> net_;
     LogFilter log_filter_;
-    uint32_t node_count_ = 0;
+    const uint64_t seed_;
+    std::atomic<uint32_t> node_count_{0};
 
     // Barrier State
     std::mutex barrier_mutex_;

--- a/testing/support/simulation_test.cc
+++ b/testing/support/simulation_test.cc
@@ -62,7 +62,7 @@ TEST(LogFilterTest, LevelComparison)
 
 TEST(LogFilterTest, SimulationIntegration)
 {
-    Simulation sim;
+    Simulation sim{0};
     sim.net().set_verbose(true);
 
     sim.set_log_filter(log_filter::level(TOX_LOG_LEVEL_ERROR) && log_filter::node(1));

--- a/testing/support/src/simulated_environment.cc
+++ b/testing/support/src/simulated_environment.cc
@@ -4,9 +4,9 @@
 
 namespace tox::test {
 
-SimulatedEnvironment::SimulatedEnvironment()
-    : sim_(std::make_unique<Simulation>())
-    , global_random_(std::make_unique<FakeRandom>(12345))
+SimulatedEnvironment::SimulatedEnvironment(uint64_t seed)
+    : sim_(std::make_unique<Simulation>(seed))
+    , global_random_(std::make_unique<FakeRandom>(seed))
     , global_memory_(std::make_unique<FakeMemory>())
 {
 }

--- a/testing/support/tox_network_test.cc
+++ b/testing/support/tox_network_test.cc
@@ -19,7 +19,7 @@ namespace {
 
     TEST(ToxNetworkTest, SetupConnectedFriends)
     {
-        Simulation sim;
+        Simulation sim{12345};
         sim.net().set_latency(5);
         auto main_node = sim.create_node();
         auto main_tox = main_node->create_tox();
@@ -63,7 +63,7 @@ namespace {
 
     TEST(ToxNetworkTest, Setup50ConnectedFriends)
     {
-        Simulation sim;
+        Simulation sim{12345};
         sim.net().set_latency(5);
         auto main_node = sim.create_node();
         auto main_tox = main_node->create_tox();
@@ -101,7 +101,7 @@ namespace {
 
     TEST(ToxNetworkTest, ConnectFriends)
     {
-        Simulation sim;
+        Simulation sim{12345};
         sim.net().set_latency(5);
         auto node1 = sim.create_node();
         auto tox1 = node1->create_tox();
@@ -138,7 +138,7 @@ namespace {
 
     TEST(ToxNetworkTest, SetupConnectedGroup)
     {
-        Simulation sim;
+        Simulation sim{12345};
         sim.net().set_latency(5);
         auto main_node = sim.create_node();
         auto main_tox = main_node->create_tox();
@@ -183,7 +183,7 @@ namespace {
 
     TEST(ToxNetworkTest, Setup50ConnectedGroup)
     {
-        Simulation sim;
+        Simulation sim{12345};
         sim.net().set_latency(5);
         auto main_node = sim.create_node();
         auto main_tox = main_node->create_tox();
@@ -229,7 +229,7 @@ namespace {
     {
         constexpr bool kDebug = false;
 
-        Simulation sim;
+        Simulation sim{0};
         sim.net().set_verbose(false);
 
         if (kDebug) {

--- a/toxcore/DHT_fuzz_test.cc
+++ b/toxcore/DHT_fuzz_test.cc
@@ -16,7 +16,7 @@ using tox::test::SimulatedEnvironment;
 
 void TestHandleRequest(Fuzz_Data &input)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
 
     CONSUME_OR_RETURN(const std::uint8_t *self_public_key, input, CRYPTO_PUBLIC_KEY_SIZE);
@@ -39,7 +39,7 @@ void TestUnpackNodes(Fuzz_Data &input)
     const int packed_count = unpack_nodes(
         nodes, node_count, &processed_data_len, input.data(), input.size(), tcp_enabled);
     if (packed_count > 0) {
-        SimulatedEnvironment env;
+        SimulatedEnvironment env{12345};
         auto c_mem = env.fake_memory().c_memory();
         Logger *logger = logger_new(&c_mem);
         std::vector<std::uint8_t> packed(packed_count * PACKED_NODE_SIZE_IP6);

--- a/toxcore/DHT_test.cc
+++ b/toxcore/DHT_test.cc
@@ -39,7 +39,7 @@ struct KeyPair {
 
 TEST(IdClosest, KeyIsClosestToItself)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     PublicKey pk0 = random_pk(&c_rng);
@@ -54,7 +54,7 @@ TEST(IdClosest, KeyIsClosestToItself)
 
 TEST(IdClosest, IdenticalKeysAreSameDistance)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     PublicKey pk0 = random_pk(&c_rng);
@@ -65,7 +65,7 @@ TEST(IdClosest, IdenticalKeysAreSameDistance)
 
 TEST(IdClosest, DistanceIsCommutative)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     PublicKey pk0 = random_pk(&c_rng);
@@ -152,7 +152,7 @@ Node_format fill(Node_format v, PublicKey const &pk, IP_Port const &ip_port)
 
 TEST(AddToList, AddsFirstKeysInOrder)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     // Make cmp_key the furthest away from 00000... as possible, so all initial inserts succeed.
@@ -255,7 +255,7 @@ TEST(AddToList, AddsFirstKeysInOrder)
 
 TEST(AddToList, KeepsKeysInOrder)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     // Any random cmp_pk should work, as well as the smallest or (approximately) largest pk.
@@ -281,7 +281,7 @@ TEST(AddToList, KeepsKeysInOrder)
 
 TEST(Request, CreateAndParse)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     auto c_rng = env.fake_random().c_random();
 
@@ -339,7 +339,7 @@ TEST(Request, CreateAndParse)
 
 TEST(AnnounceNodes, SetAndTest)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     auto c_rng = env.fake_random().c_random();
 

--- a/toxcore/TCP_client_test.cc
+++ b/toxcore/TCP_client_test.cc
@@ -25,7 +25,7 @@ using namespace tox::test;
 
 class TCPClientTest : public ::testing::Test {
 protected:
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
 
     Mono_Time *_Nonnull create_mono_time(const Memory *_Nonnull mem)
     {

--- a/toxcore/crypto_core_test.cc
+++ b/toxcore/crypto_core_test.cc
@@ -24,7 +24,7 @@ using tox::test::SimulatedEnvironment;
 
 TEST(PkEqual, TwoRandomIdsAreNotEqual)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto &rng = env.fake_random();
 
     std::uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE];
@@ -38,7 +38,7 @@ TEST(PkEqual, TwoRandomIdsAreNotEqual)
 
 TEST(PkEqual, IdCopyMakesKeysEqual)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto &rng = env.fake_random();
 
     std::uint8_t pk1[CRYPTO_PUBLIC_KEY_SIZE];
@@ -53,7 +53,7 @@ TEST(PkEqual, IdCopyMakesKeysEqual)
 
 TEST(CryptoCore, EncryptLargeData)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     auto c_rng = env.fake_random().c_random();
 
@@ -105,7 +105,7 @@ TEST(CryptoCore, IncrementNonceNumber)
 
 TEST(CryptoCore, Signatures)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     Extended_Public_Key pk;
@@ -130,7 +130,7 @@ TEST(CryptoCore, Signatures)
 
 TEST(CryptoCore, Hmac)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     HmacKey sk;

--- a/toxcore/forwarding_fuzz_test.cc
+++ b/toxcore/forwarding_fuzz_test.cc
@@ -56,7 +56,7 @@ void TestSendForwardRequest(Fuzz_Data &input)
     }
     const auto [ipp, forwarder, data, data_size] = prep.value();
 
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto node = env.create_node(ipp.port);
     configure_fuzz_memory_source(env.fake_memory(), input);
 
@@ -87,7 +87,7 @@ void TestForwardReply(Fuzz_Data &input)
     }
     const auto [ipp, forwarder, data, data_size] = prep.value();
 
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto node = env.create_node(ipp.port);
     configure_fuzz_memory_source(env.fake_memory(), input);
 

--- a/toxcore/friend_connection_test.cc
+++ b/toxcore/friend_connection_test.cc
@@ -111,7 +111,7 @@ using FriendConnNode = FriendConnTestNode<WrappedDHT>;
 
 class FriendConnectionTest : public ::testing::Test {
 protected:
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
 };
 
 TEST_F(FriendConnectionTest, CreationAndDestruction)

--- a/toxcore/group_announce_fuzz_test.cc
+++ b/toxcore/group_announce_fuzz_test.cc
@@ -25,7 +25,7 @@ void TestUnpackAnnouncesList(Fuzz_Data &input)
     // TODO(iphydf): How do we know the packed size?
     CONSUME1_OR_RETURN(const std::uint16_t, packed_size, input);
 
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Logger *logger = logger_new(&c_mem);
     if (gca_unpack_announces_list(logger, input.data(), input.size(), announces.data(), max_count)
@@ -46,7 +46,7 @@ void TestUnpackPublicAnnounce(Fuzz_Data &input)
     // TODO(iphydf): How do we know the packed size?
     CONSUME1_OR_RETURN(const std::uint16_t, packed_size, input);
 
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Logger *logger = logger_new(&c_mem);
     if (gca_unpack_public_announce(logger, input.data(), input.size(), &public_announce) != -1) {
@@ -59,7 +59,7 @@ void TestUnpackPublicAnnounce(Fuzz_Data &input)
 
 void TestDoGca(Fuzz_Data &input)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     std::unique_ptr<Logger, void (*)(Logger *)> logger(logger_new(&c_mem), logger_kill);
 

--- a/toxcore/group_announce_test.cc
+++ b/toxcore/group_announce_test.cc
@@ -22,7 +22,7 @@ using tox::test::SimulatedEnvironment;
 
 struct Announces : ::testing::Test {
 protected:
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     Memory c_mem_;
     Mono_Time *_Nullable mono_time_ = nullptr;
     GC_Announces_List *_Nullable gca_ = nullptr;
@@ -126,7 +126,7 @@ TEST_F(Announces, AnnouncesGetAndCleanup)
 
 struct AnnouncesPack : ::testing::Test {
 protected:
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     Memory c_mem_;
     std::vector<GC_Announce> announces_;
     Logger *logger_ = nullptr;

--- a/toxcore/group_moderation_fuzz_test.cc
+++ b/toxcore/group_moderation_fuzz_test.cc
@@ -13,7 +13,7 @@ using tox::test::SimulatedEnvironment;
 void TestModListUnpack(Fuzz_Data &input)
 {
     CONSUME1_OR_RETURN(const std::uint16_t, num_mods, input);
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     mod_list_unpack(&mods, input.data(), input.size(), num_mods);

--- a/toxcore/group_moderation_test.cc
+++ b/toxcore/group_moderation_test.cc
@@ -24,7 +24,7 @@ using ModerationHash = std::array<std::uint8_t, MOD_MODERATION_HASH_SIZE>;
 
 TEST(ModList, PackedSizeOfEmptyModListIsZero)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     EXPECT_EQ(mod_list_packed_size(&mods), 0);
@@ -36,7 +36,7 @@ TEST(ModList, PackedSizeOfEmptyModListIsZero)
 
 TEST(ModList, UnpackingZeroSizeArrayIsNoop)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     const std::uint8_t byte = 1;
@@ -45,7 +45,7 @@ TEST(ModList, UnpackingZeroSizeArrayIsNoop)
 
 TEST(ModList, AddRemoveMultipleMods)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     std::uint8_t sig_pk1[32] = {1};
@@ -59,7 +59,8 @@ TEST(ModList, AddRemoveMultipleMods)
 TEST(ModList, PackingAndUnpackingList)
 {
     using ModListEntry = std::array<std::uint8_t, MOD_LIST_ENTRY_SIZE>;
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
+
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     EXPECT_TRUE(mod_list_add_entry(&mods, ModListEntry{}.data()));
@@ -77,7 +78,7 @@ TEST(ModList, PackingAndUnpackingList)
 TEST(ModList, UnpackingTooManyModsFails)
 {
     using ModListEntry = std::array<std::uint8_t, MOD_LIST_ENTRY_SIZE>;
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     EXPECT_TRUE(mod_list_add_entry(&mods, ModListEntry{}.data()));
@@ -94,7 +95,7 @@ TEST(ModList, UnpackingFromEmptyBufferFails)
 {
     std::vector<std::uint8_t> packed(1);
 
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     EXPECT_EQ(mod_list_unpack(&mods, packed.data(), 0, 1), -1);
@@ -102,7 +103,7 @@ TEST(ModList, UnpackingFromEmptyBufferFails)
 
 TEST(ModList, HashOfEmptyModListZeroesOutBuffer)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     auto c_rng = env.fake_random().c_random();
 
@@ -117,7 +118,7 @@ TEST(ModList, HashOfEmptyModListZeroesOutBuffer)
 
 TEST(ModList, RemoveIndexFromEmptyModListFails)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     EXPECT_FALSE(mod_list_remove_index(&mods, 0));
@@ -126,7 +127,7 @@ TEST(ModList, RemoveIndexFromEmptyModListFails)
 
 TEST(ModList, RemoveEntryFromEmptyModListFails)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     std::uint8_t sig_pk[32] = {0};
@@ -135,7 +136,7 @@ TEST(ModList, RemoveEntryFromEmptyModListFails)
 
 TEST(ModList, ModListRemoveIndex)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     std::uint8_t sig_pk[32] = {1};
@@ -145,7 +146,7 @@ TEST(ModList, ModListRemoveIndex)
 
 TEST(ModList, CleanupOnEmptyModsIsNoop)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     mod_list_cleanup(&mods);
@@ -153,7 +154,7 @@ TEST(ModList, CleanupOnEmptyModsIsNoop)
 
 TEST(ModList, EmptyModListCannotVerifyAnySigPk)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     std::uint8_t sig_pk[32] = {1};
@@ -162,7 +163,7 @@ TEST(ModList, EmptyModListCannotVerifyAnySigPk)
 
 TEST(ModList, ModListAddVerifyRemoveSigPK)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods{&c_mem};
     std::uint8_t sig_pk[32] = {1};
@@ -174,7 +175,7 @@ TEST(ModList, ModListAddVerifyRemoveSigPK)
 
 TEST(ModList, ModListHashCheck)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mods1{&c_mem};
     std::uint8_t sig_pk1[32] = {1};
@@ -198,7 +199,7 @@ TEST(SanctionsList, PackingIntoUndersizedBufferFails)
 
 TEST(SanctionsList, PackUnpackSanctionsCreds)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Moderation mod{&c_mem};
     std::array<std::uint8_t, MOD_SANCTIONS_CREDS_SIZE> packed;
@@ -209,7 +210,7 @@ TEST(SanctionsList, PackUnpackSanctionsCreds)
 
 struct SanctionsListMod : ::testing::Test {
 protected:
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     Memory c_mem_;
     Random c_rng_;
 

--- a/toxcore/mono_time_test.cc
+++ b/toxcore/mono_time_test.cc
@@ -15,7 +15,7 @@ using tox::test::SimulatedEnvironment;
 
 TEST(MonoTime, TimeIncreasesWhenAdvanced)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Mono_Time *mono_time = mono_time_new(&c_mem, nullptr, nullptr);
     ASSERT_NE(mono_time, nullptr);
@@ -37,7 +37,7 @@ TEST(MonoTime, TimeIncreasesWhenAdvanced)
 
 TEST(MonoTime, IsTimeout)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Mono_Time *mono_time = mono_time_new(&c_mem, nullptr, nullptr);
     ASSERT_NE(mono_time, nullptr);
@@ -57,7 +57,7 @@ TEST(MonoTime, IsTimeout)
 
 TEST(MonoTime, IsTimeoutWithIntermediateUpdates)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Mono_Time *mono_time = mono_time_new(&c_mem, nullptr, nullptr);
     ASSERT_NE(mono_time, nullptr);
@@ -82,7 +82,7 @@ TEST(MonoTime, IsTimeoutWithIntermediateUpdates)
 
 TEST(MonoTime, CustomTime)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     Mono_Time *mono_time = mono_time_new(&c_mem, nullptr, nullptr);
     ASSERT_NE(mono_time, nullptr);

--- a/toxcore/net_crypto_fuzz_test.cc
+++ b/toxcore/net_crypto_fuzz_test.cc
@@ -54,7 +54,7 @@ void TestNetCrypto(Fuzz_Data &input)
     }
     const auto [ipp, iterations] = prep.value();
 
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     env.fake_clock().advance(1000000000);  // Start clock high to match legacy behavior
     auto node = env.create_node(ipp.port);
     configure_fuzz_memory_source(env.fake_memory(), input);

--- a/toxcore/net_crypto_test.cc
+++ b/toxcore/net_crypto_test.cc
@@ -207,7 +207,7 @@ using RealDHTNode = TestNode<WrappedDHT>;
 
 class NetCryptoTest : public ::testing::Test {
 protected:
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
 };
 
 TEST_F(NetCryptoTest, EndToEndDataExchange)

--- a/toxcore/network_test.cc
+++ b/toxcore/network_test.cc
@@ -13,7 +13,7 @@ namespace {
 
 TEST(SimulatedEnvironment, ProducesNonNullNetwork)
 {
-    tox::test::SimulatedEnvironment env;
+    tox::test::SimulatedEnvironment env{12345};
     auto node = env.create_node(0);
     struct Network net = node->c_network;
     EXPECT_NE(net.funcs, nullptr);

--- a/toxcore/onion_client_fuzz_test.cc
+++ b/toxcore/onion_client_fuzz_test.cc
@@ -387,7 +387,7 @@ extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size
     if (size == 0)
         return 0;
 
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     OnionClientFuzzer fuzzer(env);
     Fuzz_Data input(data, size);
     fuzzer.Run(input);

--- a/toxcore/onion_client_test.cc
+++ b/toxcore/onion_client_test.cc
@@ -121,7 +121,7 @@ public:
     }
 
 protected:
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
 };
 
 TEST_F(OnionClientTest, CreationAndDestruction)

--- a/toxcore/ping_array_test.cc
+++ b/toxcore/ping_array_test.cc
@@ -37,7 +37,7 @@ using Mono_Time_Ptr = std::unique_ptr<Mono_Time, Mono_Time_Deleter>;
 
 TEST(PingArray, MinimumTimeoutIsOne)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     EXPECT_EQ(ping_array_new(&c_mem, 1, 0), nullptr);
     EXPECT_NE(Ping_Array_Ptr(ping_array_new(&c_mem, 1, 1)), nullptr);
@@ -45,7 +45,7 @@ TEST(PingArray, MinimumTimeoutIsOne)
 
 TEST(PingArray, MinimumArraySizeIsOne)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     EXPECT_EQ(ping_array_new(&c_mem, 0, 1), nullptr);
     EXPECT_NE(Ping_Array_Ptr(ping_array_new(&c_mem, 1, 1)), nullptr);
@@ -53,7 +53,7 @@ TEST(PingArray, MinimumArraySizeIsOne)
 
 TEST(PingArray, ArraySizeMustBePowerOfTwo)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
 
     Ping_Array_Ptr arr;
@@ -70,7 +70,7 @@ TEST(PingArray, ArraySizeMustBePowerOfTwo)
 
 TEST(PingArray, StoredDataCanBeRetrieved)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     auto c_rng = env.fake_random().c_random();
 
@@ -89,7 +89,7 @@ TEST(PingArray, StoredDataCanBeRetrieved)
 
 TEST(PingArray, RetrievingDataWithTooSmallOutputBufferHasNoEffect)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     auto c_rng = env.fake_random().c_random();
 
@@ -112,7 +112,7 @@ TEST(PingArray, RetrievingDataWithTooSmallOutputBufferHasNoEffect)
 
 TEST(PingArray, ZeroLengthDataCanBeAdded)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     auto c_rng = env.fake_random().c_random();
 
@@ -129,7 +129,7 @@ TEST(PingArray, ZeroLengthDataCanBeAdded)
 
 TEST(PingArray, PingId0IsInvalid)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
 
     Ping_Array_Ptr const arr(ping_array_new(&c_mem, 2, 1));
@@ -143,7 +143,7 @@ TEST(PingArray, PingId0IsInvalid)
 // Protection against replay attacks.
 TEST(PingArray, DataCanOnlyBeRetrievedOnce)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     auto c_rng = env.fake_random().c_random();
 
@@ -161,7 +161,7 @@ TEST(PingArray, DataCanOnlyBeRetrievedOnce)
 
 TEST(PingArray, PingIdMustMatchOnCheck)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_mem = env.fake_memory().c_memory();
     auto c_rng = env.fake_random().c_random();
 

--- a/toxcore/shared_key_cache_test.cc
+++ b/toxcore/shared_key_cache_test.cc
@@ -23,7 +23,7 @@ class SharedKeyCacheTest : public ::testing::Test {
 protected:
     void SetUp() override
     {
-        sim = std::make_unique<Simulation>();
+        sim = std::make_unique<Simulation>(12345);
         node = sim->create_node();
         crypto_new_keypair(&node->c_random, alice_pk, alice_sk);
 

--- a/toxcore/test_util_test.cc
+++ b/toxcore/test_util_test.cc
@@ -16,7 +16,7 @@ using tox::test::SimulatedEnvironment;
 
 TEST(CryptoCoreTestUtil, RandomBytesDoesNotTouchZeroSizeArray)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     std::array<std::uint8_t, 32> bytes{};
@@ -28,7 +28,7 @@ TEST(CryptoCoreTestUtil, RandomBytesDoesNotTouchZeroSizeArray)
 
 TEST(CryptoCoreTestUtil, RandomBytesFillsEntireArray)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     std::array<std::uint8_t, 32> bytes{};
@@ -51,7 +51,7 @@ TEST(CryptoCoreTestUtil, RandomBytesFillsEntireArray)
 
 TEST(CryptoCoreTestUtil, RandomBytesDoesNotBufferOverrun)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto c_rng = env.fake_random().c_random();
 
     std::array<std::uint8_t, 32> bytes{};

--- a/toxcore/tox_events_fuzz_test.cc
+++ b/toxcore/tox_events_fuzz_test.cc
@@ -33,8 +33,8 @@ void TestUnpack(Fuzz_Data data)
         return;
     }
 
-    // rest of the fuzz data is input for std::malloc
-    SimulatedEnvironment env;
+    // rest of the fuzz data is input for malloc
+    SimulatedEnvironment env{12345};
     auto node = env.create_node(33445);
     configure_fuzz_memory_source(env.fake_memory(), data);
 

--- a/toxcore/tox_events_test.cc
+++ b/toxcore/tox_events_test.cc
@@ -18,7 +18,7 @@ using tox::test::SimulatedEnvironment;
 
 TEST(ToxEvents, UnpackRandomDataDoesntCrash)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto node = env.create_node(33445);
     ASSERT_NE(node->system.rng, nullptr);
     std::array<std::uint8_t, 128> data;
@@ -28,7 +28,7 @@ TEST(ToxEvents, UnpackRandomDataDoesntCrash)
 
 TEST(ToxEvents, UnpackEmptyDataFails)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto node = env.create_node(33445);
     std::array<std::uint8_t, 1> data;
     Tox_Events *events = tox_events_load(&node->system, data.data(), 0);
@@ -37,7 +37,7 @@ TEST(ToxEvents, UnpackEmptyDataFails)
 
 TEST(ToxEvents, UnpackEmptyArrayCreatesEmptyEvents)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto node = env.create_node(33445);
     std::array<std::uint8_t, 1> data{0x90};  // empty msgpack array
     Tox_Events *events = tox_events_load(&node->system, data.data(), data.size());
@@ -56,7 +56,7 @@ TEST(ToxEvents, NullEventsPacksToEmptyArray)
 
 TEST(ToxEvents, PackedEventsCanBeUnpacked)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto node = env.create_node(33445);
     // [[0, 1]] == Tox_Self_Connection_Status { .connection_status = TOX_CONNECTION_TCP }
     std::array<std::uint8_t, 6> packed{0x91, 0x92, 0xcc, 0x00, 0xcc, 0x01};
@@ -71,7 +71,7 @@ TEST(ToxEvents, PackedEventsCanBeUnpacked)
 
 TEST(ToxEvents, DealsWithHugeMsgpackArrays)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     auto node = env.create_node(33445);
     std::vector<std::uint8_t> data{0xdd, 0xff, 0xff, 0xff, 0xff};
     EXPECT_EQ(tox_events_load(&node->system, data.data(), data.size()), nullptr);

--- a/toxcore/tox_test.cc
+++ b/toxcore/tox_test.cc
@@ -10,7 +10,6 @@
 
 #include "attributes.h"
 #include "crypto_core.h"
-#include "os_random.h"
 #include "tox_log_level.h"
 #include "tox_options.h"
 #include "tox_private.h"
@@ -88,7 +87,7 @@ TEST(Tox, BootstrapErrorCodes)
 
 TEST(Tox, OneTest)
 {
-    SimulatedEnvironment env;
+    SimulatedEnvironment env{12345};
     struct Tox_Options *options = tox_options_new(nullptr);
     ASSERT_NE(options, nullptr);
 
@@ -115,8 +114,7 @@ TEST(Tox, OneTest)
 
     Tox *tox1 = tox_new_testing(options, nullptr, &testing_opts1, nullptr);
     ASSERT_NE(tox1, nullptr);
-    const Random *rng = os_random();
-    ASSERT_NE(rng, nullptr);
+    const Random *rng = &node1->c_random;
     set_random_name_and_status_message(tox1, rng, name.data(), status_message.data());
 
     auto node2 = env.create_node(33546);


### PR DESCRIPTION
Require explicit seeds for `Simulation` and `SimulatedEnvironment` to ensure reproducible test results.

Also:
- Drop packets in `FakeUdpSocket` when the receive queue is full to prevent unbounded memory growth during stress tests.
- Improve synchronization in `Simulation::run_until` by adding a timeout to the barrier wait, preventing hangs if a runner is unregistered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3023)
<!-- Reviewable:end -->
