### PR TITLE
refactor(crypto): implement increment_nonce via increment_nonce_number

### DIFF
--- a/toxcore/crypto_core.c
+++ b/toxcore/crypto_core.c
@@ -384,21 +384,7 @@ int32_t decrypt_data(const Memory *mem,
 
 void increment_nonce(uint8_t nonce[CRYPTO_NONCE_SIZE])
 {
-    /* TODO(irungentoo): use `increment_nonce_number(nonce, 1)` or
-     * sodium_increment (change to little endian).
-     *
-     * NOTE don't use breaks inside this loop.
-     * In particular, make sure, as far as possible,
-     * that loop bounds and their potential underflow or overflow
-     * are independent of user-controlled input (you may have heard of the Heartbleed bug).
-     */
-    uint_fast16_t carry = 1U;
-
-    for (uint32_t i = crypto_box_NONCEBYTES; i != 0; --i) {
-        carry += (uint_fast16_t)nonce[i - 1];
-        nonce[i - 1] = (uint8_t)carry;
-        carry >>= 8;
-    }
+    increment_nonce_number(nonce, 1);
 }
 
 void increment_nonce_number(uint8_t nonce[CRYPTO_NONCE_SIZE], uint32_t increment)


### PR DESCRIPTION
Deduplicate the carry loop in `increment_nonce` by calling `increment_nonce_number(nonce, 1)`, addressing the existing TODO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore/3079)
<!-- Reviewable:end -->
