### PR TITLE
fix: e2e fuzzing was setup wrongly and no pkgs where consumed

### DIFF
--- a/testing/fuzzing/CMakeLists.txt
+++ b/testing/fuzzing/CMakeLists.txt
@@ -19,8 +19,7 @@ function(fuzz_test target source_dir)
 endfunction()
 
 fuzz_test(bootstrap        .)  # Fuzzes the bootstrap process
-# TODO(iphydf): Fix this in the cmake build.
-# fuzz_test(e2e              .)  # Fuzzes an end-to-end connection
+fuzz_test(e2e              .)  # Fuzzes an end-to-end connection
 fuzz_test(toxsave          .)  # Fuzzes tox_new and tox_get_savedata
 
 fuzz_test(DHT              ../../toxcore)

--- a/testing/fuzzing/e2e_fuzz_test.cc
+++ b/testing/fuzzing/e2e_fuzz_test.cc
@@ -149,7 +149,7 @@ void TestEndToEnd(Fuzz_Data &input)
     env.fake_clock().advance(1000000000);  // Match legacy behavior
     auto node = env.create_node(33445);
     configure_fuzz_memory_source(env.fake_memory(), input);
-    configure_fuzz_packet_source(*node->endpoint, input);
+    //configure_fuzz_packet_source(*node->endpoint, input);
     configure_fuzz_random_source(env.fake_random(), input);
 
     // Null system replacement for event comparison
@@ -203,6 +203,11 @@ void TestEndToEnd(Fuzz_Data &input)
 
     assert(error_new == TOX_ERR_NEW_OK);
     assert(error_new_testing == TOX_ERR_NEW_TESTING_OK);
+
+    // HACK: toxcore creates itself a new socket/node.
+    for (auto sockets : node->node->fake_network().get_bound_udp_sockets()) {
+        configure_fuzz_packet_source(*sockets, input);
+    }
 
     tox_events_init(tox);
 


### PR DESCRIPTION
This is because toxcore creates it own new socket/node, not the one created for toxcore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3060)
<!-- Reviewable:end -->
