### PR TITLE
fix(gca): announce max sizes where 32bytes too large

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2474,8 +2474,8 @@ static bool self_announce_group(const Messenger *_Nonnull m, GC_Chat *_Nonnull c
     memcpy(announce.base_announce.peer_public_key, chat->self_public_key.enc, ENC_PUBLIC_KEY_SIZE);
     memcpy(announce.chat_public_key, get_chat_id(&chat->chat_public_key), ENC_PUBLIC_KEY_SIZE);
 
-    uint8_t gc_data[GCA_MAX_DATA_LENGTH];
-    const int length = gca_pack_public_announce(m->log, gc_data, GCA_MAX_DATA_LENGTH, &announce);
+    uint8_t gc_data[GCA_PUBLIC_ANNOUNCE_MAX_SIZE];
+    const int length = gca_pack_public_announce(m->log, gc_data, sizeof(gc_data), &announce);
 
     if (length <= 0) {
         onion_friend_set_gc_data(onion_friend, nullptr, 0);

--- a/toxcore/group_announce.h
+++ b/toxcore/group_announce.h
@@ -35,7 +35,7 @@ extern "C" {
 #define GCA_MAX_SENT_ANNOUNCES 4
 
 /* Maximum size of an announce. */
-#define GCA_ANNOUNCE_MAX_SIZE (ENC_PUBLIC_KEY_SIZE + 1 + 1 + (PACKED_NODE_SIZE_IP6 * 2))
+#define GCA_ANNOUNCE_MAX_SIZE (ENC_PUBLIC_KEY_SIZE + 1 + 1 + (1 + SIZE_IP6 + sizeof(uint16_t)) + PACKED_NODE_SIZE_IP6)
 
 /* Maximum size of a public announce. */
 #define GCA_PUBLIC_ANNOUNCE_MAX_SIZE (ENC_PUBLIC_KEY_SIZE + GCA_ANNOUNCE_MAX_SIZE)

--- a/toxcore/group_onion_announce.c
+++ b/toxcore/group_onion_announce.c
@@ -99,9 +99,9 @@ int create_gca_announce_request(
     }
 
     uint8_t plain[ONION_PING_ID_SIZE + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_PUBLIC_KEY_SIZE +
-                                     ONION_ANNOUNCE_SENDBACK_DATA_LENGTH + GCA_ANNOUNCE_MAX_SIZE];
+                                     ONION_ANNOUNCE_SENDBACK_DATA_LENGTH + GCA_PUBLIC_ANNOUNCE_MAX_SIZE];
     uint8_t *position_in_plain = plain;
-    const size_t encrypted_size = sizeof(plain) - GCA_ANNOUNCE_MAX_SIZE + gc_data_length;
+    const size_t encrypted_size = sizeof(plain) - GCA_PUBLIC_ANNOUNCE_MAX_SIZE + gc_data_length;
 
     memcpy(plain, ping_id, ONION_PING_ID_SIZE);
     position_in_plain += ONION_PING_ID_SIZE;

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -103,7 +103,7 @@ struct Onion_Friend {
     void *_Nullable dht_pk_callback_object;
     uint32_t dht_pk_callback_number;
 
-    uint8_t  gc_data[GCA_MAX_DATA_LENGTH];
+    uint8_t  gc_data[GCA_PUBLIC_ANNOUNCE_MAX_SIZE];
     uint8_t  gc_public_key[ENC_PUBLIC_KEY_SIZE];
     uint16_t gc_data_length;
     bool     is_groupchat;
@@ -195,6 +195,7 @@ void onion_friend_set_gc_public_key(Onion_Friend *const onion_friend, const uint
 void onion_friend_set_gc_data(Onion_Friend *const onion_friend, const uint8_t *gc_data, uint16_t gc_data_length)
 {
     if (gc_data_length > 0 && gc_data != nullptr) {
+        assert(gc_data_length <= GCA_PUBLIC_ANNOUNCE_MAX_SIZE);
         memcpy(onion_friend->gc_data, gc_data, gc_data_length);
     }
 

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -51,8 +51,6 @@
 
 #define MAX_PATH_NODES 32
 
-#define GCA_MAX_DATA_LENGTH GCA_PUBLIC_ANNOUNCE_MAX_SIZE
-
 /**
  * If no announce response packets are received within this interval tox will
  * be considered offline. We give time for a node to be pinged often enough


### PR DESCRIPTION
Analysis complained on the sender side that it might overflow. In practice this could never happen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3048)
<!-- Reviewable:end -->
