### PR TITLE
fix(dht): Suppress the warning about IPv6 nodes when IPv6 is turned off

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -1295,6 +1295,11 @@ bool dht_send_nodes_request(DHT *dht, const IP_Port *ip_port, const uint8_t *pub
     memcpy(receiver.public_key, public_key, CRYPTO_PUBLIC_KEY_SIZE);
     receiver.ip_port = *ip_port;
 
+    /* Avoid warning message when IPv6 is disabled and node address is IPv6. */
+    if (!net_socket_family_compatible(dht->net, ip_port, false)) {
+        return false;
+    }
+
     if (pack_nodes(dht->log, plain_message, sizeof(plain_message), &receiver, 1) == -1) {
         return false;
     }

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -147,6 +147,22 @@ uint16_t net_port(const Networking_Core *net)
 /* Basic network functions:
  */
 
+bool net_socket_family_compatible(const Networking_Core *net, const IP_Port *ip_port, bool log_warning)
+{
+    if (!net_family_is_ipv4(net->family) || net_family_is_ipv4(ip_port->ip.family)) {
+        return true;
+    }
+    Ip_Ntoa ip_str;
+    if (log_warning) {
+        LOGGER_WARNING(net->log, "attempted to send message with network family %d (probably IPv6) on IPv4 socket (%s)",
+                       ip_port->ip.family.value, net_ip_ntoa(&ip_port->ip, &ip_str));
+    } else {
+        LOGGER_TRACE(net->log, "attempted to send message with network family %d (probably IPv6) on IPv4 socket (%s)",
+                     ip_port->ip.family.value, net_ip_ntoa(&ip_port->ip, &ip_str));
+    }
+    return false;
+}
+
 int net_send_packet(const Networking_Core *net, const IP_Port *ip_port, Net_Packet packet)
 {
     IP_Port ipp_copy = *ip_port;
@@ -165,12 +181,9 @@ int net_send_packet(const Networking_Core *net, const IP_Port *ip_port, Net_Pack
     }
 
     /* socket TOX_AF_INET, but target IP NOT: can't send */
-    if (net_family_is_ipv4(net->family) && !net_family_is_ipv4(ipp_copy.ip.family)) {
+    if (!net_socket_family_compatible(net, ip_port, true)) {
         // TODO(iphydf): Make this an error. Occasionally we try to send to an
         // all-zero ip_port.
-        Ip_Ntoa ip_str;
-        LOGGER_WARNING(net->log, "attempted to send message with network family %d (probably IPv6) on IPv4 socket (%s)",
-                       ipp_copy.ip.family.value, net_ip_ntoa(&ipp_copy.ip, &ip_str));
         return -1;
     }
 

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -302,6 +302,14 @@ typedef struct Net_Packet {
 } Net_Packet;
 
 /**
+ * Check for the situation when socket TOX_AF_INET, but target IP is not. And log the error.
+ * This function can be used for UDP sockets only.
+ *
+ * @return true if socket if socket is compatible with address.
+ */
+bool net_socket_family_compatible(const Networking_Core *_Nonnull net, const IP_Port *_Nonnull ip_port, bool log_warning);
+
+/**
  * Function to send a network packet to a given IP/port.
  */
 int net_send_packet(const Networking_Core *_Nonnull net, const IP_Port *_Nonnull ip_port, Net_Packet packet);

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -302,6 +302,14 @@ typedef struct Net_Packet {
 } Net_Packet;
 
 /**
+ * Check for the situation when socket TOX_AF_INET, but target IP is not. And log the error.
+ * This function can be used for UDP sockets only.
+ *
+ * @return true if socket is compatible with address.
+ */
+bool net_socket_family_compatible(const Networking_Core *_Nonnull net, const IP_Port *_Nonnull ip_port, bool log_warning);
+
+/**
  * Function to send a network packet to a given IP/port.
  */
 int net_send_packet(const Networking_Core *_Nonnull net, const IP_Port *_Nonnull ip_port, Net_Packet packet);

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -376,6 +376,11 @@ int onion_send_1(const Onion *onion, const uint8_t *plain, uint16_t len, const I
         return 1;
     }
 
+    /* Avoid warning message when IPv6 is disabled and node address is IPv6. */
+    if (!net_socket_family_compatible(onion->net, &send_to, false)) {
+        return 1;
+    }
+
     uint8_t ip_port[SIZE_IPPORT];
     ipport_pack(ip_port, source);
 
@@ -438,6 +443,11 @@ static int handle_send_1(void *_Nonnull object, const IP_Port *_Nonnull source, 
     IP_Port send_to;
 
     if (ipport_unpack(&send_to, plain, len, false) == -1) {
+        return 1;
+    }
+
+    /* Avoid warning message when IPv6 is disabled and node address is IPv6. */
+    if (!net_socket_family_compatible(onion->net, &send_to, false)) {
         return 1;
     }
 
@@ -512,6 +522,11 @@ static int handle_send_2(void *_Nonnull object, const IP_Port *_Nonnull source, 
     IP_Port send_to;
 
     if (ipport_unpack(&send_to, plain, len, false) == -1) {
+        return 1;
+    }
+
+    /* Avoid warning message when IPv6 is disabled and node address is IPv6. */
+    if (!net_socket_family_compatible(onion->net, &send_to, false)) {
         return 1;
     }
 

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -930,6 +930,10 @@ static int client_ping_nodes(Onion_Client *_Nonnull onion_c, uint32_t num, const
                 }
             }
 
+            if (!net_socket_family_compatible(onion_c->net, &nodes[i].ip_port, false)) {
+                continue;
+            }
+
             if (j == list_length && good_to_ping(onion_c->mono_time, last_pinged, last_pinged_index, nodes[i].public_key)) {
                 client_send_announce_request(onion_c, num, &nodes[i].ip_port, nodes[i].public_key, nullptr, -1);
             }


### PR DESCRIPTION
If user switches off IPv6 and initiates tox, the requests to to the IPv6 bootstrap nodes is still done, which results in a lot of warning messages in the log.

In this PR we check if this is the case before calling `net_send_packet`, hence avoiding the warning.
Related to https://github.com/TokTok/c-toxcore/issues/1432

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3032)
<!-- Reviewable:end -->
