### PR TITLE
fix: disable nrvo clang warning for osx ci

### DIFF
--- a/.github/scripts/cmake-osx
+++ b/.github/scripts/cmake-osx
@@ -26,6 +26,8 @@ add_flag -Werror
 add_c_flag -Wno-c11-extensions
 add_c_flag -Wno-pre-c11-compat
 
+add_flag -Wno-nrvo
+
 cmake -GNinja -B_build -H. \
   -DCMAKE_C_FLAGS="$C_FLAGS" \
   -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3067)
<!-- Reviewable:end -->
