### PR TITLE
test: Fix VideoTest failures via codec fallbacks and add better logging.

### DIFF
--- a/toxav/av_test_support.cc
+++ b/toxav/av_test_support.cc
@@ -6,8 +6,40 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 
 #include "../toxcore/os_memory.h"
+
+static void test_log_cb(void *context, Logger_Level level, const char *file, uint32_t line,
+    const char *func, const char *message, void *userdata)
+{
+    const char *level_str = "UNKNOWN";
+
+    switch (level) {
+    case LOGGER_LEVEL_TRACE:
+        level_str = "TRACE";
+        break;
+
+    case LOGGER_LEVEL_DEBUG:
+        level_str = "DEBUG";
+        break;
+
+    case LOGGER_LEVEL_INFO:
+        level_str = "INFO";
+        break;
+
+    case LOGGER_LEVEL_WARNING:
+        level_str = "WARNING";
+        break;
+
+    case LOGGER_LEVEL_ERROR:
+        level_str = "ERROR";
+        break;
+    }
+
+    std::cerr << "[" << level_str << "] " << file << ":" << line << " " << func << ": " << message
+              << "\n";
+}
 
 // Mock Time
 std::uint64_t mock_time_cb(void *_Nullable ud) { return static_cast<MockTime *>(ud)->t; }
@@ -168,6 +200,7 @@ void AvTest::SetUp()
 {
     mem = os_memory();
     log = logger_new(mem);
+    logger_callback_log(log, test_log_cb, nullptr, nullptr);
     tm.t = 1000;
     mono_time = mono_time_new(mem, mock_time_cb, &tm);
     mono_time_update(mono_time);


### PR DESCRIPTION
Progressive fallbacks for VP8 encoder and decoder in `vc_new` and `vc_reconfigure_encoder` to handle environments with limited codec support (e.g., no threading or post-processing).

Also:
- Add a logging callback to `AvTest` to print diagnostic messages to stderr during tests.
- Upgrade several warnings to errors in `vc_new` and improve error reporting overall.

See #3022.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3024)
<!-- Reviewable:end -->
