### PR TITLE
fix(ngc): stale gconn ptr after realloc

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -6003,6 +6003,9 @@ static bool handle_gc_packet_fragment(const GC_Session *_Nonnull c, GC_Chat *_No
         return false;
     }
 
+    // realloc might have moved it
+    gconn = get_gc_connection(chat, peer_number);
+
     if (frag_ret == 0) {
         gc_send_message_ack(chat, gconn, message_id, GR_ACK_RECV);
     }
@@ -6074,6 +6077,9 @@ static bool handle_gc_lossless_packet(const GC_Session *_Nonnull c, GC_Chat *_No
     }
 
     const int lossless_ret = gcc_handle_received_message(chat->log, chat->mem, chat->mono_time, gconn, data, (uint16_t) len, packet_type, message_id, direct_conn);
+
+    // realloc might have moved it
+    gconn = get_gc_connection(chat, peer_number);
 
     if (packet_type == GP_INVITE_REQUEST && !gconn->handshaked) {  // Both peers sent request at same time
         mem_delete(chat->mem, data);


### PR DESCRIPTION
Some packet handlers call add_peer() down the call stack, which can realloc the struct array, which gconn is part of.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3057)
<!-- Reviewable:end -->
