### PR TITLE
fix(DHT): refactor memory handling of loaded dht state

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2795,27 +2795,24 @@ static State_Load_Status dht_load_state_callback(void *_Nonnull outer, const uin
                 break;
             }
 
-            mem_delete(dht->mem, dht->loaded_nodes_list);
-
-            // Copy to loaded_clients_list
+            // TODO(Green-Sky): This allocates 130KiB, might be worth reducing or retrying with smaller, partial allocations.
             Node_format *nodes = (Node_format *)mem_valloc(dht->mem, MAX_SAVED_DHT_NODES, sizeof(Node_format));
 
             if (nodes == nullptr) {
                 LOGGER_ERROR(dht->log, "could not allocate %u nodes", (unsigned int)MAX_SAVED_DHT_NODES);
-                dht->loaded_num_nodes = 0;
                 break;
             }
 
             const int num = unpack_nodes(nodes, MAX_SAVED_DHT_NODES, nullptr, data, length, false);
 
-            if (num < 0) {
-                // Unpack error happened, we ignore it.
-                dht->loaded_num_nodes = 0;
+            if (num <= 0) {
+                // Unpack error happened or list was empty, we ignore it.
+                mem_delete(dht->mem, nodes);
             } else {
+                mem_delete(dht->mem, dht->loaded_nodes_list);
                 dht->loaded_num_nodes = num;
+                dht->loaded_nodes_list = nodes;
             }
-
-            dht->loaded_nodes_list = nodes;
 
             break;
         }

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -366,7 +366,7 @@ bool dht_bootstrap(DHT *_Nonnull dht, const IP_Port *_Nonnull ip_port, const uin
  */
 bool dht_bootstrap_from_address(DHT *_Nonnull dht, const char *_Nonnull address, bool ipv6enabled, bool dns_enabled, uint16_t port, const uint8_t *_Nonnull public_key);
 
-/** @brief Start sending packets after DHT loaded_friends_list and loaded_clients_list are set.
+/** @brief Start sending packets after DHT loaded_nodes_list is set.
  *
  * @retval 0 if successful
  * @retval -1 otherwise


### PR DESCRIPTION
Previous code could double-free if more than one dht states per tox-file and a following allocation fails. (it did not set `dht->loaded_nodes_list = nullptr` after `mem_delete()`)

Also changed/removed dead var references in comments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3047)
<!-- Reviewable:end -->
