### PR TITLE
fix(LAN_discovery): use interface IP and bitwise masking for Windows broadcast calculation

### DIFF
--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -90,22 +90,21 @@ static Broadcast_Info *_Nullable fetch_broadcast_info(const Memory *_Nonnull mem
         IP_ADAPTER_INFO *adapter = adapter_info;
 
         while (adapter != nullptr) {
-            IP gateway = {0};
+            IP if_ip = {0};
             IP subnet_mask = {0};
 
             if (addr_parse_ip(adapter->IpAddressList.IpMask.String, &subnet_mask)
-                    && addr_parse_ip(adapter->GatewayList.IpAddress.String, &gateway)) {
-                if (net_family_is_ipv4(gateway.family) && net_family_is_ipv4(subnet_mask.family)) {
-                    IP *ip = &broadcast->ips[broadcast->count];
-                    ip->family = net_family_ipv4();
-                    const uint32_t gateway_ip = net_ntohl(gateway.ip.v4.uint32);
-                    const uint32_t subnet_ip = net_ntohl(subnet_mask.ip.v4.uint32);
-                    const uint32_t broadcast_ip = gateway_ip + ~subnet_ip - 1;
-                    ip->ip.v4.uint32 = net_htonl(broadcast_ip);
-                    ++broadcast->count;
+                    && addr_parse_ip(adapter->IpAddressList.IpAddress.String, &if_ip)) {
+                if (net_family_is_ipv4(if_ip.family) && net_family_is_ipv4(subnet_mask.family)) {
+                    if (if_ip.ip.v4.uint32 != 0 && subnet_mask.ip.v4.uint32 != 0) {
+                        IP *ip = &broadcast->ips[broadcast->count];
+                        ip->family = net_family_ipv4();
+                        ip->ip.v4.uint32 = if_ip.ip.v4.uint32 | ~subnet_mask.ip.v4.uint32;
+                        ++broadcast->count;
 
-                    if (broadcast->count >= MAX_INTERFACES) {
-                        break;
+                        if (broadcast->count >= MAX_INTERFACES) {
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In `toxcore/LAN_discovery.c` (`fetch_broadcast_info` on Windows), the subnet broadcast IP was computed using addition against the gateway IP:
```c
const uint32_t broadcast_ip = gateway_ip + ~subnet_ip - 1;
```

This had two issues:
1. If the gateway was anything other than `.1` (for example `.254`), `254 + 254 = 508` overflowed the lower byte and incremented the third octet, producing an invalid broadcast IP (e.g. `192.168.2.252` instead of `192.168.1.255`).
2. If an adapter had no default gateway configured (like on an isolated offline LAN or ad-hoc Wi-Fi), `GatewayList` was `"0.0.0.0"`, breaking broadcast discovery completely.

This patch switches to using the adapter's own IP address (`IpAddressList.IpAddress`) and standard bitwise subnet masking `(ip & mask) | ~mask`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3074)
<!-- Reviewable:end -->
