### PR TITLE
Hide conference_uid_size behind !TOX_HIDE_DEPRECATED

### DIFF
--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -237,6 +237,7 @@ uint32_t tox_dht_id_size(void);
 
 typedef uint8_t Tox_Dht_Id[TOX_DHT_ID_SIZE];
 
+#ifndef TOX_HIDE_DEPRECATED
 /**
  * @brief The size of a Tox Conference unique id in bytes.
  *
@@ -247,6 +248,7 @@ typedef uint8_t Tox_Dht_Id[TOX_DHT_ID_SIZE];
 uint32_t tox_conference_uid_size(void);
 
 typedef uint8_t Tox_Conference_Uid[TOX_CONFERENCE_UID_SIZE];
+#endif
 
 /**
  * @brief The size of a Tox Conference unique id in bytes.


### PR DESCRIPTION
Untested, but I don't see why this wouldn't work

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3071)
<!-- Reviewable:end -->
