### PR TITLE
chore(ci): The gold linker has been deprecated/removed.

### DIFF
--- a/other/analysis/gen-file.sh
+++ b/other/analysis/gen-file.sh
@@ -21,8 +21,6 @@ CPPFLAGS+=("-Itoxencryptsave")
 CPPFLAGS+=("-Ithird_party/cmp")
 
 LDFLAGS=("-lopus" "-lsodium" "-lvpx" "-lpthread" "-lconfig" "-lgmock" "-lgtest" "-lbenchmark")
-LDFLAGS+=("-fuse-ld=gold")
-LDFLAGS+=("-Wl,--detect-odr-violations")
 LDFLAGS+=("-Wl,--warn-common")
 LDFLAGS+=("-Wl,--warn-execstack")
 LDFLAGS+=("-Wl,-z,noexecstack")

--- a/other/analysis/run-clang
+++ b/other/analysis/run-clang
@@ -25,6 +25,7 @@ run() {
     -Wno-missing-braces \
     -Wno-missing-field-initializers \
     -Wno-missing-noreturn \
+    -Wno-nrvo \
     -Wno-nullability-completeness \
     -Wno-nullability-extension \
     -Wno-nullable-to-nonnull-conversion \

--- a/other/analysis/run-gcc
+++ b/other/analysis/run-gcc
@@ -48,6 +48,7 @@ run() {
     -Wignored-qualifiers \
     -Winit-self \
     -Wlarger-than=530000 \
+    -Wlto-type-mismatch \
     -Wmaybe-uninitialized \
     -Wmemset-transposed-args \
     -Wmisleading-indentation \

--- a/toxav/audio_bench.cc
+++ b/toxav/audio_bench.cc
@@ -176,8 +176,14 @@ BENCHMARK_DEFINE_F(AudioBench, FullSequence)(benchmark::State &state)
         int idx = frame_index % num_prefilled;
         int size
             = ac_encode(ac, pcms[idx].data(), sample_count, encoded_tmp.data(), encoded_tmp.size());
+        if (size <= 0) {
+            return;
+        }
 
         std::vector<std::uint8_t> payload(4 + size);
+        if (payload.size() != 4u + static_cast<size_t>(size)) {
+            return;  // silence gcc analyzer, recheck when gcc16
+        }
         std::uint32_t net_sr = net_htonl(sampling_rate);
         std::memcpy(payload.data(), &net_sr, 4);
         std::memcpy(payload.data() + 4, encoded_tmp.data(), size);

--- a/toxav/audio_test.cc
+++ b/toxav/audio_test.cc
@@ -61,6 +61,7 @@ TEST_F(AudioTest, EncodeDecodeLoop)
 
     // Prepare payload: 4 bytes sampling rate + Opus data
     std::vector<std::uint8_t> payload(4 + static_cast<std::size_t>(encoded_size));
+    ASSERT_EQ(payload.size(), 4 + encoded_size);  // silence gcc analyzer, recheck when gcc16
     std::uint32_t net_sr = net_htonl(sampling_rate);
     std::memcpy(payload.data(), &net_sr, 4);
     std::memcpy(payload.data() + 4, encoded.data(), static_cast<std::size_t>(encoded_size));
@@ -124,6 +125,7 @@ TEST_F(AudioTest, EncodeDecodeRealistic)
         ASSERT_GT(encoded_size, 0);
 
         std::vector<std::uint8_t> payload(4 + static_cast<std::size_t>(encoded_size));
+        ASSERT_EQ(payload.size(), 4 + encoded_size);  // silence gcc analyzer, recheck when gcc16
         std::uint32_t net_sr = net_htonl(sampling_rate);
         std::memcpy(payload.data(), &net_sr, 4);
         std::memcpy(payload.data() + 4, encoded.data(), static_cast<std::size_t>(encoded_size));
@@ -220,6 +222,7 @@ TEST_F(AudioTest, EncodeDecodeSiren)
         ASSERT_GT(encoded_size, 0);
 
         std::vector<std::uint8_t> payload(4 + static_cast<std::size_t>(encoded_size));
+        ASSERT_EQ(payload.size(), 4 + encoded_size);  // silence gcc analyzer, recheck when gcc16
         std::uint32_t net_sr = net_htonl(sampling_rate);
         std::memcpy(payload.data(), &net_sr, 4);
         std::memcpy(payload.data() + 4, encoded.data(), static_cast<std::size_t>(encoded_size));

--- a/toxav/rtp_test.cc
+++ b/toxav/rtp_test.cc
@@ -419,6 +419,7 @@ TEST_F(RtpPublicTest, MoreInvalidPackets)
 
     // 1. RTPHeader packet type and Tox protocol packet type do not agree
     std::vector<std::uint8_t> bad_pkt_1 = valid_pkt;
+    ASSERT_GE(bad_pkt_1.size(), 1);
     bad_pkt_1[0] = RTP_TYPE_AUDIO;  // Tox ID says AUDIO, but header (byte 2) still says VIDEO
     rtp_receive_packet(session, bad_pkt_1.data(), bad_pkt_1.size());
     EXPECT_EQ(sd.received_frames.size(), 0);
@@ -435,6 +436,7 @@ TEST_F(RtpPublicTest, MoreInvalidPackets)
     // From rtp.c, offset_full is at byte 20 and data_length_full at byte 24 of the RTP header.
     // The RTP header starts at index 1 of the packet.
     std::vector<std::uint8_t> bad_pkt_3 = valid_pkt;
+    ASSERT_GE(bad_pkt_3.size(), 23);
     // Set offset (bytes 21-24) to be equal to length (bytes 25-28)
     // For a small packet, both are usually 0 and sizeof(data) respectively.
     // Let's just make offset very large.
@@ -460,6 +462,7 @@ TEST_F(RtpPublicTest, MoreInvalidPackets)
     sd.sent_packets.clear();
 
     std::vector<std::uint8_t> bad_pkt_4 = audio_pkt;
+    ASSERT_GE(bad_pkt_4.size(), 81);
     // Set offset_lower (byte 1 + 76) > data_length_lower (byte 1 + 78)
     bad_pkt_4[1 + 76] = 0x01;  // offset = 256
     bad_pkt_4[1 + 77] = 0x00;
@@ -552,8 +555,10 @@ TEST_F(RtpPublicTest, OldProtocolCorruption)
     // an assertion failure in new_message().
     std::uint8_t data[10] = {0};
     rtp_send_data(log, session, data, sizeof(data), false);
+    ASSERT_GE(sd.sent_packets.size(), 1);
     std::vector<std::uint8_t> pkt = sd.sent_packets[0];
     sd.sent_packets.clear();
+    ASSERT_GE(pkt.size(), 81);
 
     // Modify data_length_lower (byte 1 + 78) to be 2, while payload is 10.
     pkt[1 + 78] = 0x00;
@@ -573,7 +578,9 @@ TEST_F(RtpPublicTest, OldProtocolCorruption)
     EXPECT_EQ(sd.received_frames.size(), 0);
 
     // Now receive a corrupted second part that claims a weird offset
+    ASSERT_GE(sd.sent_packets.size(), 2);
     std::vector<std::uint8_t> corrupted_part = sd.sent_packets[1];
+    ASSERT_GE(corrupted_part.size(), 79);
     // offset_lower is at byte 76. Set it beyond data_length_lower.
     corrupted_part[1 + 76] = 0xFF;
     corrupted_part[1 + 77] = 0xFF;


### PR DESCRIPTION
LTO should work fine by default on modern distros.

Some images where updated to ubuntu 26.04, which resulted in new findings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3036)
<!-- Reviewable:end -->
