### PR TITLE
cleanup: Generalise byte-array logging functions.

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2424,23 +2424,6 @@ static void m_connection_status_callback(Messenger *_Nonnull m, void *_Nullable 
 
 #define DUMPING_CLIENTS_FRIENDS_EVERY_N_SECONDS 60UL
 
-#define IDSTRING_LEN (CRYPTO_PUBLIC_KEY_SIZE * 2 + 1)
-/** id_str should be of length at least IDSTRING_LEN */
-static char *_Nonnull id_to_string(const uint8_t *_Nonnull pk, char *_Nonnull id_str, size_t length)
-{
-    if (length < IDSTRING_LEN) {
-        snprintf(id_str, length, "Bad buf length");
-        return id_str;
-    }
-
-    for (uint32_t i = 0; i < CRYPTO_PUBLIC_KEY_SIZE; ++i) {
-        snprintf(&id_str[i * 2], length - i * 2, "%02X", pk[i]);
-    }
-
-    id_str[CRYPTO_PUBLIC_KEY_SIZE * 2] = '\0';
-    return id_str;
-}
-
 /** @brief Minimum messenger run interval in ms
  * TODO(mannol): A/V
  */
@@ -2602,11 +2585,12 @@ void do_messenger(Messenger *m, void *userdata)
                     }
 
                     Ip_Ntoa ip_str;
-                    char id_str[IDSTRING_LEN];
+                    char id_str[TOX_BYTES_TO_STRING_BUF_SIZE];
+                    bytes_to_string(cptr->public_key, CRYPTO_PUBLIC_KEY_SIZE, id_str, sizeof(id_str));
                     LOGGER_TRACE(m->log, "C[%2u] %s:%u [%3u] %s",
                                  client, net_ip_ntoa(&assoc->ip_port.ip, &ip_str),
                                  net_ntohs(assoc->ip_port.port), last_pinged,
-                                 id_to_string(cptr->public_key, id_str, sizeof(id_str)));
+                                 id_str);
                 }
             }
         }
@@ -2649,14 +2633,16 @@ void do_messenger(Messenger *m, void *userdata)
             const DHT_Friend *const dhtfptr = dht_get_friend(m->dht, friend_idx);
 
             if (msgfptr != nullptr) {
-                char id_str[IDSTRING_LEN];
+                char id_str[TOX_BYTES_TO_STRING_BUF_SIZE];
+                bytes_to_string(msgfptr->real_pk, CRYPTO_PUBLIC_KEY_SIZE, id_str, sizeof(id_str));
                 LOGGER_TRACE(m->log, "F[%2d:%2u] <%s> %s",
                              dht2m[friend_idx], friend_idx, msgfptr->name,
-                             id_to_string(msgfptr->real_pk, id_str, sizeof(id_str)));
+                             id_str);
             } else {
-                char id_str[IDSTRING_LEN];
+                char id_str[TOX_BYTES_TO_STRING_BUF_SIZE];
+                bytes_to_string(dht_friend_public_key(dhtfptr), CRYPTO_PUBLIC_KEY_SIZE, id_str, sizeof(id_str));
                 LOGGER_TRACE(m->log, "F[--:%2u] %s", friend_idx,
-                             id_to_string(dht_friend_public_key(dhtfptr), id_str, sizeof(id_str)));
+                             id_str);
             }
 
             for (uint32_t client = 0; client < MAX_FRIEND_CLIENTS; ++client) {
@@ -2674,11 +2660,12 @@ void do_messenger(Messenger *m, void *userdata)
                         }
 
                         Ip_Ntoa ip_str;
-                        char id_str[IDSTRING_LEN];
+                        char id_str[TOX_BYTES_TO_STRING_BUF_SIZE];
+                        bytes_to_string(cptr->public_key, CRYPTO_PUBLIC_KEY_SIZE, id_str, sizeof(id_str));
                         LOGGER_TRACE(m->log, "F[%2u] => C[%2u] %s:%u [%3u] %s",
                                      friend_idx, client, net_ip_ntoa(&assoc->ip_port.ip, &ip_str),
                                      net_ntohs(assoc->ip_port.port), last_pinged,
-                                     id_to_string(cptr->public_key, id_str, sizeof(id_str)));
+                                     id_str);
                     }
                 }
             }

--- a/toxcore/net_log.c
+++ b/toxcore/net_log.c
@@ -14,27 +14,6 @@
 #include "network.h"
 #include "util.h"
 
