### PR TITLE
fix(crypto): correct assertion message in pack_extended_public_key

### DIFF
--- a/toxcore/crypto_core_pack.c
+++ b/toxcore/crypto_core_pack.c
@@ -16,7 +16,7 @@ bool pack_extended_public_key(const Extended_Public_Key *key, Bin_Pack *bp)
 {
     uint8_t ext_key[EXT_PUBLIC_KEY_SIZE];
     static_assert(sizeof(ext_key) == sizeof(key->enc) + sizeof(key->sig),
-                  "extended secret key size is not the sum of the encryption and sign secret key sizes");
+                  "extended public key size is not the sum of the encryption and sign public key sizes");
     memcpy(ext_key, key->enc, sizeof(key->enc));
     memcpy(&ext_key[sizeof(key->enc)], key->sig, sizeof(key->sig));
 


### PR DESCRIPTION
Fix static_assert message in pack_extended_public_key to reference public key sizes instead of secret key sizes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3075)
<!-- Reviewable:end -->
