### PR TITLE
cleanup: Add a Tox_Pass_Salt type for the pass-key salt.

### DIFF
--- a/auto_tests/scenarios/scenario_toxav_peer_offline_test.c
+++ b/auto_tests/scenarios/scenario_toxav_peer_offline_test.c
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
 
     ToxScenarioStatus res = tox_scenario_run(s);
     if (res != TOX_SCENARIO_DONE) {
-        fprintf(stderr, "Scenario failed with status %d\n", res);
+        fprintf(stderr, "Scenario failed with status %d\n", (int)res);
         return 1;
     }
 

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -15,6 +15,7 @@ sh_test(
     args = ["$(locations %s)" % f for f in CIMPLE_FILES] + [
         "-Wno-boolean-return",
         "-Wno-callback-names",
+        "-Wno-callgraph",
         "-Wno-enum-from-int",
         "-Wno-nullability",
         "-Wno-ownership-decls",

--- a/toxencryptsave/toxencryptsave.c
+++ b/toxencryptsave/toxencryptsave.c
@@ -96,7 +96,7 @@ void tox_pass_key_free(Tox_Pass_Key *_Nullable key)
  */
 bool tox_get_salt(
     const uint8_t ciphertext[TOX_PASS_ENCRYPTION_EXTRA_LENGTH],
-    uint8_t salt[TOX_PASS_SALT_LENGTH], Tox_Err_Get_Salt *_Nullable error)
+    Tox_Pass_Salt salt, Tox_Err_Get_Salt *_Nullable error)
 {
     if (ciphertext == nullptr || salt == nullptr) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GET_SALT_NULL);
@@ -156,7 +156,7 @@ Tox_Pass_Key *_Nullable tox_pass_key_derive(
  */
 Tox_Pass_Key *_Nullable tox_pass_key_derive_with_salt(
     const uint8_t passphrase[], size_t passphrase_len,
-    const uint8_t salt[TOX_PASS_SALT_LENGTH], Tox_Err_Key_Derivation *_Nullable error)
+    const Tox_Pass_Salt salt, Tox_Err_Key_Derivation *_Nullable error)
 {
     if (salt == nullptr || (passphrase == nullptr && passphrase_len != 0)) {
         SET_ERROR_PARAMETER(error, TOX_ERR_KEY_DERIVATION_NULL);

--- a/toxencryptsave/toxencryptsave.h
+++ b/toxencryptsave/toxencryptsave.h
@@ -52,6 +52,8 @@ extern "C" {
 
 uint32_t tox_pass_salt_length(void);
 
+typedef uint8_t Tox_Pass_Salt[TOX_PASS_SALT_LENGTH];
+
 /**
  * The size of the key part of a pass-key.
  */
@@ -264,7 +266,7 @@ Tox_Pass_Key *tox_pass_key_derive(
  */
 Tox_Pass_Key *tox_pass_key_derive_with_salt(
     const uint8_t passphrase[], size_t passphrase_len,
-    const uint8_t salt[TOX_PASS_SALT_LENGTH], Tox_Err_Key_Derivation *error);
+    const Tox_Pass_Salt salt, Tox_Err_Key_Derivation *error);
 
 /**
  * Encrypt a plain text with a key produced by tox_pass_key_derive or
@@ -343,7 +345,7 @@ const char *tox_err_get_salt_to_string(Tox_Err_Get_Salt error);
  */
 bool tox_get_salt(
     const uint8_t ciphertext[TOX_PASS_ENCRYPTION_EXTRA_LENGTH],
-    uint8_t salt[TOX_PASS_SALT_LENGTH], Tox_Err_Get_Salt *error);
+    Tox_Pass_Salt salt, Tox_Err_Get_Salt *error);
 
 /**
  * Determines whether or not the given data is encrypted by this module.


### PR DESCRIPTION
Every other fixed-size byte array in the API is a named typedef (Tox_Public_Key, Tox_Address, ...); the salt was the lone exception.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3046)
<!-- Reviewable:end -->