-static uint32_t data_0(uint16_t buflen, const uint8_t *_Nonnull buffer)
-{
-    uint32_t data = 0;
-
-    if (buflen > 4) {
-        net_unpack_u32(buffer + 1, &data);
-    }
-
-    return data;
-}
-static uint32_t data_1(uint16_t buflen, const uint8_t *_Nonnull buffer)
-{
-    uint32_t data = 0;
-
-    if (buflen > 8) {
-        net_unpack_u32(buffer + 5, &data);
-    }
-
-    return data;
-}
-
 static const char *_Nonnull net_packet_type_name(Net_Packet_Type type)
 {
     switch (type) {
@@ -154,27 +133,45 @@ void net_log_data(const Logger *log, const char *message, const uint8_t *buffer,
                   uint16_t buflen, const IP_Port *ip_port, long res)
 {
     if (res < 0) { /* Windows doesn't necessarily know `%zu` */
+        char data_str[TOX_BYTES_TO_STRING_BUF_SIZE] = {'\0'};
+
+        if (buflen > 1) {
+            bytes_to_string(buffer + 1, buflen - 1, data_str, sizeof(data_str));
+        }
+
         Ip_Ntoa ip_str;
         const int error = net_error();
         Net_Strerror error_str;
-        LOGGER_TRACE(log, "[%02x = %-21s] %s %3u%c %s:%u (%d: %s) | %08x%08x...%02x",
+        LOGGER_TRACE(log, "[%02x = %-21s] %s %3u%c %s:%u (%d: %s) | %s",
                      buffer[0], net_packet_type_name((Net_Packet_Type)buffer[0]), message,
                      min_u16(buflen, 999), 'E',
                      net_ip_ntoa(&ip_port->ip, &ip_str), net_ntohs(ip_port->port), error,
-                     net_strerror(error, &error_str), data_0(buflen, buffer), data_1(buflen, buffer), buffer[buflen - 1]);
+                     net_strerror(error, &error_str), data_str);
     } else if ((res > 0) && ((size_t)res <= buflen)) {
+        char data_str[TOX_BYTES_TO_STRING_BUF_SIZE] = {'\0'};
+
+        if (res > 1) {
+            bytes_to_string(buffer + 1, (size_t)res - 1, data_str, sizeof(data_str));
+        }
+
         Ip_Ntoa ip_str;
-        LOGGER_TRACE(log, "[%02x = %-21s] %s %3u%c %s:%u (%d: %s) | %08x%08x...%02x",
+        LOGGER_TRACE(log, "[%02x = %-21s] %s %3u%c %s:%u (%d: %s) | %s",
                      buffer[0], net_packet_type_name((Net_Packet_Type)buffer[0]), message,
                      min_u16(res, 999), (size_t)res < buflen ? '<' : '=',
                      net_ip_ntoa(&ip_port->ip, &ip_str), net_ntohs(ip_port->port), 0, "OK",
-                     data_0(buflen, buffer), data_1(buflen, buffer), buffer[buflen - 1]);
+                     data_str);
     } else { /* empty or overwrite */
+        char data_str[TOX_BYTES_TO_STRING_BUF_SIZE] = {'\0'};
+
+        if (buflen > 1) {
+            bytes_to_string(buffer + 1, buflen - 1, data_str, sizeof(data_str));
+        }
+
         Ip_Ntoa ip_str;
-        LOGGER_TRACE(log, "[%02x = %-21s] %s %ld%c%u %s:%u (%d: %s) | %08x%08x...%02x",
+        LOGGER_TRACE(log, "[%02x = %-21s] %s %ld%c%u %s:%u (%d: %s) | %s",
                      buffer[0], net_packet_type_name((Net_Packet_Type)buffer[0]), message,
                      res, res == 0 ? '!' : '>', buflen,
                      net_ip_ntoa(&ip_port->ip, &ip_str), net_ntohs(ip_port->port), 0, "OK",
-                     data_0(buflen, buffer), data_1(buflen, buffer), buffer[buflen - 1]);
+                     data_str);
     }
 }

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -13,6 +13,7 @@
 
 #include "util.h"
 
+#include <stdio.h>
 #include <string.h>
 
 #include "ccompat.h"
@@ -179,4 +180,38 @@ uint32_t jenkins_one_at_a_time_hash(const uint8_t *key, size_t len)
     hash ^= hash >> 11;
     hash += (uint32_t)((uint64_t)hash << 15);
     return hash;
+}
+
+void bytes_to_string(const uint8_t *bytes, size_t bytes_length, char *str, size_t str_length)
+{
+    if (str_length == 0) {
+        return;
+    }
+
+    if (bytes_length * 2 + 1 <= str_length) {
+        for (size_t i = 0; i < bytes_length; ++i) {
+            snprintf(&str[i * 2], str_length - i * 2, "%02X", bytes[i]);
+        }
+        str[bytes_length * 2] = '\0';
+        return;
+    }
+
+    if (str_length < 6) {
+        snprintf(str, str_length, "...");
+        return;
+    }
+
+    const size_t start_chars = str_length - 6;
+    const size_t start_bytes = start_chars / 2;
+
+    size_t current_pos = 0;
+    for (size_t i = 0; i < start_bytes; ++i) {
+        snprintf(str + current_pos, str_length - current_pos, "%02X", bytes[i]);
+        current_pos += 2;
+    }
+
+    snprintf(str + current_pos, str_length - current_pos, "...");
+    current_pos += 3;
+
+    snprintf(str + current_pos, str_length - current_pos, "%02X", bytes[bytes_length - 1]);
 }

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -97,6 +97,18 @@ uint32_t jenkins_one_at_a_time_hash(const uint8_t *_Nonnull key, size_t len);
  */
 uint16_t data_checksum(const uint8_t *_Nonnull data, uint32_t length);
 
+#define TOX_BYTES_TO_STRING_BUF_SIZE 25
+
+/**
+ * @brief Generic function to print bytes as String.
+ *
+ * @param bytes Bytes to be printed as String.
+ * @param bytes_length The length in bytes
+ * @param str The string to save the result to.
+ * @param str_length Length of the string
+ */
+void bytes_to_string(const uint8_t *_Nonnull bytes, size_t bytes_length, char *_Nonnull str, size_t str_length);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/toxcore/util_test.cc
+++ b/toxcore/util_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <climits>
+#include <cstring>
 
 namespace {
 
@@ -18,6 +19,77 @@ TEST(Cmp, OrdersNumbersCorrectly)
     EXPECT_EQ(cmp_uint(0, UINT64_MAX), -1);
     EXPECT_EQ(cmp_uint(UINT64_MAX, 0), 1);
     EXPECT_EQ(cmp_uint(UINT64_MAX, UINT64_MAX), 0);
+}
+
+TEST(BytesToString, FormatsCorrectly)
+{
+    uint8_t bytes[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE};
+    char str[32];
+
+    // Case 1: Full string fits
+    // Length needed: 5*2 + 1 = 11. Buffer: 12.
+    bytes_to_string(bytes, 5, str, 12);
+    EXPECT_STREQ(str, "AABBCCDDEE");
+
+    // Case 2: Exact fit
+    // Length needed: 11. Buffer: 11.
+    bytes_to_string(bytes, 5, str, 11);
+    EXPECT_STREQ(str, "AABBCCDDEE");
+
+    // Case 3: Truncation needed (1 byte less than full)
+    // Buffer: 10. Available hex: 10 - 6 = 4. Start bytes: 2. End bytes: 1.
+    // Result: AABB...EE
+    bytes_to_string(bytes, 5, str, 10);
+    EXPECT_STREQ(str, "AABB...EE");
+
+    // Case 4: Truncation needed (more severe)
+    // Buffer: 8. Available hex: 8 - 6 = 2. Start bytes: 1. End bytes: 1.
+    // Result: AA...EE
+    bytes_to_string(bytes, 5, str, 8);
+    EXPECT_STREQ(str, "AA...EE");
+
+    // Case 6: Small buffer (< 6)
+    // Buffer: 5.
+    // Result: ...
+    bytes_to_string(bytes, 5, str, 5);
+    EXPECT_STREQ(str, "...");
+
+    // Case 7: Zero length
+    str[0] = 'X';
+    bytes_to_string(bytes, 5, str, 0);
+    EXPECT_EQ(str[0], 'X');  // Should not touch buffer
+}
+
+TEST(BytesToString, HandlesShortInputs)
+{
+    uint8_t bytes[] = {0x11, 0x22};
+    char str[32];
+
+    // Fits easily
+    bytes_to_string(bytes, 2, str, 10);
+    EXPECT_STREQ(str, "1122");
+
+    // Exact fit
+    bytes_to_string(bytes, 2, str, 5);
+    EXPECT_STREQ(str, "1122");
+
+    // Force truncation even on short input if buffer is tiny
+    // Buffer: 4. Full need: 5.
+    // Truncation path: Buffer 4 < 6. Result: ...
+    bytes_to_string(bytes, 2, str, 4);
+    EXPECT_STREQ(str, "...");
+}
+
+TEST(BytesToString, EmptyBytesNullTerminates)
+{
+    uint8_t bytes[] = {0xFF};
+    char str[8];
+    memset(str, 'X', sizeof(str));
+
+    // bytes_length == 0 with a non-zero str_length should produce an empty
+    // null-terminated string, not leave str untouched.
+    bytes_to_string(bytes, 0, str, sizeof(str));
+    EXPECT_STREQ(str, "");
 }
 
 }  // namespace


### PR DESCRIPTION
Add a `bytes_to_string` function that formats a byte array as hex, truncating with `...` when the buffer is too small. Replaces the ad-hoc `id_to_string` in Messenger.c and `data_0`/`data_1` in net_log.c with a shared helper function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3029)
<!-- Reviewable:end -->
