### PR TITLE
fix: error check the result of encrypt_precompute

### DIFF
--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -347,9 +347,9 @@ static int handle_handshake(TCP_Client_Connection *_Nonnull tcp_conn, const uint
     }
 
     memcpy(tcp_conn->recv_nonce, plain + CRYPTO_PUBLIC_KEY_SIZE, CRYPTO_NONCE_SIZE);
-    encrypt_precompute(plain, tcp_conn->temp_secret_key, tcp_conn->con.shared_key);
+    const int ret = encrypt_precompute(plain, tcp_conn->temp_secret_key, tcp_conn->con.shared_key);
     crypto_memzero(tcp_conn->temp_secret_key, CRYPTO_SECRET_KEY_SIZE);
-    return 0;
+    return ret;
 }
 
 /**
@@ -664,7 +664,12 @@ TCP_Client_Connection *new_tcp_connection(
     temp->con.net_profile = net_profile;
     memcpy(temp->public_key, public_key, CRYPTO_PUBLIC_KEY_SIZE);
     memcpy(temp->self_public_key, self_public_key, CRYPTO_PUBLIC_KEY_SIZE);
-    encrypt_precompute(temp->public_key, self_secret_key, temp->con.shared_key);
+    if (encrypt_precompute(temp->public_key, self_secret_key, temp->con.shared_key) != 0) {
+        LOGGER_WARNING(logger, "Failed to precompute shared key.");
+        mem_delete(mem, temp);
+        kill_sock(ns, sock);
+        return nullptr;
+    }
     temp->ip_port = *ip_port;
     temp->proxy_info = *proxy_info;
 
@@ -686,8 +691,8 @@ TCP_Client_Connection *new_tcp_connection(
 
             if (generate_handshake(temp) == -1) {
                 LOGGER_ERROR(logger, "Failed to generate handshake");
-                kill_sock(ns, sock);
                 mem_delete(mem, temp);
+                kill_sock(ns, sock);
                 return nullptr;
             }
 

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -322,7 +322,10 @@ static int handle_tcp_handshake(const Logger *_Nonnull logger, TCP_Secure_Connec
     }
 
     uint8_t shared_key[CRYPTO_SHARED_KEY_SIZE];
-    encrypt_precompute(data, self_secret_key, shared_key);
+    if (encrypt_precompute(data, self_secret_key, shared_key) != 0) {
+        LOGGER_ERROR(logger, "invalid TCP handshake, shared key pre-computation failed");
+        return -1;
+    }
     uint8_t plain[TCP_HANDSHAKE_PLAIN_SIZE];
     int len = decrypt_data_symmetric(con->con.mem, shared_key, data + CRYPTO_PUBLIC_KEY_SIZE,
                                      data + CRYPTO_PUBLIC_KEY_SIZE + CRYPTO_NONCE_SIZE, TCP_HANDSHAKE_PLAIN_SIZE + CRYPTO_MAC_SIZE, plain);
@@ -359,7 +362,12 @@ static int handle_tcp_handshake(const Logger *_Nonnull logger, TCP_Secure_Connec
         return -1;
     }
 
-    encrypt_precompute(plain, temp_secret_key, con->con.shared_key);
+    if (encrypt_precompute(plain, temp_secret_key, con->con.shared_key) != 0) {
+        LOGGER_ERROR(logger, "invalid TCP handshake, session shared key precomputation failed");
+        crypto_memzero(shared_key, sizeof(shared_key));
+        return -1;
+    }
+
     con->status = TCP_STATUS_UNCONFIRMED;
 
     crypto_memzero(shared_key, sizeof(shared_key));

--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -348,7 +348,9 @@ int32_t encrypt_data(const Memory *mem,
     }
 
     uint8_t k[crypto_box_BEFORENMBYTES];
-    encrypt_precompute(public_key, secret_key, k);
+    if (encrypt_precompute(public_key, secret_key, k) != 0) {
+        return -1;
+    }
     const int ret = encrypt_data_symmetric(mem, k, nonce, plain, length, encrypted);
     crypto_memzero(k, sizeof(k));
     return ret;
@@ -365,7 +367,9 @@ int32_t decrypt_data(const Memory *mem,
     }
 
     uint8_t k[crypto_box_BEFORENMBYTES];
-    encrypt_precompute(public_key, secret_key, k);
+    if (encrypt_precompute(public_key, secret_key, k) != 0) {
+        return -1;
+    }
     const int ret = decrypt_data_symmetric(mem, k, nonce, encrypted, length, plain);
     crypto_memzero(k, sizeof(k));
     return ret;

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -342,6 +342,9 @@ int32_t decrypt_data(const Memory *_Nonnull mem, const uint8_t public_key[_Nonnu
  * Use if this is not a one-time communication. `encrypt_precompute` does the
  * shared-key generation once so it does not have to be performed on every
  * encrypt/decrypt.
+ * When it fails, it either does not touch @p shared_key, or it was zeroed-out.
+ *
+ * @retval 0 on success.
  */
 int32_t encrypt_precompute(const uint8_t public_key[_Nonnull CRYPTO_PUBLIC_KEY_SIZE], const uint8_t secret_key[_Nonnull CRYPTO_SECRET_KEY_SIZE],
                            uint8_t shared_key[_Nonnull CRYPTO_SHARED_KEY_SIZE]);

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -3926,10 +3926,10 @@ static int handle_gc_topic(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat,
 
 /** @brief Handles a key exchange packet.
  *
- * Return 0 if packet is handled correctly.
- * Return -1 if length is invalid.
- * Return -2 if we fail to create a new session keypair.
- * Return -3 if response packet fails to send.
+ * @retval 0 if packet is handled correctly.
+ * @retval -1 if length is invalid.
+ * @retval -2 if we failed to create a new session shared key.
+ * @retval -3 if response packet fails to send.
  */
 static int handle_gc_key_exchange(const GC_Chat *_Nonnull chat, GC_Connection *_Nonnull gconn, const uint8_t *_Nullable data, uint16_t length)
 {
@@ -3949,7 +3949,10 @@ static int handle_gc_key_exchange(const GC_Chat *_Nonnull chat, GC_Connection *_
         }
 
         // now that we have response we can compute our new shared key and begin using it
-        gcc_make_session_shared_key(gconn, sender_public_session_key);
+        if (!gcc_make_session_shared_key(gconn, sender_public_session_key)) {
+            LOGGER_WARNING(chat->log, "failed generating session shared key with peer %u", gconn->public_key_hash);
+            return -2;
+        }
 
         gconn->pending_key_rotation_request = false;
 
@@ -3986,10 +3989,14 @@ static int handle_gc_key_exchange(const GC_Chat *_Nonnull chat, GC_Connection *_
     memcpy(gconn->session_public_key, new_session_pk, sizeof(gconn->session_public_key));
     memcpy(gconn->session_secret_key, new_session_sk, sizeof(gconn->session_secret_key));
 
-    gcc_make_session_shared_key(gconn, sender_public_session_key);
-
     crypto_memzero(new_session_sk, sizeof(new_session_sk));
     crypto_memunlock(new_session_sk, sizeof(new_session_sk));
+
+    if (!gcc_make_session_shared_key(gconn, sender_public_session_key)) {
+        crypto_memzero(gconn->session_public_key, sizeof(new_session_sk));
+        crypto_memzero(gconn->session_secret_key, sizeof(new_session_sk));
+        return -2;
+    }
 
     gconn->last_key_rotation = mono_time_get(chat->mono_time);
 
@@ -5640,7 +5647,9 @@ static int handle_gc_handshake_response(const GC_Chat *_Nonnull chat, const IP_P
 
     const uint8_t *sender_session_pk = data;
 
-    gcc_make_session_shared_key(gconn, sender_session_pk);
+    if (!gcc_make_session_shared_key(gconn, sender_session_pk)) {
+        return -1;
+    }
 
     set_sig_pk(&gconn->addr.public_key, data + ENC_PUBLIC_KEY_SIZE);
 
@@ -5792,13 +5801,17 @@ static int handle_gc_handshake_request(GC_Chat *_Nonnull chat, const IP_Port *_N
 
     const uint8_t *sender_session_pk = data;
 
-    gcc_make_session_shared_key(gconn, sender_session_pk);
+    if (!gcc_make_session_shared_key(gconn, sender_session_pk)) {
+        LOGGER_WARNING(chat->log, "Session shared key generation failed for new peer");
+        gcc_mark_for_deletion(gconn, chat->tcp_conn, GC_EXIT_TYPE_DISCONNECTED, nullptr, 0);
+        return -1;
+    }
 
     set_sig_pk(&gconn->addr.public_key, public_sig_key);
 
     if (join_type == HJ_PUBLIC && !is_public_chat(chat)) {
-        gcc_mark_for_deletion(gconn, chat->tcp_conn, GC_EXIT_TYPE_DISCONNECTED, nullptr, 0);
         LOGGER_DEBUG(chat->log, "Ignoring invalid invite request");
+        gcc_mark_for_deletion(gconn, chat->tcp_conn, GC_EXIT_TYPE_DISCONNECTED, nullptr, 0);
         return -1;
     }
 

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -3927,10 +3927,10 @@ static int handle_gc_topic(const GC_Session *_Nonnull c, GC_Chat *_Nonnull chat,
 
 /** @brief Handles a key exchange packet.
  *
- * Return 0 if packet is handled correctly.
- * Return -1 if length is invalid.
- * Return -2 if we fail to create a new session keypair.
- * Return -3 if response packet fails to send.
+ * @retval 0 if packet is handled correctly.
+ * @retval -1 if length is invalid.
+ * @retval -2 if we failed to create a new session shared key.
+ * @retval -3 if response packet fails to send.
  */
 static int handle_gc_key_exchange(const GC_Chat *_Nonnull chat, GC_Connection *_Nonnull gconn, const uint8_t *_Nullable data, uint16_t length)
 {
@@ -3950,7 +3950,10 @@ static int handle_gc_key_exchange(const GC_Chat *_Nonnull chat, GC_Connection *_
         }
 
         // now that we have response we can compute our new shared key and begin using it
-        gcc_make_session_shared_key(gconn, sender_public_session_key);
+        if (!gcc_make_session_shared_key(gconn, sender_public_session_key)) {
+            LOGGER_WARNING(chat->log, "failed generating session shared key with peer %u", gconn->public_key_hash);
+            return -2;
+        }
 
         gconn->pending_key_rotation_request = false;
 
@@ -3987,10 +3990,14 @@ static int handle_gc_key_exchange(const GC_Chat *_Nonnull chat, GC_Connection *_
     memcpy(gconn->session_public_key, new_session_pk, sizeof(gconn->session_public_key));
     memcpy(gconn->session_secret_key, new_session_sk, sizeof(gconn->session_secret_key));
 
-    gcc_make_session_shared_key(gconn, sender_public_session_key);
-
     crypto_memzero(new_session_sk, sizeof(new_session_sk));
     crypto_memunlock(new_session_sk, sizeof(new_session_sk));
+
+    if (!gcc_make_session_shared_key(gconn, sender_public_session_key)) {
+        crypto_memzero(gconn->session_public_key, sizeof(new_session_sk));
+        crypto_memzero(gconn->session_secret_key, sizeof(new_session_sk));
+        return -2;
+    }
 
     gconn->last_key_rotation = mono_time_get(chat->mono_time);
 
@@ -5641,7 +5648,9 @@ static int handle_gc_handshake_response(const GC_Chat *_Nonnull chat, const IP_P
 
     const uint8_t *sender_session_pk = data;
 
-    gcc_make_session_shared_key(gconn, sender_session_pk);
+    if (!gcc_make_session_shared_key(gconn, sender_session_pk)) {
+        return -1;
+    }
 
     set_sig_pk(&gconn->addr.public_key, data + ENC_PUBLIC_KEY_SIZE);
 
@@ -5793,13 +5802,17 @@ static int handle_gc_handshake_request(GC_Chat *_Nonnull chat, const IP_Port *_N
 
     const uint8_t *sender_session_pk = data;
 
-    gcc_make_session_shared_key(gconn, sender_session_pk);
+    if (!gcc_make_session_shared_key(gconn, sender_session_pk)) {
+        LOGGER_WARNING(chat->log, "Session shared key generation failed for new peer");
+        gcc_mark_for_deletion(gconn, chat->tcp_conn, GC_EXIT_TYPE_DISCONNECTED, nullptr, 0);
+        return -1;
+    }
 
     set_sig_pk(&gconn->addr.public_key, public_sig_key);
 
     if (join_type == HJ_PUBLIC && !is_public_chat(chat)) {
-        gcc_mark_for_deletion(gconn, chat->tcp_conn, GC_EXIT_TYPE_DISCONNECTED, nullptr, 0);
         LOGGER_DEBUG(chat->log, "Ignoring invalid invite request");
+        gcc_mark_for_deletion(gconn, chat->tcp_conn, GC_EXIT_TYPE_DISCONNECTED, nullptr, 0);
         return -1;
     }
 

--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -653,9 +653,9 @@ int gcc_encrypt_and_send_lossless_packet(const GC_Chat *chat, GC_Connection *gco
     return 0;
 }
 
-void gcc_make_session_shared_key(GC_Connection *gconn, const uint8_t *sender_pk)
+bool gcc_make_session_shared_key(GC_Connection *gconn, const uint8_t *sender_pk)
 {
-    encrypt_precompute(sender_pk, gconn->session_secret_key, gconn->session_shared_key);
+    return encrypt_precompute(sender_pk, gconn->session_secret_key, gconn->session_shared_key) == 0;
 }
 
 bool gcc_conn_is_direct(const Mono_Time *mono_time, const GC_Connection *gconn)

--- a/toxcore/group_connection.h
+++ b/toxcore/group_connection.h
@@ -114,8 +114,10 @@ void gcc_resend_packets(const GC_Chat *_Nonnull chat, GC_Connection *_Nonnull gc
  *
  * Puts the result in the shared session key buffer for `gconn`, which must have room for
  * CRYPTO_SHARED_KEY_SIZE bytes. This resulting shared key should be treated as a secret key.
+ *
+ * @return True on success.
  */
-void gcc_make_session_shared_key(GC_Connection *_Nonnull gconn, const uint8_t *_Nonnull sender_pk);
+bool gcc_make_session_shared_key(GC_Connection *_Nonnull gconn, const uint8_t *_Nonnull sender_pk);
 
 /** @brief Return true if we have a direct connection with `gconn`. */
 bool gcc_conn_is_direct(const Mono_Time *_Nonnull mono_time, const GC_Connection *_Nonnull gconn);

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -1698,7 +1698,9 @@ static int handle_packet_crypto_hs(const Net_Crypto *_Nonnull c, int crypt_conne
     }
 
     if (pk_equal(dht_public_key, conn->dht_public_key)) {
-        encrypt_precompute(conn->peersessionpublic_key, conn->sessionsecret_key, conn->shared_key);
+        if (encrypt_precompute(conn->peersessionpublic_key, conn->sessionsecret_key, conn->shared_key) != 0) {
+            return -1;
+        }
 
         if (conn->status == CRYPTO_CONN_COOKIE_REQUESTING) {
             if (create_send_handshake(c, crypt_connection_id, cookie, dht_public_key) != 0) {
@@ -1977,7 +1979,10 @@ static int handle_new_connection_handshake(Net_Crypto *_Nonnull c, const IP_Port
 
             memcpy(conn->recv_nonce, n_c.recv_nonce, CRYPTO_NONCE_SIZE);
             memcpy(conn->peersessionpublic_key, n_c.peersessionpublic_key, CRYPTO_PUBLIC_KEY_SIZE);
-            encrypt_precompute(conn->peersessionpublic_key, conn->sessionsecret_key, conn->shared_key);
+            if (encrypt_precompute(conn->peersessionpublic_key, conn->sessionsecret_key, conn->shared_key) != 0) {
+                mem_delete(c->mem, n_c.cookie);
+                return -1;
+            }
 
             crypto_connection_add_source(c, crypt_connection_id, source);
 
@@ -2035,7 +2040,11 @@ int accept_crypto_connection(Net_Crypto *c, const New_Connection *n_c)
     memcpy(conn->peersessionpublic_key, n_c->peersessionpublic_key, CRYPTO_PUBLIC_KEY_SIZE);
     random_nonce(c->rng, conn->sent_nonce);
     crypto_new_keypair(c->rng, conn->sessionpublic_key, conn->sessionsecret_key);
-    encrypt_precompute(conn->peersessionpublic_key, conn->sessionsecret_key, conn->shared_key);
+    if (encrypt_precompute(conn->peersessionpublic_key, conn->sessionsecret_key, conn->shared_key) != 0) {
+        kill_tcp_connection_to(c->tcp_c, conn->connection_number_tcp);
+        wipe_crypto_connection(c, crypt_connection_id);
+        return -1;
+    }
     conn->status = CRYPTO_CONN_NOT_CONFIRMED;
 
     if (create_send_handshake(c, crypt_connection_id, n_c->cookie, n_c->dht_public_key) != 0) {

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -18,6 +18,7 @@
 #include "logger.h"
 #include "mem.h"
 #include "mono_time.h"
+#include "net.h"
 #include "network.h"
 #include "shared_key_cache.h"
 #include "util.h"
@@ -109,8 +110,8 @@ static int ipport_unpack(IP_Port *_Nonnull target, const uint8_t *_Nonnull data,
  *
  * new_path must be an empty memory location of at least Onion_Path size.
  *
- * return -1 on failure.
- * return 0 on success.
+ * @retval -1 on failure.
+ * @retval 0 on success.
  */
 int create_onion_path(const Random *rng, const DHT *dht, Onion_Path *new_path, const Node_format *nodes)
 {
@@ -118,18 +119,28 @@ int create_onion_path(const Random *rng, const DHT *dht, Onion_Path *new_path, c
         return -1;
     }
 
-    encrypt_precompute(nodes[0].public_key, dht_get_self_secret_key(dht), new_path->shared_key1);
-    memcpy(new_path->public_key1, dht_get_self_public_key(dht), CRYPTO_PUBLIC_KEY_SIZE);
+    if (!net_family_is_tcp_server(nodes[0].ip_port.ip.family)) {
+        // If the first hop is a tcp-relay, pubkey and sharedkey are never written or read.
+
+        if (encrypt_precompute(nodes[0].public_key, dht_get_self_secret_key(dht), new_path->shared_key1) != 0) {
+            return -1;
+        }
+        memcpy(new_path->public_key1, dht_get_self_public_key(dht), CRYPTO_PUBLIC_KEY_SIZE);
+    }
 
     uint8_t random_public_key[CRYPTO_PUBLIC_KEY_SIZE];
     uint8_t random_secret_key[CRYPTO_SECRET_KEY_SIZE];
 
     crypto_new_keypair(rng, random_public_key, random_secret_key);
-    encrypt_precompute(nodes[1].public_key, random_secret_key, new_path->shared_key2);
+    if (encrypt_precompute(nodes[1].public_key, random_secret_key, new_path->shared_key2) != 0) {
+        return -1;
+    }
     memcpy(new_path->public_key2, random_public_key, CRYPTO_PUBLIC_KEY_SIZE);
 
     crypto_new_keypair(rng, random_public_key, random_secret_key);
-    encrypt_precompute(nodes[2].public_key, random_secret_key, new_path->shared_key3);
+    if (encrypt_precompute(nodes[2].public_key, random_secret_key, new_path->shared_key3) != 0) {
+        return -1;
+    }
     memcpy(new_path->public_key3, random_public_key, CRYPTO_PUBLIC_KEY_SIZE);
 
     crypto_memzero(random_secret_key, sizeof(random_secret_key));

--- a/toxcore/onion.h
+++ b/toxcore/onion.h
@@ -89,8 +89,8 @@ typedef struct Onion_Path {
  *
  * new_path must be an empty memory location of at least Onion_Path size.
  *
- * return -1 on failure.
- * return 0 on success.
+ * @retval -1 on failure.
+ * @retval 0 on success.
  */
 int create_onion_path(const Random *_Nonnull rng, const DHT *_Nonnull dht, Onion_Path *_Nonnull new_path, const Node_format *_Nonnull nodes);
 


### PR DESCRIPTION
It can fail when the supplied public key is bad (see libsodium).

memzero over the shared key on failure is not needed. The array is either not touched, or already all zero.

tcp-relay'd onion paths are annoying, since they set the pubkey for the first hop to zero, so this is now worked around.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3056)
<!-- Reviewable:end -->
